### PR TITLE
xdg-desktop-portal-bootstrap: fix dir

### DIFF
--- a/xdg-desktop-portal-bootstrap/PKGBUILD
+++ b/xdg-desktop-portal-bootstrap/PKGBUILD
@@ -3,6 +3,7 @@
 # Contributor: Patrick Griffis <tingping@tingping.se>
 
 pkgname=xdg-desktop-portal-bootstrap
+_pkgname=xdg-desktop-portal
 pkgver=1.12.1
 pkgrel=1
 pkgdesc="Desktop integration portals for sandboxed apps - Bootstrap"
@@ -18,29 +19,29 @@ source=("git+https://github.com/flatpak/xdg-desktop-portal#commit=$_commit")
 sha256sums=('SKIP')
 
 pkgver() {
-  cd $pkgname
+  cd $_pkgname
   git describe --tags | sed 's/[^-]*-g/r&/;s/-/+/g'
 }
 
 prepare() {
-  cd $pkgname
+  cd $_pkgname
   NOCONFIGURE=1 ./autogen.sh
 }
 
 build() {
-  cd $pkgname
+  cd $_pkgname
   ./configure --prefix=/usr --libexecdir=/usr/lib
   make 
 }
 
 check() {
-  cd $pkgname
+  cd $_pkgname
   make check
 }
 
 package() {
   depends+=(xdg-desktop-portal-impl)
 
-  cd $pkgname
+  cd $_pkgname
   make DESTDIR="$pkgdir" install
 }


### PR DESCRIPTION
My fault :cry: 

Build order: `xdg-desktop-portal-bootstrap` -> `xdg-desktop-portal`