### PR TITLE
Addpkg: js91

### DIFF
--- a/js91/riscv64.patch
+++ b/js91/riscv64.patch
@@ -1,0 +1,108 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,9 +12,11 @@ makedepends=(zip autoconf2.13 python-setuptools python-psutil rust llvm clang ll
+ checkdepends=(mercurial git)
+ options=(!lto)
+ _relver=${pkgver}esr
+-source=(https://archive.mozilla.org/pub/firefox/releases/$_relver/source/firefox-$_relver.source.tar.xz{,.asc})
++source=(https://archive.mozilla.org/pub/firefox/releases/$_relver/source/firefox-$_relver.source.tar.xz{,.asc}
++        tests-skip-some-tests-on-rv64.patch)
+ sha256sums=('36049694505ff5edd1a086480e5a3d29fedd3f0b0d4a8a27a271a66e8fc6cd1f'
+-            'SKIP')
++            'SKIP'
++            '1518e134fd5448d48f960bedbe7db061d5a8b368d43db2cac7f4b1adf094c748')
+ validpgpkeys=('14F26682D0916CDD81E37B6D61B7B526D98F0353') # Mozilla Software Releases <release@mozilla.com>
+ 
+ # Make sure the duplication between bin and lib is found
+@@ -24,6 +26,7 @@ prepare() {
+   mkdir mozbuild
+   cd firefox-$pkgver
+ 
++  patch -Np1 < "../tests-skip-some-tests-on-rv64.patch" 
+   cat >../mozconfig <<END
+ ac_add_options --enable-application=js
+ mk_add_options MOZ_OBJDIR=${PWD@Q}/obj
+@@ -33,12 +36,13 @@ ac_add_options --enable-release
+ ac_add_options --enable-hardening
+ ac_add_options --enable-optimize
+ ac_add_options --enable-rust-simd
+-ac_add_options --enable-linker=lld
++ac_add_options --enable-linker=bfd
+ ac_add_options --disable-bootstrap
+ ac_add_options --disable-debug
+ ac_add_options --disable-debug-symbols
+ ac_add_options --disable-jemalloc
+ ac_add_options --disable-strip
++ac_add_options --disable-jit
+ 
+ # System libraries
+ ac_add_options --with-system-zlib
+@@ -59,43 +63,42 @@ build() {
+   export MOZBUILD_STATE_PATH="$srcdir/mozbuild"
+   export MACH_USE_SYSTEM_PYTHON=1
+ 
+-  # Do 3-tier PGO
+-  echo "Building instrumented JS..."
++  ## Do 3-tier PGO
++  #echo "Building instrumented JS..."
+   cat >.mozconfig ../mozconfig - <<END
+-ac_add_options --enable-profile-generate=cross
+ END
+   ./mach build
+ 
+-  echo "Profiling instrumented JS..."
+-  (
+-    local js="$PWD/obj/dist/bin/js"
+-    export LLVM_PROFILE_FILE="$PWD/js-%p-%m.profraw"
++  #echo "Profiling instrumented JS..."
++  #(
++  #  local js="$PWD/obj/dist/bin/js"
++  #  export LLVM_PROFILE_FILE="$PWD/js-%p-%m.profraw"
+ 
+-    cd js/src/octane
+-    "$js" run.js
++  #  cd js/src/octane
++  #  "$js" run.js
+ 
+-    cd ../../../third_party/webkit/PerformanceTests/ARES-6
+-    "$js" cli.js
++  #  cd ../../../third_party/webkit/PerformanceTests/ARES-6
++  #  "$js" cli.js
+ 
+-    cd ../SunSpider/sunspider-0.9.1
+-    "$js" sunspider-standalone-driver.js
+-  )
++  #  cd ../SunSpider/sunspider-0.9.1
++  #  "$js" sunspider-standalone-driver.js
++  #)
+ 
+-  llvm-profdata merge -o merged.profdata *.profraw
++  #illvm-profdata merge -o merged.profdata *.profraw
+ 
+-  stat -c "Profile data found (%s bytes)" merged.profdata
+-  test -s merged.profdata
++  #stat -c "Profile data found (%s bytes)" merged.profdata
++  #test -s merged.profdata
+ 
+-  echo "Removing instrumented JS..."
+-  ./mach clobber
++  #echo "Removing instrumented JS..."
++  #./mach clobber
+ 
+-  echo "Building optimized JS..."
+-  cat >.mozconfig ../mozconfig - <<END
+-ac_add_options --enable-lto=cross
+-ac_add_options --enable-profile-use=cross
+-ac_add_options --with-pgo-profile-path=${PWD@Q}/merged.profdata
+-END
+-  ./mach build
++  #echo "Building optimized JS..."
++  #cat >.mozconfig ../mozconfig - <<END
++#ac_add_options --enable-lto=cross
++#ac_add_options --enable-profile-use=cross
++#ac_add_options --with-pgo-profile-path=${PWD@Q}/merged.profdata
++#END
++#  ./mach build
+ }
+ 
+ check() {

--- a/js91/riscv64.patch
+++ b/js91/riscv64.patch
@@ -1,20 +1,20 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -12,9 +12,11 @@ makedepends=(zip autoconf2.13 python-setuptools python-psutil rust llvm clang ll
+@@ -12,9 +12,11 @@
  checkdepends=(mercurial git)
  options=(!lto)
  _relver=${pkgver}esr
 -source=(https://archive.mozilla.org/pub/firefox/releases/$_relver/source/firefox-$_relver.source.tar.xz{,.asc})
 +source=(https://archive.mozilla.org/pub/firefox/releases/$_relver/source/firefox-$_relver.source.tar.xz{,.asc}
 +        tests-skip-some-tests-on-rv64.patch)
- sha256sums=('36049694505ff5edd1a086480e5a3d29fedd3f0b0d4a8a27a271a66e8fc6cd1f'
+ sha256sums=('7e802832152c39588b9a5c8392e90c1b00036bf948fa4a97a7af0d1435ba09a1'
 -            'SKIP')
 +            'SKIP'
 +            '1518e134fd5448d48f960bedbe7db061d5a8b368d43db2cac7f4b1adf094c748')
  validpgpkeys=('14F26682D0916CDD81E37B6D61B7B526D98F0353') # Mozilla Software Releases <release@mozilla.com>
  
  # Make sure the duplication between bin and lib is found
-@@ -24,6 +26,7 @@ prepare() {
+@@ -24,6 +26,7 @@
    mkdir mozbuild
    cd firefox-$pkgver
  
@@ -22,7 +22,7 @@
    cat >../mozconfig <<END
  ac_add_options --enable-application=js
  mk_add_options MOZ_OBJDIR=${PWD@Q}/obj
-@@ -33,12 +36,13 @@ ac_add_options --enable-release
+@@ -33,12 +36,13 @@
  ac_add_options --enable-hardening
  ac_add_options --enable-optimize
  ac_add_options --enable-rust-simd
@@ -37,7 +37,7 @@
  
  # System libraries
  ac_add_options --with-system-zlib
-@@ -59,43 +63,42 @@ build() {
+@@ -59,43 +63,42 @@
    export MOZBUILD_STATE_PATH="$srcdir/mozbuild"
    export MACH_USE_SYSTEM_PYTHON=1
  

--- a/js91/tests-skip-some-tests-on-rv64.patch
+++ b/js91/tests-skip-some-tests-on-rv64.patch
@@ -1,0 +1,27 @@
+diff --unified --recursive --text a/js/src/tests/non262/Array/regress-157652.js b/js/src/tests/non262/Array/regress-157652.js
+--- a/js/src/tests/non262/Array/regress-157652.js	2022-02-16 20:45:04.795659521 +0800
++++ b/js/src/tests/non262/Array/regress-157652.js	2022-02-16 21:58:08.905996653 +0800
+@@ -1,4 +1,4 @@
+-// |reftest| skip-if(xulRuntime.XPCOMABI.match(/x86_64|aarch64|ppc64|ppc64le|s390x|mips64/)||Android) -- No test results
++// |reftest| skip-if(xulRuntime.XPCOMABI.match(/x86_64|aarch64|ppc64|ppc64le|s390x|mips64|riscv64/)||Android) -- No test results
+ /* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+ /* This Source Code Form is subject to the terms of the Mozilla Public
+  * License, v. 2.0. If a copy of the MPL was not distributed with this
+diff --unified --recursive --text a/js/src/tests/non262/Array/regress-330812.js b/js/src/tests/non262/Array/regress-330812.js
+--- a/js/src/tests/non262/Array/regress-330812.js	2022-02-16 20:45:04.798992836 +0800
++++ b/js/src/tests/non262/Array/regress-330812.js	2022-02-16 21:58:54.699088464 +0800
+@@ -1,4 +1,4 @@
+-// |reftest| slow-if(xulRuntime.XPCOMABI.match(/x86_64|aarch64|ppc64|ppc64le|s390x|mips64/)||Android) -- No test results
++// |reftest| skip-if(xulRuntime.XPCOMABI.match(/x86_64|aarch64|ppc64|ppc64le|s390x|mips64|riscv64/)||Android) -- No test results
+ /* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+ /* This Source Code Form is subject to the terms of the Mozilla Public
+  * License, v. 2.0. If a copy of the MPL was not distributed with this
+diff --unified --recursive --text a/js/src/tests/non262/regress/regress-422348.js b/js/src/tests/non262/regress/regress-422348.js
+--- a/js/src/tests/non262/regress/regress-422348.js	2022-02-16 20:45:04.715659964 +0800
++++ b/js/src/tests/non262/regress/regress-422348.js	2022-02-16 21:59:55.658750431 +0800
+@@ -1,4 +1,4 @@
+-// |reftest| skip-if(xulRuntime.XPCOMABI.match(/x86_64|aarch64|ppc64|ppc64le|s390x|mips64/)) -- On 64-bit, takes forever rather than throwing
++// |reftest| skip-if(xulRuntime.XPCOMABI.match(/x86_64|aarch64|ppc64|ppc64le|s390x|mips64|riscv64/)) -- On 64-bit, takes forever rather than throwing
+ /* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+ /* This Source Code Form is subject to the terms of the Mozilla Public
+  * License, v. 2.0. If a copy of the MPL was not distributed with this


### PR DESCRIPTION
1. Refer to [js78](https://github.com/felixonmars/archriscv-packages/pull/87) to determine mozconfig options .
2. Refer to [this](https://sources.debian.org/patches/mozjs78/78.4.0-2/tests-Use-DEB_HOST_ARCH_BITS-to-skip-some-tests-on-64-bit.patch/) to skip some tests.(Some tests need to be skipped on 64-bit architectures.)