### PR TITLE
addpkg: clpeak

### DIFF
--- a/clpeak/riscv64.patch
+++ b/clpeak/riscv64.patch
@@ -1,0 +1,30 @@
+diff --git PKGBUILD PKGBUILD
+index c7247fd..594874d 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -7,12 +7,22 @@ arch=('x86_64')
+ url="https://github.com/krrishnarraj/clpeak"
+ license=(custom:unlicense)
+ depends=('ocl-icd' 'gcc-libs')
+-makedepends=('cmake' 'opencl-headers')
+-source=("$pkgname-$pkgver.tar.gz::https://github.com/krrishnarraj/clpeak/archive/$pkgver.tar.gz")
+-sha512sums=('748c603397aa7ac3c1e4b5440312123a2e8442f50b8623ed22c277276ea279c69479c9005d6e2d3cf6f5500e25ee7a39ac9c2ea664c6041dd908e8d947f879f3')
++makedepends=('cmake' 'opencl-headers' 'opencl-clhpp')
++source=("$pkgname-$pkgver.tar.gz::https://github.com/krrishnarraj/clpeak/archive/$pkgver.tar.gz"
++        "0000-c0c7735d.patch::https://github.com/krrishnarraj/clpeak/commit/c0c7735d5d282943273e45fb6b042b7412d263a1.patch"
++        "0001-fix-issue-73.patch::https://github.com/krrishnarraj/clpeak/commit/db42d30028bace27cda3c7d95f122a5c14743246.patch")
++sha512sums=('748c603397aa7ac3c1e4b5440312123a2e8442f50b8623ed22c277276ea279c69479c9005d6e2d3cf6f5500e25ee7a39ac9c2ea664c6041dd908e8d947f879f3'
++            'bbd70e5073845b7f4f8f05d97f36c9f1a45cd2341d6bfaebba90610f79e2ec61717a6a57ce3b104609fae5029a1fac1fad30081e5afef62ecd3718b4b886214d'
++            '59751b0f89654299e283dd0e494e7a4559f2acba4bf795aff6247496ab774306819e8a0dd1c7c92738879251aa510cfce4769cfc921eb3ec37b1421b486657bb')
+ 
+ prepare() {
+     mkdir $pkgname-$pkgver/build
++
++    # Prepare for fix-issue-73.patch
++    patch -Np1 -d $pkgname-$pkgver -i $srcdir/0000-c0c7735d.patch
++
++    # This fixes https://github.com/krrishnarraj/clpeak/issues/73
++    patch -Np1 -d $pkgname-$pkgver -i $srcdir/0001-fix-issue-73.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
This patch applies unreleased changes fixing krrishnarraj/clpeak#73.

Could get upstreamed to Arch Linux.