### PR TITLE
addpkg: selene-linter

### DIFF
--- a/riscv64.patch
+++ b/riscv64.patch
@@ -1,0 +1,12 @@
+diff --git PKGBUILD PKGBUILD
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,7 +15,7 @@ b2sums=('d322c76ee4fe81d33641741d2f012b048b7bcb60c7722d6e1914004a4528a9ba9b24876
+ 
+ prepare() {
+   cd $_name-$pkgver
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  cargo fetch --locked
+ }
+ 
+ build() {


### PR DESCRIPTION
This should fix the `error: Error loading target specification: Could not find specification for target "riscv64-unknown-linux-gnu".` error.