### PR TITLE
fixpkg: linuxsampler

### DIFF
--- a/linuxsampler/riscv64.patch
+++ b/linuxsampler/riscv64.patch
@@ -1,7 +1,12 @@
+diff --git PKGBUILD PKGBUILD
+index e9277d6..4a07fe8 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -19,13 +19,16 @@ optdepends=('dssi-host: for DSSI plugin'
+@@ -17,15 +17,19 @@ makedepends=('clang' 'dssi' 'ladspa' 'lv2')
+ optdepends=('dssi-host: for DSSI plugin'
+             'lv2-host: for LV2 plugin')
  provides=('liblinuxsampler.so')
++options=(!lto)
  source=("https://download.linuxsampler.org/packages/${pkgname}-${pkgver}.tar.bz2"
          "${pkgname}-2.2.0-libdir.patch"
 -        "${pkgname}-2.2.0-libgig_package.patch")
@@ -20,7 +25,7 @@
  
  prepare(){
    cd "${pkgname}-${pkgver}"
-@@ -33,6 +36,8 @@ prepare(){
+@@ -33,6 +37,8 @@ prepare(){
    patch -Np1 -i ../"${pkgname}-2.2.0-libdir.patch"
    # fix generation of instruments in package()
    patch -Np1 -i ../"${pkgname}-2.2.0-libgig_package.patch"


### PR DESCRIPTION
LTO plugin for clang is broken. Disable it.