### PR TITLE
addpkg: mdbook

### DIFF
--- a/mdbook/riscv64.patch
+++ b/mdbook/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD.orig	2021-10-22 23:03:41.029865198 +0800
++++ PKGBUILD	2021-10-23 16:38:51.671324534 +0800
+@@ -20,7 +20,7 @@
+ prepare() {
+   cd "mdBook-${pkgver}"
+   mkdir completions/
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  cargo fetch --locked
+ }
+ 
+ build() {


### PR DESCRIPTION
This can't be built with qemu-user or `cargo test` will fail.