### PR TITLE
addpkg: wit

### DIFF
--- a/wit/riscv64.patch
+++ b/wit/riscv64.patch
@@ -1,0 +1,12 @@
+diff --git PKGBUILD PKGBUILD
+--- PKGBUILD
++++ PKGBUILD
+@@ -42,6 +42,8 @@ prepare() {
+ }
+ 
+ build() {
++  export CFLAGS="$CFLAGS -Wl,-plugin-opt=-target-abi=lp64d"
++  export CXXFLAGS="$CXXFLAGS -Wl,-plugin-opt=-target-abi=lp64d"
+   make INSTALL_PATH="${pkgdir}/usr" CC=clang -C wiimms-iso-tools/project tools
+   make INSTALL_PATH="${pkgdir}/usr" CC=clang -C wiimms-iso-tools/project doc
+ }


### PR DESCRIPTION
This should fix the below error.

```text
/usr/bin/ld: /tmp/lto-llvm-d65f10.o: can't link soft-float modules with double-float modules
```