### PR TITLE
addpkg: java-rxtx

### DIFF
--- a/java-rxtx/fix-format-security.patch
+++ b/java-rxtx/fix-format-security.patch
@@ -1,0 +1,60 @@
+diff -uprN rxtx-2.2pre2/src/ParallelImp.c rxtx-2.2pre2-patch/src/ParallelImp.c
+--- rxtx-2.2pre2/src/ParallelImp.c	2008-11-28 04:01:48.000000000 +0800
++++ rxtx-2.2pre2-patch/src/ParallelImp.c	2021-11-13 23:02:42.608071635 +0800
+@@ -920,7 +920,7 @@ void throw_java_exception_system_msg( JN
+ void report_error(char *msg)
+ {
+ #ifndef DEBUG_MW
+-	fprintf(stderr, msg);
++	fprintf(stderr, "%s", msg);
+ #else
+ 	mexWarnMsgTxt( msg );
+ #endif /* DEBUG_MW */
+@@ -938,7 +938,7 @@ void report_error(char *msg)
+ void report(char *msg)
+ {
+ #ifdef DEBUG
+-        fprintf(stderr, msg);
++        fprintf(stderr, "%s", msg);
+ #endif /* DEBUG */
+ }
+ 
+diff -uprN rxtx-2.2pre2/src/SerialImp.c rxtx-2.2pre2-patch/src/SerialImp.c
+--- rxtx-2.2pre2/src/SerialImp.c	2009-02-05 06:06:16.000000000 +0800
++++ rxtx-2.2pre2-patch/src/SerialImp.c	2021-11-13 22:56:22.439555164 +0800
+@@ -5096,7 +5096,7 @@ void throw_java_exception( JNIEnv *env,
+ void report_warning(char *msg)
+ {
+ #ifndef DEBUG_MW
+-	fprintf(stderr, msg);
++	fprintf(stderr, "%s", msg);
+ #else
+ 	mexWarnMsgTxt( (const char *) msg );
+ #endif /* DEBUG_MW */
+@@ -5117,7 +5117,7 @@ void report_verbose(char *msg)
+ #ifdef DEBUG_MW
+ 	mexErrMsgTxt( msg );
+ #else
+-	fprintf(stderr, msg);
++	fprintf(stderr, "%s", msg);
+ #endif /* DEBUG_MW */
+ #endif /* DEBUG_VERBOSE */
+ }
+@@ -5133,7 +5133,7 @@ void report_verbose(char *msg)
+ void report_error(char *msg)
+ {
+ #ifndef DEBUG_MW
+-	fprintf(stderr, msg);
++	fprintf(stderr, "%s", msg);
+ #else
+ 	mexWarnMsgTxt( msg );
+ #endif /* DEBUG_MW */
+@@ -5152,7 +5152,7 @@ void report(char *msg)
+ {
+ #ifdef DEBUG
+ #	ifndef DEBUG_MW
+-		fprintf(stderr, msg);
++		fprintf(stderr, "%s", msg);
+ #	else
+ 		mexPrintf( msg );
+ #	endif /* DEBUG_MW */

--- a/java-rxtx/fix-riscv64-build.patch
+++ b/java-rxtx/fix-riscv64-build.patch
@@ -1,0 +1,15 @@
+diff -uprN rxtx-2.2pre2/src/RawImp.c rxtx-2.2pre2-patch/src/RawImp.c
+--- rxtx-2.2pre2/src/RawImp.c	2007-11-19 06:32:42.000000000 +0800
++++ rxtx-2.2pre2-patch/src/RawImp.c	2021-11-13 23:08:57.066631988 +0800
+@@ -100,9 +100,9 @@
+ #	include <linux/version.h>
+ #endif
+ #ifndef __APPLE__  /* dima */
+-#ifndef PPC
++#if !defined(PPC) && !defined(__riscv)
+ #include <sys/io.h>
+-#endif /* PPC */
++#endif /* PPC & RISC-V */
+ #endif /* dima */
+ 
+ extern int errno;

--- a/java-rxtx/riscv64.patch
+++ b/java-rxtx/riscv64.patch
@@ -1,0 +1,39 @@
+diff --git PKGBUILD PKGBUILD
+index 83e48ac..88d5f52 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -21,7 +21,9 @@ source=(http://rxtx.qbang.org/pub/$_pkgname/$_pkgname-$pkgver.zip
+         ttyACM_port.patch
+         java10.patch
+         java11.patch
+-        rxtx-2.2-undefined_symbol.patch)
++        rxtx-2.2-undefined_symbol.patch
++        fix-format-security.patch
++        fix-riscv64-build.patch)
+ md5sums=('7eedb18e3f33a427e2b0e9be8ce3f94c'
+          '2f21ec5eb108f871815242698b6150f1'
+          '1f7c43d582bfe9daea22d7f7057436da'
+@@ -29,7 +31,9 @@ md5sums=('7eedb18e3f33a427e2b0e9be8ce3f94c'
+          '903a3fe0067d0682dd5f64483c741df6'
+          '683dd95e6e419b2b63851c08ede7ca86'
+          '1db5c64e239c80294d00c932237889dd'
+-         '4695fe9bb28a7c9b21447f998fb46b02')
++         '4695fe9bb28a7c9b21447f998fb46b02'
++         '55150cf1dd7dfc510809b1881a06a1f2'
++         'a99178f7f50e2cfdb99d2eb3ed167421')
+ 
+ prepare() {
+   cd $_pkgname-$pkgver
+@@ -55,6 +59,12 @@ prepare() {
+   # Fix undefined symbol
+   patch -Np1 -i ../rxtx-2.2-undefined_symbol.patch
+ 
++  # Fix format security
++  patch -Np1 -i ../fix-format-security.patch
++
++  # Fix build on RISC-V 64
++  patch -Np1 -i ../fix-riscv64-build.patch
++
+   rm *.m4
+   autoreconf -fi
+ }


### PR DESCRIPTION
`fix-format-security.patch` could get upstreamed to Arch Linux.

Upstream source is **NO LONGER MAINTAINED**.