### PR TITLE
addpkg: cern-vdt

### DIFF
--- a/cern-vdt/riscv64.patch
+++ b/cern-vdt/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -18,7 +18,8 @@ build() {
+     cd "${srcdir}/${_pkgname}-${pkgver}"
+ 
+     mkdir build && cd build
+-    cmake .. -DCMAKE_INSTALL_PREFIX=/usr
++    # close SSE because it is not supported in RISC-V
++    cmake .. -DCMAKE_INSTALL_PREFIX=/usr -DSSE=OFF
+     make
+ }
+ 


### PR DESCRIPTION
SSE is not supported except for x86_64.