### PR TITLE
addpkg: qt5-webkit

### DIFF
--- a/qt5-webkit/riscv64.patch
+++ b/qt5-webkit/riscv64.patch
@@ -1,0 +1,41 @@
+diff --git PKGBUILD PKGBUILD
+index 0cb3e56..5320b85 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,7 +14,8 @@ source=("https://github.com/qtwebkit/qtwebkit/releases/download/qtwebkit-$_pkgve
+          icu68.patch
+          glib-2.68.patch
+          qt5-webkit-python-3.9.patch::"https://github.com/qtwebkit/qtwebkit/commit/78360c01.patch"
+-         qt5-webkit-bison-3.7.patch::"https://github.com/qtwebkit/qtwebkit/commit/d92b11fe.patch")
++         qt5-webkit-bison-3.7.patch::"https://github.com/qtwebkit/qtwebkit/commit/d92b11fe.patch"
++         qt5-webkit-riscv-no-jit.patch::"https://github.com/qtwebkit/qtwebkit/commit/d9824ec806b6c6171862a7ba758fc28e6a20aada.patch")
+ depends=(qt5-location qt5-sensors qt5-webchannel libwebp libxslt libxcomposite gst-plugins-base hyphen woff2)
+ makedepends=(cmake ruby gperf python qt5-doc qt5-tools)
+ optdepends=('gst-plugins-good: Webm codec support')
+@@ -22,7 +23,8 @@ sha256sums=('9ca126da9273664dd23a3ccd0c9bebceb7bb534bddd743db31caf6a5a6d4a9e6'
+             '0b40ed924f03ff6081af610bb0ee01560b7bd1fb68f8af02053304a01d4ccdf0'
+             '4969dd03e482155e2490b50307dada81dda7bbc9e5398e3a53c20bc474f7c04e'
+             '6e0cee08e4fa57b04752e80817f33562f48aa42608a3a620930b6040259b4932'
+-            '34f37b53ee0bc31c63ce85ebd1ae95543a8ba28483e387b20efd50574bd813be')
++            '34f37b53ee0bc31c63ce85ebd1ae95543a8ba28483e387b20efd50574bd813be'
++            '2824cac9eacd35908b13bec626fc484253bca52aa956b4e7c96bd4659e924ada')
+ 
+ prepare() {
+   cd qtwebkit-$_pkgver
+@@ -30,6 +32,7 @@ prepare() {
+   patch -p1 -i ../glib-2.68.patch # https://github.com/qtwebkit/qtwebkit/issues/1057
+   patch -p1 -i ../qt5-webkit-python-3.9.patch # Fix build with python 3.9
+   patch -p1 -i ../qt5-webkit-bison-3.7.patch # Fix build with bison 3.7
++  patch -p1 -i ../qt5-webkit-riscv-no-jit.patch
+ }
+ 
+ build() {
+@@ -37,6 +40,8 @@ build() {
+     -DCMAKE_INSTALL_PREFIX=/usr \
+     -DCMAKE_CXX_FLAGS="${CXXFLAGS} -DNDEBUG" \
+     -DPORT=Qt \
++    -DENABLE_JIT=OFF\
++    -DTHREADS_PREFER_PTHREAD_FLAG=ON\
+     -DENABLE_TOOLS=OFF
+   cmake --build build
+ }


### PR DESCRIPTION
1. Reference https://github.com/qtwebkit/qtwebkit/pull/982 ,set `-DTHREADS_PREFER_PTHREAD_FLAG=ON` .
2. Since
```
/build/qt5-webkit/src/qtwebkit-5.212.0-alpha4/Source/JavaScriptCore/assembler/MacroAssembler.h:64:2: error: #error "The MacroAssembler is not supported on this platform."
    64 | #error "The MacroAssembler is not supported on this platform."
```
so set `-DENABLE_JIT=OFF`. 