### PR TITLE
addpkg: sympol

### DIFF
--- a/sympol/riscv64.patch
+++ b/sympol/riscv64.patch
@@ -1,0 +1,30 @@
+diff --git PKGBUILD PKGBUILD
+index 6ae176f..7ac2312 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -10,13 +10,15 @@ license=(GPL2)
+ source=($pkgname-$pkgver::"https://github.com/tremlin/SymPol/archive/v$pkgver.tar.gz"
+         cddlib-0.94k.patch
+         sympol-fix-headers.patch
+-        sympol-lrs-071.patch)
++        sympol-lrs-071.patch
++        sympol-fix-bliss-interface.patch)
+ depends=(boost-libs lrs cddlib)
+ makedepends=(cmake permlib eigen bliss)
+ sha256sums=('6753b8fb30745b66a0886e125c18b539417afcf62b804799eb220bd5a59ccc37'
+             '23f85255ad1acbaf9c63134c6d331e0f3b8d06230a05e3f63e57399863579649'
+             'f3ed90e6b9af5dae0728c52ce4bb9107f3040481cac6c08116dbf8c19bfe3971'
+-            '0aa37a4b87021ed04e02fcdae525dc305a8b0490c98bfb82bba2d9af04ef1d35')
++            '0aa37a4b87021ed04e02fcdae525dc305a8b0490c98bfb82bba2d9af04ef1d35'
++            'dc68c20f8db35e544c2b5ee3b37cab2b7e6974facb78faaea38a87286d66a416')
+ 
+ prepare() {
+   cd SymPol-$pkgver
+@@ -25,6 +27,7 @@ prepare() {
+   patch -p1 -i ../cddlib-0.94k.patch # Fix build with cddlib 0.94k
+   patch -p1 -i ../sympol-fix-headers.patch # Keep headers directory structure
+   patch -p0 -i ../sympol-lrs-071.patch # Fix build with lrs 071 (Fedora)
++  patch -p1 -i ../sympol-fix-bliss-interface.patch # Adapt to libbliss update
+ }
+ 
+ build() {

--- a/sympol/sympol-fix-bliss-interface.patch
+++ b/sympol/sympol-fix-bliss-interface.patch
@@ -1,0 +1,87 @@
+diff -uprN SymPol-0.1.9/sympol/symmetrygroupconstruction/graphconstructionbliss.cpp SymPol-0.1.9-patch/sympol/symmetrygroupconstruction/graphconstructionbliss.cpp
+--- SymPol-0.1.9/sympol/symmetrygroupconstruction/graphconstructionbliss.cpp	2016-05-09 03:52:35.000000000 +0800
++++ SymPol-0.1.9-patch/sympol/symmetrygroupconstruction/graphconstructionbliss.cpp	2021-10-12 00:50:30.823315747 +0800
+@@ -16,35 +16,6 @@ using namespace permlib;
+ static LoggerPtr logger(Logger::getLogger("SymGraphB "));
+ 
+ 
+-/// data structure used for the bliss callback
+-struct BlissData {
+-	unsigned int T;
+-	std::list<Permutation::ptr> generators;
+-};
+-
+-
+-/// bliss callback for graph automorphism generators
+-static
+-void blisshook(
+-	void*                 user_param,
+-	unsigned int          n,
+-	const unsigned int*   aut
+-	)
+-{
+-	BOOST_ASSERT( user_param != 0 );
+-	BlissData* bliss = reinterpret_cast<BlissData*>(user_param);
+-	
+-	BOOST_ASSERT( n % bliss->T == 0 );
+-	Permutation::perm proj(n / bliss->T);
+-	for (unsigned int i = 0; i < proj.size(); ++i) {
+-		proj[i] = aut[i];
+-		BOOST_ASSERT( aut[i] < proj.size() );
+-	}
+-	Permutation::ptr p(new Permutation(proj));
+-	bliss->generators.push_back(p);
+-}
+-
+-
+ boost::shared_ptr<sympol::PermutationGroup> GraphConstructionBliss::compute(const MatrixConstruction* matrix) const {
+ 	const unsigned int T = static_cast<unsigned int>(std::ceil( log2((double) matrix->k() + 1.0) ));
+ 	const unsigned int matrixRows = matrix->dimension();
+@@ -71,14 +42,29 @@ boost::shared_ptr<sympol::PermutationGro
+ 	YALLOG_DEBUG(logger, "start graph automorphism search with bliss");
+ 	
+ 	bliss::Stats stats;
+-	BlissData data;
+-	data.T = T;
++	std::list<Permutation::ptr> generators;
++
++	/// bliss callback for graph automorphism generators
++	auto blisshook = [T, &generators](
++		unsigned int n,
++		const unsigned int* aut
++		)
++	{
++		BOOST_ASSERT( n % T == 0 );
++		Permutation::perm proj(n / T);
++		for (unsigned int i = 0; i < proj.size(); ++i) {
++			proj[i] = aut[i];
++			BOOST_ASSERT( aut[i] < proj.size() );
++		}
++		Permutation::ptr p(new Permutation(proj));
++		generators.push_back(p);
++	};
+ 	/* Prefer splitting partition cells corresponding to nodes with color 0 or 1,
+ 	 * so that we obtain a group basis beginning with them. */
+ 	G.set_splitting_heuristic(bliss::Graph::shs_f);
+ 	// disable component recursion as advised by Tommi Junttila from bliss
+ 	G.set_component_recursion(false);
+-	G.find_automorphisms(stats, blisshook, &data);
++	G.find_automorphisms(stats, blisshook);
+ 	if (yal::DEBUG <= yal::ReportLevel::get())
+ 		stats.print(stdout);
+ 	else 
+@@ -103,12 +89,12 @@ boost::shared_ptr<sympol::PermutationGro
+ 	
+ 	KnownBSGSConstruction<PERMUTATION, TRANSVERSAL> bsgsSetup(matrixRows);
+ 	boost::shared_ptr<PermutationGroup> group(new PermutationGroup(
+-		bsgsSetup.construct(data.generators.begin(), data.generators.end(), baseVars.begin(), baseVars.end())
++		bsgsSetup.construct(generators.begin(), generators.end(), baseVars.begin(), baseVars.end())
+ 	));
+ #else
+ 	SchreierSimsConstruction<PERMUTATION, TRANSVERSAL> bsgsSetup(matrixRows);
+ 	boost::shared_ptr<PermutationGroup> group(new PermutationGroup(
+-		bsgsSetup.construct(data.generators.begin(), data.generators.end())
++		bsgsSetup.construct(generators.begin(), generators.end())
+ 	));
+ #endif
+ 


### PR DESCRIPTION
This patch adapts `sympol` to `bliss-0.77`, which has interface changes since `0.75`.

Could get upstreamed to Arch Linux when `bliss-0.73-2-x86_64` gets updated.