### PR TITLE
addpkg: pyside2

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -40,6 +40,7 @@ perl
 perl-par-packer
 procs
 pueue
+pyside2
 python-prctl
 qconf
 qpdfview


### PR DESCRIPTION
llvm-config crashed in qemu-user because it can't locate clang's built-in include directory (neither by checking the environment variables LLVM_INSTALL_DIR, CLANG_INSTALL_DIR  nor running llvm-config).

And it can be built without any modification in Unmatched board.