### PR TITLE
addpkg: python-gdstk

### DIFF
--- a/python-gdstk/riscv64.patch
+++ b/python-gdstk/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index f384906e..30d93b5d 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,6 +15,8 @@ sha512sums=('c89e53a8e1dbb56050f20ef1c8ebe0892747a7e75f3ba9f8aa8fde0d025a9af6690
+ 
+ build() {
+   cd gdstk-$pkgver
++  CFLAGS="$CFLAGS -ffp-contract=off" \
++  CXXFLAGS="$CXXFLAGS -ffp-contract=off" \
+   python setup.py build
+ }
+ 


### PR DESCRIPTION
By default gcc uses `-ffp-contract=fast` which causes precision lost in tests. This patch disables this behavior.