### PR TITLE
addpkg: libltc

### DIFF
--- a/libltc/riscv64.patch
+++ b/libltc/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index b14a63eb..8e500dd0 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -29,7 +29,7 @@ build() {
+ 
+ check(){
+   cd "${pkgname}-${pkgver}"
+-  make check
++  make -j1 check
+ }
+ 
+ package() {


### PR DESCRIPTION
Force `-j1` to avoid conflict `mv` operations.