### PR TITLE
addpkg: cargo-nextest

### DIFF
--- a/cargo-nextest/riscv64.patch
+++ b/cargo-nextest/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,7 +17,7 @@ b2sums=('e983a9f0da490b46dca5819b920e9dbc7ed2afbc95f519d09c72b5b8884c6c25b63a615
+ prepare() {
+   mv "nextest-$pkgname-$pkgver" "$pkgname-$pkgver"
+   cd "$pkgname-$pkgver"
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  cargo fetch --locked
+ }
+ 
+ build() {


### PR DESCRIPTION
This patch resolves the following build error:
```
error: failed to run `rustc` to learn about target-specific information

Caused by:
  process didn't exit successfully: `rustc - --crate-name ___ --print=file-names --target riscv64-unknown-linux-gnu --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=cfg` (exit status: 1)
  --- stderr
  error: Error loading target specification: Could not find specification for target "riscv64-unknown-linux-gnu". Run `rustc --print target-list` for a list of built-in targets
```