### PR TITLE
addpkg: cargo-spellcheck

### DIFF
--- a/cargo-spellcheck/riscv64.patch
+++ b/cargo-spellcheck/riscv64.patch
@@ -1,0 +1,13 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -16,7 +16,9 @@ options=('!lto')
+ 
+ prepare() {
+   cd "$pkgname-$pkgver"
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
++  cargo update -p ring
++  cargo fetch --locked
+   mkdir -p completions
+ }
+


### PR DESCRIPTION
This patch fixes the target issue related to rustc and build error from ring.

```
error: failed to run `rustc` to learn about target-specific information

Caused by:
  process didn't exit successfully: `rustc - --crate-name ___ --print=file-names --target riscv64-unknown-linux-gnu --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=cfg` (exit status: 1)
  --- stderr
  error: Error loading target specification: Could not find specification for target "riscv64-unknown-linux-gnu". Run `rustc --print target-list` for a list of built-in targets
```

```
error: failed to run custom build command for `ring v0.16.20`

Caused by:
  process didn't exit successfully: `/build/cargo-spellcheck/src/cargo-spellcheck-0.11.2/target/release/build/ring-bbf6e39716668f57/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', /build/.cargo/registry/src/github.com-1ecc6299db9ec823/ring-0.16.20/build.rs:358:10
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```