### PR TITLE
fixpkg: libretro-dolphin

### DIFF
--- a/libretro-dolphin/riscv64.patch
+++ b/libretro-dolphin/riscv64.patch
@@ -1,8 +1,15 @@
-Index: PKGBUILD
-===================================================================
---- PKGBUILD	(revision 1016142)
-+++ PKGBUILD	(working copy)
-@@ -72,6 +72,7 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -65,6 +65,8 @@ pkgver() {
+ build() {
+   export CC=clang
+   export CXX=clang++
++  export CFLAGS="$CFLAGS -Wl,-plugin-opt=-target-abi=lp64d"
++  export CXXFLAGS="$CXXFLAGS -Wl,-plugin-opt=-target-abi=lp64d"
+   cmake -S libretro-dolphin -B build -G Ninja \
+     -DCMAKE_BUILD_TYPE=None \
+     -DCMAKE_INSTALL_PREFIX=/usr \
+@@ -72,6 +74,7 @@ build() {
      -DENABLE_NOGUI=OFF \
      -DENABLE_QT=OFF \
      -DENABLE_TESTS=OFF \


### PR DESCRIPTION
Fixed error:
```
    /usr/bin/ld: /tmp/lto-llvm-f63000.o: can't link soft-float modules with double-float modules
    /usr/bin/ld: failed to merge target specific data of file /tmp/lto-llvm-f63000.o
    clang-13: error: linker command failed with exit code 1 (use -v to see invocation)
    ninja: build stopped: subcommand failed.
```