### PR TITLE
addpkg: echoping

### DIFF
--- a/echoping/riscv64.patch
+++ b/echoping/riscv64.patch
@@ -1,0 +1,12 @@
+diff --git PKGBUILD PKGBUILD
+index a0aafb51..73aebdb5 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -6,6 +6,7 @@ pkgrel=10
+ pkgdesc="tests performance of a remote host by sending HTTP, TCP and UDP requests"
+ arch=('x86_64')
+ url="http://echoping.sourceforge.net/"
++options=(!lto)
+ license=('GPL')
+ depends=(libidn popt libldap)
+ #source=(https://sourceforge.net/projects/$pkgname/files/$pkgname/$pkgver/$pkgname-$pkgver.tar.gz)


### PR DESCRIPTION
Investigation from [FS#73709](https://bugs.archlinux.org/task/73709):

> `echoping` fails to build from source due to a configure check breaking when LTO is enabled so `libm` is not added to the libs to link to.

Disabling LTO for `echoping` to fix that.