### PR TITLE
addpkg: findomain

### DIFF
--- a/findomain/riscv64.patch
+++ b/findomain/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -18,6 +18,11 @@ options=(!lto)
+ 
+ build() {
+   cd ${_pkgname}-${pkgver}
++
++  # using patched 'ring'
++  sed -i "/patch.crates-io/a ring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" Cargo.toml
++  cargo update -p ring
++
+   cargo build --release --locked
+ }
+ 


### PR DESCRIPTION
This PR fixed error:

```
error: failed to run custom build command for `ring v0.16.20`

Caused by:
  process didn't exit successfully: `/build/findomain/src/Findomain-8.1.0/target/release/build/ring-923f77b482ab3681/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', /build/.cargo/registry/src/github.com-1ecc6299db9ec823/ring-0.16.20/build.rs:358:10
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Closes #732 as outdated.