### PR TITLE
addpkg: gn

### DIFF
--- a/gn/riscv64.patch
+++ b/gn/riscv64.patch
@@ -1,0 +1,12 @@
+diff --git PKGBUILD PKGBUILD
+index 4a6226f..64c60df 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,6 +12,7 @@ depends=('gcc-libs')
+ makedepends=('clang' 'ninja' 'python' 'git')
+ source=(git+https://gn.googlesource.com/gn#commit=$_commit)
+ sha256sums=('SKIP')
++options=(!lto)
+ 
+ pkgver() {
+   cd $pkgname


### PR DESCRIPTION
ld can't link soft-float modules with double-float modules with lto enabled. This package can be built with the lto option off. But lto is not the main reason for the build failure. So this patch can be removed when lto is correctly handling the float module.