### PR TITLE
addpkg: gist

### DIFF
--- a/gist/riscv64.patch
+++ b/gist/riscv64.patch
@@ -1,0 +1,12 @@
+diff --git PKGBUILD.orig PKGBUILD
+index 29c1d43..9be6f94 100644
+--- PKGBUILD.orig
++++ PKGBUILD
+@@ -19,6 +19,7 @@
+ 
+ build() {
+   cd ${pkgname}-${pkgver}
++  sed -i 's/README.1/README.md.1/g' Rakefile
+   rake build
+ }
+ 


### PR DESCRIPTION
Arch Linux use `ruby-ronn-ng` instead of `ruby-ronn` now. The build script should make a small change.

The original `PKGBUILD` also failed in `x86_64`.

Upstream Bug Report: https://bugs.archlinux.org/task/73170