### PR TITLE
upgpkg: lldb

### DIFF
--- a/lldb/riscv64.patch
+++ b/lldb/riscv64.patch
@@ -1,6 +1,6 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -11,20 +11,28 @@ license=('custom:Apache 2.0 with LLVM Exception')
+@@ -11,14 +11,20 @@ license=('custom:Apache 2.0 with LLVM Exception')
  depends=('llvm-libs' 'clang' 'python' 'python-six')
  makedepends=('llvm' 'cmake' 'ninja' 'swig' 'python-sphinx')
  _source_base=https://github.com/llvm/llvm-project/releases/download/llvmorg-$pkgver
@@ -23,11 +23,3 @@
    mkdir build
  }
  
- build() {
-   cd "$srcdir/$pkgname-$pkgver.src/build"
- 
-+  CFLAGS="$CFLAGS -pthread"
-+  CXXFLAGS="$CXXFLAGS -pthread"
-   cmake .. -G Ninja \
-     -DCMAKE_BUILD_TYPE=Release \
-     -DCMAKE_INSTALL_PREFIX=/usr \


### PR DESCRIPTION
Not bumping `pkgrel` since rebuild is not required, and we can rebuild when the next release / upstream `pkgrel` bump happens.