### PR TITLE
addpkg: muse

### DIFF
--- a/muse/riscv64.patch
+++ b/muse/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -13,6 +13,7 @@ makedepends=('alsa-lib' 'cmake' 'dssi' 'fluidsynth' 'glib2' 'jack' 'ladspa'
+ 'liblo' 'liblrdf' 'libsamplerate' 'libsndfile' 'lilv' 'lv2' 'qt5-tools'
+ 'rtaudio' 'rubberband' 'serd')
+ provides=('dssi-host' 'ladspa-host' 'lv2-host' 'vst-host')
++options=(!lto)
+ source=("$pkgname-$pkgver.tar.gz::https://github.com/muse-sequencer/muse/archive/refs/tags/${pkgver}.tar.gz")
+ sha512sums=('316d8afaa4412c1de3febd06f517245fcc0f380b78efab8a59041653c70828496e95f4ebd2e06ea080fb494c69ab73457e77264166be50b85abf093835d6c2d4')
+ b2sums=('7b9fd19d5f9a5bf776d00f3c4695b7fb214de4e5be629c05edb82daa0113784b7cd42e2204ebca83fd7f6b82801a0bb9b815cc5618fa48d8d512a30af3e9b09f')


### PR DESCRIPTION
Disabled LTO due to the following errors:

```
(trimmed)
/usr/bin/ld: driver/libmuse_driver.so: undefined reference to `MusECore::MidiDevice::latencyCompWriteOffsetMidi(bool) const'
/usr/bin/ld: libmuse_lv2host_module.so: undefined reference to `MusECore::SynthIF::fileName() const'
/usr/bin/ld: driver/libmuse_driver.so: undefined reference to `MusECore::MidiDevice::canDominateEndPointLatencyMidi(bool) const'
/usr/bin/ld: libmuse_lv2host_module.so: undefined reference to `MusECore::SynthIF::pluginID()'
/usr/bin/ld: libmuse_lv2host_module.so: undefined reference to `MusECore::SynthIF::readConfiguration(MusECore::Xml&, bool)'
/usr/bin/ld: libmuse_lv2host_module.so: undefined reference to `MusECore::SynthIF::setOn(bool)'
/usr/bin/ld: driver/libmuse_driver.so: undefined reference to `MusECore::MidiDevice::canPassThruLatencyMidi(bool) const'
/usr/bin/ld: driver/libmuse_driver.so: undefined reference to `MusECore::MidiDevice::canDominateInputLatencyMidi(bool) const'
/usr/bin/ld: libmuse_lv2host_module.so: undefined reference to `MusECore::SynthIF::hasBypass() const'
collect2: error: ld returned 1 exit status
```