### PR TITLE
addpkg: gjs

### DIFF
--- a/gjs/riscv64.patch
+++ b/gjs/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index 0c00f66..fa52079 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,7 +12,7 @@
+ depends=(cairo gobject-introspection-runtime js78 dconf readline
+          libsysprof-capture)
+ makedepends=(gobject-introspection git meson dbus)
+-checkdepends=(valgrind xorg-server-xvfb gtk3 gtk4)
++checkdepends=(xorg-server-xvfb gtk3 gtk4)
+ provides=(libgjs.so)
+ _commit=f17afbffec385030c1b47dab992f7e08232fea50  # tags/1.70.1^0
+ source=("git+https://gitlab.gnome.org/GNOME/gjs.git#commit=$_commit")


### PR DESCRIPTION
According to upstream [hacking guide](https://gitlab.gnome.org/GNOME/gjs/-/blob/1.70.1/doc/Hacking.md#valgrind), running the test suite under Valgrind's memcheck tool should use args `--setup=valgrind`, but it doesn't actually do this in tests on official x86_64 repository. [FS#73716](https://bugs.archlinux.org/task/73716)