### PR TITLE
addpkg: telegram-desktop

### DIFF
--- a/telegram-desktop/riscv64.patch
+++ b/telegram-desktop/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -21,7 +21,7 @@ build() {
+     cd tdesktop-$pkgver-full
+ 
+     # Fix https://bugs.archlinux.org/task/73220
+-    export CXXFLAGS+=" -Wp,-U_GLIBCXX_ASSERTIONS"
++    export CXXFLAGS+=" -Wp,-U_GLIBCXX_ASSERTIONS -latomic"
+ 
+     export PKG_CONFIG_PATH='/usr/lib/ffmpeg4.4/pkgconfig'
+     # Turns out we're allowed to use the official API key that telegram uses for their snap builds:


### PR DESCRIPTION
Tried to fix it upstream ([telegramdesktop/tdesktop](https://github.com/telegramdesktop/tdesktop), PR 24275), but upstream refused to merge.

Explicitly link to `libatomic` via `CXXFLAGS` to fix the `undefined reference` error for atomic functions.