### PR TITLE
addpkg: difftastic

### DIFF
--- a/difftastic/riscv64.patch
+++ b/difftastic/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -25,7 +25,7 @@ prepare() {
+   cd "$pkgname"
+ 
+   # download dependencies
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  cargo fetch --locked
+ }
+ 
+ build() {


### PR DESCRIPTION
Fixed error: `Error loading target specification: Could not find specification for target "riscv64-unknown-linux-gnu".`