### PR TITLE
addpkg: suitesparse

### DIFF
--- a/suitesparse/riscv64.patch
+++ b/suitesparse/riscv64.patch
@@ -1,0 +1,20 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -26,7 +26,7 @@ prepare() {
+ build() {
+   cd SuiteSparse-$pkgver
+ 
+-  BLAS=-lblas LAPACK=-llapack TBB=-ltbb SPQR_CONFIG=-DHAVE_TBB MY_METIS_LIB=/usr/lib/libmetis.so make
++  BLAS=-lblas LAPACK=-llapack MY_METIS_LIB=/usr/lib/libmetis.so make
+ }
+ 
+ 
+@@ -34,7 +34,7 @@ package() {
+   cd SuiteSparse-$pkgver
+   install -dm755 "${pkgdir}"/usr/{include,lib}
+ 
+-  BLAS=-lblas LAPACK=-llapack TBB=-ltbb SPQR_CONFIG=-DHAVE_TBB MY_METIS_LIB=/usr/lib/libmetis.so \
++  BLAS=-lblas LAPACK=-llapack MY_METIS_LIB=/usr/lib/libmetis.so \
+   make INSTALL_LIB="${pkgdir}"/usr/lib INSTALL_INCLUDE="${pkgdir}"/usr/include install
+ 
+   # fix RPATH


### PR DESCRIPTION
According to the upstream https://github.com/DrTimothyAldenDavis/SuiteSparse/issues/72 , the FTBFS issue caused by TBB is not patch-able. For now, we have to set the `HAVE_TBB` option to `NO` (see also https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=252651 )