### PR TITLE
addpkg: python-behave

### DIFF
--- a/python-behave/riscv64.patch
+++ b/python-behave/riscv64.patch
@@ -1,0 +1,22 @@
+diff --git PKGBUILD.orig PKGBUILD
+index 0eaa36f..09146d0 100644
+--- PKGBUILD.orig
++++ PKGBUILD
+@@ -10,8 +10,15 @@
+ depends=('python-cucumber-tag-expressions' 'python-parse' 'python-parse-type' 'python-six')
+ makedepends=('python-setuptools')
+ checkdepends=('python-mock' 'python-path' 'python-pyhamcrest' 'python-pytest' 'python-pytest-html')
+-source=("https://github.com/behave/behave/archive/v$pkgver/$pkgname-$pkgver.tar.gz")
+-sha512sums=('a352a2f1594831b3c85a54225e5bd4f425ab06c38e708b6ec65f1c8fb2eb3a92924baa15d5742c344e58ac95773f00393aa1338bd839dd8345f701eb37ce62b6')
++source=("https://github.com/behave/behave/archive/v$pkgver/$pkgname-$pkgver.tar.gz"
++        "remove_use_2to3.patch::https://github.com/behave/behave/commit/34ec5097f33c9b1620714d8dd95e75901559668b.patch")
++sha512sums=('a352a2f1594831b3c85a54225e5bd4f425ab06c38e708b6ec65f1c8fb2eb3a92924baa15d5742c344e58ac95773f00393aa1338bd839dd8345f701eb37ce62b6'
++            '73947299bce238426c1bec25ad0f762b43fc2cb0b79eb3b56568b68be8a9e7dbc9eebf5d1694df3cabdef08b43976f4a0ea19a30d523f7fa4be974294283fce3')
++
++prepare() {
++  cd behave-$pkgver
++  patch -Np1 -i ../remove_use_2to3.patch
++}
+ 
+ build() {
+   cd behave-$pkgver


### PR DESCRIPTION
- depends: python-cucumber-tag-expressions #618 should build first.
- checkdeps: python-pytest-html, python-pytest-metadata should rebuild first.