### PR TITLE
addpkg: diskonaut

### DIFF
--- a/diskonaut/fix.patch
+++ b/diskonaut/fix.patch
@@ -1,0 +1,24 @@
+diff --git Cargo.toml Cargo.toml
+index 83e0bb2..53264b6 100644
+--- Cargo.toml
++++ Cargo.toml
+@@ -23,3 +23,6 @@ winapi = { version = "0.3", features = ["securitybaseapi","debugapi"] }
+ 
+ [dev-dependencies]
+ insta = "0.16.0"
++
++[patch.crates-io]
++libc = { git = "https://github.com/rust-lang/libc", tag = "0.2.118" }
+diff --git src/tests/fakes/fake_input.rs src/tests/fakes/fake_input.rs
+index a8637e6..4193bc3 100644
+--- src/tests/fakes/fake_input.rs
++++ src/tests/fakes/fake_input.rs
+@@ -18,7 +18,7 @@ impl Iterator for TerminalEvents {
+             Some(ev) => match ev {
+                 Some(ev) => Some(ev),
+                 None => {
+-                    thread::sleep(time::Duration::from_millis(200));
++                    thread::sleep(time::Duration::from_secs(1));
+                     self.next()
+                 }
+             },

--- a/diskonaut/riscv64.patch
+++ b/diskonaut/riscv64.patch
@@ -1,0 +1,22 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -8,12 +8,16 @@ arch=('x86_64')
+ url="https://github.com/imsnif/diskonaut"
+ license=('MIT')
+ makedepends=('cargo')
+-source=(https://github.com/imsnif/${pkgname}/archive/${pkgver}/${pkgname}-${pkgver}.tar.gz)
+-b2sums=('20d4fbd713c82dd19901574361d80161e717eaefcf4568a9b1b52723f235b94999dc1579ad37461013661de7be569e7608a0c63de576bf9fa59d6d897f725aa6')
++source=(https://github.com/imsnif/${pkgname}/archive/${pkgver}/${pkgname}-${pkgver}.tar.gz
++        fix.patch)
++b2sums=('20d4fbd713c82dd19901574361d80161e717eaefcf4568a9b1b52723f235b94999dc1579ad37461013661de7be569e7608a0c63de576bf9fa59d6d897f725aa6'
++        'cc1e887fcb57bcbf676b1fa8f652adc5ec00948d73ccfcdd782221061202b072d6acd77594fb845d9d720ea970e8c60dd9d4825219de9b02deb64a93d651c1e1')
+ 
+ prepare() {
+   cd "${pkgname}-${pkgver}"
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  patch -p0 -Ni ../fix.patch
++  cargo update -p libc
++  cargo fetch --locked
+ }
+ 
+ build() {


### PR DESCRIPTION
This patch fix three error:

1. The [target specification issue].

2. Crate libc can not be compiled due to symbol missing.

	This is fixed in [rust-lang/libc PR #2668], and release in 0.2.118
version.

3. Test failure

	Some tests of diskonaut depend on the previous events. It take a snapshot of the TUI pixels output, then compare those snapshot pixel by pixel to determine if the cli is working correctly. However those test are not reliable. If the previous event took too long to finish, the TUI output will not match what is expected. The current workaround is to increase the event interval. One second interval is enough for all event to finish its jobs.

	Tested in 5950x QEMU environment.

[target specification issue]: https://github.com/felixonmars/archriscv-packages/issues/670#issuecomment-1025646326
[rust-lang/libc PR #2668]: https://github.com/rust-lang/libc/pull/2668