### PR TITLE
addpkg: prometheus-blackbox-exporter

### DIFF
--- a/prometheus-blackbox-exporter/riscv64.patch
+++ b/prometheus-blackbox-exporter/riscv64.patch
@@ -1,0 +1,12 @@
+diff --git PKGBUILD PKGBUILD
+--- PKGBUILD
++++ PKGBUILD
+@@ -25,7 +25,7 @@ build() {
+     -buildmode=pie \
+     -mod=readonly \
+     -modcacherw \
+-    -ldflags "-linkmode external -extldflags ${LDFLAGS} \
++    -ldflags "-linkmode external -extldflags \"${LDFLAGS} -Wl,-plugin-opt=-target-abi=lp64d\" \
+       -X github.com/prometheus/common/version.Version=$pkgver \
+       -X github.com/prometheus/common/version.Revision=$pkgver \
+       -X github.com/prometheus/common/version.Branch=tarball \


### PR DESCRIPTION
This patch fix the -flto flag not found issue.

Notice:
  - One of the test needs to resolve ipv6.google.com, so a proper resolver is required.