### PR TITLE
updpkg: qt5-base

### DIFF
--- a/qt5-base/riscv64.patch
+++ b/qt5-base/riscv64.patch
@@ -1,17 +1,8 @@
-Index: PKGBUILD
-===================================================================
---- PKGBUILD	(revision 424590)
-+++ PKGBUILD	(working copy)
-@@ -13,7 +13,7 @@
- depends=('libjpeg-turbo' 'xcb-util-keysyms' 'xcb-util-renderutil' 'libgl' 'fontconfig' 'xdg-utils'
-          'shared-mime-info' 'xcb-util-wm' 'libxrender' 'libxi' 'sqlite' 'xcb-util-image' 'mesa'
-          'tslib' 'libinput' 'libxkbcommon-x11' 'libproxy' 'libcups' 'double-conversion' 'md4c')
--makedepends=('libfbclient' 'mariadb-libs' 'unixodbc' 'postgresql-libs' 'alsa-lib' 'gst-plugins-base-libs'
-+makedepends=('mariadb-libs' 'unixodbc' 'postgresql-libs' 'alsa-lib' 'gst-plugins-base-libs'
-              'gtk3' 'libpulse' 'cups' 'freetds' 'vulkan-headers' 'git')
- optdepends=('qt5-svg: to use SVG icon themes'
-             'qt5-wayland: to run Qt applications in a Wayland session'
-@@ -47,6 +47,8 @@
+diff --git PKGBUILD PKGBUILD
+index ade41d18..8afac7e4 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -47,6 +47,8 @@ prepare() {
  
    patch -p1 < ../qt5-base-cflags.patch # Use system CFLAGS in qmake
    patch -p1 < ../qt5-base-nostrip.patch # Don't strip binaries with qmake
@@ -20,20 +11,3 @@ Index: PKGBUILD
  }
  
  build() {
-@@ -60,7 +62,7 @@
-     -datadir /usr/share/qt \
-     -sysconfdir /etc/xdg \
-     -examplesdir /usr/share/doc/qt/examples \
--    -plugin-sql-{psql,mysql,sqlite,odbc,ibase} \
-+    -plugin-sql-{psql,mysql,sqlite,odbc} \
-     -system-sqlite \
-     -openssl-linked \
-     -nomake examples \
-@@ -70,7 +72,6 @@
-     -journald \
-     -no-mimetype-database \
-     -no-use-gold-linker \
--    -reduce-relocations \
-     -no-strip
-   make
- }


### PR DESCRIPTION
Note that removal of `libfbclient` from `makedepends` might be unnecessary. Currently working on building `libfbclient` on RISC-V.