### PR TITLE
addpkg: npm

### DIFF
--- a/npm/riscv64.patch
+++ b/npm/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -18,6 +18,12 @@ sha512sums=('c4fa90ca1f244c1b0096c2a2127e8c88ce92f9a0a0d57bfe18fa41941f201566281
+ 
+ prepare() {
+   cd cli-$pkgver
++
++  # fix: possible racing condition fails the build process, so we invoke this manually
++  node ./bin/npm-cli.js install --ignore-scripts --no-audit
++  # guard test: this should success, indicating a successful install
++  node ./bin/npm-cli.js ls
++
+   mkdir -p node_modules/.bin
+   ln -sf /usr/bin/marked{,-man} node_modules/.bin/
+ 


### PR DESCRIPTION
The `node ./bin/npm-cli.js install --ignore-scripts --no-audit` command is provided in `Makefile`. In practice, this `Makefile` target might cause the test to fail (in a vague way) if it didn't install dependencies correctly.

This PR attempts to make sure dependencies are correctly installed in `prepare()` stage.