### PR TITLE
Updpkg: firefox to 99.0.1

### DIFF
--- a/firefox/Remove-VideoFrameSurfaceVAAPI-and-use-VideoFrameSurface-only.patch
+++ b/firefox/Remove-VideoFrameSurfaceVAAPI-and-use-VideoFrameSurface-only.patch
@@ -1,0 +1,616 @@
+# From: xdong181@gmail.com
+# backport https://bugzilla.mozilla.org/show_bug.cgi?id=1758610 to firefox 99.0.1 
+
+# https://phabricator.services.mozilla.com/D141831
+diff --git a/dom/media/platforms/ffmpeg/FFmpegVideoFramePool.h b/dom/media/platforms/ffmpeg/FFmpegVideoFramePool.h
+--- a/dom/media/platforms/ffmpeg/FFmpegVideoFramePool.h
++++ b/dom/media/platforms/ffmpeg/FFmpegVideoFramePool.h
+@@ -109,11 +109,11 @@
+  private:
+   virtual ~VideoFrameSurfaceVAAPI();
+ 
+   const RefPtr<DMABufSurface> mSurface;
+   const FFmpegLibWrapper* mLib;
+-  AVBufferRef* mAVHWFramesContext;
++  AVBufferRef* mAVHWDeviceContext;
+   AVBufferRef* mHWAVBuffer;
+ };
+ 
+ // VideoFramePool class is thread-safe.
+ class VideoFramePool final {
+diff --git a/dom/media/platforms/ffmpeg/FFmpegVideoFramePool.cpp b/dom/media/platforms/ffmpeg/FFmpegVideoFramePool.cpp
+--- a/dom/media/platforms/ffmpeg/FFmpegVideoFramePool.cpp
++++ b/dom/media/platforms/ffmpeg/FFmpegVideoFramePool.cpp
+@@ -20,11 +20,11 @@
+ }
+ 
+ VideoFrameSurfaceVAAPI::VideoFrameSurfaceVAAPI(DMABufSurface* aSurface)
+     : mSurface(aSurface),
+       mLib(nullptr),
+-      mAVHWFramesContext(nullptr),
++      mAVHWDeviceContext(nullptr),
+       mHWAVBuffer(nullptr) {
+   // Create global refcount object to track mSurface usage over
+   // gects rendering engine. We can't release it until it's used
+   // by GL compositor / WebRender.
+   MOZ_ASSERT(mSurface);
+@@ -38,11 +38,11 @@
+                                            AVFrame* aAVFrame,
+                                            FFmpegLibWrapper* aLib) {
+   FFMPEG_LOG("VideoFrameSurfaceVAAPI: VAAPI locking dmabuf surface UID = %d",
+              mSurface->GetUID());
+   mLib = aLib;
+-  mAVHWFramesContext = aLib->av_buffer_ref(aAVCodecContext->hw_frames_ctx);
++  mAVHWDeviceContext = aLib->av_buffer_ref(aAVCodecContext->hw_device_ctx);
+   mHWAVBuffer = aLib->av_buffer_ref(aAVFrame->buf[0]);
+ }
+ 
+ void VideoFrameSurfaceVAAPI::ReleaseVAAPIData(bool aForFrameRecycle) {
+   FFMPEG_LOG("VideoFrameSurfaceVAAPI: VAAPI releasing dmabuf surface UID = %d",
+@@ -54,11 +54,11 @@
+   // In such case we don't care as the dmabuf surface will not be
+   // recycled for another frame and stays here untill last fd of it
+   // is closed.
+   if (mLib) {
+     mLib->av_buffer_unref(&mHWAVBuffer);
+-    mLib->av_buffer_unref(&mAVHWFramesContext);
++    mLib->av_buffer_unref(&mAVHWDeviceContext);
+   }
+ 
+   // If we want to recycle the frame, make sure it's not used
+   // by gecko rendering pipeline.
+   if (aForFrameRecycle) {
+
+# https://phabricator.services.mozilla.com/D141827
+diff --git a/dom/media/platforms/ffmpeg/FFmpegVideoFramePool.h b/dom/media/platforms/ffmpeg/FFmpegVideoFramePool.h
+--- a/dom/media/platforms/ffmpeg/FFmpegVideoFramePool.h
++++ b/dom/media/platforms/ffmpeg/FFmpegVideoFramePool.h
+@@ -15,46 +15,21 @@
+ #include "mozilla/widget/DMABufSurface.h"
+ 
+ namespace mozilla {
+ 
+ class VideoFramePool;
+-class VideoFrameSurfaceVAAPI;
+ 
+-class VideoFrameSurface {
+- public:
+-  NS_INLINE_DECL_THREADSAFE_REFCOUNTING(VideoFrameSurface)
+-
+-  VideoFrameSurface() = default;
+-
+-  virtual VideoFrameSurfaceVAAPI* AsVideoFrameSurfaceVAAPI() { return nullptr; }
+-
+-  virtual void SetYUVColorSpace(gfx::YUVColorSpace aColorSpace) = 0;
+-  virtual void SetColorRange(gfx::ColorRange aColorRange) = 0;
+-
+-  virtual RefPtr<DMABufSurfaceYUV> GetDMABufSurface() { return nullptr; };
+-  virtual RefPtr<layers::Image> GetAsImage() = 0;
+-
+-  // Don't allow VideoFrameSurface plain copy as it leads to
+-  // unexpected DMABufSurface/HW buffer releases and we don't want to
+-  // deep copy them.
+-  VideoFrameSurface(const VideoFrameSurface&) = delete;
+-  const VideoFrameSurface& operator=(VideoFrameSurface const&) = delete;
+-
+- protected:
+-  virtual ~VideoFrameSurface(){};
+-};
+-
+-// VideoFrameSurfaceVAAPI holds a reference to GPU data with a video frame.
++// VideoFrameSurface holds a reference to GPU data with a video frame.
+ //
+ // Actual GPU pixel data are stored at DMABufSurface and
+ // DMABufSurface is passed to gecko GL rendering pipeline via.
+ // DMABUFSurfaceImage.
+ //
+-// VideoFrameSurfaceVAAPI can optionally hold VA-API ffmpeg related data to keep
++// VideoFrameSurface can optionally hold VA-API ffmpeg related data to keep
+ // GPU data locked untill we need them.
+ //
+-// VideoFrameSurfaceVAAPI is used for both HW accelerated video decoding
++// VideoFrameSurface is used for both HW accelerated video decoding
+ // (VA-API) and ffmpeg SW decoding.
+ //
+ // VA-API scenario
+ //
+ // When VA-API decoding is running, ffmpeg allocates AVHWFramesContext - a pool
+@@ -70,17 +45,17 @@
+ // and used as a texture in our rendering engine.
+ //
+ // Unfortunately there isn't any obvious way how to mark particular VASurface
+ // as used. The best we can do is to hold a reference to particular AVBuffer
+ // from decoded AVFrame and AVHWFramesContext which owns the AVBuffer.
+-class VideoFrameSurfaceVAAPI final : public VideoFrameSurface {
++class VideoFrameSurface {
+   friend class VideoFramePool;
+ 
+  public:
+-  explicit VideoFrameSurfaceVAAPI(DMABufSurface* aSurface);
++  NS_INLINE_DECL_THREADSAFE_REFCOUNTING(VideoFrameSurface)
+ 
+-  VideoFrameSurfaceVAAPI* AsVideoFrameSurfaceVAAPI() final { return this; }
++  explicit VideoFrameSurface(DMABufSurface* aSurface);
+ 
+   void SetYUVColorSpace(mozilla::gfx::YUVColorSpace aColorSpace) {
+     mSurface->GetAsDMABufSurfaceYUV()->SetYUVColorSpace(aColorSpace);
+   }
+   void SetColorRange(mozilla::gfx::ColorRange aColorRange) {
+@@ -91,10 +66,16 @@
+     return mSurface->GetAsDMABufSurfaceYUV();
+   };
+ 
+   RefPtr<layers::Image> GetAsImage();
+ 
++  // Don't allow VideoFrameSurface plain copy as it leads to
++  // unexpected DMABufSurface/HW buffer releases and we don't want to
++  // deep copy them.
++  VideoFrameSurface(const VideoFrameSurface&) = delete;
++  const VideoFrameSurface& operator=(VideoFrameSurface const&) = delete;
++
+  protected:
+   // Lock VAAPI related data
+   void LockVAAPIData(AVCodecContext* aAVCodecContext, AVFrame* aAVFrame,
+                      FFmpegLibWrapper* aLib);
+   // Release VAAPI related data, DMABufSurface can be reused
+@@ -105,11 +86,11 @@
+   // (WebRender or GL compositor) or by DMABUFSurfaceImage/VideoData.
+   bool IsUsed() const { return mSurface->IsGlobalRefSet(); }
+   void MarkAsUsed() { mSurface->GlobalRefAdd(); }
+ 
+  private:
+-  virtual ~VideoFrameSurfaceVAAPI();
++  virtual ~VideoFrameSurface();
+ 
+   const RefPtr<DMABufSurface> mSurface;
+   const FFmpegLibWrapper* mLib;
+   AVBufferRef* mAVHWDeviceContext;
+   AVBufferRef* mHWAVBuffer;
+@@ -132,7 +113,7 @@
+  private:
+   // Protect mDMABufSurfaces pool access
+   Mutex mSurfaceLock;
+-  nsTArray<RefPtr<VideoFrameSurfaceVAAPI>> mDMABufSurfaces;
++  nsTArray<RefPtr<VideoFrameSurface>> mDMABufSurfaces;
+   // We may fail to create texture over DMABuf memory due to driver bugs so
+   // check that before we export first DMABuf video frame.
+   Maybe<bool> mTextureCreationWorks;
+
+
+diff --git a/dom/media/platforms/ffmpeg/FFmpegVideoFramePool.cpp b/dom/media/platforms/ffmpeg/FFmpegVideoFramePool.cpp
+--- a/dom/media/platforms/ffmpeg/FFmpegVideoFramePool.cpp
++++ b/dom/media/platforms/ffmpeg/FFmpegVideoFramePool.cpp
+@@ -13,41 +13,41 @@
+ #define FFMPEG_LOG(str, ...) \
+   MOZ_LOG(sPDMLog, mozilla::LogLevel::Debug, (str, ##__VA_ARGS__))
+ 
+ namespace mozilla {
+ 
+-RefPtr<layers::Image> VideoFrameSurfaceVAAPI::GetAsImage() {
++RefPtr<layers::Image> VideoFrameSurface::GetAsImage() {
+   return new layers::DMABUFSurfaceImage(mSurface);
+ }
+ 
+-VideoFrameSurfaceVAAPI::VideoFrameSurfaceVAAPI(DMABufSurface* aSurface)
++VideoFrameSurface::VideoFrameSurface(DMABufSurface* aSurface)
+     : mSurface(aSurface),
+       mLib(nullptr),
+       mAVHWDeviceContext(nullptr),
+       mHWAVBuffer(nullptr) {
+   // Create global refcount object to track mSurface usage over
+   // gects rendering engine. We can't release it until it's used
+   // by GL compositor / WebRender.
+   MOZ_ASSERT(mSurface);
+   MOZ_RELEASE_ASSERT(mSurface->GetAsDMABufSurfaceYUV());
+   mSurface->GlobalRefCountCreate();
+-  FFMPEG_LOG("VideoFrameSurfaceVAAPI: creating surface UID = %d",
++  FFMPEG_LOG("VideoFrameSurface: creating surface UID = %d",
+              mSurface->GetUID());
+ }
+ 
+-void VideoFrameSurfaceVAAPI::LockVAAPIData(AVCodecContext* aAVCodecContext,
+-                                           AVFrame* aAVFrame,
+-                                           FFmpegLibWrapper* aLib) {
+-  FFMPEG_LOG("VideoFrameSurfaceVAAPI: VAAPI locking dmabuf surface UID = %d",
++void VideoFrameSurface::LockVAAPIData(AVCodecContext* aAVCodecContext,
++                                      AVFrame* aAVFrame,
++                                      FFmpegLibWrapper* aLib) {
++  FFMPEG_LOG("VideoFrameSurface: VAAPI locking dmabuf surface UID = %d",
+              mSurface->GetUID());
+   mLib = aLib;
+   mAVHWDeviceContext = aLib->av_buffer_ref(aAVCodecContext->hw_device_ctx);
+   mHWAVBuffer = aLib->av_buffer_ref(aAVFrame->buf[0]);
+ }
+ 
+-void VideoFrameSurfaceVAAPI::ReleaseVAAPIData(bool aForFrameRecycle) {
+-  FFMPEG_LOG("VideoFrameSurfaceVAAPI: VAAPI releasing dmabuf surface UID = %d",
++void VideoFrameSurface::ReleaseVAAPIData(bool aForFrameRecycle) {
++  FFMPEG_LOG("VideoFrameSurface: VAAPI releasing dmabuf surface UID = %d",
+              mSurface->GetUID());
+ 
+   // It's possible to unref GPU data while IsUsed() is still set.
+   // It can happens when VideoFramePool is deleted while decoder shutdown
+   // but related dmabuf surfaces are still used in another process.
+@@ -65,12 +65,12 @@
+     MOZ_DIAGNOSTIC_ASSERT(!IsUsed());
+     mSurface->ReleaseSurface();
+   }
+ }
+ 
+-VideoFrameSurfaceVAAPI::~VideoFrameSurfaceVAAPI() {
+-  FFMPEG_LOG("VideoFrameSurfaceVAAPI: deleting dmabuf surface UID = %d",
++VideoFrameSurface::~VideoFrameSurface() {
++  FFMPEG_LOG("VideoFrameSurface: deleting dmabuf surface UID = %d",
+              mSurface->GetUID());
+   // We're about to quit, no need to recycle the frames.
+   ReleaseVAAPIData(/* aForFrameRecycle */ false);
+ }
+ 
+@@ -82,24 +82,22 @@
+ }
+ 
+ void VideoFramePool::ReleaseUnusedVAAPIFrames() {
+   MutexAutoLock lock(mSurfaceLock);
+   for (const auto& surface : mDMABufSurfaces) {
+-    auto* vaapiSurface = surface->AsVideoFrameSurfaceVAAPI();
+-    if (!vaapiSurface->IsUsed()) {
+-      vaapiSurface->ReleaseVAAPIData();
++    if (!surface->IsUsed()) {
++      surface->ReleaseVAAPIData();
+     }
+   }
+ }
+ 
+ RefPtr<VideoFrameSurface> VideoFramePool::GetFreeVideoFrameSurface() {
+   for (auto& surface : mDMABufSurfaces) {
+     if (surface->IsUsed()) {
+       continue;
+     }
+-    auto* vaapiSurface = surface->AsVideoFrameSurfaceVAAPI();
+-    vaapiSurface->ReleaseVAAPIData();
++    surface->ReleaseVAAPIData();
+     return surface;
+   }
+   return nullptr;
+ }
+ 
+@@ -119,11 +117,11 @@
+         DMABufSurfaceYUV::CreateYUVSurface(aVaDesc);
+     if (!surface) {
+       return nullptr;
+     }
+     FFMPEG_LOG("Created new VA-API DMABufSurface UID = %d", surface->GetUID());
+-    RefPtr<VideoFrameSurfaceVAAPI> surf = new VideoFrameSurfaceVAAPI(surface);
++    RefPtr<VideoFrameSurface> surf = new VideoFrameSurface(surface);
+     if (!mTextureCreationWorks) {
+       mTextureCreationWorks = Some(surface->VerifyTextureCreation());
+     }
+     if (!*mTextureCreationWorks) {
+       FFMPEG_LOG("  failed to create texture over DMABuf memory!");
+@@ -136,14 +134,11 @@
+     if (!surface->UpdateYUVData(aVaDesc)) {
+       return nullptr;
+     }
+     FFMPEG_LOG("Reusing VA-API DMABufSurface UID = %d", surface->GetUID());
+   }
+-
+-  auto* vaapiSurface = videoSurface->AsVideoFrameSurfaceVAAPI();
+-  vaapiSurface->LockVAAPIData(aAVCodecContext, aAVFrame, aLib);
+-  vaapiSurface->MarkAsUsed();
+-
++  videoSurface->LockVAAPIData(aAVCodecContext, aAVFrame, aLib);
++  videoSurface->MarkAsUsed();
+   return videoSurface;
+ }
+ 
+ }  // namespace mozilla
+
+# https://phabricator.services.mozilla.com/D141828
+diff --git a/dom/media/platforms/ffmpeg/FFmpegVideoDecoder.h b/dom/media/platforms/ffmpeg/FFmpegVideoDecoder.h
+--- a/dom/media/platforms/ffmpeg/FFmpegVideoDecoder.h
++++ b/dom/media/platforms/ffmpeg/FFmpegVideoDecoder.h
+@@ -14,18 +14,20 @@
+ #include "mozilla/ScopeExit.h"
+ #include "nsTHashSet.h"
+ #if LIBAVCODEC_VERSION_MAJOR >= 57 && LIBAVUTIL_VERSION_MAJOR >= 56
+ #  include "mozilla/layers/TextureClient.h"
+ #endif
++#ifdef MOZ_WAYLAND_USE_VAAPI
++#  include "FFmpegVideoFramePool.h"
++#endif
+ 
+ struct _VADRMPRIMESurfaceDescriptor;
+ typedef struct _VADRMPRIMESurfaceDescriptor VADRMPRIMESurfaceDescriptor;
+ 
+ namespace mozilla {
+ 
+ class ImageBufferWrapper;
+-class VideoFramePool;
+ 
+ template <int V>
+ class FFmpegVideoDecoder : public FFmpegDataDecoder<V> {};
+ 
+ template <>
+@@ -134,11 +136,11 @@
+ 
+ #ifdef MOZ_WAYLAND_USE_VAAPI
+   AVBufferRef* mVAAPIDeviceContext;
+   bool mEnableHardwareDecoding;
+   VADisplay mDisplay;
+-  UniquePtr<VideoFramePool> mVideoFramePool;
++  UniquePtr<VideoFramePool<LIBAV_VER>> mVideoFramePool;
+   static nsTArray<AVCodecID> mAcceleratedFormats;
+ #endif
+   RefPtr<KnowsCompositor> mImageAllocator;
+   RefPtr<ImageContainer> mImageContainer;
+   VideoInfo mInfo;
+diff --git a/dom/media/platforms/ffmpeg/FFmpegVideoDecoder.cpp b/dom/media/platforms/ffmpeg/FFmpegVideoDecoder.cpp
+--- a/dom/media/platforms/ffmpeg/FFmpegVideoDecoder.cpp
++++ b/dom/media/platforms/ffmpeg/FFmpegVideoDecoder.cpp
+@@ -802,11 +802,11 @@
+     }
+ 
+ #  ifdef MOZ_WAYLAND_USE_VAAPI
+     // Create VideoFramePool in case we need it.
+     if (!mVideoFramePool && mEnableHardwareDecoding) {
+-      mVideoFramePool = MakeUnique<VideoFramePool>();
++      mVideoFramePool = MakeUnique<VideoFramePool<LIBAV_VER>>();
+     }
+ 
+     // Release unused VA-API surfaces before avcodec_receive_frame() as
+     // ffmpeg recycles VASurface for HW decoding.
+     if (mVideoFramePool) {
+diff --git a/dom/media/platforms/ffmpeg/FFmpegVideoFramePool.h b/dom/media/platforms/ffmpeg/FFmpegVideoFramePool.h
+--- a/dom/media/platforms/ffmpeg/FFmpegVideoFramePool.h
++++ b/dom/media/platforms/ffmpeg/FFmpegVideoFramePool.h
+@@ -5,21 +5,20 @@
+  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ 
+ #ifndef __FFmpegVideoFramePool_h__
+ #define __FFmpegVideoFramePool_h__
+ 
+-#include "FFmpegVideoDecoder.h"
+ #include "FFmpegLibWrapper.h"
++#include "FFmpegLibs.h"
++#include "FFmpegLog.h"
+ 
+ #include "mozilla/layers/DMABUFSurfaceImage.h"
+ #include "mozilla/widget/DMABufLibWrapper.h"
+ #include "mozilla/widget/DMABufSurface.h"
+ 
+ namespace mozilla {
+ 
+-class VideoFramePool;
+-
+ // VideoFrameSurface holds a reference to GPU data with a video frame.
+ //
+ // Actual GPU pixel data are stored at DMABufSurface and
+ // DMABufSurface is passed to gecko GL rendering pipeline via.
+ // DMABUFSurfaceImage.
+@@ -45,12 +44,23 @@
+ // and used as a texture in our rendering engine.
+ //
+ // Unfortunately there isn't any obvious way how to mark particular VASurface
+ // as used. The best we can do is to hold a reference to particular AVBuffer
+ // from decoded AVFrame and AVHWFramesContext which owns the AVBuffer.
+-class VideoFrameSurface {
+-  friend class VideoFramePool;
++template <int V>
++class VideoFrameSurface {};
++template <>
++class VideoFrameSurface<LIBAV_VER>;
++
++template <int V>
++class VideoFramePool {};
++template <>
++class VideoFramePool<LIBAV_VER>;
++
++template <>
++class VideoFrameSurface<LIBAV_VER> {
++  friend class VideoFramePool<LIBAV_VER>;
+ 
+  public:
+   NS_INLINE_DECL_THREADSAFE_REFCOUNTING(VideoFrameSurface)
+ 
+   explicit VideoFrameSurface(DMABufSurface* aSurface);
+@@ -95,27 +105,28 @@
+   AVBufferRef* mAVHWDeviceContext;
+   AVBufferRef* mHWAVBuffer;
+ };
+ 
+ // VideoFramePool class is thread-safe.
+-class VideoFramePool final {
++template <>
++class VideoFramePool<LIBAV_VER> {
+  public:
+   VideoFramePool();
+   ~VideoFramePool();
+ 
+-  RefPtr<VideoFrameSurface> GetVideoFrameSurface(
++  RefPtr<VideoFrameSurface<LIBAV_VER>> GetVideoFrameSurface(
+       VADRMPRIMESurfaceDescriptor& aVaDesc, AVCodecContext* aAVCodecContext,
+       AVFrame* aAVFrame, FFmpegLibWrapper* aLib);
+   void ReleaseUnusedVAAPIFrames();
+ 
+  private:
+-  RefPtr<VideoFrameSurface> GetFreeVideoFrameSurface();
++  RefPtr<VideoFrameSurface<LIBAV_VER>> GetFreeVideoFrameSurface();
+ 
+  private:
+   // Protect mDMABufSurfaces pool access
+   Mutex mSurfaceLock;
+-  nsTArray<RefPtr<VideoFrameSurface>> mDMABufSurfaces;
++  nsTArray<RefPtr<VideoFrameSurface<LIBAV_VER>>> mDMABufSurfaces;
+   // We may fail to create texture over DMABuf memory due to driver bugs so
+   // check that before we export first DMABuf video frame.
+   Maybe<bool> mTextureCreationWorks;
+ };
+ 
+diff --git a/dom/media/platforms/ffmpeg/FFmpegVideoFramePool.cpp b/dom/media/platforms/ffmpeg/FFmpegVideoFramePool.cpp
+--- a/dom/media/platforms/ffmpeg/FFmpegVideoFramePool.cpp
++++ b/dom/media/platforms/ffmpeg/FFmpegVideoFramePool.cpp
+@@ -3,25 +3,26 @@
+ /* This Source Code Form is subject to the terms of the Mozilla Public
+  * License, v. 2.0. If a copy of the MPL was not distributed with this
+  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+ 
+ #include "FFmpegVideoFramePool.h"
++#include "PlatformDecoderModule.h"
+ #include "FFmpegLog.h"
+ #include "mozilla/widget/DMABufLibWrapper.h"
+ #include "libavutil/pixfmt.h"
+ 
+ #undef FFMPEG_LOG
+ #define FFMPEG_LOG(str, ...) \
+   MOZ_LOG(sPDMLog, mozilla::LogLevel::Debug, (str, ##__VA_ARGS__))
+ 
+ namespace mozilla {
+ 
+-RefPtr<layers::Image> VideoFrameSurface::GetAsImage() {
++RefPtr<layers::Image> VideoFrameSurface<LIBAV_VER>::GetAsImage() {
+   return new layers::DMABUFSurfaceImage(mSurface);
+ }
+ 
+-VideoFrameSurface::VideoFrameSurface(DMABufSurface* aSurface)
++VideoFrameSurface<LIBAV_VER>::VideoFrameSurface(DMABufSurface* aSurface)
+     : mSurface(aSurface),
+       mLib(nullptr),
+       mAVHWDeviceContext(nullptr),
+       mHWAVBuffer(nullptr) {
+   // Create global refcount object to track mSurface usage over
+@@ -32,21 +33,21 @@
+   mSurface->GlobalRefCountCreate();
+   FFMPEG_LOG("VideoFrameSurface: creating surface UID = %d",
+              mSurface->GetUID());
+ }
+ 
+-void VideoFrameSurface::LockVAAPIData(AVCodecContext* aAVCodecContext,
+-                                      AVFrame* aAVFrame,
+-                                      FFmpegLibWrapper* aLib) {
++void VideoFrameSurface<LIBAV_VER>::LockVAAPIData(
++    AVCodecContext* aAVCodecContext, AVFrame* aAVFrame,
++    FFmpegLibWrapper* aLib) {
+   FFMPEG_LOG("VideoFrameSurface: VAAPI locking dmabuf surface UID = %d",
+              mSurface->GetUID());
+   mLib = aLib;
+   mAVHWDeviceContext = aLib->av_buffer_ref(aAVCodecContext->hw_device_ctx);
+   mHWAVBuffer = aLib->av_buffer_ref(aAVFrame->buf[0]);
+ }
+ 
+-void VideoFrameSurface::ReleaseVAAPIData(bool aForFrameRecycle) {
++void VideoFrameSurface<LIBAV_VER>::ReleaseVAAPIData(bool aForFrameRecycle) {
+   FFMPEG_LOG("VideoFrameSurface: VAAPI releasing dmabuf surface UID = %d",
+              mSurface->GetUID());
+ 
+   // It's possible to unref GPU data while IsUsed() is still set.
+   // It can happens when VideoFramePool is deleted while decoder shutdown
+@@ -65,63 +66,68 @@
+     MOZ_DIAGNOSTIC_ASSERT(!IsUsed());
+     mSurface->ReleaseSurface();
+   }
+ }
+ 
+-VideoFrameSurface::~VideoFrameSurface() {
++VideoFrameSurface<LIBAV_VER>::~VideoFrameSurface() {
+   FFMPEG_LOG("VideoFrameSurface: deleting dmabuf surface UID = %d",
+              mSurface->GetUID());
+   // We're about to quit, no need to recycle the frames.
+   ReleaseVAAPIData(/* aForFrameRecycle */ false);
+ }
+ 
+-VideoFramePool::VideoFramePool() : mSurfaceLock("VideoFramePoolSurfaceLock") {}
++VideoFramePool<LIBAV_VER>::VideoFramePool()
++    : mSurfaceLock("VideoFramePoolSurfaceLock") {}
+ 
+-VideoFramePool::~VideoFramePool() {
++VideoFramePool<LIBAV_VER>::~VideoFramePool() {
+   MutexAutoLock lock(mSurfaceLock);
+   mDMABufSurfaces.Clear();
+ }
+ 
+-void VideoFramePool::ReleaseUnusedVAAPIFrames() {
++void VideoFramePool<LIBAV_VER>::ReleaseUnusedVAAPIFrames() {
+   MutexAutoLock lock(mSurfaceLock);
+   for (const auto& surface : mDMABufSurfaces) {
+     if (!surface->IsUsed()) {
+       surface->ReleaseVAAPIData();
+     }
+   }
+ }
+ 
+-RefPtr<VideoFrameSurface> VideoFramePool::GetFreeVideoFrameSurface() {
++RefPtr<VideoFrameSurface<LIBAV_VER>>
++VideoFramePool<LIBAV_VER>::GetFreeVideoFrameSurface() {
+   for (auto& surface : mDMABufSurfaces) {
+     if (surface->IsUsed()) {
+       continue;
+     }
+     surface->ReleaseVAAPIData();
+     return surface;
+   }
+   return nullptr;
+ }
+ 
+-RefPtr<VideoFrameSurface> VideoFramePool::GetVideoFrameSurface(
++RefPtr<VideoFrameSurface<LIBAV_VER>>
++VideoFramePool<LIBAV_VER>::GetVideoFrameSurface(
+     VADRMPRIMESurfaceDescriptor& aVaDesc, AVCodecContext* aAVCodecContext,
+     AVFrame* aAVFrame, FFmpegLibWrapper* aLib) {
+   if (aVaDesc.fourcc != VA_FOURCC_NV12 && aVaDesc.fourcc != VA_FOURCC_YV12 &&
+       aVaDesc.fourcc != VA_FOURCC_P010) {
+     FFMPEG_LOG("Unsupported VA-API surface format %d", aVaDesc.fourcc);
+     return nullptr;
+   }
+ 
+   MutexAutoLock lock(mSurfaceLock);
+-  RefPtr<VideoFrameSurface> videoSurface = GetFreeVideoFrameSurface();
++  RefPtr<VideoFrameSurface<LIBAV_VER>> videoSurface =
++      GetFreeVideoFrameSurface();
+   if (!videoSurface) {
+     RefPtr<DMABufSurfaceYUV> surface =
+         DMABufSurfaceYUV::CreateYUVSurface(aVaDesc);
+     if (!surface) {
+       return nullptr;
+     }
+     FFMPEG_LOG("Created new VA-API DMABufSurface UID = %d", surface->GetUID());
+-    RefPtr<VideoFrameSurface> surf = new VideoFrameSurface(surface);
++    RefPtr<VideoFrameSurface<LIBAV_VER>> surf =
++        new VideoFrameSurface<LIBAV_VER>(surface);
+     if (!mTextureCreationWorks) {
+       mTextureCreationWorks = Some(surface->VerifyTextureCreation());
+     }
+     if (!*mTextureCreationWorks) {
+       FFMPEG_LOG("  failed to create texture over DMABuf memory!");
+diff --git a/dom/media/platforms/ffmpeg/ffmpeg58/moz.build b/dom/media/platforms/ffmpeg/ffmpeg58/moz.build
+--- a/dom/media/platforms/ffmpeg/ffmpeg58/moz.build
++++ b/dom/media/platforms/ffmpeg/ffmpeg58/moz.build
+@@ -28,9 +28,12 @@
+   ]
+ if CONFIG['MOZ_WAYLAND']:
+   CXXFLAGS += CONFIG['MOZ_GTK3_CFLAGS']
+   DEFINES['MOZ_WAYLAND_USE_VAAPI'] = 1
+   USE_LIBS += ['mozva']
++  UNIFIED_SOURCES += [
++    '../FFmpegVideoFramePool.cpp',
++  ]
+ 
+ include("/ipc/chromium/chromium-config.mozbuild")
+ 
+ FINAL_LIBRARY = 'xul'
+diff --git a/dom/media/platforms/ffmpeg/ffmpeg59/moz.build b/dom/media/platforms/ffmpeg/ffmpeg59/moz.build
+--- a/dom/media/platforms/ffmpeg/ffmpeg59/moz.build
++++ b/dom/media/platforms/ffmpeg/ffmpeg59/moz.build
+@@ -28,9 +28,12 @@
+     ]
+ if CONFIG["MOZ_WAYLAND"]:
+     CXXFLAGS += CONFIG["MOZ_GTK3_CFLAGS"]
+     DEFINES["MOZ_WAYLAND_USE_VAAPI"] = 1
+     USE_LIBS += ["mozva"]
++    UNIFIED_SOURCES += [
++        "../FFmpegVideoFramePool.cpp",
++    ]
+ 
+ include("/ipc/chromium/chromium-config.mozbuild")
+ 
+ FINAL_LIBRARY = "xul"
+

--- a/firefox/makotokato-riscv64-support-and-zenithal-backported.patch
+++ b/firefox/makotokato-riscv64-support-and-zenithal-backported.patch
@@ -66,7 +66,7 @@ diff --git a/Cargo.lock b/Cargo.lock
 index 7e17939fad48b..8519d3d0e95a6 100644
 --- a/Cargo.lock
 +++ b/Cargo.lock
-@@ -316,8 +316,7 @@ dependencies = [
+@@ -317,8 +317,7 @@ dependencies = [
  [[package]]
  name = "authenticator"
  version = "0.3.1"
@@ -1995,9 +1995,9 @@ index 0000000000000..a784e9bf4600b
 +pub const _HIDIOCGRDESC: __u32 = 2416199682;
 --- a/toolkit/library/rust/shared/Cargo.toml    2022-02-10 20:41:52.387673027 +0800
 +++ b/toolkit/library/rust/shared/Cargo.toml    2022-02-12 17:34:42.861720793 +0800
-@@ -24,7 +24,7 @@
- cubeb-pulse = { git = "https://github.com/mozilla/cubeb-pulse-rs", rev="f2456201dbfdc467b80f0ff6bbb1b8a6faf7df02", optional = true, features=["pulse-dlopen"] }
- cubeb-sys = { version = "0.9", optional = true, features=["gecko-in-tree"] }
+@@ -28,7 +28,7 @@
+ audioipc-client = { git = "https://github.com/mozilla/audioipc-2", rev = "515bb210a93f520642fd3a60f391652680b3e988", optional = true }
+ audioipc-server = { git = "https://github.com/mozilla/audioipc-2", rev = "515bb210a93f520642fd3a60f391652680b3e988", optional = true }
  encoding_glue = { path = "../../../../intl/encoding_glue" }
 -authenticator = "0.3.1"
 +authenticator = { git = "https://github.com/makotokato/authenticator-rs", rev = "eed8919d50559f4959e2d7d2af7b4d48869b5366" }
@@ -2014,7 +2014,7 @@ Subject: [PATCH] signal handler
  1 file changed, 9 insertions(+)
 --- a/js/src/wasm/WasmSignalHandlers.cpp        2022-02-12 19:29:33.566924464 +0800
 +++ b/js/src/wasm/WasmSignalHandlers.cpp        2022-02-12 19:50:29.499985612 +0800
-@@ -156,6 +156,11 @@
+@@ -162,6 +162,11 @@
  #      define R01_sig(p) ((p)->uc_mcontext.gp_regs[1])
  #      define R32_sig(p) ((p)->uc_mcontext.gp_regs[32])
  #    endif
@@ -2026,10 +2026,10 @@ Subject: [PATCH] signal handler
  #  elif defined(__NetBSD__)
  #    define EIP_sig(p) ((p)->uc_mcontext.__gregs[_REG_EIP])
  #    define EBP_sig(p) ((p)->uc_mcontext.__gregs[_REG_EBP])
-@@ -376,6 +381,10 @@
- #    define PC_sig(p) R32_sig(p)
- #    define SP_sig(p) R01_sig(p)
- #    define FP_sig(p) R01_sig(p)
+@@ -404,6 +410,10 @@
+ #    define FP_sig(p) RFP_sig(p)
+ #    define SP_sig(p) RSP_sig(p)
+ #    define LR_sig(p) RRA_sig(p)
 +#elif defined(__riscv) && __riscv_xlen == 64
 +#  define PC_sig(p) EPC_sig(p)
 +#  define SP_sig(p) X02_sig(p)

--- a/firefox/riscv64.patch
+++ b/firefox/riscv64.patch
@@ -1,7 +1,7 @@
---- PKGBUILD	(版本 439382)
-+++ PKGBUILD	(工作副本)
+--- PKGBUILD	(revision 442457)
++++ PKGBUILD	(working copy)
 @@ -12,8 +12,7 @@
- depends=(gtk3 libxt mime-types dbus-glib ffmpeg4.4 nss ttf-font libpulse)
+ depends=(gtk3 libxt mime-types dbus-glib ffmpeg nss ttf-font libpulse)
  makedepends=(unzip zip diffutils yasm mesa imake inetutils xorg-server-xvfb
               autoconf2.13 rust clang llvm jack nodejs cbindgen nasm
 -             python-setuptools python-psutil python-zstandard lld dump_syms
@@ -10,28 +10,33 @@
  optdepends=('networkmanager: Location detection via available WiFi networks'
              'libnotify: Notification integration'
              'pulseaudio: Audio support'
-@@ -22,9 +21,11 @@
+@@ -22,9 +21,13 @@
              'xdg-desktop-portal: Screensharing with Wayland')
  options=(!emptydirs !makeflags !strip !lto !debug)
  source=(https://archive.mozilla.org/pub/firefox/releases/$pkgver/source/firefox-$pkgver.source.tar.xz{,.asc}
 +        makotokato-riscv64-support-and-zenithal-backported.patch
++        Remove-VideoFrameSurfaceVAAPI-and-use-VideoFrameSurface-only.patch
          $pkgname.desktop identity-icons-brand.svg)
- sha256sums=('c144b6016aaa8ceab8154b9f0b2bbeee6cbc22ab7f811fcece28d36e49565890'
+ sha256sums=('76d22279ce99588a728bb2d034064be0d5918b5900631f2148d4565b8a72e00b'
              'SKIP'
-+            '9d07f897dac63225fa734da490583aaa72868ccf6305d621916d7405d0bf9a83'
++            '4f50b78e7ad77de7e7a4844971856505820a1ffbd3fec78926a2b0a314e3d089'
++            '3da2f17fd6f4f53043e3a854822c39e4e8697fde72e03f5281532432edc6f801'
              '298eae9de76ec53182f38d5c549d0379569916eebf62149f9d7f4a7edef36abf'
              'a9b8b4a0a1f4a7b4af77d5fc70c2686d624038909263c795ecc81e0aec7711e9')
  validpgpkeys=('14F26682D0916CDD81E37B6D61B7B526D98F0353') # Mozilla Software Releases <release@mozilla.com>
-@@ -45,6 +46,8 @@
+@@ -45,6 +48,11 @@
    mkdir mozbuild
    cd firefox-$pkgver
  
 +  patch -Np1 -i ../makotokato-riscv64-support-and-zenithal-backported.patch
 +
++  #https://bugzilla.mozilla.org/show_bug.cgi?id=1758610
++  patch -Np1 -i ../Remove-VideoFrameSurfaceVAAPI-and-use-VideoFrameSurface-only.patch
++
    echo -n "$_google_api_key" >google-api-key
    echo -n "$_mozilla_api_key" >mozilla-api-key
  
-@@ -53,15 +56,22 @@
+@@ -53,15 +61,22 @@
  mk_add_options MOZ_OBJDIR=${PWD@Q}/obj
  
  ac_add_options --prefix=/usr
@@ -59,7 +64,7 @@
  # Branding
  ac_add_options --enable-official-branding
  ac_add_options --enable-update-channel=release
-@@ -68,7 +78,8 @@
+@@ -68,7 +83,8 @@
  ac_add_options --with-distribution-id=org.archlinux
  ac_add_options --with-unsigned-addon-scopes=app,system
  ac_add_options --allow-addon-sideload
@@ -69,7 +74,7 @@
  export MOZ_APP_REMOTINGNAME=${pkgname//-/}
  
  # Keys
-@@ -83,7 +94,7 @@
+@@ -83,7 +99,7 @@
  # Features
  ac_add_options --enable-alsa
  ac_add_options --enable-jack
@@ -78,7 +83,7 @@
  ac_add_options --disable-updater
  ac_add_options --disable-tests
  END
-@@ -101,39 +112,41 @@
+@@ -101,39 +117,41 @@
    ulimit -n 4096
  
    # Do 3-tier PGO
@@ -151,7 +156,7 @@
  }
  
  package() {
-@@ -201,12 +214,12 @@
+@@ -201,12 +219,12 @@
      ln -srfv "$pkgdir/usr/lib/libnssckbi.so" "$nssckbi"
    fi
  


### PR DESCRIPTION
1. firefox build error: undefined reference to `mozilla::VideoFramePool::~VideoFramePool()`,see https://bugzilla.mozilla.org/show_bug.cgi?id=1758610 .
2. this patch use `hw_device_ctx`,and `hw_device_ctx` was imported in https://phabricator.services.mozilla.com/D141831 .
3.Combine the patches above into one patch.