### PR TITLE
addpkg: sheldon

### DIFF
--- a/sheldon/riscv64.patch
+++ b/sheldon/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -27,7 +27,7 @@ prepare() {
+   git cherry-pick --no-commit 9aa06fdd5cb284daae8c48648d614e3823f3f9f3
+ 
+   # download dependencies
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  cargo fetch --locked
+ }
+ 
+ build() {


### PR DESCRIPTION
Fixed error: `error: Error loading target specification: Could not find specification for target "riscv64-unknown-linux-gnu".`