### PR TITLE
addpkg: efitools

### DIFF
--- a/efitools/efitools-1.9.2-riscv64_build.patch
+++ b/efitools/efitools-1.9.2-riscv64_build.patch
@@ -1,0 +1,26 @@
+diff --git a/Make.rules b/Make.rules
+index 903a5a4..8f6ad07 100644
+--- a/Make.rules
++++ b/Make.rules
+@@ -10,6 +10,8 @@ else ifeq ($(ARCH),aarch64)
+ ARCH3264 =
+ else ifeq ($(ARCH),arm)
+ ARCH3264 =
++else ifeq ($(ARCH),riscv64)
++ARCH3264 =
+ else
+ $(error unknown architecture $(ARCH))
+ endif
+@@ -56,6 +58,11 @@ ifeq ($(ARCH),aarch64)
+   FORMAT = -O binary
+ endif
+ 
++ifeq ($(ARCH),riscv64)
++  LDFLAGS += --defsym=EFI_SUBSYSTEM=0x0a
++  FORMAT = -O binary
++endif
++
+ %.efi: %.so
+        $(OBJCOPY) -j .text -j .sdata -j .data -j .dynamic -j .dynsym \
+                   -j .rel -j .rela -j .rel.* -j .rela.* -j .rel* -j .rela* \
+

--- a/efitools/riscv64.patch
+++ b/efitools/riscv64.patch
@@ -1,0 +1,26 @@
+diff --git PKGBUILD.orig PKGBUILD
+index 65f7c82..55c2ac9 100644
+--- PKGBUILD.orig
++++ PKGBUILD
+@@ -13,15 +13,19 @@
+ makedepends=('git' 'gnu-efi-libs' 'help2man' 'perl-file-slurp' 'sbsigntools')
+ depends=('glibc' 'openssl')
+ source=("git+https://git.kernel.org/pub/scm/linux/kernel/git/jejb/$pkgname.git#tag=v${pkgver}?signed"
+-        "${pkgname}-1.9.2-console_warning_typo.patch")
++        "${pkgname}-1.9.2-console_warning_typo.patch"
++        "${pkgname}-1.9.2-riscv64_build.patch")
+ sha512sums=('SKIP'
+-            '9e609eb4fb2a7116166626d15470d66e2eb66a25867618d4065d48636304f88549a71c5e827ac92750183f0fabaa3b84beea3dffa905031a2867939bfae955e7')
++            '9e609eb4fb2a7116166626d15470d66e2eb66a25867618d4065d48636304f88549a71c5e827ac92750183f0fabaa3b84beea3dffa905031a2867939bfae955e7'
++            'f8cee091497aca1979a6f7275a8b0f7ab8305482ee72f2c3e8f9da1f7da18ff523520dc9a09a99639fcbcfb7c00bda7f24537ce4be42a60ed8e2ca688727839c')
++
+ validpgpkeys=('D5606E73C8B46271BEAD9ADF814AE47C214854D6') # James Bottomley <jejb@kernel.org>
+ 
+ prepare() {
+   mv -v "${pkgname}" "${pkgname}-${pkgver}"
+   cd "${pkgname}-${pkgver}"
+   patch -Np1 -i "../${pkgname}-1.9.2-console_warning_typo.patch"
++  patch -Np1 -i "../${pkgname}-1.9.2-riscv64_build.patch"
+ }
+ 
+ build() {


### PR DESCRIPTION
Add riscv64 build support.

If build failed with error:
```
objcopy -j .text -j .sdata -j .data -j .dynamic -j .dynsym \
           -j .rel -j .rela -j .rel.* -j .rela.* -j .rel* -j .rela* \
           -j .reloc -O binary HelloWorld.so HelloWorld.efi
openssl req -new -x509 -newkey rsa:2048 -subj "/CN=DB/" -keyout DB.key -out DB.crt -days 3650 -nodes -sha256
Generating a RSA private key
...+++++
...............................................+++++
writing new private key to 'DB.key'
-----
sbsign --key DB.key --cert DB.crt --output HelloWorld-signed.efi HelloWorld.efi
Invalid PE header magic
make: *** [Make.rules:130: HelloWorld-signed.efi] Error 1
```

`sbsigntools` should be patched first. See #524 