### PR TITLE
addpkg: libvorbis

### DIFF
--- a/libvorbis/riscv64.patch
+++ b/libvorbis/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index 6f2f7535..9bfab51a 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -46,7 +46,7 @@ build() {
+ }
+ 
+ check() {
+-  make -C vorbis check
++  make -j1 -C vorbis check
+ }
+ 
+ package() {


### PR DESCRIPTION
Force `-j1` to avoid racing on moving the `.Tpo` file.