### PR TITLE
addpkg: trash-cli

### DIFF
--- a/trash-cli/riscv64.patch
+++ b/trash-cli/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD.orig PKGBUILD
+index 0fecb71..ce497f9 100644
+--- PKGBUILD.orig
++++ PKGBUILD
+@@ -12,7 +12,7 @@
+ license=('GPL')
+ depends=('python-psutil')
+ makedepends=('python-setuptools')
+-checkdepends=('python-pytest')
++checkdepends=('python-pytest' 'python-six')
+ source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/${pkgver}.tar.gz")
+ sha256sums=('37601b714b9a42b217765c6eb7ae20b36796b92c642feea6bd275e1c702799ed')
+ 


### PR DESCRIPTION
Package [python-six](https://archlinux.org/packages/extra/any/python-six/) is no longer a dependencies of [python-packaging](https://archlinux.org/packages/extra/any/python-packaging/) in official testing repo.

python-setuptools -> python-packaging -> python-six

So `python-six` is missing in checkdepends now.

See also: 

https://github.com/andreafrancia/trash-cli/blob/6af27f3f1dd79a2b0989db618be9f10215c230c8/requirements-dev.txt#L1-L3
