### PR TITLE
upgpkg: dtc 1.6.1-3

### DIFF
--- a/dtc/riscv64.patch
+++ b/dtc/riscv64.patch
@@ -1,19 +1,10 @@
-Index: PKGBUILD
-===================================================================
---- PKGBUILD	(revision 1010218)
-+++ PKGBUILD	(working copy)
+diff --git PKGBUILD PKGBUILD
+index 98a08790..d5e3b17f 100644
+--- PKGBUILD
++++ PKGBUILD
 @@ -9,7 +9,6 @@
  arch=(x86_64)
  license=(GPL2)
  makedepends=(swig python)
 -checkdepends=(valgrind)
- source=(https://www.kernel.org/pub/software/utils/dtc/dtc-$pkgver.tar.xz)
- sha256sums=('65cec529893659a49a89740bb362f507a3b94fc8cd791e76a8d6a2b6f3203473')
- 
-@@ -30,5 +29,5 @@
- 
- package() {
-   cd dtc-$pkgver
--  DESTDIR="$pkgdir" make SETUP_PREFIX="$pkgdir/usr" PREFIX="$pkgdir/usr" install
-+  DESTDIR="$pkgdir" make SETUP_PREFIX="$pkgdir/usr" PREFIX="$pkgdir/usr" install -j1
- }
+ source=(https://www.kernel.org/pub/software/utils/dtc/dtc-$pkgver.tar.xz


### PR DESCRIPTION
`-j1` appears not needed.