### PR TITLE
addpkg: spectmorph

### DIFF
--- a/spectmorph/riscv64.patch
+++ b/spectmorph/riscv64.patch
@@ -1,0 +1,26 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,14 +17,18 @@ optdepends=('jack: for smjack and smsampleedit'
+ provides=('libspectmorphjack.so' 'libspectmorphgui.so' 'libspectmorphglui.so'
+ 'libspectmorph.so')
+ source=("http://www.spectmorph.org/files/releases/${pkgname}-${pkgver}.tar.bz2"
+-        "http://spectmorph.org/files/instruments/${pkgname}-instruments-${pkgver}.tar.xz")
+-sha512sums=('c98607ca3dc0f1a3063bf376431e2d43241a1ccbc864e03ed8726e366d9ab8d43a1f82547743bbb3111494ba819ece8b96deac34c151beccee479e2c4055013c'
+-            '7c1353be42b04e0b0107a994a0236b4be5ddf387e436786eeca7173751961f4dcf3b887de84c538d43119a3c9fb3b50cab3850afee4d1634e64803a83daef7da')
+-b2sums=('0abba1ae9e7e37880ba0b7ae8c6e4de535e863d14bd8d579be1afa432d62d44ba0b04bd28b007513c6095e5d132b1a0ed51675841f3cc712a4a252aa40c9bd8c'
+-        '213d844979c262af63d78f28cba301a2d255c9b31442c3c31b0ce900ffb56d1d0fd38829b3156c159e476b9321790b2af0279dd1dfbf88dd9c86ed2d0863a979')
++        "http://spectmorph.org/files/instruments/${pkgname}-instruments-${pkgver}.tar.xz"
++        "0000-fix-m128-fnstcw.patch::https://github.com/swesterfeld/spectmorph/pull/13.diff")
++sha512sums=('cf2a6801624d9935b75ab393160e824e2bd4434fa58e7f068fbba463edec1f66438ea07abc4f86bac69fab453d34d0344dfe495349e28e4fd83e7c72b7a2a317'
++            '7c1353be42b04e0b0107a994a0236b4be5ddf387e436786eeca7173751961f4dcf3b887de84c538d43119a3c9fb3b50cab3850afee4d1634e64803a83daef7da'
++            '025a0540fb8ccd8a5853cf8805e9c7546608668c77989eee5af0fa7fc5c43d611dde3de9e25c460441aa5c390e51777782053e038df45632b7c5bc37c6a9452b')
++b2sums=('f7c1215544b42367735a78c799e0b6e5c164ae8537296291b05f04d08aea7af51c66e74fc751fae5264fa352859c875bf990f18c838ff589d934ebed9cd06937'
++        '213d844979c262af63d78f28cba301a2d255c9b31442c3c31b0ce900ffb56d1d0fd38829b3156c159e476b9321790b2af0279dd1dfbf88dd9c86ed2d0863a979'
++        '14450d388f4dfbde94be4c627dcc62a4fdb518f7b91386688d46d02fe5a48bf700111b830da55aafa51889f5c9cd88a472938015dca7ced5581a2b33b8303b68')
+ 
+ prepare() {
+   cd "$pkgname-$pkgver"
++  patch -p1 -i ../0000-fix-m128-fnstcw.patch
+   autoreconf -vfi
+ }
+ 


### PR DESCRIPTION
Submitted a PR to upstream: https://github.com/swesterfeld/spectmorph/pull/13

The checksum of `spectmorph-0.5.2.tar.bz2` has changed.