### PR TITLE
upgpkg: cargo-msrv

### DIFF
--- a/cargo-msrv/riscv64.patch
+++ b/cargo-msrv/riscv64.patch
@@ -1,12 +1,12 @@
-diff --git PKGBUILD PKGBUILD
-index 88a5cd39e..d4fd809a1 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -14,7 +14,7 @@ sha256sums=('97ca8350ad703df1745aa51209e9c9dfced65c00db2f8a3ef9edbbcf89dd6f80')
+@@ -15,7 +15,9 @@ options=('!lto')
  
  prepare() {
    cd "$pkgname-$pkgver"
 -  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
++  cargo update -p ring
 +  cargo fetch --locked
  }
  


### PR DESCRIPTION
This patch resolves the following build error:
```
error: failed to run custom build command for `ring v0.16.20`

Caused by:
  process didn't exit successfully: `/build/cargo-msrv/src/cargo-msrv-0.15.1/target/release/build/ring-59766f52eca1bd5e/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', /build/.cargo/registry/src/github.com-1ecc6299db9ec823/ring-0.16.20/build.rs:358:10
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```