### PR TITLE
upgpkg: gcc

### DIFF
--- a/gcc/riscv64.patch
+++ b/gcc/riscv64.patch
@@ -4,21 +4,26 @@
  # toolchain build order: linux-api-headers->glibc->binutils->gcc->glibc->binutils->gcc
  # NOTE: libtool requires rebuilt with each new gcc version
  
--pkgname=(gcc gcc-libs gcc-fortran gcc-objc gcc-ada gcc-go lib32-gcc-libs gcc-d)
-+pkgname=(gcc gcc-libs gcc-fortran gcc-objc gcc-go gcc-d)
+-pkgname=(gcc gcc-libs lib32-gcc-libs gcc-fortran gcc-objc gcc-ada gcc-go gcc-d libgccjit)
++pkgname=(gcc gcc-libs gcc-fortran gcc-objc gcc-go gcc-d libgccjit)
  pkgver=11.2.0
  _majorver=${pkgver%%.*}
  _islver=0.24
-@@ -16,7 +16,7 @@ pkgdesc='The GNU Compiler Collection'
- arch=(x86_64)
- license=(GPL LGPL FDL custom)
- url='https://gcc.gnu.org'
--makedepends=(binutils libmpc gcc-ada doxygen lib32-glibc lib32-gcc-libs python git libxcrypt zstd)
-+makedepends=(binutils libmpc doxygen python git zstd)
- checkdepends=(dejagnu inetutils tcl expect python-pytest)
- options=(!emptydirs !lto debug)
- _libdir=usr/lib/gcc/$CHOST/${pkgver%%+*}
-@@ -27,6 +27,7 @@ source=(https://sourceware.org/pub/gcc/releases/gcc-${pkgver}/gcc-${pkgver}.tar.
+@@ -19,13 +19,9 @@ url='https://gcc.gnu.org'
+ makedepends=(
+   binutils
+   doxygen
+-  gcc-ada
+   git
+-  lib32-glibc
+-  lib32-gcc-libs
+   libisl
+   libmpc
+-  libxcrypt
+   python
+   zstd
+ )
+@@ -44,6 +40,7 @@ source=(https://sourceware.org/pub/gcc/releases/gcc-${pkgver}/gcc-${pkgver}.tar.
          c89 c99
          gdc_phobos_path.patch
          gcc-ada-repro.patch
@@ -26,7 +31,7 @@
  )
  validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
                86CFFCA918CF3AF47147588051E8B148A9999C34  # evangelos@foutrelis.com
-@@ -38,7 +39,8 @@ sha256sums=('d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b'
+@@ -54,7 +51,8 @@ sha256sums=('d08edc536b54c372a1010ff6619dd274c0f1603aa49212ba20f7aa2cda36fa8b'
              'de48736f6e4153f03d0a5d38ceb6c6fdb7f054e8f47ddd6af0a3dbf14f27b931'
              '2513c6d9984dd0a2058557bf00f06d8d5181734e41dcfe07be7ed86f2959622a'
              'c86372c207d174c0918d4aedf1cb79f7fc093649eb1ad8d9450dccc46849d308'
@@ -36,18 +41,27 @@
  
  prepare() {
    [[ ! -d gcc ]] && ln -s gcc-${pkgver/+/-} gcc
-@@ -62,6 +64,8 @@ prepare() {
+@@ -72,6 +70,8 @@ prepare() {
    # Reproducible gcc-ada
    patch -Np0 < "$srcdir/gcc-ada-repro.patch"
  
 +  patch -Np1 < "$srcdir/change-lto-arg.patch"  # disable lto bootstrap because it is faulty
 +
    mkdir -p "$srcdir/gcc-build"
+   mkdir -p "$srcdir/libgccjit-build"
  }
+@@ -95,7 +95,7 @@ build() {
+       --enable-gnu-unique-object \
+       --enable-linker-build-id \
+       --enable-lto \
+-      --enable-multilib \
++      --disable-multilib \
+       --enable-plugin \
+       --enable-shared \
+       --enable-threads=posix \
+@@ -108,6 +108,9 @@ build() {
  
-@@ -73,6 +77,9 @@ build() {
-   CXXFLAGS=${CXXFLAGS/-flto/}
-   LDFLAGS=${LDFLAGS/-flto/}
+   cd gcc-build
  
 +  CFLAGS=${CFLAGS/-Wp,-D_FORTIFY_SOURCE=2/}
 +  CXXFLAGS=${CXXFLAGS/-Wp,-D_FORTIFY_SOURCE=2/}
@@ -55,25 +69,16 @@
    # Credits @allanmcrae
    # https://github.com/allanmcrae/toolchain/blob/f18604d70c5933c31b51a320978711e4e6791cf1/gcc/PKGBUILD
    # TODO: properly deal with the build issues resulting from this
-@@ -85,7 +92,7 @@ build() {
-       --mandir=/usr/share/man \
-       --infodir=/usr/share/info \
-       --with-bugurl=https://bugs.archlinux.org/ \
--      --enable-languages=c,c++,ada,fortran,go,lto,objc,obj-c++,d \
-+      --enable-languages=c,c++,fortran,go,lto,objc,obj-c++,d \
-       --with-isl \
-       --with-linker-hash-style=gnu \
-       --with-system-zlib \
-@@ -99,7 +106,7 @@ build() {
-       --enable-gnu-unique-object \
-       --enable-linker-build-id \
-       --enable-lto \
--      --enable-multilib \
-+      --disable-multilib \
-       --enable-pgo-build=lto \
-       --enable-plugin \
-       --enable-shared \
-@@ -137,7 +144,7 @@ package_gcc-libs() {
+@@ -115,7 +118,7 @@ build() {
+   CXXFLAGS=${CXXFLAGS/-Werror=format-security/}
+ 
+   "$srcdir/gcc/configure" \
+-    --enable-languages=c,c++,ada,fortran,go,lto,objc,obj-c++,d \
++    --enable-languages=c,c++,fortran,go,lto,objc,obj-c++,d \
+     --enable-bootstrap \
+     $_confflags
+ 
+@@ -165,7 +168,7 @@ package_gcc-libs() {
    depends=('glibc>=2.27')
    options=(!emptydirs !strip)
    provides=($pkgname-multilib libgo.so libgfortran.so libgphobos.so
@@ -82,7 +87,7 @@
    replaces=($pkgname-multilib libgphobos)
  
    cd gcc-build
-@@ -148,11 +155,9 @@ package_gcc-libs() {
+@@ -176,11 +179,9 @@ package_gcc-libs() {
               libgfortran \
               libgo \
               libgomp \
@@ -96,7 +101,7 @@
      make -C $CHOST/$lib DESTDIR="$pkgdir" install-toolexeclibLTLIBRARIES
    done
  
-@@ -164,14 +169,10 @@ package_gcc-libs() {
+@@ -192,14 +193,10 @@ package_gcc-libs() {
    rm -f "$pkgdir"/usr/lib/libgphobos.spec
  
    for lib in libgomp \
@@ -111,15 +116,15 @@
    # Install Runtime Library Exception
    install -Dm644 "$srcdir/gcc/COPYING.RUNTIME" \
      "$pkgdir/usr/share/licenses/gcc-libs/RUNTIME.LIBRARY.EXCEPTION"
-@@ -181,7 +182,6 @@ package_gcc() {
+@@ -209,7 +206,6 @@ package_gcc() {
    pkgdesc="The GNU Compiler Collection - C and C++ frontends"
-   depends=("gcc-libs=$pkgver-$pkgrel" 'binutils>=2.28' libmpc zstd)
+   depends=("gcc-libs=$pkgver-$pkgrel" 'binutils>=2.28' libmpc zstd libisl.so)
    groups=('base-devel')
 -  optdepends=('lib32-gcc-libs: for generating code for 32-bit ABI')
    provides=($pkgname-multilib)
    replaces=($pkgname-multilib)
    options=(!emptydirs staticlibs debug)
-@@ -195,22 +195,18 @@ package_gcc() {
+@@ -223,22 +219,18 @@ package_gcc() {
    install -m755 -t "$pkgdir/${_libdir}/" gcc/{cc1,cc1plus,collect2,lto1}
  
    make -C $CHOST/libgcc DESTDIR="$pkgdir" install
@@ -144,7 +149,7 @@
  
    make DESTDIR="$pkgdir" install-fixincludes
    make -C gcc DESTDIR="$pkgdir" install-mkheaders
-@@ -221,20 +217,14 @@ package_gcc() {
+@@ -249,20 +241,14 @@ package_gcc() {
      "$pkgdir/usr/lib/bfd-plugins/"
  
    make -C $CHOST/libgomp DESTDIR="$pkgdir" install-nodist_{libsubinclude,toolexeclib}HEADERS
@@ -166,7 +171,7 @@
  
    make -C libcpp DESTDIR="$pkgdir" install
    make -C gcc DESTDIR="$pkgdir" install-po
-@@ -249,9 +239,6 @@ package_gcc() {
+@@ -277,9 +263,6 @@ package_gcc() {
    # install the libstdc++ man pages
    make -C $CHOST/libstdc++-v3/doc DESTDIR="$pkgdir" doc-install-man
  
@@ -176,7 +181,7 @@
    # byte-compile python libraries
    python -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
    python -O -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
-@@ -271,8 +258,6 @@ package_gcc-fortran() {
+@@ -299,8 +282,6 @@ package_gcc-fortran() {
    cd gcc-build
    make -C $CHOST/libgfortran DESTDIR="$pkgdir" install-cafexeclibLTLIBRARIES \
      install-{toolexeclibDATA,nodist_fincludeHEADERS,gfor_cHEADERS}
@@ -185,13 +190,13 @@
    make -C $CHOST/libgomp DESTDIR="$pkgdir" install-nodist_fincludeHEADERS
    make -C gcc DESTDIR="$pkgdir" fortran.install-{common,man,info}
    install -Dm755 gcc/f951 "$pkgdir/${_libdir}/f951"
-@@ -302,45 +287,6 @@ package_gcc-objc() {
+@@ -330,45 +311,6 @@ package_gcc-objc() {
      "$pkgdir/usr/share/licenses/$pkgname/"
  }
  
 -package_gcc-ada() {
 -  pkgdesc='Ada front-end for GCC (GNAT)'
--  depends=("gcc=$pkgver-$pkgrel")
+-  depends=("gcc=$pkgver-$pkgrel" libisl.so)
 -  provides=($pkgname-multilib)
 -  replaces=($pkgname-multilib)
 -  options=(!emptydirs staticlibs debug)
@@ -230,8 +235,8 @@
 -
  package_gcc-go() {
    pkgdesc='Go front-end for GCC'
-   depends=("gcc=$pkgver-$pkgrel")
-@@ -350,11 +296,10 @@ package_gcc-go() {
+   depends=("gcc=$pkgver-$pkgrel" libisl.so)
+@@ -378,11 +320,10 @@ package_gcc-go() {
  
    cd gcc-build
    make -C $CHOST/libgo DESTDIR="$pkgdir" install-exec-am
@@ -244,7 +249,7 @@
    install -Dm755 gcc/go1 "$pkgdir/${_libdir}/go1"
  
    # Install Runtime Library Exception
-@@ -363,43 +308,6 @@ package_gcc-go() {
+@@ -391,43 +332,6 @@ package_gcc-go() {
      "$pkgdir/usr/share/licenses/$pkgname/"
  }
  
@@ -287,8 +292,8 @@
 -
  package_gcc-d() {
    pkgdesc="D frontend for GCC"
-   depends=("gcc=$pkgver-$pkgrel")
-@@ -415,7 +323,6 @@ package_gcc-d() {
+   depends=("gcc=$pkgver-$pkgrel" libisl.so)
+@@ -443,7 +347,6 @@ package_gcc-d() {
  
    make -C $CHOST/libphobos DESTDIR="$pkgdir" install
    rm -f "$pkgdir/usr/lib/"lib{gphobos,gdruntime}.so*


### PR DESCRIPTION
Package `libisl`, required by `libgccjit`, needs to be built before attempting to build `gcc`. It is marked as `#ready` now.