### PR TITLE
upgpkg: nsjail

### DIFF
--- a/nsjail/riscv64.patch
+++ b/nsjail/riscv64.patch
@@ -1,33 +1,31 @@
-diff --git PKGBUILD PKGBUILD
-index 39f4add4c..68d9c4e1d 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -11,14 +11,26 @@ depends=(protobuf libnl)
+@@ -10,11 +10,26 @@ license=(Apache)
+ depends=(protobuf libnl)
  makedepends=(git)
- source=("https://github.com/google/nsjail/archive/${pkgver}/${pkgname}-${pkgver}.tar.gz"
-         'git+https://github.com/google/kafel.git#commit=8e69b8efae415cde3debffbb1e379d9e7a16835a'
--        replace-YYUSE-with-attribute-unused-in-src-parser.y.patch)
-+        replace-YYUSE-with-attribute-unused-in-src-parser.y.patch
-+        'https://github.com/google/kafel/commit/21b96af0fde8df6d4636d854de690c3ac48da655.patch'
-+        'https://github.com/google/kafel/commit/362ac7b675d789aeec6321b8d771e7c9d9655832.patch'
-+        'https://github.com/google/kafel/commit/edcd379bc6f9ac9d0e5a7319ebbe657a3bc04efd.patch'
-+        'https://github.com/google/kafel/commit/fdc1d644241e4fdad53b16b3c39e0e4ca49acb9d.patch')
- sha256sums=('cfa66d3ed136b2e221752287b95e544915e8a6760aa866f023b604d14a374919'
-             'SKIP'
--            '9773c57a2eaa3460a0656a5fdc3603d141aac34ded53e18e29a890fd5b7a71f8')
-+            '9773c57a2eaa3460a0656a5fdc3603d141aac34ded53e18e29a890fd5b7a71f8'
+ source=(https://github.com/google/nsjail/archive/${pkgver}/${pkgname}-${pkgver}.tar.gz
+-        git+https://github.com/google/kafel.git#commit=00532cc1ee142355c2db8a58001bcc669893cff8)
++        git+https://github.com/google/kafel.git#commit=00532cc1ee142355c2db8a58001bcc669893cff8
++        $pkgname-1.patch::https://github.com/google/kafel/commit/21b96af0fde8df6d4636d854de690c3ac48da655.patch
++        $pkgname-2.patch::https://github.com/google/kafel/commit/862f8f33b7c9f6a7a1a8ecec7be17e3fd57716ef.patch
++        $pkgname-3.patch::https://github.com/google/kafel/commit/362ac7b675d789aeec6321b8d771e7c9d9655832.patch
++        $pkgname-4.patch::https://github.com/google/kafel/commit/edcd379bc6f9ac9d0e5a7319ebbe657a3bc04efd.patch
++        $pkgname-5.patch::https://github.com/google/kafel/commit/fdc1d644241e4fdad53b16b3c39e0e4ca49acb9d.patch)
+ sha256sums=('c944ce9b6dbfae7cc42b67ce720f997b3b12a2b41ba3462e133627a838f3ff3c'
+-            'SKIP')
++            'SKIP'
 +            '7b7cee40aa3f7dc1c4accaa76a5a0349405d44348e7a8870a7cc3dc80e04be97'
++            '5f1b9513593852397854164b87e866a3de988def2250cfa34b602bd9480637ea'
 +            '1a18bc64525a725f585c7e249f5fb24622cc80ea56e7dc8aacc941cf46527946'
 +            '3720d1176e9a9fdd1e77803f425bb4c6f0bebed76e9368e531eb270d5b9d8836'
 +            'eab5598deb6d969094aa195c7d4c4809bc73f207d371b76dcbfbad68e9e6fbc9')
  
  prepare() {
-     # https://github.com/google/kafel/pull/28
-     patch -Np1 -d kafel <replace-YYUSE-with-attribute-unused-in-src-parser.y.patch
-+    patch -Np1 -d kafel <21b96af0fde8df6d4636d854de690c3ac48da655.patch
-+    patch -Np1 -d kafel <362ac7b675d789aeec6321b8d771e7c9d9655832.patch
-+    patch -Np1 -d kafel <edcd379bc6f9ac9d0e5a7319ebbe657a3bc04efd.patch
-+    patch -Np1 -d kafel <fdc1d644241e4fdad53b16b3c39e0e4ca49acb9d.patch
-     mv kafel ${pkgname}-${pkgver}
++  patch -Np1 -d kafel < $pkgname-1.patch
++  patch -Np1 -d kafel < $pkgname-2.patch
++  patch -Np1 -d kafel < $pkgname-3.patch
++  patch -Np1 -d kafel < $pkgname-4.patch
++  patch -Np1 -d kafel < $pkgname-5.patch
+   mv kafel ${pkgname}-${pkgver}
  }
  


### PR DESCRIPTION
After the official Arch Linux repository upgraded this package, the patch and compilation no longer work.

This PR fixed both.