### PR TITLE
addpkg: eva

### DIFF
--- a/eva/riscv64.patch
+++ b/eva/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,7 +17,7 @@ sha256sums=('05e2cdcfd91e6abef91cb01ad3074583b8289f6e74054e070bfbf6a4e684865e')
+ 
+ prepare() {
+ 	cd "$_archive"
+-	cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++	cargo fetch --locked
+ }
+ 
+ build() {


### PR DESCRIPTION
Fixed error: `Error loading target specification: Could not find specification for target "riscv64-unknown-linux-gnu".`