### PR TITLE
addpkg: prometheuse-blackbox-exporter

### DIFF
--- a/prometheus-blackbox-exporter/riscv64.patch
+++ b/prometheus-blackbox-exporter/riscv64.patch
@@ -1,0 +1,12 @@
+diff --git PKGBUILD PKGBUILD
+index a1159da..ff75688 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,6 +12,7 @@ makedepends=(go git)
+ source=($pkgname-$pkgver.tar.gz::https://github.com/prometheus/blackbox_exporter/archive/v${pkgver}.tar.gz prometheus-blackbox-exporter.service)
+ sha512sums=('86b11bc7afa0d8261d0961ca21563047b1ea8bfd1a9d4d034c393a8b098b035147883a44011cdafca8e9795a5e9a043cc15235375990f3424137af63469a8878'
+             'b32d7772cbd8a2fc741d827a7f221d1302ab0c5833c095e5b6dc6befa46a1b12c22e91252fd0e4cf07c9c309d6315c6e1d020508a3baaaa891ab9f7f7d690eae')
++options=(!lto)
+ 
+ check() {
+   cd blackbox_exporter-$pkgver


### PR DESCRIPTION
* check
  The test is failing on IPV6 request. This test can be skipped by setting environment variable `CI`.

* build
  The `-flto` ldflags is unnecessary for building the program.