### PR TITLE
addpkg: libretro-sameboy

### DIFF
--- a/libretro-sameboy/riscv64.patch
+++ b/libretro-sameboy/riscv64.patch
@@ -1,0 +1,11 @@
+diff --git PKGBUILD PKGBUILD
+--- PKGBUILD
++++ PKGBUILD
+@@ -23,6 +23,7 @@ makedepends=(
+ _commit=68f67b3db7747ba7aac84c5c253bc71d5a906525
+ source=(libretro-sameboy::git+https://github.com/libretro/SameBoy.git#commit=${_commit})
+ sha256sums=(SKIP)
++options=(!lto)
+ 
+ pkgver() {
+   cd libretro-sameboy


### PR DESCRIPTION
This should fix the linker error:

1. /usr/bin/ld: warning: LLVM gold plugin: <unknown>:0:0: loop not unrolled:
the optimizer was unable to perform the requested transformation; the
transformation might be disabled or specified as part of an unsupported
transformation ordering
2. /usr/bin/ld: /tmp/lto-llvm-2e9ce6.o: can't link soft-float modules with
double-float modules

Signed-off-by: Avimitin <avimitin@gmail.com>