### PR TITLE
addpkg: ksysguard

### DIFF
--- a/ksysguard/riscv64.patch
+++ b/ksysguard/riscv64.patch
@@ -1,0 +1,14 @@
+diff --git PKGBUILD PKGBUILD
+index 9fe30f6..d89ddcc 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,7 +14,8 @@
+ source=(https://download.kde.org/stable/$pkgname/$pkgver/$pkgname-$pkgver.tar.xz{,.sig})
+ sha256sums=('0f9c624e5fbb2aee906d8d9563c5a7eb09eaf38bc8e4382c072f9e6d8854622d'
+             'SKIP')
+-validpgpkeys=('E0A3EB202F8E57528E13E72FD7574483BB57B18D'  # Jonathan Esk-Riddell <jr@jriddell.org>
++validpgpkeys=('2D1D5B0588357787DE9EE225EC94D18F7F05997E'  # Jonathan Riddell <jr@jriddell.org>
++              'E0A3EB202F8E57528E13E72FD7574483BB57B18D'  # Jonathan Esk-Riddell <jr@jriddell.org>
+               '0AAC775BB6437A8D9AF7A3ACFE0784117FBCE11D'  # Bhushan Shah <bshah@kde.org>
+               'D07BD8662C56CB291B316EB2F5675605C74E02CF'  # David Edmundson <davidedmundson@kde.org>
+               '1FA881591C26B276D7A5518EEAAF29B42A678C20') # Marco Martin <notmart@gmail.com>


### PR DESCRIPTION
The validgpgkey has been changed since https://github.com/archlinux/svntogit-packages/commit/08e076c13c6dd6e4471a5f4672b5d7c87907c439

[FS#73800](https://bugs.archlinux.org/task/73800)
