### PR TITLE
addpkg: gdk-pixbuf2

### DIFF
--- a/gdk-pixbuf2/fix-sigkill.patch
+++ b/gdk-pixbuf2/fix-sigkill.patch
@@ -1,0 +1,13 @@
+diff --git tests/meson.build tests/meson.build
+index 7c6cb11..a6393f9 100644
+--- tests/meson.build
++++ tests/meson.build
+@@ -79,7 +79,7 @@ installed_tests = {
+   },
+   'pixbuf-fail': { 'suites': ['conform', 'slow'], },
+   'pixbuf-icon-serialize': { 'suites': ['conform'], },
+-  'pixbuf-randomly-modified': { 'suites': ['slow'], },
++  'pixbuf-randomly-modified': { 'skip': true, },
+   'pixbuf-threads': { 'suites': ['io'], },
+   'pixbuf-gif': {
+     'suites': ['io'],

--- a/gdk-pixbuf2/riscv64.patch
+++ b/gdk-pixbuf2/riscv64.patch
@@ -1,0 +1,25 @@
+diff --git PKGBUILD PKGBUILD
+index f80cf74..01ca8e6 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -25,9 +25,11 @@ _commit=bca00032ad68d0b0aa2c1f7558db931e52bd9cd2  # tags/2.42.8^0
+ source=(
+   "git+https://gitlab.gnome.org/GNOME/gdk-pixbuf.git#commit=$_commit"
+   gdk-pixbuf-query-loaders.hook
++  fix-sigkill.patch
+ )
+ sha256sums=('SKIP'
+-            '9fb71d95e6a212779eb0f88dde5a3cee0df7f4d9183f8f9ce286f8cdc14428f0')
++            '9fb71d95e6a212779eb0f88dde5a3cee0df7f4d9183f8f9ce286f8cdc14428f0'
++            '112abe91db897d8b6220b3f047a6ac38508feb753fbedce9fc49dd256b0106b0')
+ 
+ pkgver() {
+   cd gdk-pixbuf
+@@ -36,6 +38,7 @@ pkgver() {
+ 
+ prepare() {
+   cd gdk-pixbuf
++  patch -p0 -Ni ../fix-sigkill.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
The "pixbuf-randomly-modified" test randomly modifies the file and then tries to load it, which needs vast amounts of RAM and then is killed by the SIGKILL signal. There are some similar issue reports on:

* Debian i386: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=942124
* FreeBSD-amd64: https://buildd.debian.org/status/fetch.php?pkg=gdk-pixbuf&arch=kfreebsd-amd64&ver=2.40.0%2Bdfsg-2&stamp=1582013991&raw=0
* Yocto: http://bugzilla.yoctoproject.org/show_bug.cgi?id=13840

The test error was reported on GNOME GitLab issues, and one of the contributors thinks they should replace the test. But two years have gone by, the issue is not active now. No contributor take action on it. So I decide to skip this test.

* Upstream Report: https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/issues/146