### PR TITLE
addpkg: step-ca

### DIFF
--- a/step-ca/riscv64.patch
+++ b/step-ca/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -28,7 +28,7 @@ build() {
+ }
+ 
+ check() {
+-  go test -v ./...
++  go test -v ./... -timeout 20m
+ }
+ 
+ package() {


### PR DESCRIPTION
This patch resolves the following test error:
```
panic: test timed out after 10m0s
```

The tests in [github.com/smallstep/certificates/kms/pkcs11/pkcs11_test.go](https://github.com/smallstep/certificates/blob/dc9db5fbbad2d722b553beaa49775b88e6342f90/kms/pkcs11/pkcs11_test.go) are time-costly. Sometimes they reach the time limit of 10 minutes.