### PR TITLE
addpkg: gnome-passwordsafe

### DIFF
--- a/gnome-passwordsafe/remove-incorrect-i18n.merge_file-argument.patch
+++ b/gnome-passwordsafe/remove-incorrect-i18n.merge_file-argument.patch
@@ -1,0 +1,20 @@
+diff --git a/data/meson.build b/data/meson.build
+index 46f63735..26a2c185 100644
+--- a/data/meson.build
++++ b/data/meson.build
+@@ -35,7 +35,6 @@ if get_option('profile') == 'development'
+ endif
+ desktop_conf.set('ICON', application_id)
+ desktop = i18n.merge_file(
+-  'desktop',
+   input: configure_file(
+     input: files('org.gnome.PasswordSafe.desktop.in.in'),
+     output: 'org.gnome.PasswordSafe.desktop.in',
+@@ -65,7 +64,6 @@ if get_option('profile') == 'development'
+ endif
+ appdata_conf.set('APPID', application_id)
+ appdata = i18n.merge_file(
+-  'appdata',
+   input: configure_file(
+     input: files('org.gnome.PasswordSafe.appdata.xml.in.in'),
+     output: 'org.gnome.PasswordSafe.appdata.xml.in',

--- a/gnome-passwordsafe/riscv64.patch
+++ b/gnome-passwordsafe/riscv64.patch
@@ -1,0 +1,29 @@
+diff --git PKGBUILD PKGBUILD
+index b86c485..7cade20 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -10,14 +10,22 @@
+ depends=(libhandy libpwquality python-gobject python-pykeepass)
+ makedepends=(git gobject-introspection meson)
+ _commit=868a3a9c25258033bc2859b80bea554838dbecf4
+-source=("git+https://gitlab.gnome.org/World/PasswordSafe.git/#commit=$_commit")
+-sha256sums=('SKIP')
++source=("git+https://gitlab.gnome.org/World/PasswordSafe.git/#commit=$_commit"
++        "remove-incorrect-i18n.merge_file-argument.patch")
++sha256sums=('SKIP'
++            '4a8ff344004c6e106c576fe9dd90e736e5a3225321a849f35a4853d6ab4fb7c4')
+ 
+ pkgver() {
+   cd PasswordSafe
+   git describe --tags | sed 's/-/+/g'
+ }
+ 
++prepare() {
++  cd PasswordSafe
++  # https://gitlab.gnome.org/World/secrets/-/merge_requests/604
++  patch -Np1 -i ../remove-incorrect-i18n.merge_file-argument.patch
++}
++
+ build() {
+   arch-meson PasswordSafe build
+   ninja -C build


### PR DESCRIPTION
Note: The latest upstream release changed the project name from "Passwordsafe" to "Secrets" which may cause the package name of archlinux to become the latter one.

