### PR TITLE
addpkg: av1an

### DIFF
--- a/av1an/fix-dependencies.patch
+++ b/av1an/fix-dependencies.patch
@@ -1,0 +1,38 @@
+diff '--color=auto' --text --unified -r --new-file A/Av1an-0.2.0/av1an-cli/Cargo.toml B/Av1an-0.2.0/av1an-cli/Cargo.toml
+--- A/Av1an-0.2.0/av1an-cli/Cargo.toml	2021-11-01 04:56:47.000000000 +0800
++++ B/Av1an-0.2.0/av1an-cli/Cargo.toml	2021-12-17 21:24:03.226824815 +0800
+@@ -30,7 +30,8 @@
+ ] }
+ 
+ [dependencies.ffmpeg-next]
+-version = "4.4.0"
++git = "https://github.com/Avimitin/rust-ffmpeg"
++branch = "risc-v"
+ 
+ [features]
+ ffmpeg_static = ["ffmpeg-next/static", "ffmpeg-next/build"]
+diff '--color=auto' --text --unified -r --new-file A/Av1an-0.2.0/av1an-core/Cargo.toml B/Av1an-0.2.0/av1an-core/Cargo.toml
+--- A/Av1an-0.2.0/av1an-core/Cargo.toml	2021-11-01 04:56:47.000000000 +0800
++++ B/Av1an-0.2.0/av1an-core/Cargo.toml	2021-12-17 21:23:31.633492631 +0800
+@@ -42,7 +42,8 @@
+ paste = "1.0.5"
+ 
+ [dependencies.ffmpeg-next]
+-version = "4.4.0"
++git = "https://github.com/Avimitin/rust-ffmpeg"
++branch = "risc-v"
+ 
+ [dependencies.plotters]
+ version = "0.3.1"
+diff '--color=auto' --text --unified -r --new-file A/Av1an-0.2.0/Cargo.toml B/Av1an-0.2.0/Cargo.toml
+--- A/Av1an-0.2.0/Cargo.toml	2021-12-17 21:21:54.993496146 +0800
++++ B/Av1an-0.2.0/Cargo.toml	2021-12-17 21:22:30.633494850 +0800
+@@ -18,7 +18,7 @@
+ [dependencies]
+ anyhow = "1.0.42"
+ serde_json = "1.0.64"
+-serde = { version = "1.0.126", features = ["serde_derive"] }
++serde = { version = "1.0.132", features = ["serde_derive"] }
+ shlex = "1.0.0"
+ ctrlc = "3.1.9"
+ path_abs = "0.5.1"

--- a/av1an/riscv64.patch
+++ b/av1an/riscv64.patch
@@ -1,0 +1,23 @@
+diff --git PKGBUILD PKGBUILD
+index 15a676a..470c9f5 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,8 +17,16 @@ optdepends=('svt-av1: SVT-AV1 encoder support'
+             'mkvtoolnix-cli: mkvmerge support'
+             'ffms2: FFMS2 chunk detection support'
+             'vapoursynth-plugin-lsmashsource: L-SMASH chunk detection support')
+-source=("$pkgname-$pkgver.tar.gz"::https://github.com/master-of-zen/Av1an/archive/refs/tags/$pkgver.tar.gz)
+-sha256sums=('68169f0c8760cb7d42ab484a969ca5f092551352998d89c602ac3527542e6538')
++source=("$pkgname-$pkgver.tar.gz"::https://github.com/master-of-zen/Av1an/archive/refs/tags/$pkgver.tar.gz
++        fix-dependencies.patch)
++sha256sums=('68169f0c8760cb7d42ab484a969ca5f092551352998d89c602ac3527542e6538'
++            '749e022ce23acca8452f604f2fcd9b248a9c7d2a1e90c2160487c4728216bbba')
++
++prepare() {
++  cd "Av1an-${pkgver}"
++  patch -p2 -i ../fix-dependencies.patch
++  cargo fetch
++}
+ 
+ build() {
+   cd "Av1an-${pkgver}"


### PR DESCRIPTION
This patch will fix two dependencies sources:

* Replace ffmpeg-next with my patched version

The patched ffmpeg-next crate fixed the "Unrecognize arch riscv64gc..."
issue. This crate seems deprecated now. So I have to patch it myself
and use the git source to build the av1an.

Reference: Avimitin/rust-ffmpeg-sys@3e2b72b

* Update serde to 1.0.132

The 1.0.132 version enables atomic64 on RISC-V.
So the std::sync::atomic can be serialized by serde.

Reference: serde-rs/serde@0508cb5