### PR TITLE
addpkg: python-pytest-flake8

### DIFF
--- a/python-pytest-flake8/riscv64.patch
+++ b/python-pytest-flake8/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD.orig PKGBUILD
+index ad9d962..9c109f6 100644
+--- PKGBUILD.orig
++++ PKGBUILD
+@@ -11,7 +11,7 @@
+ source=("$pkgname-$pkgver.tar.gz::https://github.com/tholo/pytest-flake8/archive/$pkgver.tar.gz"
+         $pkgname-python310.patch::https://github.com/tholo/pytest-flake8/pull/82.patch)
+ sha512sums=('c71d08eefcafe5503a660d8495c3520a9ae26ba701095c13111b33dc420fed03a2cbffa889eef08488ab5254ed001fd43b3a4757ffa2011cc3b4bd80d078f3c1'
+-            '7b7e5793216ac2aef35ce96122b99ce63f4e2acbdf9ae5a6d8f5719cafa1e725ac3afa5d1421c106bc1ce3f6d2d6794ff2c98c67204194e4651fc170c52670f1')
++            'af8fd1c68fba1c678f13aba6ce80dbb23d0c1ed91a9fb507657d217d7d01b4e6fd6ad0f49b12eaced304e93fd0557cb1b67c4a7982f19e9cb9ca24716c148df5')
+ 
+ prepare() {
+   cd pytest-flake8-$pkgver


### PR DESCRIPTION
upstream pr has force pushes, which break the checksum.

https://github.com/tholo/pytest-flake8/pull/82#issuecomment-999525745