### PR TITLE
addpkg: alot

### DIFF
--- a/alot/riscv64.patch
+++ b/alot/riscv64.patch
@@ -1,0 +1,19 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -39,7 +39,16 @@ build() {
+ 
+ check() {
+   cd alot-$pkgver
++
++  # Provide empty config file for alot to make it happy
++  mkdir -p $HOME/.config/alot
++  touch $HOME/.config/alot/hooks.py
++  # Provide empty config file for notmuch to make it happy
++  touch $HOME/.notmuch-config
++
+   python setup.py test
++
++  rm -rf $HOME/.config/alot $HOME/.notmuch-config
+ }
+ 
+ package() {


### PR DESCRIPTION
Requires dependencies to be rebuilt before merge: `outdated_dep [python-magic] [python-urwidtrees]`