### PR TITLE
addpkg: python-mtrpacket

### DIFF
--- a/python-mtrpacket/riscv64.patch
+++ b/python-mtrpacket/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -9,7 +9,7 @@ license=('MIT')
+ arch=('any')
+ depends=('mtr' 'python')
+ makedepends=('python-setuptools')
+-checkdepends=('gnu-netcat')
++checkdepends=('openbsd-netcat')
+ source=("https://github.com/matt-kimball/mtr-packet-python/archive/$pkgver/$pkgname-$pkgver.tar.gz")
+ sha512sums=('15d201256f0ab372f71fefab32a6836194a180aa45d1b0460716c9bcd5ebc51aa241bcb982613f81ccda2384bef0e97decfebbe94b19f3f4a9e6a3deda62f89b')
+ 


### PR DESCRIPTION
`gnu-netcat` does not work properly on `riscv64` architecture, causing the 2nd test case to fail. This is not related to `qemu`.