### PR TITLE
addpkg: rustypaste-cli

### DIFF
--- a/rustypaste-cli/riscv64.patch
+++ b/rustypaste-cli/riscv64.patch
@@ -1,0 +1,14 @@
+diff --git PKGBUILD PKGBUILD
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,7 +15,9 @@ sha256sums=('b64ab8ce00af9de5ba1e384c623e0f12d0f01a399472b7b3aab3b5d1bb50606c')
+ 
+ prepare() {
+   cd "${pkgname}-${pkgver}"
+-  cargo fetch --locked --target "${CARCH}-unknown-linux-gnu"
++  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
++  cargo update -p ring
++  cargo fetch --locked
+ }
+ 
+ build(){


### PR DESCRIPTION
This patch fix two issue:
* error: Error loading target specification: Could not find specification
for target "riscv64-unknown-linux-gnu".
* ring: thread 'main' panicked at 'called `Option::unwrap()` on a `None`
value'

Signed-off-by: Avimitin <avimitin@gmail.com>