### PR TITLE
addpkg: findomain

### DIFF
--- a/findomain/riscv64.patch
+++ b/findomain/riscv64.patch
@@ -1,0 +1,12 @@
+diff --git PKGBUILD PKGBUILD
+index 067b417..66a261f 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,6 +14,7 @@ makedepends=('cargo')
+ optdepends=('postgresql: for subdomain monitoring')
+ source=("https://github.com/${_pkgname}/${_pkgname}/archive/${pkgver}/${pkgname}-${pkgver}.tar.gz")
+ b2sums=('a3c1440cedd6e522a3a1df5685db040bd915f25ea8bfbdc9224445309e649e26bf568182a4d3ce93ab0fb194ef2caaccff8eb54da0581cc586306551e5a8cfe2')
++options=(!lto)
+ 
+ build() {
+   cd ${_pkgname}-${pkgver}


### PR DESCRIPTION
The rustc compiler fail to link library due to the lto option.