### PR TITLE
upgpkg: miniserve

### DIFF
--- a/miniserve/riscv64.patch
+++ b/miniserve/riscv64.patch
@@ -1,13 +1,12 @@
-Index: PKGBUILD
-===================================================================
---- PKGBUILD	(revision 1012943)
-+++ PKGBUILD	(working copy)
-@@ -14,6 +14,8 @@
- 
+diff --git PKGBUILD PKGBUILD
+--- PKGBUILD
++++ PKGBUILD
+@@ -16,6 +16,8 @@ sha512sums=('036893098a31c4962ff247eca74762b629ed8bec65a8bbdb568fef8a4bc35ab0bb3
  build() {
    cd "$srcdir/$pkgname-$pkgver"
-+  echo -e "ring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
-+  cargo update -p ring
  
++  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
++  cargo update -p ring
    cargo build --release --locked
  }
+ 


### PR DESCRIPTION
There are multiple ring denpendencies in miniserve. And the `[patch]`
manifest section can help us overwrite all the dependency.

This patch declare that we're patching the source crates.io. This can
effectively add the git source of `ring` to the crates.io registry.
Whenever crates.io is queried for versions of `ring` it will return the
git source.

Reference:
----------
* https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html