### PR TITLE
addpkg: portmidi

### DIFF
--- a/portmidi/0001-fix-build-with-Werror-format-security.patch
+++ b/portmidi/0001-fix-build-with-Werror-format-security.patch
@@ -20,7 +20,7 @@ index 507648c..a3d5b4c 100755
      char line[STRING_MAX];
      int n = 0, i;
 -    printf(prompt);
-+    fputs(prompt, stdout);
++    printf("%s", prompt);
      while (n != 1) {
          n = scanf("%d", &i);
          fgets(line, STRING_MAX, stdin);
@@ -33,7 +33,7 @@ index 60fcf7a..4031ab0 100644
      char line[STRING_MAX];
      int n = 0, i;
 -    printf(prompt);
-+    fputs(prompt, stdout);
++    printf("%s", prompt);
      while (n != 1) {
          n = scanf("%d", &i);
          fgets(line, STRING_MAX, stdin);
@@ -42,7 +42,7 @@ index 60fcf7a..4031ab0 100644
                          TIME_PROC, TIME_INFO, LATENCY);
      if (err) {
 -        printf(Pm_GetErrorText(err));
-+        puts(Pm_GetErrorText(err));
++        printf("%s", Pm_GetErrorText(err));
          goto error_exit_no_device;
      }
      active = true;
@@ -55,7 +55,7 @@ index 209ff74..16406af 100755
      char line[STRING_MAX];
      int n = 0, i;
 -    printf(prompt);
-+    fputs(prompt, stdout);
++    printf("%s", prompt);
      while (n != 1) {
          n = scanf("%d", &i);
          fgets(line, STRING_MAX, stdin);
@@ -64,7 +64,7 @@ index 209ff74..16406af 100755
      while ((count = Pm_Read(midi_in, &event, 1))) {
          if (count == 1) output(event.message);
 -        else            printf(Pm_GetErrorText(count));
-+        else            puts(Pm_GetErrorText(count));
++        else            printf("%s", Pm_GetErrorText(count));
      }
  }
  
@@ -73,7 +73,7 @@ index 209ff74..16406af 100755
      err = Pm_OpenInput(&midi_in, inp, NULL, 512, NULL, NULL);
      if (err) {
 -        printf(Pm_GetErrorText(err));
-+        puts(Pm_GetErrorText(err));
++        printf("%s", Pm_GetErrorText(err));
          Pt_Stop();
          mmexit(1);
      }
@@ -82,7 +82,7 @@ index 209ff74..16406af 100755
      /* note octave correction below */
      sprintf(result, "%s%d", ptos[p % 12], (p / 12) - 1);
 -    printf(result);
-+    fputs(result, stdout);
++    printf("%s", result);
      return strlen(result);
  }
  
@@ -95,7 +95,7 @@ index 627a3df..512d603 100755
      char line[STRING_MAX];
      int n = 0, i;
 -    printf(prompt);
