### PR TITLE
Update qemu-user-blacklist

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -41,6 +41,7 @@ rbutil
 shfmt
 shotgun
 smplayer
+smtube
 sudo
 sweep
 swtpm


### PR DESCRIPTION
The smtube can't be built on QEMU for now due to the qmake specs issue.