### PR TITLE
addpkg: libsecp256k1

### DIFF
--- a/libsecp256k1/riscv64.patch
+++ b/libsecp256k1/riscv64.patch
@@ -1,0 +1,19 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -11,11 +11,14 @@ arch=(x86_64)
+ url="https://github.com/bitcoin-core/secp256k1"
+ license=(MIT)
+ depends=(glibc)
+-source=(${url}/archive/${_gitcommit}/${pkgname}-${pkgver}.tar.gz)
+-sha256sums=('0b950fb4d1ff56c514c343b183bfac285faaa751bc1e286e54ad0b7c9d76595f')
++source=(${url}/archive/${_gitcommit}/${pkgname}-${pkgver}.tar.gz
++        ${pkgname}-fix-asm-check.patch::${url}/pull/1104.patch)
++sha256sums=('0b950fb4d1ff56c514c343b183bfac285faaa751bc1e286e54ad0b7c9d76595f'
++            'b05f778cef9fcf894510643afdd9ccea212ff787581e7771a7bd94e11d7f5e5b')
+ 
+ prepare() {
+   cd secp256k1-${_gitcommit}
++  patch -Np1 -i ../${pkgname}-fix-asm-check.patch
+   autoreconf -vfi
+ }
+ 


### PR DESCRIPTION
Fixed x86_64 asm check in upstream: https://github.com/bitcoin-core/secp256k1/pull/1104