### PR TITLE
addpkg: gdk-pixbuf2

### DIFF
--- a/gdk-pixbuf2/fix-timeout.patch
+++ b/gdk-pixbuf2/fix-timeout.patch
@@ -1,0 +1,13 @@
+diff --git tests/meson.build tests/meson.build
+index 7c6cb11..7f88381 100644
+--- tests/meson.build
++++ tests/meson.build
+@@ -203,7 +203,7 @@ foreach test_name, test_data: installed_tests
+ 
+   # Two particularly slow tests
+   if test_suites.contains('slow')
+-    timeout = 300
++    timeout = 500
+   else
+     timeout = 30
+   endif

--- a/gdk-pixbuf2/riscv64.patch
+++ b/gdk-pixbuf2/riscv64.patch
@@ -1,0 +1,24 @@
+diff --git PKGBUILD PKGBUILD
+--- PKGBUILD
++++ PKGBUILD
+@@ -25,9 +25,11 @@ _commit=bca00032ad68d0b0aa2c1f7558db931e52bd9cd2  # tags/2.42.8^0
+ source=(
+   "git+https://gitlab.gnome.org/GNOME/gdk-pixbuf.git#commit=$_commit"
+   gdk-pixbuf-query-loaders.hook
++  fix-timeout.patch
+ )
+ sha256sums=('SKIP'
+-            '9fb71d95e6a212779eb0f88dde5a3cee0df7f4d9183f8f9ce286f8cdc14428f0')
++            '9fb71d95e6a212779eb0f88dde5a3cee0df7f4d9183f8f9ce286f8cdc14428f0'
++            '6b99f30b72778b8469def8277771b2ed2988e8da792f2dd97744859b0dc0fa01')
+ 
+ pkgver() {
+   cd gdk-pixbuf
+@@ -36,6 +38,7 @@ pkgver() {
+ 
+ prepare() {
+   cd gdk-pixbuf
++  patch -p0 -Ni ../fix-timeout.patch
+ }
+ 
+ build() {

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -16,6 +16,7 @@ findutils
 fish
 foot
 gauche
+gdk-pixbuf2
 go
 gpxsee
 gupnp


### PR DESCRIPTION
This patch add gdk-pixbuf2 into noqemu list and increase the timeout limit for "pixbuf-randomly-modified" test.

This package can't be built in qemu user environment. The "pixbuf-randomly-modified" test randomly modifies the file and then tries to load it. This test process needs vast amounts of RAM and then the test will be killed by the SIGKILL signal.

It can be built successfully on Unmatched board, but we still can't pass the "picbuf-randomly-modified" test. This time the failure is caused by timeout. 500s is a reasonable value for the Unmatched performance.