### PR TITLE
addpkg: qt6-base

### DIFF
--- a/qt6-base/riscv64.patch
+++ b/qt6-base/riscv64.patch
@@ -1,0 +1,12 @@
+diff --git PKGBUILD PKGBUILD
+index 937ea28..b8c2d9e 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -55,6 +55,7 @@ build() {
+     -DQT_FEATURE_openssl_linked=ON \
+     -DQT_FEATURE_system_sqlite=ON \
+     -DQT_FEATURE_system_xcb_xinput=ON \
++    -DQT_FEATURE_forkfd_pidfd=OFF \
+     -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON
+   cmake --build build
+ }


### PR DESCRIPTION
Add compilation flag to disable `forkfd_pidfd`.