### PR TITLE
addpkg: element

### DIFF
--- a/element/riscv64.patch
+++ b/element/riscv64.patch
@@ -1,0 +1,31 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -9,7 +9,7 @@ url="https://github.com/kushview/element"
+ license=(GPL3)
+ groups=(pro-audio)
+ depends=(gcc-libs glibc hicolor-icon-theme libx11 libxext)
+-makedepends=(alsa-lib boost curl freetype2 git gtk3 imagemagick jack juce
++makedepends=(alsa-lib boost clang curl freetype2 git gtk3 imagemagick jack juce
+ ladspa ldoc libxcomposite libxcursor libxinerama lilv lua lv2 pango readline
+ serd sord sratom suil waf xorg-xrandr)
+ checkdepends=(xorg-server-xvfb)
+@@ -31,6 +31,10 @@ b2sums=('SKIP'
+         'SKIP'
+         'SKIP')
+ validpgpkeys=('52CB000FABB9DBE345CD478980A5F4BE60360CDE') # Michael Fisher <mfisher@kushview.net>
++# Can't use -Wl,-plugin-opt=-target-abi=lp64d, because both CFLAGS and CXXFLAGS need it,
++# but specifying both will cause LLVMgold to complain about multiple -target-abi.
++# Also, -ffat-lto-objects can't resolve the compile error here. We have to set !lto
++options+=(!lto)
+ 
+ prepare() {
+   cd $pkgname
+@@ -45,7 +49,7 @@ prepare() {
+ 
+ build() {
+   cd $pkgname
+-  export LINKFLAGS="$LDFLAGS"
++  export CC=clang CXX=clang++ LINKFLAGS="$LDFLAGS"
+   waf configure --prefix=/usr \
+                 --enable-docking \
+                 --test

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -8,6 +8,7 @@ datovka
 dbus
 dovecot
 dqlite
+element
 ell
 ethtool
 fd


### PR DESCRIPTION
<details>
<summary>Fixed lock-free static assertion errors</summary>

```
In file included from ../libs/JUCE/modules/juce_core/juce_core.h:224,
                 from ../libs/JUCE/modules/juce_graphics/juce_graphics.h:57,
                 from ../libs/JUCE/modules/juce_gui_basics/juce_gui_basics.h:56,
                 from ../libs/JUCE/modules/juce_audio_processors/juce_audio_processors.h:56,
                 from ../libs/jlv2/modules/jlv2_host/jlv2_host.h:60,
                 from ../libs/compat/JuceHeader.h:17,
                 from ../src/ElementApp.h:21,
                 from ../src/engine/AudioEngine.h:22,
                 from ../src/session/Session.cpp:20:
../libs/JUCE/modules/juce_core/memory/juce_Atomic.h: In instantiation of ‘juce::Atomic<Type>::~Atomic() [with Type = bool]’:
../src/engine/Transport.h:33:13:   required from here
../libs/JUCE/modules/juce_core/memory/juce_Atomic.h:58:43: error: static assertion failed: This class can only be used for lock-free types
   58 |         static_assert (std::atomic<Type>::is_always_lock_free,
      |                                           ^~~~~~~~~~~~~~~~~~~
../libs/JUCE/modules/juce_core/memory/juce_Atomic.h:58:43: note: ‘std::atomic<bool>::is_always_lock_free’ evaluates to false

In file included from ../libs/JUCE/modules/juce_core/juce_core.h:224,
                 from ../libs/JUCE/modules/juce_graphics/juce_graphics.h:57,
                 from ../libs/JUCE/modules/juce_gui_basics/juce_gui_basics.h:56,
                 from ../libs/JUCE/modules/juce_audio_processors/juce_audio_processors.h:56,
                 from ../libs/jlv2/modules/jlv2_host/jlv2_host.h:60,
                 from ../libs/compat/JuceHeader.h:17,
                 from ../src/engine/nodes/BaseProcessor.h:22,
                 from ../src/engine/nodes/MidiRouterNode.cpp:20:
../libs/JUCE/modules/juce_core/memory/juce_Atomic.h: In instantiation of ‘juce::Atomic<Type>::~Atomic() [with Type = bool]’:
../src/engine/Transport.h:33:13:   required from here
../libs/JUCE/modules/juce_core/memory/juce_Atomic.h:58:43: error: static assertion failed: This class can only be used for lock-free types
   58 |         static_assert (std::atomic<Type>::is_always_lock_free,
      |                                           ^~~~~~~~~~~~~~~~~~~
../libs/JUCE/modules/juce_core/memory/juce_Atomic.h:58:43: note: ‘std::atomic<bool>::is_always_lock_free’ evaluates to false

In file included from ../libs/JUCE/modules/juce_core/juce_core.h:224,
                 from ../libs/JUCE/modules/juce_graphics/juce_graphics.h:57,
                 from ../libs/JUCE/modules/juce_gui_basics/juce_gui_basics.h:56,
                 from ../libs/JUCE/modules/juce_audio_processors/juce_audio_processors.h:56,
                 from ../libs/jlv2/modules/jlv2_host/jlv2_host.h:60,
                 from ../libs/compat/JuceHeader.h:17,
                 from ../src/engine/nodes/BaseProcessor.h:22,
                 from ../src/engine/nodes/AudioFilePlayerNode.h:22,
                 from ../src/engine/nodes/AudioFilePlayerNode.cpp:20:
../libs/JUCE/modules/juce_core/memory/juce_Atomic.h: In instantiation of ‘juce::Atomic<Type>::~Atomic() [with Type = bool]’:
../src/engine/Transport.h:33:13:   required from here
../libs/JUCE/modules/juce_core/memory/juce_Atomic.h:58:43: error: static assertion failed: This class can only be used for lock-free types
   58 |         static_assert (std::atomic<Type>::is_always_lock_free,
      |                                           ^~~~~~~~~~~~~~~~~~~
../libs/JUCE/modules/juce_core/memory/juce_Atomic.h:58:43: note: ‘std::atomic<bool>::is_always_lock_free’ evaluates to false

In file included from ../libs/JUCE/modules/juce_core/juce_core.h:224,
                 from ../libs/JUCE/modules/juce_graphics/juce_graphics.h:57,
                 from ../libs/JUCE/modules/juce_gui_basics/juce_gui_basics.h:56,
                 from ../libs/JUCE/modules/juce_audio_processors/juce_audio_processors.h:56,
                 from ../libs/jlv2/modules/jlv2_host/jlv2_host.h:60,
                 from ../libs/compat/JuceHeader.h:17,
                 from ../src/ElementApp.h:21,
                 from ../src/engine/NodeObject.cpp:21:
../libs/JUCE/modules/juce_core/memory/juce_Atomic.h: In instantiation of ‘juce::Atomic<Type>::~Atomic() [with Type = bool]’:
../src/engine/Transport.h:33:13:   required from here
../libs/JUCE/modules/juce_core/memory/juce_Atomic.h:58:43: error: static assertion failed: This class can only be used for lock-free types
   58 |         static_assert (std::atomic<Type>::is_always_lock_free,
      |                                           ^~~~~~~~~~~~~~~~~~~
../libs/JUCE/modules/juce_core/memory/juce_Atomic.h:58:43: note: ‘std::atomic<bool>::is_always_lock_free’ evaluates to false

In file included from ../libs/JUCE/modules/juce_core/juce_core.h:224,
                 from ../libs/JUCE/modules/juce_graphics/juce_graphics.h:57,
                 from ../libs/JUCE/modules/juce_gui_basics/juce_gui_basics.h:56,
                 from ../libs/JUCE/modules/juce_audio_processors/juce_audio_processors.h:56,
                 from ../libs/jlv2/modules/jlv2_host/jlv2_host.h:60,
                 from ../libs/compat/JuceHeader.h:17,
                 from ../src/ElementApp.h:21,
                 from ../src/controllers/Controller.h:22,
                 from ../src/controllers/AppController.h:22,
                 from ../src/controllers/EngineController.h:22,
                 from ../src/plugins/PluginProcessor.cpp:20:
../libs/JUCE/modules/juce_core/memory/juce_Atomic.h: In instantiation of ‘juce::Atomic<Type>::~Atomic() [with Type = bool]’:
../src/engine/Transport.h:33:13:   required from here
../libs/JUCE/modules/juce_core/memory/juce_Atomic.h:58:43: error: static assertion failed: This class can only be used for lock-free types
   58 |         static_assert (std::atomic<Type>::is_always_lock_free,
      |                                           ^~~~~~~~~~~~~~~~~~~
../libs/JUCE/modules/juce_core/memory/juce_Atomic.h:58:43: note: ‘std::atomic<bool>::is_always_lock_free’ evaluates to false

In file included from ../libs/JUCE/modules/juce_core/juce_core.h:224,
                 from ../libs/JUCE/modules/juce_graphics/juce_graphics.h:57,
                 from ../libs/JUCE/modules/juce_gui_basics/juce_gui_basics.h:56,
                 from ../libs/JUCE/modules/juce_audio_processors/juce_audio_processors.h:56,
                 from ../libs/jlv2/modules/jlv2_host/jlv2_host.h:60,
                 from ../libs/compat/JuceHeader.h:17,
                 from ../src/ElementApp.h:21,
                 from ../src/session/Node.h:22,
                 from ../src/gui/widgets/SessionGraphsListBox.h:22,
                 from ../src/gui/widgets/SessionGraphsListBox.cpp:20:
../libs/JUCE/modules/juce_core/memory/juce_Atomic.h: In instantiation of ‘juce::Atomic<Type>::~Atomic() [with Type = bool]’:
../src/engine/Transport.h:33:13:   required from here
../libs/JUCE/modules/juce_core/memory/juce_Atomic.h:58:43: error: static assertion failed: This class can only be used for lock-free types
   58 |         static_assert (std::atomic<Type>::is_always_lock_free,
      |                                           ^~~~~~~~~~~~~~~~~~~
../libs/JUCE/modules/juce_core/memory/juce_Atomic.h:58:43: note: ‘std::atomic<bool>::is_always_lock_free’ evaluates to false

In file included from ../libs/JUCE/modules/juce_core/juce_core.h:224,
                 from ../libs/JUCE/modules/juce_graphics/juce_graphics.h:57,
                 from ../libs/JUCE/modules/juce_gui_basics/juce_gui_basics.h:56,
                 from ../libs/JUCE/modules/juce_audio_processors/juce_audio_processors.h:56,
                 from ../libs/jlv2/modules/jlv2_host/jlv2_host.h:60,
                 from ../libs/compat/JuceHeader.h:17,
                 from ../src/ElementApp.h:21,
                 from ../src/engine/InternalFormat.cpp:20:
../libs/JUCE/modules/juce_core/memory/juce_Atomic.h: In instantiation of ‘juce::Atomic<Type>::~Atomic() [with Type = bool]’:
../src/engine/Transport.h:33:13:   required from here
../libs/JUCE/modules/juce_core/memory/juce_Atomic.h:58:43: error: static assertion failed: This class can only be used for lock-free types
   58 |         static_assert (std::atomic<Type>::is_always_lock_free,
      |                                           ^~~~~~~~~~~~~~~~~~~
../libs/JUCE/modules/juce_core/memory/juce_Atomic.h:58:43: note: ‘std::atomic<bool>::is_always_lock_free’ evaluates to false

In file included from ../libs/JUCE/modules/juce_core/juce_core.h:224,
                 from ../libs/JUCE/modules/juce_graphics/juce_graphics.h:57,
                 from ../libs/JUCE/modules/juce_gui_basics/juce_gui_basics.h:56,
                 from ../libs/JUCE/modules/juce_audio_processors/juce_audio_processors.h:56,
                 from ../libs/jlv2/modules/jlv2_host/jlv2_host.h:60,
                 from ../libs/compat/JuceHeader.h:17,
                 from ../src/ElementApp.h:21,
                 from ../src/controllers/Controller.h:22,
                 from ../src/controllers/AppController.h:22,
                 from ../src/scripting/LuaBindings.cpp:22:
../libs/JUCE/modules/juce_core/memory/juce_Atomic.h: In instantiation of ‘juce::Atomic<Type>::~Atomic() [with Type = bool]’:
../src/engine/Transport.h:33:13:   required from here
../libs/JUCE/modules/juce_core/memory/juce_Atomic.h:58:43: error: static assertion failed: This class can only be used for lock-free types
   58 |         static_assert (std::atomic<Type>::is_always_lock_free,
      |                                           ^~~~~~~~~~~~~~~~~~~
../libs/JUCE/modules/juce_core/memory/juce_Atomic.h:58:43: note: ‘std::atomic<bool>::is_always_lock_free’ evaluates to false
```
</details>

by switching compiler to `clang` from `gcc`.

---

And this package will stuck in `PKGBUILD`'s `check()` in QEMU, but can pass on Unmatched boards.