### PR TITLE
Test repos branch instead of trunk

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     container: archlinux/archlinux:latest
     steps:
       - name: Install dependencies
-        run: pacman -Syu --noconfirm asp patch
+        run: pacman -Syu --noconfirm patch subversion
       - name: Fix git unsafe repository
         run: git config --global --add safe.directory /__w/archriscv-packages/archriscv-packages
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     container: archlinux/archlinux:latest
     steps:
       - name: Install dependencies
-        run: pacman -Syu --noconfirm patch subversion
+        run: pacman -Syu --noconfirm git patch subversion
       - name: Fix git unsafe repository
         run: git config --global --add safe.directory /__w/archriscv-packages/archriscv-packages
       - uses: actions/checkout@v2


### PR DESCRIPTION
Starting from today (15/4/2022), the sync script is aware of repos/
branch and won't use trunk anymore. Patches in this repository is
now defined as patches for stable repos (core, extra, community)
instead of trunk or testing/staging repos.