### PR TITLE
addpkg: llvm

### DIFF
--- a/llvm/riscv64.patch
+++ b/llvm/riscv64.patch
@@ -1,0 +1,43 @@
+diff --git PKGBUILD PKGBUILD
+index 73edf4a..706d55e 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -3,7 +3,7 @@
+ 
+ pkgname=('llvm' 'llvm-libs' 'llvm-ocaml')
+ pkgver=13.0.1
+-pkgrel=2
++pkgrel=2.1
+ _ocaml_ver=4.13.1
+ arch=('x86_64')
+ url="https://llvm.org/"
+@@ -19,14 +19,16 @@ source=($_source_base/$pkgname-$pkgver.src.tar.xz{,.sig}
+         don-t-move-DBG_VALUE-instructions.patch
+         no-strict-aliasing-DwarfCompileUnit.patch
+         disable-bswap-for-spir.patch
+-        llvm-config.h)
++        llvm-config.h
++        backport-riscv-insn-directive.patch::https://github.com/llvm/llvm-project/commit/283879793dc787225992496587581ec77b6b0610.patch)
+ sha256sums=('ec6b80d82c384acad2dc192903a6cf2cdbaffb889b84bfb98da9d71e630fc834'
+             'SKIP'
+             'a7e902a7612d0fdabe436a917468b043cc296bc89d8954bfc3126f737beb9ac4'
+             'f7d69f84241416398fdb3df8bb44f9fae3c49d89889c7ffa3b37aa2e9d78f708'
+             'd1eff24508e35aae6c26a943dbaa3ef5acb60a145b008fd1ef9ac6f6c4faa662'
+             'af163392fbc19d65d11ab4b1510a2eae39b417d6228023b3ba5395b138bb41f5'
+-            '597dc5968c695bbdbb0eac9e8eb5117fcd2773bc91edf5ec103ecffffab8bc48')
++            '597dc5968c695bbdbb0eac9e8eb5117fcd2773bc91edf5ec103ecffffab8bc48'
++            '03917e6e558a2de500aa59478e66aaff317d338c2282345d1d4d85fda4e3bf4d')
+ validpgpkeys+=('B6C8F98282B944E3B0D5C2530FC3042E345AD05D') # Hans Wennborg <hans@chromium.org>
+ validpgpkeys+=('474E22316ABF4785A88C6E8EA2C794A986419D8A') # Tom Stellard <tstellar@redhat.com>
+ 
+@@ -47,6 +49,10 @@ prepare() {
+ 
+   # Fix an ISPC build failure (https://github.com/ispc/ispc/issues/2189)
+   patch -Np2 -i ../disable-bswap-for-spir.patch
++
++  # Backport llvm14 feature for Rust 1.59.0
++  # Related: https://github.com/rust-lang/stdarch/issues/1291
++  patch -Np2 -i ../backport-riscv-insn-directive.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
Backport for Rust 1.59.0

Related PR:
Divergence: https://github.com/rust-lang/llvm-project/pull/121
Direct cause for build failure on RISC-V: https://github.com/rust-lang/stdarch/pull/1271 , https://github.com/rust-lang/stdarch/pull/1278