### PR TITLE
addpkg: hatari

### DIFF
--- a/hatari/fix-name-conflicts.patch
+++ b/hatari/fix-name-conflicts.patch
@@ -1,0 +1,1068 @@
+diff -uprN hatari-2.3.1/src/bios.c hatari-2.3.1-patch/src/bios.c
+--- hatari-2.3.1/src/bios.c	2020-12-27 05:50:12.000000000 +0800
++++ hatari-2.3.1-patch/src/bios.c	2021-10-10 15:21:11.887011052 +0800
+@@ -134,7 +134,7 @@ bool Bios(void)
+ 	Uint16 BiosCall;
+ 
+ 	/* Get call */
+-	Params = Regs[REG_A7];
++	Params = Regs[M68K_REG_A7];
+ 	BiosCall = STMemory_ReadWord(Params);
+ 	Params += SIZE_WORD;
+ 
+diff -uprN hatari-2.3.1/src/cpu/hatari-glue.c hatari-2.3.1-patch/src/cpu/hatari-glue.c
+--- hatari-2.3.1/src/cpu/hatari-glue.c	2020-12-27 05:50:12.000000000 +0800
++++ hatari-2.3.1-patch/src/cpu/hatari-glue.c	2021-10-10 15:21:11.917011530 +0800
+@@ -327,9 +327,9 @@ uae_u32 REGPARAM3 OpCode_VDI(uae_u32 opc
+  */
+ uae_u32 REGPARAM3 OpCode_NatFeat_ID(uae_u32 opcode)
+ {
+-	Uint32 stack = Regs[REG_A7] + SIZE_LONG;	/* skip return address */
++	Uint32 stack = Regs[M68K_REG_A7] + SIZE_LONG;	/* skip return address */
+ 
+-	if (NatFeat_ID(stack, &(Regs[REG_D0])))
++	if (NatFeat_ID(stack, &(Regs[M68K_REG_D0])))
+ 	{
+ 		CpuDoNOP ();
+ 	}
+@@ -341,12 +341,12 @@ uae_u32 REGPARAM3 OpCode_NatFeat_ID(uae_
+  */
+ uae_u32 REGPARAM3 OpCode_NatFeat_Call(uae_u32 opcode)
+ {
+-	Uint32 stack = Regs[REG_A7] + SIZE_LONG;	/* skip return address */
++	Uint32 stack = Regs[M68K_REG_A7] + SIZE_LONG;	/* skip return address */
+ 	Uint16 SR = M68000_GetSR();
+ 	bool super;
+ 
+ 	super = ((SR & SR_SUPERMODE) == SR_SUPERMODE);
+-	if (NatFeat_Call(stack, super, &(Regs[REG_D0])))
++	if (NatFeat_Call(stack, super, &(Regs[M68K_REG_D0])))
+ 	{
+ 		CpuDoNOP ();
+ 	}
+diff -uprN hatari-2.3.1/src/debug/console.c hatari-2.3.1-patch/src/debug/console.c
+--- hatari-2.3.1/src/debug/console.c	2020-12-27 05:50:12.000000000 +0800
++++ hatari-2.3.1-patch/src/debug/console.c	2021-10-10 15:21:11.897011212 +0800
+@@ -205,7 +205,7 @@ void Console_Check(void)
+ 	 *   could be an issue but hopefully don't match device number
+ 	 *   in any of the TOSes nor in MiNT or its conout devices)
+ 	 */
+-	stackbeg = stack = Regs[REG_A7];
++	stackbeg = stack = Regs[M68K_REG_A7];
+ 	stackend = stack + 16;
+ 	increment = SIZE_LONG;
+ 	while (STMemory_ReadWord(stack) != ConOutDevice) {
+diff -uprN hatari-2.3.1/src/debug/debugcpu.c hatari-2.3.1-patch/src/debug/debugcpu.c
+--- hatari-2.3.1/src/debug/debugcpu.c	2020-12-27 05:50:12.000000000 +0800
++++ hatari-2.3.1-patch/src/debug/debugcpu.c	2021-10-10 15:21:11.897011212 +0800
+@@ -302,7 +302,7 @@ int DebugCpu_GetRegisterAddress(const ch
+ 	{
+ 		if (r1 >= 0 && r1 <= 7)
+ 		{
+-			*addr = &(regs.regs[REG_D0 + r1]);
++			*addr = &(regs.regs[M68K_REG_D0 + r1]);
+ 			return 32;
+ 		}
+ 		fprintf(stderr,"\tBad data register, valid values are 0-7\n");
+@@ -312,7 +312,7 @@ int DebugCpu_GetRegisterAddress(const ch
+ 	{
+ 		if (r1 >= 0 && r1 <= 7)
+ 		{
+-			*addr = &(regs.regs[REG_A0 + r1]);
++			*addr = &(regs.regs[M68K_REG_A0 + r1]);
+ 			return 32;
+ 		}
+ 		fprintf(stderr,"\tBad address register, valid values are 0-7\n");
+diff -uprN hatari-2.3.1/src/debug/vars.c hatari-2.3.1-patch/src/debug/vars.c
+--- hatari-2.3.1/src/debug/vars.c	2020-12-27 05:50:12.000000000 +0800
++++ hatari-2.3.1-patch/src/debug/vars.c	2021-10-10 15:21:11.893677825 +0800
+@@ -75,11 +75,11 @@ static inline bool isTrap(Uint8 trap)
+ static inline Uint16 getControlOpcode(void)
+ {
+ 	/* Control[] address from D1, opcode in Control[0] */
+-	return STMemory_ReadWord(STMemory_ReadLong(Regs[REG_D1]));
++	return STMemory_ReadWord(STMemory_ReadLong(Regs[M68K_REG_D1]));
+ }
+ static inline Uint16 getStackOpcode(void)
+ {
+-	return STMemory_ReadWord(Regs[REG_A7]);
++	return STMemory_ReadWord(Regs[M68K_REG_A7]);
+ }
+ 
+ /* Actual TOS OS call opcode accessor functions */
+@@ -115,7 +115,7 @@ static Uint32 GetXbiosOpcode(void)
+ Uint32 Vars_GetAesOpcode(void)
+ {
+ 	if (isTrap(2)) {
+-		Uint16 d0 = Regs[REG_D0];
++		Uint16 d0 = Regs[M68K_REG_D0];
+ 		if (d0 == 0xC8) {
+ 			return getControlOpcode();
+ 		} else if (d0 == 0xC9) {
+@@ -128,7 +128,7 @@ Uint32 Vars_GetAesOpcode(void)
+ Uint32 Vars_GetVdiOpcode(void)
+ {
+ 	if (isTrap(2)) {
+-		Uint16 d0 = Regs[REG_D0];
++		Uint16 d0 = Regs[M68K_REG_D0];
+ 		if (d0 == 0x73) {
+ 			return getControlOpcode();
+ 		} else if (d0 == 0xFFFE) {
+@@ -144,7 +144,7 @@ Uint32 Vars_GetVdiOpcode(void)
+ static Uint32 GetOsCallParam(void)
+ {
+ 	/* skip OS call opcode */
+-	return STMemory_ReadWord(Regs[REG_A7]+SIZE_WORD);
++	return STMemory_ReadWord(Regs[M68K_REG_A7]+SIZE_WORD);
+ }
+ 
+ static Uint32 GetNextPC(void)
+diff -uprN hatari-2.3.1/src/gemdos.c hatari-2.3.1-patch/src/gemdos.c
+--- hatari-2.3.1/src/gemdos.c	2020-12-27 05:50:12.000000000 +0800
++++ hatari-2.3.1-patch/src/gemdos.c	2021-10-10 15:21:11.937011847 +0800
+@@ -1562,15 +1562,15 @@ static bool GemDOS_Cconws(Uint32 Params)
+ 	    && !STMemory_CheckAreaType(Addr, 80 * 25, ABFLAG_RAM))
+ 	{
+ 		Log_Printf(LOG_WARN, "GEMDOS Cconws() failed due to invalid RAM range at 0x%x\n", Addr);
+-		Regs[REG_D0] = GEMDOS_ERANGE;
++		Regs[M68K_REG_D0] = GEMDOS_ERANGE;
+ 		return true;
+ 	}
+ 
+ 	pBuffer = (char *)STMemory_STAddrToPointer(Addr);
+ 	if (fwrite(pBuffer, strnlen(pBuffer, 80 * 25), 1, stdout) < 1)
+-		Regs[REG_D0] = GEMDOS_ERROR;
++		Regs[M68K_REG_D0] = GEMDOS_ERROR;
+ 	else
+-		Regs[REG_D0] = GEMDOS_EOK;
++		Regs[M68K_REG_D0] = GEMDOS_EOK;
+ 
+ 	return true;
+ }
+@@ -1627,7 +1627,7 @@ static bool GemDOS_DFree(Uint32 Params)
+ 	if ( !STMemory_CheckAreaType ( Address, 16, ABFLAG_RAM ) )
+ 	{
+ 		Log_Printf(LOG_WARN, "GEMDOS Dfree() failed due to invalid RAM range 0x%x+%i\n", Address, 16);
+-		Regs[REG_D0] = GEMDOS_ERANGE;
++		Regs[M68K_REG_D0] = GEMDOS_ERANGE;
+ 		return true;
+ 	}
+ 
+@@ -1677,7 +1677,7 @@ static bool GemDOS_DFree(Uint32 Params)
+ 
+ 	STMemory_WriteLong(Address+SIZE_LONG*2, 512);   /* bytes per sector */
+ 	STMemory_WriteLong(Address+SIZE_LONG*3, 2);     /* sectors per cluster (cluster = 1KB) */
+-	Regs[REG_D0] = GEMDOS_EOK;
++	Regs[M68K_REG_D0] = GEMDOS_EOK;
+ 	return true;
+ }
+ 
+@@ -1747,7 +1747,7 @@ static bool GemDOS_MkDir(Uint32 Params)
+ 	if (ConfigureParams.HardDisk.nWriteProtection == WRITEPROT_ON)
+ 	{
+ 		Log_Printf(LOG_WARN, "PREVENTED: GEMDOS Dcreate(\"%s\")\n", pDirName);
+-		Regs[REG_D0] = GEMDOS_EWRPRO;
++		Regs[M68K_REG_D0] = GEMDOS_EWRPRO;
+ 		return true;
+ 	}
+ 
+@@ -1755,7 +1755,7 @@ static bool GemDOS_MkDir(Uint32 Params)
+ 	if (!psDirPath)
+ 	{
+ 		perror("GemDOS_MkDir");
+-		Regs[REG_D0] = GEMDOS_ENSMEM;
++		Regs[M68K_REG_D0] = GEMDOS_ENSMEM;
+ 		return true;
+ 	}
+ 	
+@@ -1764,9 +1764,9 @@ static bool GemDOS_MkDir(Uint32 Params)
+ 	
+ 	/* Attempt to make directory */
+ 	if (mkdir(psDirPath, 0755) == 0)
+-		Regs[REG_D0] = GEMDOS_EOK;
++		Regs[M68K_REG_D0] = GEMDOS_EOK;
+ 	else
+-		Regs[REG_D0] = errno2gemdos(errno, ERROR_PATH);
++		Regs[M68K_REG_D0] = errno2gemdos(errno, ERROR_PATH);
+ 	free(psDirPath);
+ 	return true;
+ }
+@@ -1805,7 +1805,7 @@ static bool GemDOS_RmDir(Uint32 Params)
+ 	if (ConfigureParams.HardDisk.nWriteProtection == WRITEPROT_ON)
+ 	{
+ 		Log_Printf(LOG_WARN, "PREVENTED: GEMDOS Ddelete(\"%s\")\n", pDirName);
+-		Regs[REG_D0] = GEMDOS_EWRPRO;
++		Regs[M68K_REG_D0] = GEMDOS_EWRPRO;
+ 		return true;
+ 	}
+ 
+@@ -1813,7 +1813,7 @@ static bool GemDOS_RmDir(Uint32 Params)
+ 	if (!psDirPath)
+ 	{
+ 		perror("GemDOS_RmDir");
+-		Regs[REG_D0] = GEMDOS_ENSMEM;
++		Regs[M68K_REG_D0] = GEMDOS_ENSMEM;
+ 		return true;
+ 	}
+ 
+@@ -1822,9 +1822,9 @@ static bool GemDOS_RmDir(Uint32 Params)
+ 
+ 	/* Attempt to remove directory */
+ 	if (rmdir(psDirPath) == 0)
+-		Regs[REG_D0] = GEMDOS_EOK;
++		Regs[M68K_REG_D0] = GEMDOS_EOK;
+ 	else
+-		Regs[REG_D0] = errno2gemdos(errno, ERROR_PATH);
++		Regs[M68K_REG_D0] = errno2gemdos(errno, ERROR_PATH);
+ 	free(psDirPath);
+ 	return true;
+ }
+@@ -1848,7 +1848,7 @@ static bool GemDOS_ChDir(Uint32 Params)
+ 		LOG_TRACE(TRACE_OS_GEMDOS,
+ 		          "GEMDOS 0x3B Dsetpath with illegal file name (0x%x) at PC 0x%X\n",
+ 		          nStrAddr, CallingPC);
+-		Regs[REG_D0] = GEMDOS_EPTHNF;
++		Regs[M68K_REG_D0] = GEMDOS_EPTHNF;
+ 		return true;
+ 	}
+ 
+@@ -1865,7 +1865,7 @@ static bool GemDOS_ChDir(Uint32 Params)
+ 	/* Empty string does nothing */
+ 	if (*pDirName == '\0')
+ 	{
+-		Regs[REG_D0] = GEMDOS_EOK;
++		Regs[M68K_REG_D0] = GEMDOS_EOK;
+ 		return true;
+ 	}
+ 
+@@ -1874,7 +1874,7 @@ static bool GemDOS_ChDir(Uint32 Params)
+ 	if (!psTempDirPath)
+ 	{
+ 		perror("GemDOS_ChDir");
+-		Regs[REG_D0] = GEMDOS_ENSMEM;
++		Regs[M68K_REG_D0] = GEMDOS_ENSMEM;
+ 		return true;
+ 	}
+ 
+@@ -1887,7 +1887,7 @@ static bool GemDOS_ChDir(Uint32 Params)
+ 	{
+ 		/* error */
+ 		free(psTempDirPath);
+-		Regs[REG_D0] = GEMDOS_EPTHNF;
++		Regs[M68K_REG_D0] = GEMDOS_EPTHNF;
+ 		return true;
+ 	}
+ 
+@@ -1901,11 +1901,11 @@ static bool GemDOS_ChDir(Uint32 Params)
+ 	{
+ 		strlcpy(emudrives[Drive-2]->fs_currpath, psTempDirPath,
+ 		        sizeof(emudrives[Drive-2]->fs_currpath));
+-		Regs[REG_D0] = GEMDOS_EOK;
++		Regs[M68K_REG_D0] = GEMDOS_EOK;
+ 	}
+ 	else
+ 	{
+-		Regs[REG_D0] = GEMDOS_EPTHNF;
++		Regs[M68K_REG_D0] = GEMDOS_EPTHNF;
+ 	}
+ 	free(psTempDirPath);
+ 
+@@ -1979,7 +1979,7 @@ static bool GemDOS_Create(Uint32 Params)
+ 	{
+ 		Log_Printf(LOG_WARN, "Warning: Hatari doesn't support GEMDOS volume"
+ 			   " label setting\n(for '%s')\n", pszFileName);
+-		Regs[REG_D0] = GEMDOS_EFILNF;         /* File not found */
++		Regs[M68K_REG_D0] = GEMDOS_EFILNF;         /* File not found */
+ 		return true;
+ 	}
+ 
+@@ -1987,7 +1987,7 @@ static bool GemDOS_Create(Uint32 Params)
+ 	if (ConfigureParams.HardDisk.nWriteProtection == WRITEPROT_ON)
+ 	{
+ 		Log_Printf(LOG_WARN, "PREVENTED: GEMDOS Fcreate(\"%s\")\n", pszFileName);
+-		Regs[REG_D0] = GEMDOS_EWRPRO;
++		Regs[M68K_REG_D0] = GEMDOS_EWRPRO;
+ 		return true;
+ 	}
+ 
+@@ -2000,7 +2000,7 @@ static bool GemDOS_Create(Uint32 Params)
+ 	if (Index == -1)
+ 	{
+ 		/* No free handles, return error code */
+-		Regs[REG_D0] = GEMDOS_ENHNDL;       /* No more handles */
++		Regs[M68K_REG_D0] = GEMDOS_ENHNDL;       /* No more handles */
+ 		return true;
+ 	}
+ 	
+@@ -2033,8 +2033,8 @@ static bool GemDOS_Create(Uint32 Params)
+ 			 "%s", szActualFileName);
+ 
+ 		/* Return valid ST file handle from our range (from BASE_FILEHANDLE upwards) */
+-		Regs[REG_D0] = Index+BASE_FILEHANDLE;
+-		LOG_TRACE(TRACE_OS_GEMDOS|TRACE_OS_BASE, "-> FD %d (%s)\n", Regs[REG_D0],
++		Regs[M68K_REG_D0] = Index+BASE_FILEHANDLE;
++		LOG_TRACE(TRACE_OS_GEMDOS|TRACE_OS_BASE, "-> FD %d (%s)\n", Regs[M68K_REG_D0],
+ 			  Mode & GEMDOS_FILE_ATTRIB_READONLY ? "read-only":"read/write");
+ 		return true;
+ 	}
+@@ -2046,7 +2046,7 @@ static bool GemDOS_Create(Uint32 Params)
+ 	{
+ 		Log_Printf(LOG_WARN, "GEMDOS failed to create/truncate '%s'\n",
+ 			   szActualFileName);
+-		Regs[REG_D0] = GEMDOS_EACCDN;
++		Regs[M68K_REG_D0] = GEMDOS_EACCDN;
+ 		return true;
+ 	}
+ 
+@@ -2055,11 +2055,11 @@ static bool GemDOS_Create(Uint32 Params)
+ 	 */
+ 	if (errno == ENOTDIR || GemDOS_FilePathMissing(szActualFileName))
+ 	{
+-		Regs[REG_D0] = GEMDOS_EPTHNF; /* Path not found */
++		Regs[M68K_REG_D0] = GEMDOS_EPTHNF; /* Path not found */
+ 		return true;
+ 	}
+ 
+-	Regs[REG_D0] = GEMDOS_EFILNF;         /* File not found */
++	Regs[M68K_REG_D0] = GEMDOS_EFILNF;         /* File not found */
+ 	return true;
+ }
+ 
+@@ -2114,7 +2114,7 @@ static bool GemDOS_Open(Uint32 Params)
+ 			return redirect_to_TOS();
+ 
+ 		/* No free handles, return error code */
+-		Regs[REG_D0] = GEMDOS_ENHNDL;       /* No more handles */
++		Regs[M68K_REG_D0] = GEMDOS_ENHNDL;       /* No more handles */
+ 		return true;
+ 	}
+ 
+@@ -2181,9 +2181,9 @@ static bool GemDOS_Open(Uint32 Params)
+ 			 "%s", szActualFileName);
+ 
+ 		/* Return valid ST file handle from our range (BASE_FILEHANDLE upwards) */
+-		Regs[REG_D0] = Index+BASE_FILEHANDLE;
++		Regs[M68K_REG_D0] = Index+BASE_FILEHANDLE;
+ 		LOG_TRACE(TRACE_OS_GEMDOS|TRACE_OS_BASE, "-> FD %d (%s -> %s)\n",
+-			  Regs[REG_D0], Modes[Mode], RealMode);
++			  Regs[M68K_REG_D0], Modes[Mode], RealMode);
+ 		return true;
+ 	}
+ 
+@@ -2192,19 +2192,19 @@ static bool GemDOS_Open(Uint32 Params)
+ 	{
+ 		Log_Printf(LOG_WARN, "GEMDOS missing %s permission to file '%s'\n",
+ 			   Modes[Mode], szActualFileName);
+-		Regs[REG_D0] = GEMDOS_EACCDN;
++		Regs[M68K_REG_D0] = GEMDOS_EACCDN;
+ 	}
+ 	else if (errno == ENOTDIR || GemDOS_FilePathMissing(szActualFileName))
+ 	{
+ 		/* Path not found */
+-		Regs[REG_D0] = GEMDOS_EPTHNF;
++		Regs[M68K_REG_D0] = GEMDOS_EPTHNF;
+ 	}
+ 	else
+ 	{
+ 		/* File not found / error opening */
+-		Regs[REG_D0] = GEMDOS_EFILNF;
++		Regs[M68K_REG_D0] = GEMDOS_EFILNF;
+ 	}
+-	LOG_TRACE(TRACE_OS_GEMDOS|TRACE_OS_BASE, "-> ERROR %d (errno = %d)\n", Regs[REG_D0], errno);
++	LOG_TRACE(TRACE_OS_GEMDOS|TRACE_OS_BASE, "-> ERROR %d (errno = %d)\n", Regs[M68K_REG_D0], errno);
+ 	return true;
+ }
+ 
+@@ -2245,7 +2245,7 @@ static bool GemDOS_Close(Uint32 Params)
+ 			GemDOS_UnforceFileHandle(i);
+ 	}
+ 	/* Return no error */
+-	Regs[REG_D0] = GEMDOS_EOK;
++	Regs[M68K_REG_D0] = GEMDOS_EOK;
+ 	return true;
+ }
+ 
+@@ -2283,7 +2283,7 @@ static bool GemDOS_Read(Uint32 Params)
+ 	if (TosVersion < 0x400 && (Size & 0x80000000))
+ 	{
+ 		/* return -1 as original GEMDOS */
+-		Regs[REG_D0] = -1;
++		Regs[M68K_REG_D0] = -1;
+ 		return true;
+ 	}
+ 	
+@@ -2292,14 +2292,14 @@ static bool GemDOS_Read(Uint32 Params)
+ 	if (CurrentPos == -1L
+ 	    || fseeko(FileHandles[Handle].FileHandle, 0, SEEK_END) != 0)
+ 	{
+-		Regs[REG_D0] = GEMDOS_E_SEEK;
++		Regs[M68K_REG_D0] = GEMDOS_E_SEEK;
+ 		return true;
+ 	}
+ 	FileSize = ftello(FileHandles[Handle].FileHandle);
+ 	if (FileSize == -1L
+ 	    || fseeko(FileHandles[Handle].FileHandle, CurrentPos, SEEK_SET) != 0)
+ 	{
+-		Regs[REG_D0] = GEMDOS_E_SEEK;
++		Regs[M68K_REG_D0] = GEMDOS_E_SEEK;
+ 		return true;
+ 	}
+ 
+@@ -2309,7 +2309,7 @@ static bool GemDOS_Read(Uint32 Params)
+ 	if (Size <= 0 || nBytesLeft <= 0)
+ 	{
+ 		/* return zero (bytes read) as original GEMDOS/EmuTOS */
+-		Regs[REG_D0] = 0;
++		Regs[M68K_REG_D0] = 0;
+ 		return true;
+ 	}
+ 
+@@ -2321,7 +2321,7 @@ static bool GemDOS_Read(Uint32 Params)
+ 	if ( !STMemory_CheckAreaType ( Addr, Size, ABFLAG_RAM ) )
+ 	{
+ 		Log_Printf(LOG_WARN, "GEMDOS Fread() failed due to invalid RAM range 0x%x+%i\n", Addr, Size);
+-		Regs[REG_D0] = GEMDOS_ERANGE;
++		Regs[M68K_REG_D0] = GEMDOS_ERANGE;
+ 		return true;
+ 	}
+ 
+@@ -2336,10 +2336,10 @@ static bool GemDOS_Read(Uint32 Params)
+ 	{
+ 		Log_Printf(LOG_WARN, "GEMDOS failed to read from '%s': %s\n",
+ 			   FileHandles[Handle].szActualName, strerror(errno));
+-		Regs[REG_D0] = errno2gemdos(errno, ERROR_FILE);
++		Regs[M68K_REG_D0] = errno2gemdos(errno, ERROR_FILE);
+ 	} else
+ 		/* Return number of bytes read */
+-		Regs[REG_D0] = nBytesRead;
++		Regs[M68K_REG_D0] = nBytesRead;
+ 
+ 	return true;
+ }
+@@ -2375,7 +2375,7 @@ static bool GemDOS_Write(Uint32 Params)
+ 		if (ConfigureParams.HardDisk.nWriteProtection == WRITEPROT_ON)
+ 		{
+ 			Log_Printf(LOG_WARN, "PREVENTED: GEMDOS Fwrite(%d,...)\n", Handle);
+-			Regs[REG_D0] = GEMDOS_EWRPRO;
++			Regs[M68K_REG_D0] = GEMDOS_EWRPRO;
+ 			return true;
+ 		}
+ 		fp = FileHandles[fh_idx].FileHandle;
+@@ -2394,7 +2394,7 @@ static bool GemDOS_Write(Uint32 Params)
+ 	if (!STMemory_CheckAreaType(Addr, Size, ABFLAG_RAM | ABFLAG_ROM))
+ 	{
+ 		Log_Printf(LOG_WARN, "GEMDOS Fwrite() failed due to invalid RAM range 0x%x+%i\n", Addr, Size);
+-		Regs[REG_D0] = GEMDOS_ERANGE;
++		Regs[M68K_REG_D0] = GEMDOS_ERANGE;
+ 		return true;
+ 	}
+ 
+@@ -2404,12 +2404,12 @@ static bool GemDOS_Write(Uint32 Params)
+ 	{
+ 		Log_Printf(LOG_WARN, "GEMDOS failed to write to '%s'\n",
+ 			   FileHandles[fh_idx].szActualName);
+-		Regs[REG_D0] = errno2gemdos(errno, ERROR_FILE);
++		Regs[M68K_REG_D0] = errno2gemdos(errno, ERROR_FILE);
+ 	}
+ 	else
+ 	{
+ 		fflush(fp);
+-		Regs[REG_D0] = nBytesWritten;      /* OK */
++		Regs[M68K_REG_D0] = nBytesWritten;      /* OK */
+ 	}
+ 	return true;
+ }
+@@ -2449,7 +2449,7 @@ static bool GemDOS_FDelete(Uint32 Params
+ 	if (ConfigureParams.HardDisk.nWriteProtection == WRITEPROT_ON)
+ 	{
+ 		Log_Printf(LOG_WARN, "PREVENTED: GEMDOS Fdelete(\"%s\")\n", pszFileName);
+-		Regs[REG_D0] = GEMDOS_EWRPRO;
++		Regs[M68K_REG_D0] = GEMDOS_EWRPRO;
+ 		return true;
+ 	}
+ 
+@@ -2457,7 +2457,7 @@ static bool GemDOS_FDelete(Uint32 Params
+ 	if (!psActualFileName)
+ 	{
+ 		perror("GemDOS_FDelete");
+-		Regs[REG_D0] = GEMDOS_ENSMEM;
++		Regs[M68K_REG_D0] = GEMDOS_ENSMEM;
+ 		return true;
+ 	}
+ 
+@@ -2466,9 +2466,9 @@ static bool GemDOS_FDelete(Uint32 Params
+ 
+ 	/* Now delete file?? */
+ 	if (unlink(psActualFileName) == 0)
+-		Regs[REG_D0] = GEMDOS_EOK;          /* OK */
++		Regs[M68K_REG_D0] = GEMDOS_EOK;          /* OK */
+ 	else
+-		Regs[REG_D0] = errno2gemdos(errno, ERROR_FILE);
++		Regs[M68K_REG_D0] = errno2gemdos(errno, ERROR_FILE);
+ 
+ 	free(psActualFileName);
+ 	return true;
+@@ -2511,7 +2511,7 @@ static bool GemDOS_LSeek(Uint32 Params)
+ 	/* Determine the size of the file */
+ 	if (fseek(fhndl, 0L, SEEK_END) != 0 || nOldPos < 0)
+ 	{
+-		Regs[REG_D0] = GEMDOS_E_SEEK;
++		Regs[M68K_REG_D0] = GEMDOS_E_SEEK;
+ 		return true;
+ 	}
+ 	nFileSize = ftell(fhndl);
+@@ -2529,14 +2529,14 @@ static bool GemDOS_LSeek(Uint32 Params)
+ 		/* Restore old position and return error */
+ 		if (fseek(fhndl, nOldPos, SEEK_SET) != 0)
+ 			perror("GemDOS_LSeek");
+-		Regs[REG_D0] = GEMDOS_ERANGE;
++		Regs[M68K_REG_D0] = GEMDOS_ERANGE;
+ 		return true;
+ 	}
+ 
+ 	/* Seek to new position and return offset from start of file */
+ 	if (fseek(fhndl, nDestPos, SEEK_SET) != 0)
+ 		perror("GemDOS_LSeek");
+-	Regs[REG_D0] = ftell(fhndl);
++	Regs[M68K_REG_D0] = ftell(fhndl);
+ 
+ 	return true;
+ }
+@@ -2585,18 +2585,18 @@ static bool GemDOS_Fattrib(Uint32 Params
+ 	if (nAttrib == GEMDOS_FILE_ATTRIB_VOLUME_LABEL)
+ 	{
+ 		Log_Printf(LOG_WARN, "Hatari doesn't support GEMDOS volume label setting\n(for '%s')\n", sActualFileName);
+-		Regs[REG_D0] = GEMDOS_EFILNF;         /* File not found */
++		Regs[M68K_REG_D0] = GEMDOS_EFILNF;         /* File not found */
+ 		return true;
+ 	}
+ 	if (stat(sActualFileName, &FileStat) != 0)
+ 	{
+-		Regs[REG_D0] = GEMDOS_EFILNF;         /* File not found */
++		Regs[M68K_REG_D0] = GEMDOS_EFILNF;         /* File not found */
+ 		return true;
+ 	}
+ 	if (nRwFlag == 0)
+ 	{
+ 		/* Read attributes */
+-		Regs[REG_D0] = GemDOS_ConvertAttribute(FileStat.st_mode);
++		Regs[M68K_REG_D0] = GemDOS_ConvertAttribute(FileStat.st_mode);
+ 		return true;
+ 	}
+ 
+@@ -2604,7 +2604,7 @@ static bool GemDOS_Fattrib(Uint32 Params
+ 	if (ConfigureParams.HardDisk.nWriteProtection != WRITEPROT_OFF)
+ 	{
+ 		Log_Printf(LOG_WARN, "PREVENTED: GEMDOS Fattrib(\"%s\",...)\n", psFileName);
+-		Regs[REG_D0] = GEMDOS_EWRPRO;
++		Regs[M68K_REG_D0] = GEMDOS_EWRPRO;
+ 		return true;
+ 	}
+ 
+@@ -2613,7 +2613,7 @@ static bool GemDOS_Fattrib(Uint32 Params
+ 		if (!S_ISDIR(FileStat.st_mode))
+ 		{
+ 			/* file, not dir -> path not found */
+-			Regs[REG_D0] = GEMDOS_EPTHNF;
++			Regs[M68K_REG_D0] = GEMDOS_EPTHNF;
+ 			return true;
+ 		}
+ 	}
+@@ -2622,7 +2622,7 @@ static bool GemDOS_Fattrib(Uint32 Params
+ 		if (S_ISDIR(FileStat.st_mode))
+ 		{
+ 			/* dir, not file -> file not found */
+-			Regs[REG_D0] = GEMDOS_EFILNF;
++			Regs[M68K_REG_D0] = GEMDOS_EFILNF;
+ 			return true;
+ 		}
+ 	}
+@@ -2632,7 +2632,7 @@ static bool GemDOS_Fattrib(Uint32 Params
+ 		/* set read-only (readable by all) */
+ 		if (chmod(sActualFileName, S_IRUSR|S_IRGRP|S_IROTH) == 0)
+ 		{
+-			Regs[REG_D0] = nAttrib;
++			Regs[M68K_REG_D0] = nAttrib;
+ 			return true;
+ 		}
+ 	}
+@@ -2641,7 +2641,7 @@ static bool GemDOS_Fattrib(Uint32 Params
+ 		/* set writable (by user, readable by all) */
+ 		if (chmod(sActualFileName, S_IWUSR|S_IRUSR|S_IRGRP|S_IROTH) == 0)
+ 		{
+-			Regs[REG_D0] = nAttrib;
++			Regs[M68K_REG_D0] = nAttrib;
+ 			return true;
+ 		}
+ 	}
+@@ -2652,7 +2652,7 @@ static bool GemDOS_Fattrib(Uint32 Params
+ 	 * and set whenever file is written to.
+ 	 */
+ 
+-	Regs[REG_D0] = errno2gemdos(errno, (nAttrib & GEMDOS_FILE_ATTRIB_SUBDIRECTORY) ? ERROR_PATH : ERROR_FILE);
++	Regs[M68K_REG_D0] = errno2gemdos(errno, (nAttrib & GEMDOS_FILE_ATTRIB_SUBDIRECTORY) ? ERROR_PATH : ERROR_FILE);
+ 	return true;
+ }
+ 
+@@ -2694,7 +2694,7 @@ static bool GemDOS_Force(Uint32 Params)
+ 	ForcedHandles[std].Basepage = STMemory_ReadLong(act_pd);
+ 	ForcedHandles[std].Handle = own;
+ 
+-	Regs[REG_D0] = GEMDOS_EOK;
++	Regs[M68K_REG_D0] = GEMDOS_EOK;
+ 	return true;
+ }
+ 
+@@ -2741,7 +2741,7 @@ static bool GemDOS_GetDir(Uint32 Params)
+ 		if ( !STMemory_CheckAreaType ( Address, len, ABFLAG_RAM ) )
+ 		{
+ 			Log_Printf(LOG_WARN, "GEMDOS Dgetpath() failed due to invalid RAM range 0x%x+%i\n", Address, len);
+-			Regs[REG_D0] = GEMDOS_ERANGE;
++			Regs[M68K_REG_D0] = GEMDOS_ERANGE;
+ 			return true;
+ 		}
+ 		for (i = 0; i <= len; i++)
+@@ -2751,7 +2751,7 @@ static bool GemDOS_GetDir(Uint32 Params)
+ 		}
+ 		LOG_TRACE(TRACE_OS_GEMDOS, "-> '%s'\n", (char *)STMemory_STAddrToPointer(Address));
+ 
+-		Regs[REG_D0] = GEMDOS_EOK;          /* OK */
++		Regs[M68K_REG_D0] = GEMDOS_EOK;          /* OK */
+ 
+ 		return true;
+ 	}
+@@ -2827,7 +2827,7 @@ static int GemDOS_Pexec(Uint32 Params)
+ 	fh = fopen(sFileName, "rb");
+ 	if (!fh)
+ 	{
+-		Regs[REG_D0] = GEMDOS_EFILNF;
++		Regs[M68K_REG_D0] = GEMDOS_EFILNF;
+ 		return true;
+ 	}
+ 	len = fread(prgh, 1, sizeof(prgh), fh);
+@@ -2835,19 +2835,19 @@ static int GemDOS_Pexec(Uint32 Params)
+ 	if (len != sizeof(prgh) || prgh[0] != 0x60 || prgh[1] != 0x1a
+ 	    || prgh[2] & 0x80 || prgh[6] & 0x80 || prgh[10] & 0x80)
+ 	{
+-		Regs[REG_D0] = GEMDOS_EPLFMT;
++		Regs[M68K_REG_D0] = GEMDOS_EPLFMT;
+ 		return true;
+ 	}
+ 	Symbols_ChangeCurrentProgram(sFileName);
+ 
+ 	/* Prepare stack to run "create basepage": */
+-	Regs[REG_A7] -= 16;
+-	STMemory_WriteWord(Regs[REG_A7], 0x4b);	/* Pexec number */
+-	STMemory_WriteWord(Regs[REG_A7] + 2, TosVersion >= 0x200 ? 7 : 5);
+-	STMemory_WriteLong(Regs[REG_A7] + 4, prgh[22] << 24 | prgh[23] << 16 
++	Regs[M68K_REG_A7] -= 16;
++	STMemory_WriteWord(Regs[M68K_REG_A7], 0x4b);	/* Pexec number */
++	STMemory_WriteWord(Regs[M68K_REG_A7] + 2, TosVersion >= 0x200 ? 7 : 5);
++	STMemory_WriteLong(Regs[M68K_REG_A7] + 4, prgh[22] << 24 | prgh[23] << 16 
+ 	                                     | prgh[24] << 8 | prgh[25]);
+-	STMemory_WriteLong(Regs[REG_A7] + 8, cmdline);
+-	STMemory_WriteLong(Regs[REG_A7] + 12, env_string);
++	STMemory_WriteLong(Regs[M68K_REG_A7] + 8, cmdline);
++	STMemory_WriteLong(Regs[M68K_REG_A7] + 12, env_string);
+ 
+ 	nSavedPexecParams = Params;
+ 
+@@ -2876,7 +2876,7 @@ static bool GemDOS_SNext(void)
+ 	if ( !STMemory_CheckAreaType ( DTA_Gemdos, sizeof(DTA), ABFLAG_RAM ) )
+ 	{
+ 		Log_Printf(LOG_WARN, "GEMDOS Fsnext() failed due to invalid DTA address 0x%x\n", DTA_Gemdos);
+-		Regs[REG_D0] = GEMDOS_EINTRN;    /* "internal error */
++		Regs[M68K_REG_D0] = GEMDOS_EINTRN;    /* "internal error */
+ 		return true;
+ 	}
+ 	pDTA = (DTA *)STMemory_STAddrToPointer(DTA_Gemdos);
+@@ -2891,7 +2891,7 @@ static bool GemDOS_SNext(void)
+ 	if (nAttrSFirst == GEMDOS_FILE_ATTRIB_VOLUME_LABEL)
+ 	{
+ 		/* Volume label was given already in Sfirst() */
+-		Regs[REG_D0] = GEMDOS_ENMFIL;
++		Regs[M68K_REG_D0] = GEMDOS_ENMFIL;
+ 		return true;
+ 	}
+ 
+@@ -2904,7 +2904,7 @@ static bool GemDOS_SNext(void)
+ 		 * (if Fsetdta() has been used by any process)
+ 		 */
+ 		Log_Printf(LOG_WARN, "GEMDOS Fsnext(): Invalid DTA\n");
+-		Regs[REG_D0] = GEMDOS_ENMFIL;
++		Regs[M68K_REG_D0] = GEMDOS_ENMFIL;
+ 		return true;
+ 	}
+ 
+@@ -2916,7 +2916,7 @@ static bool GemDOS_SNext(void)
+ 			/* older TOS versions zero file name if there are no (further) matches */
+ 			if (TosVersion < 0x0400)
+ 				pDTA->dta_name[0] = 0;
+-			Regs[REG_D0] = GEMDOS_ENMFIL;    /* No more files */
++			Regs[M68K_REG_D0] = GEMDOS_ENMFIL;    /* No more files */
+ 			return true;
+ 		}
+ 
+@@ -2928,11 +2928,11 @@ static bool GemDOS_SNext(void)
+ 	if (ret == DTA_ERR)
+ 	{
+ 		Log_Printf(LOG_WARN, "GEMDOS Fsnext(): Error setting DTA\n");
+-		Regs[REG_D0] = GEMDOS_EINTRN;
++		Regs[M68K_REG_D0] = GEMDOS_EINTRN;
+ 		return true;
+ 	}
+ 
+-	Regs[REG_D0] = GEMDOS_EOK;
++	Regs[M68K_REG_D0] = GEMDOS_EOK;
+ 	return true;
+ }
+ 
+@@ -2985,7 +2985,7 @@ static bool GemDOS_SFirst(Uint32 Params)
+ 	if ( !STMemory_CheckAreaType ( DTA_Gemdos, sizeof(DTA), ABFLAG_RAM ) )
+ 	{
+ 		Log_Printf(LOG_WARN, "GEMDOS Fsfirst() failed due to invalid DTA address 0x%x\n", DTA_Gemdos);
+-		Regs[REG_D0] = GEMDOS_EINTRN;    /* "internal error */
++		Regs[M68K_REG_D0] = GEMDOS_EINTRN;    /* "internal error */
+ 		return true;
+ 	}
+ 
+@@ -3026,7 +3026,7 @@ static bool GemDOS_SFirst(Uint32 Params)
+ 		/* Volume name */
+ 		strcpy(pDTA->dta_name,"EMULATED.001");
+ 		pDTA->dta_name[11] = '0' + Drive;
+-		Regs[REG_D0] = GEMDOS_EOK;          /* Got volume */
++		Regs[M68K_REG_D0] = GEMDOS_EOK;          /* Got volume */
+ 		return true;
+ 	}
+ 
+@@ -3038,7 +3038,7 @@ static bool GemDOS_SFirst(Uint32 Params)
+ 
+ 	if (fsdir == NULL)
+ 	{
+-		Regs[REG_D0] = GEMDOS_EPTHNF;        /* Path not found */
++		Regs[M68K_REG_D0] = GEMDOS_EPTHNF;        /* Path not found */
+ 		return true;
+ 	}
+ 	/* close directory */
+@@ -3048,7 +3048,7 @@ static bool GemDOS_SFirst(Uint32 Params)
+ 	/* File (directory actually) not found */
+ 	if (count < 0)
+ 	{
+-		Regs[REG_D0] = GEMDOS_EFILNF;
++		Regs[M68K_REG_D0] = GEMDOS_EFILNF;
+ 		return true;
+ 	}
+ 
+@@ -3080,7 +3080,7 @@ static bool GemDOS_SFirst(Uint32 Params)
+ 	{
+ 		free(files);
+ 		InternalDTAs[useidx].found = NULL;
+-		Regs[REG_D0] = GEMDOS_EFILNF;        /* File not found */
++		Regs[M68K_REG_D0] = GEMDOS_EFILNF;        /* File not found */
+ 		return true;
+ 	}
+ 
+@@ -3160,7 +3160,7 @@ static bool GemDOS_Rename(Uint32 Params)
+ 	if (ConfigureParams.HardDisk.nWriteProtection == WRITEPROT_ON)
+ 	{
+ 		Log_Printf(LOG_WARN, "PREVENTED: GEMDOS Frename(\"%s\", \"%s\")\n", pszOldFileName, pszNewFileName);
+-		Regs[REG_D0] = GEMDOS_EWRPRO;
++		Regs[M68K_REG_D0] = GEMDOS_EWRPRO;
+ 		return true;
+ 	}
+ 
+@@ -3172,9 +3172,9 @@ static bool GemDOS_Rename(Uint32 Params)
+ 
+ 	/* Rename files */
+ 	if (rename(szOldActualFileName,szNewActualFileName) == 0)
+-		Regs[REG_D0] = GEMDOS_EOK;
++		Regs[M68K_REG_D0] = GEMDOS_EOK;
+ 	else
+-		Regs[REG_D0] = errno2gemdos(errno, ERROR_FILE);
++		Regs[M68K_REG_D0] = errno2gemdos(errno, ERROR_FILE);
+ 	return true;
+ }
+ 
+@@ -3212,15 +3212,15 @@ static bool GemDOS_GSDToF(Uint32 Params)
+ 		if (ConfigureParams.HardDisk.nWriteProtection == WRITEPROT_ON)
+ 		{
+ 			Log_Printf(LOG_WARN, "PREVENTED: GEMDOS Fdatime(,%d,)\n", Handle);
+-			Regs[REG_D0] = GEMDOS_EWRPRO;
++			Regs[M68K_REG_D0] = GEMDOS_EWRPRO;
+ 			return true;
+ 		}
+ 		DateTime.timeword = STMemory_ReadWord(pBuffer);
+ 		DateTime.dateword = STMemory_ReadWord(pBuffer+SIZE_WORD);
+ 		if (GemDOS_SetFileInformation(Handle, &DateTime) == true)
+-			Regs[REG_D0] = GEMDOS_EOK;
++			Regs[M68K_REG_D0] = GEMDOS_EOK;
+ 		else
+-			Regs[REG_D0] = GEMDOS_EACCDN;        /* Access denied */
++			Regs[M68K_REG_D0] = GEMDOS_EACCDN;        /* Access denied */
+ 		return true;
+ 	}
+ 
+@@ -3231,17 +3231,17 @@ static bool GemDOS_GSDToF(Uint32 Params)
+ 		{
+ 			STMemory_WriteWord(pBuffer, DateTime.timeword);
+ 			STMemory_WriteWord(pBuffer+SIZE_WORD, DateTime.dateword);
+-			Regs[REG_D0] = GEMDOS_EOK;
++			Regs[M68K_REG_D0] = GEMDOS_EOK;
+ 		}
+ 		else
+ 		{
+ 			Log_Printf(LOG_WARN, "GEMDOS Fdatime() failed due to invalid RAM range 0x%x+%i\n", pBuffer, 4);
+-			Regs[REG_D0] = GEMDOS_ERANGE;
++			Regs[M68K_REG_D0] = GEMDOS_ERANGE;
+ 		}
+ 	}
+ 	else
+ 	{
+-		Regs[REG_D0] = GEMDOS_ERROR; /* Generic error */
++		Regs[M68K_REG_D0] = GEMDOS_ERROR; /* Generic error */
+ 	}
+ 	return true;
+ }
+@@ -3355,14 +3355,14 @@ static bool GemDOS_Super(Uint32 Params)
+ 		return false;
+ 
+ 	/* Get SR, return address and vector offset from stack frame */
+-	nSR = STMemory_ReadWord(Regs[REG_A7]);
+-	nRetAddr = STMemory_ReadLong(Regs[REG_A7] + SIZE_WORD);
++	nSR = STMemory_ReadWord(Regs[M68K_REG_A7]);
++	nRetAddr = STMemory_ReadLong(Regs[M68K_REG_A7] + SIZE_WORD);
+ 	if (currprefs.cpu_level > 0)
+-		nVec = STMemory_ReadWord(Regs[REG_A7] + SIZE_WORD + SIZE_LONG);
++		nVec = STMemory_ReadWord(Regs[M68K_REG_A7] + SIZE_WORD + SIZE_LONG);
+ 
+ 	if (nParam == 1)                /* Query mode? */
+ 	{
+-		Regs[REG_D0] = (nSR & SR_SUPERMODE) ? -1 : 0;
++		Regs[M68K_REG_D0] = (nSR & SR_SUPERMODE) ? -1 : 0;
+ 		return true;
+ 	}
+ 
+@@ -3376,14 +3376,14 @@ static bool GemDOS_Super(Uint32 Params)
+ 	else
+ 		nExcFrameSize = SIZE_WORD + SIZE_LONG;
+ 
+-	Regs[REG_D0] = Regs[REG_A7] + nExcFrameSize;
+-	Regs[REG_A7] = nParam - nExcFrameSize;
++	Regs[M68K_REG_D0] = Regs[M68K_REG_A7] + nExcFrameSize;
++	Regs[M68K_REG_A7] = nParam - nExcFrameSize;
+ 
+ 	nSR ^= SR_SUPERMODE;
+ 
+-	STMemory_WriteWord(Regs[REG_A7], nSR);
+-	STMemory_WriteLong(Regs[REG_A7] + SIZE_WORD, nRetAddr);
+-	STMemory_WriteWord(Regs[REG_A7] + SIZE_WORD + SIZE_LONG, nVec);
++	STMemory_WriteWord(Regs[M68K_REG_A7], nSR);
++	STMemory_WriteLong(Regs[M68K_REG_A7] + SIZE_WORD, nRetAddr);
++	STMemory_WriteWord(Regs[M68K_REG_A7] + SIZE_WORD + SIZE_LONG, nVec);
+ 
+ 	return true;
+ }
+@@ -3955,13 +3955,13 @@ int GemDOS_Trap(void)
+ 	Uint16 sr = M68000_GetSR();
+ 
+ 	/* Read SReg from stack to see if parameters are on User or Super stack  */
+-	CallingSReg = STMemory_ReadWord(Regs[REG_A7]);
+-	CallingPC = STMemory_ReadLong(Regs[REG_A7] + SIZE_WORD);
++	CallingSReg = STMemory_ReadWord(Regs[M68K_REG_A7]);
++	CallingPC = STMemory_ReadLong(Regs[M68K_REG_A7] + SIZE_WORD);
+ 	if (!(CallingSReg & SR_SUPERMODE))      /* Calling from user mode */
+ 		Params = regs.usp;
+ 	else
+  	{
+-		Params = Regs[REG_A7] + SIZE_WORD + SIZE_LONG;  /* skip SR & PC pushed to super stack */
++		Params = Regs[M68K_REG_A7] + SIZE_WORD + SIZE_LONG;  /* skip SR & PC pushed to super stack */
+ 		if (currprefs.cpu_level > 0)
+ 			Params += SIZE_WORD;   /* Skip extra word if CPU is >=68010 */
+ 	}
+@@ -4167,7 +4167,7 @@ int GemDOS_Trap(void)
+ 		{
+ 			if (GemDOSCall >= 0x58)   /* Ignore optional calls */
+ 			{
+-				Regs[REG_D0] = GEMDOS_EINVFN;
++				Regs[M68K_REG_D0] = GEMDOS_EINVFN;
+ 				M68000_SetSR(sr | SR_ZERO);
+ 				return true;
+ 			}
+@@ -4376,17 +4376,17 @@ void GemDOS_PexecBpCreated(void)
+ 
+ 	GemDOS_CreateHardDriveFileName(GemDOS_FileName2HardDriveID(sStFileName),
+ 	                               sStFileName, sFileName, sizeof(sFileName));
+-	errcode = GemDOS_LoadAndReloc(sFileName, Regs[REG_D0], false);
++	errcode = GemDOS_LoadAndReloc(sFileName, Regs[M68K_REG_D0], false);
+ 	if (errcode)
+ 	{
+-		Regs[REG_A0] = Regs[REG_D0];
+-		Regs[REG_D0] = errcode;
++		Regs[M68K_REG_A0] = Regs[M68K_REG_D0];
++		Regs[M68K_REG_D0] = errcode;
+ 		sr &= ~SR_ZERO;
+ 	} else if (mode == 0)
+ 	{
+ 		/* Run another "just-go" Pexec call to start the program */
+ 		STMemory_WriteWord(nSavedPexecParams, TosVersion >= 0x104 ? 6 : 4);
+-		STMemory_WriteLong(nSavedPexecParams + 6, Regs[REG_D0]);
++		STMemory_WriteLong(nSavedPexecParams + 6, Regs[M68K_REG_D0]);
+ 		sr |= SR_OVERFLOW;
+ 	}
+ 	else
+diff -uprN hatari-2.3.1/src/includes/m68000.h hatari-2.3.1-patch/src/includes/m68000.h
+--- hatari-2.3.1/src/includes/m68000.h	2020-12-27 05:50:12.000000000 +0800
++++ hatari-2.3.1-patch/src/includes/m68000.h	2021-10-10 15:21:11.943678620 +0800
+@@ -29,22 +29,22 @@
+ 
+ /* 68000 Register defines */
+ enum {
+-  REG_D0,    /* D0.. */
+-  REG_D1,
+-  REG_D2,
+-  REG_D3,
+-  REG_D4,
+-  REG_D5,
+-  REG_D6,
+-  REG_D7,    /* ..D7 */
+-  REG_A0,    /* A0.. */
+-  REG_A1,
+-  REG_A2,
+-  REG_A3,
+-  REG_A4,
+-  REG_A5,
+-  REG_A6,
+-  REG_A7    /* ..A7 (also SP) */
++  M68K_REG_D0,    /* D0.. */
++  M68K_REG_D1,
++  M68K_REG_D2,
++  M68K_REG_D3,
++  M68K_REG_D4,
++  M68K_REG_D5,
++  M68K_REG_D6,
++  M68K_REG_D7,    /* ..D7 */
++  M68K_REG_A0,   /* A0.. */ // This symbol conflicts with macros in riscv system headers
++  M68K_REG_A1,
++  M68K_REG_A2,
++  M68K_REG_A3,
++  M68K_REG_A4,
++  M68K_REG_A5,
++  M68K_REG_A6,
++  M68K_REG_A7    /* ..A7 (also SP) */
+ };
+ 
+ /* 68000 Condition code's */
+diff -uprN hatari-2.3.1/src/uae-cpu/hatari-glue.c hatari-2.3.1-patch/src/uae-cpu/hatari-glue.c
+--- hatari-2.3.1/src/uae-cpu/hatari-glue.c	2020-12-27 05:50:12.000000000 +0800
++++ hatari-2.3.1-patch/src/uae-cpu/hatari-glue.c	2021-10-10 15:21:11.947012006 +0800
+@@ -289,9 +289,9 @@ unsigned long OpCode_VDI(uae_u32 opcode)
+  */
+ unsigned long OpCode_NatFeat_ID(uae_u32 opcode)
+ {
+-	Uint32 stack = Regs[REG_A7] + SIZE_LONG;	/* skip return address */
++	Uint32 stack = Regs[M68K_REG_A7] + SIZE_LONG;	/* skip return address */
+ 
+-	if (NatFeat_ID(stack, &(Regs[REG_D0]))) {
++	if (NatFeat_ID(stack, &(Regs[M68K_REG_D0]))) {
+ 		CpuDoNOP ();
+ 	}
+ 	return 4;
+@@ -302,12 +302,12 @@ unsigned long OpCode_NatFeat_ID(uae_u32
+  */
+ unsigned long OpCode_NatFeat_Call(uae_u32 opcode)
+ {
+-	Uint32 stack = Regs[REG_A7] + SIZE_LONG;	/* skip return address */
++	Uint32 stack = Regs[M68K_REG_A7] + SIZE_LONG;	/* skip return address */
+ 	Uint16 SR = M68000_GetSR();
+ 	bool super;
+ 	
+ 	super = ((SR & SR_SUPERMODE) == SR_SUPERMODE);
+-	if (NatFeat_Call(stack, super, &(Regs[REG_D0]))) {
++	if (NatFeat_Call(stack, super, &(Regs[M68K_REG_D0]))) {
+ 		CpuDoNOP ();
+ 	}
+ 	return 4;
+diff -uprN hatari-2.3.1/src/vdi.c hatari-2.3.1-patch/src/vdi.c
+--- hatari-2.3.1/src/vdi.c	2020-12-27 05:50:12.000000000 +0800
++++ hatari-2.3.1-patch/src/vdi.c	2021-10-10 15:21:11.933678461 +0800
+@@ -443,7 +443,7 @@ void AES_Info(FILE *fp, Uint32 bShowOpco
+ 	if (opcode != INVALID_OPCODE)
+ 	{
+ 		/* we're on AES trap -> store new values */
+-		if (!AES_StoreVars(Regs[REG_D1]))
++		if (!AES_StoreVars(Regs[M68K_REG_D1]))
+ 			return;
+ 	}
+ 	else
+@@ -857,7 +857,7 @@ void VDI_Info(FILE *fp, Uint32 bShowOpco
+ 	if (opcode != INVALID_OPCODE)
+ 	{
+ 		/* we're on VDI trap -> store new values */
+-		if (!VDI_StoreVars(Regs[REG_D1]))
++		if (!VDI_StoreVars(Regs[M68K_REG_D1]))
+ 			return;
+ 	}
+ 	else
+@@ -930,9 +930,9 @@ static inline bool VDI_isWorkstationOpen
+  */
+ bool VDI_AES_Entry(void)
+ {
+-	Uint16 call = Regs[REG_D0];
++	Uint16 call = Regs[M68K_REG_D0];
+ #if ENABLE_TRACING
+-	Uint32 TablePtr = Regs[REG_D1];
++	Uint32 TablePtr = Regs[M68K_REG_D1];
+ 
+ 	/* AES call? */
+ 	if (call == 0xC8)
+diff -uprN hatari-2.3.1/src/xbios.c hatari-2.3.1-patch/src/xbios.c
+--- hatari-2.3.1/src/xbios.c	2020-12-27 05:50:12.000000000 +0800
++++ hatari-2.3.1-patch/src/xbios.c	2021-10-10 15:21:11.940345234 +0800
+@@ -86,7 +86,7 @@ static bool XBios_Dbmsg(Uint32 Params)
+ 	}
+ 
+ 	/* return value != function opcode, to indicate it's implemented */
+-	Regs[REG_D0] = 0;
++	Regs[M68K_REG_D0] = 0;
+ 	return true;
+ }
+ 
+@@ -107,7 +107,7 @@ static bool XBios_Scrdmp(Uint32 Params)
+ 	/* Scrdmp() doesn't have return value, but return something else than
+ 	 * function number to indicate this XBios opcode was implemented
+ 	 */
+-	Regs[REG_D0] = 0;
++	Regs[M68K_REG_D0] = 0;
+ 	return true;
+ }
+ 
+@@ -129,7 +129,7 @@ static bool XBios_HatariControl(Uint32 P
+ 	Control_ProcessBuffer(pText);
+ 
+ 	/* return value != function opcode, to indicate it's implemented */
+-	Regs[REG_D0] = 0;
++	Regs[M68K_REG_D0] = 0;
+ 	return true;
+ }
+ 
+@@ -444,7 +444,7 @@ bool XBios(void)
+ 	Uint16 XBiosCall;
+ 
+ 	/* Find call */
+-	Params = Regs[REG_A7];
++	Params = Regs[M68K_REG_A7];
+ 	XBiosCall = STMemory_ReadWord(Params);
+ 	Params += SIZE_WORD;
+ 
+diff -uprN hatari-2.3.1/tests/debugger/test-evaluate.c hatari-2.3.1-patch/tests/debugger/test-evaluate.c
+--- hatari-2.3.1/tests/debugger/test-evaluate.c	2020-12-27 05:50:12.000000000 +0800
++++ hatari-2.3.1-patch/tests/debugger/test-evaluate.c	2021-10-10 15:21:11.883677666 +0800
+@@ -43,7 +43,7 @@ int main(int argc, const char *argv[])
+ 	/* set values needed by above successful calculations */
+ 	nVBLs = VBL_VALUE;
+ 	memset(Regs, 0, sizeof(Regs));
+-	Regs[REG_D0] = 10;
++	Regs[M68K_REG_D0] = 10;
+ 	memset(STRam, 0, STRamEnd);
+ 	/* expressions use long access, 3*3 -> 9 */
+ 	STMemory_WriteLong(2+5, 3);

--- a/hatari/riscv64.patch
+++ b/hatari/riscv64.patch
@@ -1,0 +1,21 @@
+diff --git PKGBUILD PKGBUILD
+index 10a5b24..88d373e 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -9,8 +9,14 @@ url='http://hatari.sourceforge.net/'
+ license=('GPL')
+ depends=('sdl2' 'libpng' 'portaudio' 'systemd-libs' 'hicolor-icon-theme')
+ makedepends=('cmake' 'systemd')
+-source=("https://download.tuxfamily.org/${pkgname}/${pkgver}/${pkgname}-${pkgver}.tar.bz2")
+-sha256sums=('44a2f62ca995e38d9e0874806956f0b9c3cc84ea89e0169a63849b63cd3b64bd')
++source=("https://download.tuxfamily.org/${pkgname}/${pkgver}/${pkgname}-${pkgver}.tar.bz2"
++        "fix-name-conflicts.patch")
++sha256sums=('44a2f62ca995e38d9e0874806956f0b9c3cc84ea89e0169a63849b63cd3b64bd'
++            '7756052ef6254eb210e2b808c168b15980bc3675cb4aed50e6b5184f2f98efe6')
++
++prepare() {
++  patch -Np1 < fix-name-conflicts.patch -d ${pkgname}-${pkgver}
++}
+ 
+ build() {
+   cd ${pkgname}-${pkgver}


### PR DESCRIPTION
This patch is ugly. `REG_A0` is already defined in `sys/ucontext.h` on RISC-V.

Request for better workaround.