### PR TITLE
upgpkg: sfizz

### DIFF
--- a/sfizz/riscv64.patch
+++ b/sfizz/riscv64.patch
@@ -1,25 +1,27 @@
-diff --git PKGBUILD PKGBUILD
-index d790989..2423f28 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -20,12 +20,20 @@ optdepends=(
+@@ -20,9 +20,15 @@ optdepends=(
    'vst3-host: for the VST3 plugin'
  )
- provides=('libsfizz.so' 'soundfont-synthesizer')
+ provides=(libsfizz.so)
 -source=("https://github.com/sfztools/${pkgname}/releases/download/${pkgver}/${pkgname}-${pkgver}.tar.gz")
--sha512sums=('541f07c18e96ebf7dfa9977b4e6aa69b37e7146f3b2e88276363f7cc5c6f34d3d71a166854fcdc688f89368beeb8eb3a78edf5c8fedb3c89bd2f79f32b31d941')
--b2sums=('2d9b1cabc58d312ee0ac6837bb917369d8ec1785d1dd59a9d0e00d51b4371f98cfddb58fc713f9cafcec072129b8d5cf13870efbf00715fff44aa38a59ec3ddf')
+-sha512sums=('fd8500a9e94acee4cd61053ce9d6fd85e6dcee56c198e986557bb40b35a7ac902a4e3544bce4a13349a00f9d3024509db1a805ef442abdf94cb63cfadf0df81d')
+-b2sums=('cecedcd1a1f6268f84b1e878b264226566d43b091cfc8d522084ed3af24a030b0840833dc093300d3e8b933398401b6ea619f36fe1df6ff04544eabf2850665c')
 +source=("https://github.com/sfztools/${pkgname}/releases/download/${pkgver}/${pkgname}-${pkgver}.tar.gz"
-+		"add_riscv64_support.patch"
-+		"add_missing_header.patch")
-+sha512sums=('541f07c18e96ebf7dfa9977b4e6aa69b37e7146f3b2e88276363f7cc5c6f34d3d71a166854fcdc688f89368beeb8eb3a78edf5c8fedb3c89bd2f79f32b31d941'
-+            "07713b5663d2532b1c54246675d1627f42ba802702ec55c9ac6e3d9229e444cee7f3c8b8f85c44454e36e4fa4800ea6409e34389a26650f8c0a284901ef8516d"
-+            "aad8d252300a8d8f67e8203b59fd44412151e0f72440d897fc323b09cc80c6065f1019bf30e8872cd116c6c714a0b7d147a8bca1af00dbc16b628626df8c82f1")
-+b2sums=('2d9b1cabc58d312ee0ac6837bb917369d8ec1785d1dd59a9d0e00d51b4371f98cfddb58fc713f9cafcec072129b8d5cf13870efbf00715fff44aa38a59ec3ddf'
-+        "3948cf918d548f23e153f059589ac44c3c03d4f028b4aec1a7ba12d5f3d76e16f4e93a2882f30925d3824b15655bdf238a8d90080cab6ec8b7f97ab5feb985d8"
-+        "22c4aaaeeef497ff596069b591b6089abb4d699c4480efbefaff7c399b355a82d0f90d4d825c13fed6327b3236a9bf05d2016a6cbc31aa9a5fe088309563d251")
++        "add_riscv64_support.patch"
++        "add_missing_header.patch")
++sha512sums=('fd8500a9e94acee4cd61053ce9d6fd85e6dcee56c198e986557bb40b35a7ac902a4e3544bce4a13349a00f9d3024509db1a805ef442abdf94cb63cfadf0df81d'
++            '07713b5663d2532b1c54246675d1627f42ba802702ec55c9ac6e3d9229e444cee7f3c8b8f85c44454e36e4fa4800ea6409e34389a26650f8c0a284901ef8516d'
++            'aad8d252300a8d8f67e8203b59fd44412151e0f72440d897fc323b09cc80c6065f1019bf30e8872cd116c6c714a0b7d147a8bca1af00dbc16b628626df8c82f1')
++b2sums=('cecedcd1a1f6268f84b1e878b264226566d43b091cfc8d522084ed3af24a030b0840833dc093300d3e8b933398401b6ea619f36fe1df6ff04544eabf2850665c'
++        '3948cf918d548f23e153f059589ac44c3c03d4f028b4aec1a7ba12d5f3d76e16f4e93a2882f30925d3824b15655bdf238a8d90080cab6ec8b7f97ab5feb985d8'
++        '22c4aaaeeef497ff596069b591b6089abb4d699c4480efbefaff7c399b355a82d0f90d4d825c13fed6327b3236a9bf05d2016a6cbc31aa9a5fe088309563d251')
  
  prepare() {
+   # symlink tests data to top-level location so that tests can get to them
+@@ -34,6 +40,8 @@ prepare() {
+   cp -av /usr/include/vst3sdk/* plugins/vst/external/VST_SDK/VST3_SDK/
+   )
    cd "$pkgname-$pkgver"
 +  patch -Np1 -i ../add_riscv64_support.patch
 +  patch -Np1 -i ../add_missing_header.patch


### PR DESCRIPTION
Leaf package `vst3sdk` needs to be built before building this package. `vst3sdk`'s status is stalled; it does not depend on `gtkmm3` any more, and could be built directly from source.