### PR TITLE
addpkg: libgweather-4

### DIFF
--- a/libgweather-4/riscv64.patch
+++ b/libgweather-4/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index 12ca6d2..bde45bf 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -37,7 +37,7 @@ build() {
+ }
+
+ check() {
+-  meson test -C build --print-errorlogs
++  meson test -C build --print-errorlogs -t 5
+ }
+
+ package_libgweather-4() {


### PR DESCRIPTION
~~1. There have been problems with `pylint` while it's (probably?) worthless to check for linting when packaging.~~ (fixed in #1092)
2. Increased test timeout (qemu is slow, give it more time) (it's taking 41secs avg on my Laptop)