### PR TITLE
Update noqemu list

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -59,6 +59,7 @@ swtpm
 texstudio
 tiled
 tinyssh
+tmuxp
 vim
 x2goclient
 zram-generator


### PR DESCRIPTION
A test in package tmuxp will run into infinite loop. The test,
"test_automatic_rename_option", use the pane name as loop break
condition. However in the QEMU environment, the name of the pane will
always be "qemu-riscv64-static", no matter what program user is using.

Upstream report:
https://github.com/tmux-python/tmuxp/issues/620#issuecomment-1102074020