### PR TITLE
addpkg: av1an

### DIFF
--- a/av1an/fix-dependency.patch
+++ b/av1an/fix-dependency.patch
@@ -1,0 +1,41 @@
+diff --git Cargo.toml Cargo.toml
+index 4f2762c..d77cea4 100644
+--- Cargo.toml
++++ Cargo.toml
+@@ -18,7 +18,7 @@ name = "av1an"
+ [dependencies]
+ anyhow = "1.0.42"
+ serde_json = "1.0.64"
+-serde = { version = "1.0.126", features = ["serde_derive"] }
++serde = { version = "1.0.132", features = ["serde_derive"] }
+ shlex = "1.0.0"
+ path_abs = "0.5.1"
+ av1an-cli = { path = "av1an-cli", version = "0.3.1" }
+diff --git av1an-cli/Cargo.toml av1an-cli/Cargo.toml
+index afbc8eb..472cb8b 100644
+--- av1an-cli/Cargo.toml
++++ av1an-cli/Cargo.toml
+@@ -32,7 +32,8 @@ default-features = false
+ features = ["git", "build", "rustc", "cargo"]
+ 
+ [dependencies.ffmpeg-next]
+-version = "4.4.0"
++git = "https://github.com/Avimitin/rust-ffmpeg"
++branch = "risc-v"
+ 
+ [features]
+ ffmpeg_static = ["ffmpeg-next/static", "ffmpeg-next/build"]
+diff --git av1an-core/Cargo.toml av1an-core/Cargo.toml
+index 5a44c58..5c1b579 100644
+--- av1an-core/Cargo.toml
++++ av1an-core/Cargo.toml
+@@ -58,7 +58,8 @@ default-features = false
+ features = ["const_generics", "const_new", "union"]
+ 
+ [dependencies.ffmpeg-next]
+-version = "4.4.0"
++git = "https://github.com/Avimitin/rust-ffmpeg"
++branch = "risc-v"
+ 
+ [dependencies.plotters]
+ version = "0.3.1"

--- a/av1an/riscv64.patch
+++ b/av1an/riscv64.patch
@@ -1,0 +1,24 @@
+diff --git PKGBUILD PKGBUILD
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,8 +17,18 @@ optdepends=('svt-av1: SVT-AV1 encoder support'
+             'mkvtoolnix-cli: mkvmerge support'
+             'ffms2: FFMS2 chunk detection support'
+             'vapoursynth-plugin-lsmashsource: L-SMASH chunk detection support')
+-source=("$pkgname-$pkgver.tar.gz"::https://github.com/master-of-zen/Av1an/archive/refs/tags/$pkgver.tar.gz)
+-sha256sums=('67afe7ad356e91c3a5da6ed8085f796e9bcd7cb8c4f1df48b00d4c9f4db460c7')
++source=("$pkgname-$pkgver.tar.gz"::https://github.com/master-of-zen/Av1an/archive/refs/tags/$pkgver.tar.gz
++        "fix-dependency.patch")
++sha256sums=('67afe7ad356e91c3a5da6ed8085f796e9bcd7cb8c4f1df48b00d4c9f4db460c7'
++            '1cbfb90b8aed783e5b1f8a55f5869e056dd049bafb997b5b71f35db2aaa1f8de')
++
++prepare() {
++  cd "Av1an-${pkgver}"
++  patch -p0 -Ni ../fix-dependency.patch
++  cargo update -p serde
++  cargo update --manifest-path av1an-cli/Cargo.toml -p ffmpeg-next
++  cargo update --manifest-path av1an-core/Cargo.toml -p ffmpeg-next
++}
+ 
+ build() {
+   cd "Av1an-${pkgver}"


### PR DESCRIPTION
This patch will fix two dependencies sources:

* Replace ffmpeg-next with my patched version

The `ffmpeg-next` crate relies on the `ffmpeg-sys-next` crate. And the
`ffmpeg-sys-next` misuses the arch type that LLVM can't recognize.

I've fixed this and made a PR for the `ffmpeg-sys-next`, but the
upstream is not active for nearly three months. So I have to replace
the crates.io source with my patched repository.

Reference: Avimitin/rust-ffmpeg-sys@3e2b72b

* Update serde to 1.0.132

The 1.0.132 version enables atomic64 serialization on RISC-V. And av1an
relies on this feature.

Reference: serde-rs/serde@0508cb5

Additional information: We must precisely update the `serde` and
`ffmpeg-next` crate. This may seem redundant but one of the dependencies
of the av1an, indicatif, didn't follow semver convention and make
breaking changes in the same major version. So we should not simply run
`cargo update` here.

Signed-off-by: Avimitin <avimitin@gmail.com>