### PR TITLE
upgpkg: amdvlk 2022.Q1.3-1

### DIFF
--- a/amdvlk/riscv64.patch
+++ b/amdvlk/riscv64.patch
@@ -1,21 +1,21 @@
 diff --git PKGBUILD PKGBUILD
-index 95b9cc91..19269311 100644
+index 9f524bc1..f81d5c96 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -11,8 +11,10 @@ license=('MIT')
- provides=('vulkan-driver')
+@@ -12,8 +12,10 @@ provides=('vulkan-driver')
  makedepends=('perl-xml-xpath' 'python' 'wayland' 'libxrandr' 'xorg-server-devel' 'cmake' 'ninja' 'git')
- makedepends+=('python2') # spvgen
+ makedepends+=('python2' 'clang' 'lld')
+ options=('!lto')
 -source=("https://github.com/GPUOpen-Drivers/AMDVLK/archive/v-${pkgver}.tar.gz")
--sha256sums=('5d6a83f835a5feb4e1d230115bd5a3303d8905ea2f4ba1d6b0735b2130a6b38f')
+-sha256sums=('1ffed5af4d7109e0762b101ca65e608c78e6703ee3caceaf05f17b72f3576138')
 +source=("https://github.com/GPUOpen-Drivers/AMDVLK/archive/v-${pkgver}.tar.gz"
 +        "add_riscv_support.patch")
-+sha256sums=('5d6a83f835a5feb4e1d230115bd5a3303d8905ea2f4ba1d6b0735b2130a6b38f'
++sha256sums=('1ffed5af4d7109e0762b101ca65e608c78e6703ee3caceaf05f17b72f3576138'
 +            '6b57cd0d2edbcc91f84655dd707341b0bb63cc627cff30f2622f827b323d23d9')
              
  prepare() {
    local nrepos path name revision
-@@ -30,6 +32,8 @@ prepare() {
+@@ -31,21 +33,16 @@ prepare() {
        popd
      (( nrepos-- ))
    done
@@ -24,3 +24,18 @@ index 95b9cc91..19269311 100644
  }
  
  build() {
+   cd ${srcdir}/spvgen/external
+   python2 fetch_external_sources.py
+ 
+-  # use lld and clang to fix linking error
+-  # https://github.com/GPUOpen-Drivers/llpc/issues/1645
+   cd ${srcdir}/xgl
+   cmake -H. -Bbuilds/Release64 \
+-    -DCMAKE_C_COMPILER=clang \
+-    -DCMAKE_CXX_COMPILER=clang++ \
+-    -DLLVM_USE_LINKER=lld \
+-    -DCMAKE_EXE_LINKER_FLAGS='-fuse-ld=lld' \
+-    -DCMAKE_SHARED_LINKER_FLAGS='-fuse-ld=lld' \
+     -DCMAKE_BUILD_TYPE=Release \
+     -DBUILD_WAYLAND_SUPPORT=On \
+     -G Ninja


### PR DESCRIPTION
It is no longer required to use lld and clang because the linking error has been fixed. See https://github.com/GPUOpen-Drivers/llpc/issues/1645 and https://github.com/GPUOpen-Drivers/llpc/pull/1698.