### PR TITLE
addpkg: non-sequencer

### DIFF
--- a/non-sequencer/riscv64.patch
+++ b/non-sequencer/riscv64.patch
@@ -1,0 +1,23 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -10,8 +10,8 @@ groups=('non-daw' 'pro-audio')
+ depends=('cairo' 'gcc-libs' 'glibc' 'hicolor-icon-theme' 'libjack.so'
+ 'liblo.so' 'libntk.so' 'libntk_images.so' 'libsigc++' 'libx11')
+ makedepends=('waf')
+-source=("$pkgname-$pkgver.tar.gz::https://git.tuxfamily.org/non/non.git/snapshot/${pkgname}-v${pkgver}.tar.gz"
+-        "https://raw.githubusercontent.com/original-male/non/d958df0486c7397c243f5ac36bf4acbc461a1e50/tools.waf/ntk_fluid.py")
++source=("$pkgname-$pkgver.tar.gz::https://pb.mgt.moe/qk6o.tar.gz"  # extracted from https://repo.ialab.dsu.edu/archlinux/sources/community/
++        "https://raw.githubusercontent.com/linuxaudio/non/d958df0486c7397c243f5ac36bf4acbc461a1e50/tools.waf/ntk_fluid.py")
+ sha512sums=('1c7537586671293c6f4463f00a6848d3ae5528aabbea82084b9b82e043790bebcea5ec877cacd88c31a953807a19db4b4027ad763a1f869e0725e677a89d2162'
+             '9f45474fa51a8c3eed672d633a77d968ddee6b841589764378f08386f711ae1a6801c795c19d8987f1af9a36b5a6bcdaab2230db5359004ad73e791dbac50bc4')
+ 
+@@ -29,7 +29,8 @@ prepare() {
+ 
+ build() {
+   cd "${pkgname}-${pkgver}"
+-  waf configure --prefix=/usr --project=sequencer
++  CXXFLAGS+=" -std=c++14"
++  waf configure --prefix=/usr --project=sequencer --disable-sse
+   waf
+ }
+ 


### PR DESCRIPTION
FS#72109

> Also note that `CXXFLAGS+=" -std=c++14"` must be appended before waf configure to make it work. Otherwise, g++ will complain:
>
> ```
> ../sequencer/src/grid.H:127:11: error: reference to ‘data’ is ambiguous
> 127 | const data * volatile _rd;
>     |       ^~~~
> ```
>
> This is caused by `using namespace std;` and `std::data`.

This identifier occurs in such a great amount of files, that simply renaming the `data` identifier becomes too risky.