### PR TITLE
addpkg: wolf-spectrum

### DIFF
--- a/wolf-spectrum/add-riscv64-support.patch
+++ b/wolf-spectrum/add-riscv64-support.patch
@@ -1,0 +1,30 @@
+diff --unified --recursive --text a/dpf/dgl/Makefile.mk b/dpf/dgl/Makefile.mk
+--- a/dpf/dgl/Makefile.mk	2021-10-12 13:01:09.573443248 +0000
++++ b/dpf/dgl/Makefile.mk	2021-10-12 13:04:00.486890824 +0000
+@@ -25,6 +25,10 @@
+ BASE_FLAGS = -Wall -Wextra -pipe -MD -MP
+ BASE_OPTS  = -O2 -mtune=generic -msse -msse2 -fdata-sections -ffunction-sections
+ 
++ifneq ($(findstring riscv64, $(shell uname -a)),)
++# RISCV flags
++BASE_OPTS = -O2 -fdata-sections -ffunction-sections
++endif
+ ifeq ($(MACOS),true)
+ # MacOS linker flags
+ LINK_OPTS  = -fdata-sections -ffunction-sections -Wl,-dead_strip -Wl,-dead_strip_dylibs
+diff --unified --recursive --text a/Makefile.mk b/Makefile.mk
+--- a/Makefile.mk	2021-10-12 13:39:37.316992538 +0000
++++ b/Makefile.mk	2021-10-12 13:41:26.783268125 +0000
+@@ -40,6 +40,12 @@
+ BASE_OPTS += -mfpmath=sse
+ endif
+ 
++ifneq ($(findstring riscv64, $(shell uname -a)),)
++# RISCV support
++BASE_OPTS  = -O2 -ffast-math -fdata-sections -ffunction-sections
++endif
++
++
+ ifeq ($(MACOS),true)
+ # MacOS linker flags
+ LINK_OPTS  = -fdata-sections -ffunction-sections -Wl,-dead_strip -Wl,-dead_strip_dylibs

--- a/wolf-spectrum/riscv64.patch
+++ b/wolf-spectrum/riscv64.patch
@@ -1,0 +1,26 @@
+diff --git PKGBUILD PKGBUILD
+index 35939fda6..e444744bc 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -10,8 +10,10 @@ license=('GPL3')
+ groups=('lv2-plugins' 'pro-audio' 'vst-plugins')
+ depends=('jack' 'libglvnd')
+ makedepends=('gendesk' 'lv2')
+-source=("https://github.com/pdesaulniers/${pkgname}/releases/download/v${pkgver}/${pkgname}-v${pkgver}-source.tar.gz")
+-sha512sums=('e84abfef3a08d8da8fe5350088f43d7670c5ff828ec7bf7ddcd4b3c19c1cdba6560be7b69ab5b9af1d27c80c195f123e635d2337e0a297282564935d54b8d501')
++source=("https://github.com/pdesaulniers/${pkgname}/releases/download/v${pkgver}/${pkgname}-v${pkgver}-source.tar.gz"
++        "add-riscv64-support.patch")
++sha512sums=('e84abfef3a08d8da8fe5350088f43d7670c5ff828ec7bf7ddcd4b3c19c1cdba6560be7b69ab5b9af1d27c80c195f123e635d2337e0a297282564935d54b8d501'
++            '6b2ed11d081fdd1be63d6d68e395d10f6e740e433c9cc543744638b12c88f985af1a6c3b22f40d3da3d528614541183bf05bca59a9868493a5919a8d01623873')
+ 
+ prepare() {
+   mv -v "$pkgname" "$pkgname-$pkgver"
+@@ -21,6 +23,8 @@ prepare() {
+           --pkgname ${pkgname} \
+           --pkgdesc "${pkgdesc}" \
+           --categories "AudioVideo;Audio"
++
++  patch -Np1 -i ../add-riscv64-support.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
The [`Makefile`](https://github.com/wolf-plugins/wolf-spectrum/blob/v1.0.0/Makefile.mk) for this package has been rewritten. I will retry adding riscv64 to the new [`makefile`](https://github.com/wolf-plugins/wolf-spectrum/blob/master/Makefile) later.

