### PR TITLE
updpkg: gcc

### DIFF
--- a/gcc/riscv64.patch
+++ b/gcc/riscv64.patch
@@ -1,5 +1,5 @@
 diff --git PKGBUILD PKGBUILD
-index 167aed24..f31567af 100644
+index 167aed24..23e6ac62 100644
 --- PKGBUILD
 +++ PKGBUILD
 @@ -7,7 +7,7 @@
@@ -100,7 +100,18 @@ index 167aed24..f31567af 100644
      --enable-bootstrap \
      $_confflags
  
-@@ -163,9 +174,9 @@ check() {
+@@ -129,6 +140,10 @@ build() {
+   # make documentation
+   make -O -C $CHOST/libstdc++-v3/doc doc-man-doxygen
+ 
++  # Patch spec strings embedded in binaries
++  sed -i 's/%{pthread:--push-state --as-needed -latomic --pop-state}/  --push-state --as-needed -latomic --pop-state         /' gcc/xgcc
++  sed -i 's/%{pthread:--push-state --as-needed -latomic --pop-state}/  --push-state --as-needed -latomic --pop-state         /' gcc/xg++
++
+   # Build libgccjit separately, to avoid building all compilers with --enable-host-shared
+   # which brings a performance penalty
+   cd "${srcdir}"/libgccjit-build
+@@ -163,9 +178,9 @@ check() {
  package_gcc-libs() {
    pkgdesc='Runtime libraries shipped by GCC'
    depends=('glibc>=2.27')
@@ -112,7 +123,7 @@ index 167aed24..f31567af 100644
    replaces=($pkgname-multilib libgphobos)
  
    cd gcc-build
-@@ -176,11 +187,9 @@ package_gcc-libs() {
+@@ -176,11 +191,9 @@ package_gcc-libs() {
               libgfortran \
               libgo \
               libgomp \
@@ -126,7 +137,7 @@ index 167aed24..f31567af 100644
      make -C $CHOST/$lib DESTDIR="$pkgdir" install-toolexeclibLTLIBRARIES
    done
  
-@@ -192,24 +201,22 @@ package_gcc-libs() {
+@@ -192,24 +205,22 @@ package_gcc-libs() {
    rm -f "$pkgdir"/usr/lib/libgphobos.spec
  
    for lib in libgomp \
@@ -154,7 +165,7 @@ index 167aed24..f31567af 100644
    provides=($pkgname-multilib)
    replaces=($pkgname-multilib)
    options=(!emptydirs staticlibs debug)
-@@ -223,22 +230,18 @@ package_gcc() {
+@@ -223,22 +234,18 @@ package_gcc() {
    install -m755 -t "$pkgdir/${_libdir}/" gcc/{cc1,cc1plus,collect2,lto1}
  
    make -C $CHOST/libgcc DESTDIR="$pkgdir" install
@@ -179,7 +190,7 @@ index 167aed24..f31567af 100644
  
    make DESTDIR="$pkgdir" install-fixincludes
    make -C gcc DESTDIR="$pkgdir" install-mkheaders
-@@ -249,20 +252,14 @@ package_gcc() {
+@@ -249,20 +256,14 @@ package_gcc() {
      "$pkgdir/usr/lib/bfd-plugins/"
  
    make -C $CHOST/libgomp DESTDIR="$pkgdir" install-nodist_{libsubinclude,toolexeclib}HEADERS
@@ -201,7 +212,7 @@ index 167aed24..f31567af 100644
  
    make -C libcpp DESTDIR="$pkgdir" install
    make -C gcc DESTDIR="$pkgdir" install-po
-@@ -277,9 +274,6 @@ package_gcc() {
+@@ -277,9 +278,6 @@ package_gcc() {
    # install the libstdc++ man pages
    make -C $CHOST/libstdc++-v3/doc DESTDIR="$pkgdir" doc-install-man
  
@@ -211,7 +222,7 @@ index 167aed24..f31567af 100644
    # byte-compile python libraries
    python -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
    python -O -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
-@@ -299,8 +293,6 @@ package_gcc-fortran() {
+@@ -299,8 +297,6 @@ package_gcc-fortran() {
    cd gcc-build
    make -C $CHOST/libgfortran DESTDIR="$pkgdir" install-cafexeclibLTLIBRARIES \
      install-{toolexeclibDATA,nodist_fincludeHEADERS,gfor_cHEADERS}
@@ -220,7 +231,7 @@ index 167aed24..f31567af 100644
    make -C $CHOST/libgomp DESTDIR="$pkgdir" install-nodist_fincludeHEADERS
    make -C gcc DESTDIR="$pkgdir" fortran.install-{common,man,info}
    install -Dm755 gcc/f951 "$pkgdir/${_libdir}/f951"
-@@ -330,45 +322,6 @@ package_gcc-objc() {
+@@ -330,45 +326,6 @@ package_gcc-objc() {
      "$pkgdir/usr/share/licenses/$pkgname/"
  }
  
@@ -266,7 +277,7 @@ index 167aed24..f31567af 100644
  package_gcc-go() {
    pkgdesc='Go front-end for GCC'
    depends=("gcc=$pkgver-$pkgrel" libisl.so)
-@@ -378,11 +331,10 @@ package_gcc-go() {
+@@ -378,11 +335,10 @@ package_gcc-go() {
  
    cd gcc-build
    make -C $CHOST/libgo DESTDIR="$pkgdir" install-exec-am
@@ -279,7 +290,7 @@ index 167aed24..f31567af 100644
    install -Dm755 gcc/go1 "$pkgdir/${_libdir}/go1"
  
    # Install Runtime Library Exception
-@@ -391,43 +343,6 @@ package_gcc-go() {
+@@ -391,43 +347,6 @@ package_gcc-go() {
      "$pkgdir/usr/share/licenses/$pkgname/"
  }
  
@@ -323,7 +334,7 @@ index 167aed24..f31567af 100644
  package_gcc-d() {
    pkgdesc="D frontend for GCC"
    depends=("gcc=$pkgver-$pkgrel" libisl.so)
-@@ -443,7 +358,6 @@ package_gcc-d() {
+@@ -443,7 +362,6 @@ package_gcc-d() {
  
    make -C $CHOST/libphobos DESTDIR="$pkgdir" install
    rm -f "$pkgdir/usr/lib/"lib{gphobos,gdruntime}.so*


### PR DESCRIPTION
Patch the gcc spec string `*lib:` embedded in binaries to link against libatomic by default.
This is an effective workaround before inline atomic operations are implemented in gcc.