### PR TITLE
noqemu: add PyQt6 family

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -41,6 +41,12 @@ perl-par-packer
 procs
 pueue
 pyside2
+pyqt6
+pyqt6-3d
+pyqt6-charts
+pyqt6-datavisualization
+pyqt6-networkauth
+pyqt6-webengine
 python-prctl
 qalculate-qt
 qconf


### PR DESCRIPTION
PyQt6 builder calls qmake, which in turn triggers the qemu bug.