### PR TITLE
addpkg: hck

### DIFF
--- a/hck/fix-libz-ver.patch
+++ b/hck/fix-libz-ver.patch
@@ -1,0 +1,11 @@
+diff --git Cargo.toml Cargo.toml
+index 2f81b99..5004eaa 100644
+--- Cargo.toml
++++ Cargo.toml
+@@ -47,3 +47,6 @@ rstest = "0.10.0"
+ 
+ [build-dependencies]
+ built = {version ="0.5.1", features = ["git2"]}
++
++[patch.crates-io]
++libz-sys = { git = "https://github.com/rust-lang/libz-sys", tag = "1.1.4" }

--- a/hck/riscv64.patch
+++ b/hck/riscv64.patch
@@ -1,0 +1,27 @@
+diff --git PKGBUILD PKGBUILD
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,14 +12,20 @@ depends=('gcc-libs')
+ makedepends=('git' 'rust' 'cmake')
+ options=('!lto')
+ _commit='aa6988c51c372074222e056e8f7fc8b332272b4e'
+-source=("$pkgname::git+$url.git#commit=$_commit")
+-md5sums=('SKIP')
++source=("$pkgname::git+$url.git#commit=$_commit"
++	fix-libz-ver.patch)
++md5sums=('SKIP'
++         '28a396609f9e3d5516893814c0b50a6c')
+ 
+ prepare() {
+   cd "$pkgname"
+ 
++  # 1.1.4 introduce riscv support
++  patch -p0 -Ni ../fix-libz-ver.patch
++  cargo update -p libz-sys
++
+   # download dependencies
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  cargo fetch --locked
+ }
+ 
+ build() {


### PR DESCRIPTION
This patch fix two error. One is the rustc could not find specification for target "riscv64-unknown-linux-gnu" error.

Another one is related to the libz-sys version. Zlib fixes cmake arch detection in [zlib-ng #942], and the crate libz-sys update the zlib binding in [version 1.1.4]. However, the hck is using the 1.1.3 version and causing itself can't be compiled in RISC-V.

[zlib-ng #942]: https://github.com/zlib-ng/zlib-ng/commit/81f1c8a41bd1427707f402450de8820816760fca
[version 1.1.4]: https://github.com/rust-lang/libz-sys/commit/5c4704efa6ae73a95c3c6e1ccf4bd212f927be7a