### PR TITLE
addpkg: scummvm

### DIFF
--- a/scummvm/riscv64.patch
+++ b/scummvm/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,6 +12,7 @@ url="http://www.scummvm.org/"
+ depends=('libpng' 'libtheora' 'sdl2' 'sdl2_net' 'fluidsynth' 'flac' 'faad2' 'libvorbis' 'libmad' 'freetype2'
+          'libgl' 'glu' 'libjpeg-turbo' 'libmpeg2' 'curl' 'a52dec' 'giflib' 'glew' 'libspeechd' 'gtk3' 'sndio')
+ makedepends=('mesa')
++options=(!lto)
+ source=("https://downloads.scummvm.org/frs/${pkgname}/${pkgver}/${pkgname}-${pkgver}.tar.xz")
+ sha512sums=('5e5aaf247e26434dd1594547a3066dce6f52e12370532b8bff09ae22149d697f6d3ab0a94b5c1cf578b2b8cba32d1cd6e5dc30fe0cd6266c8f2b23cba13d7d03')
+ b2sums=('08fb2fa6cbeec3c1ec24a9b660aab4344f0dbcf4c42655392315aef0ce78105b2a669ef9c82fc09bc389856e592e4e5249d84512b288e7d790914d5caee3972d')


### PR DESCRIPTION
LTO disabled due to:

```
g++: fatal error: Killed signal terminated program lto1
compilation terminated.
lto-wrapper: fatal error: /usr/bin/g++ returned 1 exit status
compilation terminated.
/usr/bin/ld: error: lto-wrapper failed
collect2: error: ld returned 1 exit status
```