### PR TITLE
addpkg: cmake

### DIFF
--- a/cmake/fix-openmp-find-path.patch
+++ b/cmake/fix-openmp-find-path.patch
@@ -1,0 +1,12 @@
+diff --git a/Modules/FindOpenMP.cmake b/Modules/FindOpenMP.cmake
+index ecfb7f9b..7e2d8dfe 100644
+--- a/Modules/FindOpenMP.cmake
++++ b/Modules/FindOpenMP.cmake
+@@ -262,7 +262,6 @@ function(_OPENMP_GET_FLAGS LANG FLAG_MODE OPENMP_FLAG_VAR OPENMP_LIB_NAMES_VAR)
+                 DOC "Path to the ${_OPENMP_IMPLICIT_LIB_PLAIN} library for OpenMP"
+                 HINTS ${OpenMP_${LANG}_IMPLICIT_LINK_DIRS}
+                 CMAKE_FIND_ROOT_PATH_BOTH
+-                NO_DEFAULT_PATH
+               )
+             endif()
+             mark_as_advanced(OpenMP_${_OPENMP_IMPLICIT_LIB_PLAIN}_LIBRARY)

--- a/cmake/riscv64.patch
+++ b/cmake/riscv64.patch
@@ -1,0 +1,22 @@
+diff --git PKGBUILD PKGBUILD
+index 518399d8..d18465de 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,8 +12,15 @@ license=('custom')
+ depends=('curl' 'libarchive' 'hicolor-icon-theme' 'jsoncpp' 'libjsoncpp.so' 'libuv' 'rhash')
+ makedepends=('qt6-base' 'python-sphinx' 'emacs')
+ optdepends=('qt6-base: cmake-gui')
+-source=("https://www.cmake.org/files/v${pkgver%.*}/${pkgname}-${pkgver}.tar.gz")
+-sha512sums=('bcde8f2bf2fff6c4ab37a28c115b4b53d5fef0d4e38305420966cbd9f0026a4ffdcd4137f917a83458c1f380a137f7a7bd78f6fbd4d92fdcc5cf1dfbe4c02003')
++source=("https://www.cmake.org/files/v${pkgver%.*}/${pkgname}-${pkgver}.tar.gz"
++        "fix-openmp-find-path.patch")
++sha512sums=('bcde8f2bf2fff6c4ab37a28c115b4b53d5fef0d4e38305420966cbd9f0026a4ffdcd4137f917a83458c1f380a137f7a7bd78f6fbd4d92fdcc5cf1dfbe4c02003'
++            'ae4accf6f776a1835ea981dece8c93ef7a3030c36d4343e1ee927c88967ba1393b2612eb784ecf9849bc596f32344c80d2d40e1947f5d0e0a0683be00281e725')
++
++prepare() {
++  cd ${pkgname}-${pkgver}
++  patch -Np1 -i "../fix-openmp-find-path.patch"
++}
+ 
+ build() {
+   cd ${pkgname}-${pkgver}


### PR DESCRIPTION
The `NO_DEFAULT_PATH` option in `FindOpenMP.cmake` is causing cmake not able to correctly find paths and libraries of openmp. Disabling this.