### PR TITLE
addpkg: pipe-rename

### DIFF
--- a/pipe-rename/riscv64.patch
+++ b/pipe-rename/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -22,7 +22,7 @@ b2sums=('9a04121bf5aedd53c032d37fa93b1fe42b8a08a4f57f02ad0f272a2d447ba5376d6a46b
+ prepare() {
+   cd "$pkgname-$pkgver"
+ 
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  cargo fetch --locked
+ }
+ 
+ build() {


### PR DESCRIPTION
Fixed error: `Error loading target specification: Could not find specification for target "riscv64-unknown-linux-gnu"`