### PR TITLE
updpkg: java-openjdk

### DIFF
--- a/java-openjdk/java17-riscv64.patch
+++ b/java-openjdk/java17-riscv64.patch
@@ -37,11 +37,11 @@ Index: jdk17u-jdk-17-35/make/autoconf/jvm-features.m4
 --- jdk17u-jdk-17-35.orig/make/autoconf/jvm-features.m4
 +++ jdk17u-jdk-17-35/make/autoconf/jvm-features.m4
 @@ -307,7 +307,8 @@ AC_DEFUN_ONCE([JVM_FEATURES_CHECK_SHENAN
-   JVM_FEATURES_CHECK_AVAILABILITY(shenandoahgc, [
      AC_MSG_CHECKING([if platform is supported by Shenandoah])
      if test "x$OPENJDK_TARGET_CPU_ARCH" = "xx86" || \
--        test "x$OPENJDK_TARGET_CPU" = "xaarch64" ; then
-+        test "x$OPENJDK_TARGET_CPU" = "xaarch64" || \
+         test "x$OPENJDK_TARGET_CPU" = "xaarch64" || \
+-        test "x$OPENJDK_TARGET_CPU" = "xppc64le"; then
++        test "x$OPENJDK_TARGET_CPU" = "xppc64le" || \
 +        test "x$OPENJDK_TARGET_CPU" = "xriscv64" ; then
        AC_MSG_RESULT([yes])
      else
@@ -56879,8 +56879,8 @@ Index: jdk17u-jdk-17-35/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
  #include "utilities/defaultStream.hpp"
  
  void ShenandoahArguments::initialize() {
--#if !(defined AARCH64 || defined AMD64 || defined IA32)
-+#if !(defined AARCH64 || defined AMD64 || defined IA32 || defined RISCV64)
+-#if !(defined AARCH64 || defined AMD64 || defined IA32 || defined PPC64)
++#if !(defined AARCH64 || defined AMD64 || defined IA32 || defined PPC64 || defined RISCV64)
    vm_exit_during_initialization("Shenandoah GC is not supported on this platform.");
  #endif
  

--- a/java-openjdk/riscv64.patch
+++ b/java-openjdk/riscv64.patch
@@ -1,7 +1,7 @@
 diff --git PKGBUILD PKGBUILD
 --- PKGBUILD
 +++ PKGBUILD
-@@ -17,15 +17,17 @@
+@@ -17,16 +17,18 @@
  arch=('x86_64')
  url='https://openjdk.java.net/'
  license=('custom')
@@ -11,13 +11,14 @@ diff --git PKGBUILD PKGBUILD
 +             'libxrender' 'libxtst' 'libxt' 'libxext' 'libxrandr' 'alsa-lib'
               'graphviz' 'freetype2' 'libjpeg-turbo' 'giflib' 'libpng' 'lcms2'
               'libnet' 'bash' 'harfbuzz' 'gcc-libs' 'glibc')
+ options=(!lto)
  source=(https://github.com/openjdk/jdk${_majorver}u/archive/${_git_tag}.tar.gz
 +        java17-riscv64.patch
          freedesktop-java.desktop
          freedesktop-jconsole.desktop
          freedesktop-jshell.desktop)
- sha256sums=('8c076203a6f85ab916b3e54de1992bcbcc5ffe580c52b1ac8d52ca7afb9f02d1'
-+            'bbf96674558a801a7db691bff53bceb53f7ac39cd589c0c7f700f4522266436e'
+ sha256sums=('f985bc954c50b9c09d1f8fab698b6591cc46ce3ef6a18570aa192567ff661ca0'
++            '6f598d94ef3aa985bdc1f47e5e1ae8b4b00068e5bdc45996593c10891ef42454'
              '85c4742764590783160af74587a47269e6797fbdf17ec485c7644bd239adf61d'
              'abac1ab09a33a3654378bc69be5a7cf075263ab3ae9efec1eb25cf388e711bb7'
              'e7cce0ecf868f656d8dc2eb25ab82ab665526a0a28aba20f02632dd29962dac3')


### PR DESCRIPTION
It's currently failing due to ```Error: unrecognized opcode `fence.i'``` issues.