### PR TITLE
addpkg: rime-luna-pinyin-bootstrap

### DIFF
--- a/rime-luna-pinyin-bootstrap/PKGBUILD
+++ b/rime-luna-pinyin-bootstrap/PKGBUILD
@@ -1,0 +1,25 @@
+pkgname=rime-luna-pinyin-bootstrap
+pkgver=0.0.0.20210805
+_commit=(6e677427764b542313858eaed22c2951d8ec22fe
+         ea8576d1accd6fda339e96b415caadb56e2a07d1)
+pkgrel=1
+pkgdesc="Luna pinyin for rime (bootstrap package)"
+arch=('any')
+url="https://github.com/rime/rime-luna-pinyin"
+license=('LGPL')
+provides=('rime-luna-pinyin' 'rime-stroke')
+conflicts=('rime-luna-pinyin' 'rime-stroke')
+source=("https://github.com/rime/rime-luna-pinyin/archive/${_commit[0]}/rime-luna-pinyin-${_commit[0]}.tar.gz"
+        "https://github.com/rime/rime-stroke/archive/${_commit[1]}/rime-stroke-${_commit[1]}.tar.gz")
+
+sha512sums=('c94003e733eb1283952e9c97846e8f7f6fc0f5865e8a4c7120e36113361d74d54b60febc6b698dfdb3079ca96ff43519f8d87f328dd4e9dd49a8b7bb67ba69c5'
+            '69487ff985de24ce366eccd0e2aa77fb6921df0588bd28b772fd0215e94a3fc71b97796307fa8d31fb44e27c2fb34da5910139c5d51f09b12259e75f38f45473')
+
+
+package() {
+  cd "$srcdir/rime-luna-pinyin-${_commit[0]}"
+  install -Dm644 *.yaml -t "$pkgdir"/usr/share/rime-data/
+  cd "$srcdir/rime-stroke-${_commit[1]}"
+  install -Dm644 *.yaml -t "$pkgdir"/usr/share/rime-data/
+}
+


### PR DESCRIPTION
rime-luna-pinyin and rime-stroke have circular dependency.

Using yaml data only for bootstrap.