### PR TITLE
Update qemu-user-blacklist.txt

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -1,6 +1,7 @@
 bmake
 caps
 dovecot
+ethtool
 gpxsee
 gupnp
 gxplugins.lv2


### PR DESCRIPTION
Ethtool's functionality is limited in QEMU environment And it will cause the failure in check.