### PR TITLE
addpkg: git-cliff

### DIFF
--- a/git-cliff/riscv64.patch
+++ b/git-cliff/riscv64.patch
@@ -1,0 +1,12 @@
+diff --git PKGBUILD PKGBUILD
+index 41f2770..75e9a35 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -11,6 +11,7 @@ depends=('gcc-libs' 'zlib')
+ makedepends=('rust')
+ source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
+ sha512sums=('4be5894d30bc9c39f8e910e5ccf5f4ab158efc4b238b55f0fb4a16c86e1e8eb7abffb20f08dad8f1a0adcd154b9053f52c2309f65f6c3db24c3da16a3fd4fada')
++options=(!lto)
+ 
+ prepare() {
+   cd "$pkgname-$pkgver"


### PR DESCRIPTION
The rustc compiler fail to link library due to lto option.