### PR TITLE
addpkg: keepassxc

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -23,6 +23,7 @@ gupnp-igd
 gxplugins.lv2
 haxe
 hyperfine
+keepassxc
 libdwarf
 libfbclient
 liborcus


### PR DESCRIPTION
Stuck in 'Test #20: testsshagent' in QEMU, but can pass on Unmatched boards.

No need to patch.