### PR TITLE
addpkg: stylua

### DIFF
--- a/stylua/riscv64.patch
+++ b/stylua/riscv64.patch
@@ -1,0 +1,12 @@
+diff --git PKGBUILD PKGBUILD
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,7 +15,7 @@ b2sums=('46ce79fb17570ad7507fdac8f7707ec0b22c2d6140f17dc6a1947e82c25065f12311e2c
+ 
+ prepare() {
+   cd $_name-$pkgver
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  cargo fetch --locked
+ }
+ 
+ build() {


### PR DESCRIPTION
This should fix the `error: Error loading target specification: Could not find specification for target "riscv64-unknown-linux-gnu".` error.