### PR TITLE
fixpkg: sympol

### DIFF
--- a/sympol/riscv64.patch
+++ b/sympol/riscv64.patch
@@ -1,5 +1,5 @@
 diff --git PKGBUILD PKGBUILD
-index 6ae176f..7ac2312 100644
+index 0b42c021..8ea876a8 100644
 --- PKGBUILD
 +++ PKGBUILD
 @@ -10,13 +10,15 @@ license=(GPL2)
@@ -7,10 +7,12 @@ index 6ae176f..7ac2312 100644
          cddlib-0.94k.patch
          sympol-fix-headers.patch
 -        sympol-lrs-071.patch)
+-depends=(boost-libs lrs cddlib)
+-makedepends=(cmake permlib eigen bliss)
 +        sympol-lrs-071.patch
 +        sympol-fix-bliss-interface.patch)
- depends=(boost-libs lrs cddlib)
- makedepends=(cmake permlib eigen bliss)
++depends=(boost-libs lrs cddlib bliss)
++makedepends=(cmake permlib eigen)
  sha256sums=('6753b8fb30745b66a0886e125c18b539417afcf62b804799eb220bd5a59ccc37'
              '23f85255ad1acbaf9c63134c6d331e0f3b8d06230a05e3f63e57399863579649'
              'f3ed90e6b9af5dae0728c52ce4bb9107f3040481cac6c08116dbf8c19bfe3971'


### PR DESCRIPTION
Fix uninstalled dependency: `bliss` and bump pkgrel to 10.1
`namcap` reports reference to `libbliss.so` from `libsympol.so.0.1.9`