-+    fputs(prompt, stdout);
++    printf("%s", prompt);
      while (n != 1) {
          n = scanf("%d", &i);
          fgets(line, STRING_MAX, stdin);
@@ -108,7 +108,7 @@ index 03d6331..00707cb 100755
      char line[STRING_MAX];
      int n = 0, i;
 -    printf(prompt);
-+    fputs(prompt, stdout);
++    printf("%s", prompt);
      while (n != 1) {
          n = scanf("%d", &i);
          fgets(line, STRING_MAX, stdin);

--- a/portmidi/0001-fix-build-with-Werror-format-security.patch
+++ b/portmidi/0001-fix-build-with-Werror-format-security.patch
@@ -1,0 +1,117 @@
+From fa24b4246368c6a007b909a2754dbbbeba1c79e7 Mon Sep 17 00:00:00 2001
+From: cubercsl <2014cais01@gmail.com>
+Date: Tue, 11 Jan 2022 02:08:05 +0800
+Subject: [PATCH] fix: build with -Werror-format-security
+
+---
+ test/latency.c   | 2 +-
+ test/midiclock.c | 4 ++--
+ test/mm.c        | 8 ++++----
+ test/sysex.c     | 2 +-
+ test/test.c      | 2 +-
+ 5 files changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/test/latency.c b/test/latency.c
+index 507648c..a3d5b4c 100755
+--- a/test/latency.c
++++ b/test/latency.c
+@@ -280,7 +280,7 @@ int get_number(char *prompt)
+ {
+     char line[STRING_MAX];
+     int n = 0, i;
+-    printf(prompt);
++    fputs(prompt, stdout);
+     while (n != 1) {
+         n = scanf("%d", &i);
+         fgets(line, STRING_MAX, stdin);
+diff --git a/test/midiclock.c b/test/midiclock.c
+index 60fcf7a..4031ab0 100644
+--- a/test/midiclock.c
++++ b/test/midiclock.c
+@@ -167,7 +167,7 @@ int get_number(char *prompt)
+ {
+     char line[STRING_MAX];
+     int n = 0, i;
+-    printf(prompt);
++    fputs(prompt, stdout);
+     while (n != 1) {
+         n = scanf("%d", &i);
+         fgets(line, STRING_MAX, stdin);
+@@ -256,7 +256,7 @@ int main(int argc, char **argv)
+     err = Pm_OpenOutput(&midi, outp, DRIVER_INFO, OUTPUT_BUFFER_SIZE, 
+                         TIME_PROC, TIME_INFO, LATENCY);
+     if (err) {
+-        printf(Pm_GetErrorText(err));
++        puts(Pm_GetErrorText(err));
+         goto error_exit_no_device;
+     }
+     active = true;
+diff --git a/test/mm.c b/test/mm.c
+index 209ff74..16406af 100755
+--- a/test/mm.c
++++ b/test/mm.c
+@@ -119,7 +119,7 @@ int get_number(char *prompt)
+ {
+     char line[STRING_MAX];
+     int n = 0, i;
+-    printf(prompt);
++    fputs(prompt, stdout);
+     while (n != 1) {
+         n = scanf("%d", &i);
+         fgets(line, STRING_MAX, stdin);
+@@ -136,7 +136,7 @@ void receive_poll(PtTimestamp timestamp, void *userData)
+     if (!active) return;
+     while ((count = Pm_Read(midi_in, &event, 1))) {
+         if (count == 1) output(event.message);
+-        else            printf(Pm_GetErrorText(count));
++        else            puts(Pm_GetErrorText(count));
+     }
+ }
+ 
+@@ -168,7 +168,7 @@ int main(int argc, char **argv)
+     inp = get_number("Type input device number: ");
+     err = Pm_OpenInput(&midi_in, inp, NULL, 512, NULL, NULL);
+     if (err) {
+-        printf(Pm_GetErrorText(err));
++        puts(Pm_GetErrorText(err));
+         Pt_Stop();
+         mmexit(1);
+     }
+@@ -484,7 +484,7 @@ private int put_pitch(int p)
+         "gs", "a", "bf", "b"    };
+     /* note octave correction below */
+     sprintf(result, "%s%d", ptos[p % 12], (p / 12) - 1);
+-    printf(result);
++    fputs(result, stdout);
+     return strlen(result);
+ }
+ 
+diff --git a/test/sysex.c b/test/sysex.c
+index 627a3df..512d603 100755
+--- a/test/sysex.c
++++ b/test/sysex.c
+@@ -39,7 +39,7 @@ int get_number(char *prompt)
+ {
+     char line[STRING_MAX];
+     int n = 0, i;
+-    printf(prompt);
++    fputs(prompt, stdout);
+     while (n != 1) {
+         n = scanf("%d", &i);
+         fgets(line, STRING_MAX, stdin);
+diff --git a/test/test.c b/test/test.c
+index 03d6331..00707cb 100755
+--- a/test/test.c
++++ b/test/test.c
+@@ -37,7 +37,7 @@ int get_number(char *prompt)
+ {
+     char line[STRING_MAX];
+     int n = 0, i;
+-    printf(prompt);
++    fputs(prompt, stdout);
+     while (n != 1) {
+         n = scanf("%d", &i);
+         fgets(line, STRING_MAX, stdin);
+-- 
+2.34.1
+

--- a/portmidi/riscv64.patch
+++ b/portmidi/riscv64.patch
@@ -1,5 +1,5 @@
 diff --git PKGBUILD.orig PKGBUILD
-index 0bc7507..40b2158 100644
+index 0bc7507..61cb9ed 100644
 --- PKGBUILD.orig
 +++ PKGBUILD
 @@ -11,9 +11,17 @@
@@ -12,9 +12,9 @@ index 0bc7507..40b2158 100644
 +source=("${pkgname}-${pkgver}.tar.gz::https://github.com/mixxxdj/portmidi/archive/refs/tags/${pkgver}.tar.gz"
 +        "0001-fix-build-with-Werror-format-security.patch")
 +sha512sums=('901729440c4b8c654ab17c4c4f1e3986813bf1e4ad1a874f46e7b1ee0c9ef4ee9f1ecfdf71012fb56b055a6185194dd22c520ae87b9f2259c18af5d189ca57da'
-+            '7d633c16eae96dc111bba7908bf671505d5a152676c08bb0ac22e71ee739e906a12a8a3cdc7cea547635ec6156f0dcac5f8c6a23e20f12057b42fc0f32c54e12')
++            'f45952d72a36cb0166e45529893e2ff8b9795f592f322d9ffef35a4c3f55dff206f3d470cdd071696f71f44270f5d6ff368e34eef3153d81b154edbe5df0998d')
 +b2sums=('618c3778b8b2170a145ec956cd4721e731cc135d0192e4b1c35b2c93b6b0f0e74085d044beafe2095b3d8e02e1776f442ae174d342c3f391d04a2aab378b547a'
-+        '01014429ecea06411e312c5861eeb601e9c9e07b8716afac47dd469fefe76f30e737e654065fded11a30a6d872e201f1f2950a2d6cb2e5ea581ba374e8536098')
++        'ed782e2b208a2af19e1590bb59b5c7f5e62dd7f053b1f563e446c480c5ac8563196e0c1604b9ebe046f88c0e28835bd1875086b8a3184c659f994f7a23576f63')
 +
 +prepare() {
 +  cd "${pkgname}-${pkgver}"

--- a/portmidi/riscv64.patch
+++ b/portmidi/riscv64.patch
@@ -1,0 +1,25 @@
+diff --git PKGBUILD.orig PKGBUILD
+index 0bc7507..40b2158 100644
+--- PKGBUILD.orig
++++ PKGBUILD
+@@ -11,9 +11,17 @@
+ depends=('glibc')
+ makedepends=('alsa-lib' 'cmake')
+ provides=('libportmidi.so' 'libporttime.so')
+-source=("${pkgname}-${pkgver}.tar.gz::https://github.com/mixxxdj/portmidi/archive/refs/tags/${pkgver}.tar.gz")
+-sha512sums=('901729440c4b8c654ab17c4c4f1e3986813bf1e4ad1a874f46e7b1ee0c9ef4ee9f1ecfdf71012fb56b055a6185194dd22c520ae87b9f2259c18af5d189ca57da')
+-b2sums=('618c3778b8b2170a145ec956cd4721e731cc135d0192e4b1c35b2c93b6b0f0e74085d044beafe2095b3d8e02e1776f442ae174d342c3f391d04a2aab378b547a')
++source=("${pkgname}-${pkgver}.tar.gz::https://github.com/mixxxdj/portmidi/archive/refs/tags/${pkgver}.tar.gz"
++        "0001-fix-build-with-Werror-format-security.patch")
++sha512sums=('901729440c4b8c654ab17c4c4f1e3986813bf1e4ad1a874f46e7b1ee0c9ef4ee9f1ecfdf71012fb56b055a6185194dd22c520ae87b9f2259c18af5d189ca57da'
++            '7d633c16eae96dc111bba7908bf671505d5a152676c08bb0ac22e71ee739e906a12a8a3cdc7cea547635ec6156f0dcac5f8c6a23e20f12057b42fc0f32c54e12')
++b2sums=('618c3778b8b2170a145ec956cd4721e731cc135d0192e4b1c35b2c93b6b0f0e74085d044beafe2095b3d8e02e1776f442ae174d342c3f391d04a2aab378b547a'
++        '01014429ecea06411e312c5861eeb601e9c9e07b8716afac47dd469fefe76f30e737e654065fded11a30a6d872e201f1f2950a2d6cb2e5ea581ba374e8536098')
++
++prepare() {
++  cd "${pkgname}-${pkgver}"
++  patch -Np1 -i ../0001-fix-build-with-Werror-format-security.patch
++}
+ 
+ build() {
+   cd "${pkgname}-${pkgver}"


### PR DESCRIPTION
upstream's commit https://github.com/mixxxdj/portmidi/commit/7c82f8873962045d2aa6b1e02e1431c073ec13b4 may fix build with `-Werror-format-security`, but without a tag release.