### PR TITLE
upgpkg: rustup

### DIFF
--- a/rustup/riscv64.patch
+++ b/rustup/riscv64.patch
@@ -1,8 +1,11 @@
-Index: PKGBUILD
-===================================================================
---- PKGBUILD	(revision 1012920)
-+++ PKGBUILD	(working copy)
-@@ -22,6 +22,7 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -19,10 +19,12 @@ replaces=('cargo-tree')
+ install='post.install'
+ source=("rustup-${pkgver}.tar.gz::https://github.com/rust-lang/rustup.rs/archive/${pkgver}.tar.gz")
+ sha512sums=('43e85f1e653d451a2555a7ae9a3f47c4b9eb8e0fea0cd9cdcf381728ac933b56aaa25366ca2e1b12f20f9190b77d407a00a3f559ced6ad9c4f51fcef9efe67d7')
++options=('!lto')
+ _binlinks=('cargo' 'rustc' 'rustdoc' 'rust-gdb' 'rust-lldb' 'rls' 'rustfmt' 'cargo-fmt' 'cargo-clippy' 'clippy-driver' 'cargo-miri')
  
  build() {
      cd "$pkgname-${pkgver}"


### PR DESCRIPTION
The following linking error no longer occurs after disabling LTO.

```
error: linking with `cc` failed: exit status: 1
  |
  = note: "cc" "/build/rustup/src/rustup-1.24.3/target/release/deps/rustup_init-0609a9a7d297ef04.rustup_init.a668c382-cgu.0.rcgu.o" "-Wl,--as-needed" "-L" "/build/rustup/src/rustup-1.24.3/target/release/deps" "-L" "/usr/lib" "-L" "/build/rustup/src/rustup-1.24.3/target/release/build/ring-a26af6b5394ccfd1/out" "-L" "/build/rustup/src/rustup-1.24.3/target/release/build/sys-info-5d227f125ca2d25a/out" "-L" "/usr/lib" "-L" "/build/rustup/src/rustup-1.24.3/target/release/build/zstd-sys-fdff5888885359a8/out" "-L" "/usr/lib/rustlib/riscv64gc-unknown-linux-gnu/lib" "-Wl,-Bstatic" "/tmp/rustccxgqK7/libzstd_sys-a1b7546eb81175df.rlib" "/tmp/rustccxgqK7/libsys_info-0a2476e8f942021e.rlib" "/tmp/rustccxgqK7/libring-13d44736646dbb90.rlib" "-Wl,--start-group" "-Wl,--end-group" "/usr/lib/rustlib/riscv64gc-unknown-linux-gnu/lib/libcompiler_builtins-eb3d9462eb261ba5.rlib" "-Wl,-Bdynamic" "-llzma" "-lssl" "-lcrypto" "-lcurl" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-Wl,--eh-frame-hdr" "-Wl,-znoexecstack" "-L" "/usr/lib/rustlib/riscv64gc-unknown-linux-gnu/lib" "-o" "/build/rustup/src/rustup-1.24.3/target/release/deps/rustup_init-0609a9a7d297ef04" "-Wl,--gc-sections" "-pie" "-Wl,-zrelro,-znow" "-Wl,-O1" "-nodefaultlibs"
  = note: /usr/bin/ld: /build/rustup/src/rustup-1.24.3/target/release/deps/rustup_init-0609a9a7d297ef04.rustup_init.a668c382-cgu.0.rcgu.o: undefined reference to symbol 'ZSTD_DStreamInSize'
          /usr/bin/ld: /usr/lib/libzstd.so.1: error adding symbols: DSO missing from command line
          collect2: error: ld returned 1 exit status
          
  = help: some `extern` functions couldn't be found; some native libraries may need to be installed or have their path specified
  = note: use the `-l` flag to specify native libraries to link
  = note: use the `cargo:rustc-link-lib` directive to specify the native libraries to link with Cargo (see https://doc.rust-lang.org/cargo/reference/build-scripts.html#cargorustc-link-libkindname)
```