### PR TITLE
addpkg: python-dictpath

### DIFF
--- a/python-dictpath/riscv64.patch
+++ b/python-dictpath/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index 0c3f94a2..f64251d4 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -10,7 +10,7 @@
+ license=(BSD)
+ depends=(python)
+ makedepends=(python-build python-installer python-setuptools python-wheel)
+-checkdepends=(python-pytest-cov python-pytest-flake8)
++checkdepends=(python-pytest-cov python-pytest-flake8 python-six)
+ source=(https://pypi.io/packages/source/${_pipname:0:1}/$_pipname/$_pipname-$pkgver.tar.gz)
+ sha256sums=('751cde3b76b176d25f961b90c423a11a4d5ede9bd09ab0d64a85abb738c190d8')
+ 


### PR DESCRIPTION
`python-six` used to be installed as a dependency by `python-packaging`, but was removed in recent testing. https://github.com/archlinux/svntogit-packages/commit/a972071e011277914e65f46b2fe472a2de1ebb1a

Also FTBFS with `testing-x86_64-build` [FS#74382](https://bugs.archlinux.org/task/74382)