### PR TITLE
addpkg: smplayer

### DIFF
--- a/smplayer/riscv64.patch
+++ b/smplayer/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -33,6 +33,7 @@ prepare() {
+ build() {
+   cd ${pkgname}-${pkgver}
+   export CXXFLAGS="${CXXFLAGS} ${CPPFLAGS}"
++  export QMAKESPEC=/usr/lib/qt/mkspecs/linux-g++
+   make \
+     PREFIX=/usr \
+     DOC_PATH="\\\"/usr/share/doc/smplayer\\\"" \


### PR DESCRIPTION
This should fix the `WARNING: Could not find qmake spec 'default'` bug. I will write a blog post regarding this.

P.S. the issue is QEMU-related, so probably we should not merge this, but rather keep it as a reference for further use.