### PR TITLE
addpkg: av1an

### DIFF
--- a/av1an/fix-ffmpeg-sys.patch
+++ b/av1an/fix-ffmpeg-sys.patch
@@ -1,0 +1,26 @@
+diff --git av1an-cli/Cargo.toml av1an-cli/Cargo.toml
+index afbc8eb..b077419 100644
+--- av1an-cli/Cargo.toml
++++ av1an-cli/Cargo.toml
+@@ -32,7 +32,7 @@ default-features = false
+ features = ["git", "build", "rustc", "cargo"]
+ 
+ [dependencies.ffmpeg-next]
+-version = "4.4.0"
++version = "5.0.3"
+ 
+ [features]
+ ffmpeg_static = ["ffmpeg-next/static", "ffmpeg-next/build"]
+diff --git av1an-core/Cargo.toml av1an-core/Cargo.toml
+index 5a44c58..e088ec8 100644
+--- av1an-core/Cargo.toml
++++ av1an-core/Cargo.toml
+@@ -58,7 +58,7 @@ default-features = false
+ features = ["const_generics", "const_new", "union"]
+ 
+ [dependencies.ffmpeg-next]
+-version = "4.4.0"
++version = "5.0.3"
+ 
+ [dependencies.plotters]
+ version = "0.3.1"

--- a/av1an/riscv64.patch
+++ b/av1an/riscv64.patch
@@ -1,0 +1,23 @@
+diff --git PKGBUILD PKGBUILD
+index c3a4deb..871c6b9 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,8 +17,16 @@ optdepends=('svt-av1: SVT-AV1 encoder support'
+             'mkvtoolnix-cli: mkvmerge support'
+             'ffms2: FFMS2 chunk detection support'
+             'vapoursynth-plugin-lsmashsource: L-SMASH chunk detection support')
+-source=("$pkgname-$pkgver.tar.gz"::https://github.com/master-of-zen/Av1an/archive/refs/tags/$pkgver.tar.gz)
+-sha256sums=('67afe7ad356e91c3a5da6ed8085f796e9bcd7cb8c4f1df48b00d4c9f4db460c7')
++source=("$pkgname-$pkgver.tar.gz"::https://github.com/master-of-zen/Av1an/archive/refs/tags/$pkgver.tar.gz
++        "fix-ffmpeg-sys.patch")
++sha256sums=('67afe7ad356e91c3a5da6ed8085f796e9bcd7cb8c4f1df48b00d4c9f4db460c7'
++            'b79c0460bb535e9d7ff59b93a029fc7d4b03e0786805048e1d254ffa0dc1864a')
++
++prepare() {
++  cd "Av1an-${pkgver}"
++  patch -p0 -Ni ../fix-ffmpeg-sys.patch
++  cargo update -p ffmpeg-next
++}
+ 
+ build() {
+   cd "Av1an-${pkgver}"


### PR DESCRIPTION
This patch upgrade the ffmpeg-next version to 5.0.3, which also upgrade
the ffmpeg-sys-next crate to 5.0.1. And it can improve clang-sys compatibility
with riscv64 system libraries.