### PR TITLE
addpkg: gnu-efi

### DIFF
--- a/gnu-efi/riscv64.patch
+++ b/gnu-efi/riscv64.patch
@@ -1,0 +1,14 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 443903)
++++ PKGBUILD	(working copy)
+@@ -25,8 +25,7 @@
+   # NOTE: apply only minimal CFLAGS, as gnu-efi does not provide userspace
+   # libs, but may be used in unitialized machine state and should therefore not
+   # be architecture optmized
+-  # NOTE: fat-lto-objects is required for non-mangled (static) object files
+-  CFLAGS="-O2 -flto -ffat-lto-objects"
++  CFLAGS="-O2"
+   make
+   make -C lib
+   make -C gnuefi


### PR DESCRIPTION
`systemd` currently fails compilation with the following errors:

```
[138/2371] Generating src/boot/efi/linuxriscv64.elf.stub with a custom command
FAILED: src/boot/efi/linuxriscv64.elf.stub
/usr/bin/cc -o src/boot/efi/linuxriscv64.elf.stub -fuse-ld=bfd -L /usr/lib -nostdlib -T /usr/lib/elf_riscv64_efi.lds -Wl,--build-id=sha1 -Wl,--fatal-warnings -Wl,--no-undefined -Wl,--warn-common -Wl,-Bsymbolic -z nocombreloc /usr/lib/crt0-efi-riscv64.o -shared -Wl,--defsym=EFI_SUBSYSTEM=0xa -Wno-format-signedness -Wno-missing-field-initializers -Wno-unused-parameter -Wdate-time -Wendif-labels -Werror=format=2 -Werror=implicit-function-declaration -Werror=incompatible-pointer-types -Werror=int-conversion -Werror=overflow -Werror=override-init -Werror=return-type -Werror=shift-count-overflow -Werror=shift-overflow=2 -Werror=undef -Wfloat-equal -Wimplicit-fallthrough=5 -Winit-self -Wlogical-op -Wmissing-include-dirs -Wmissing-noreturn -Wnested-externs -Wold-style-definition -Wpointer-arith -Wredundant-decls -Wshadow -Wstrict-aliasing=2 -Wstrict-prototypes -Wsuggest-attribute=noreturn -Wunused-function -Wwrite-strings -Wno-unused-result -fno-stack-protector -fno-strict-aliasing -fpic -fwide-exec-charset=UCS2 -Wall -Wextra -Wsign-compare -nostdlib -std=gnu99 -ffreestanding -fshort-wchar -fvisibility=hidden -isystem /usr/include/efi -isystem /usr/include/efi/riscv64 -I /build/systemd/src/systemd-stable/src/fundamental -DSD_BOOT -DGNU_EFI_USE_MS_ABI -include src/boot/efi/efi_config.h -include version.h -flto -O2 -ffile-prefix-map=/build/systemd/src=/usr/src/debug src/boot/efi/bootspec-fundamental.c.o src/boot/efi/efivars-fundamental.c.o src/boot/efi/sha256.c.o src/boot/efi/string-util-fundamental.c.o src/boot/efi/assert.c.o src/boot/efi/devicetree.c.o src/boot/efi/disk.c.o src/boot/efi/graphics.c.o src/boot/efi/measure.c.o src/boot/efi/pe.c.o src/boot/efi/secure-boot.c.o src/boot/efi/util.c.o src/boot/efi/cpio.c.o src/boot/efi/initrd.c.o src/boot/efi/splash.c.o src/boot/efi/stub.c.o src/boot/efi/linux.c.o -lefi -lgnuefi -lgcc
/usr/bin/ld.bfd: /tmp/ccvPeJD9.ltrans0.ltrans.o: in function `.L0 ':
/build/gnu-efi/src/gnu-efi-3.0.14//lib/print.c:628: undefined reference to `memset'
collect2: error: ld returned 1 exit status
[155/2371] Generating src/boot/efi/systemd_boot.so with a custom command
FAILED: src/boot/efi/systemd_boot.so
/usr/bin/cc -o src/boot/efi/systemd_boot.so -fuse-ld=bfd -L /usr/lib -nostdlib -T /usr/lib/elf_riscv64_efi.lds -Wl,--build-id=sha1 -Wl,--fatal-warnings -Wl,--no-undefined -Wl,--warn-common -Wl,-Bsymbolic -z nocombreloc /usr/lib/crt0-efi-riscv64.o -shared -Wl,--defsym=EFI_SUBSYSTEM=0xa -Wno-format-signedness -Wno-missing-field-initializers -Wno-unused-parameter -Wdate-time -Wendif-labels -Werror=format=2 -Werror=implicit-function-declaration -Werror=incompatible-pointer-types -Werror=int-conversion -Werror=overflow -Werror=override-init -Werror=return-type -Werror=shift-count-overflow -Werror=shift-overflow=2 -Werror=undef -Wfloat-equal -Wimplicit-fallthrough=5 -Winit-self -Wlogical-op -Wmissing-include-dirs -Wmissing-noreturn -Wnested-externs -Wold-style-definition -Wpointer-arith -Wredundant-decls -Wshadow -Wstrict-aliasing=2 -Wstrict-prototypes -Wsuggest-attribute=noreturn -Wunused-function -Wwrite-strings -Wno-unused-result -fno-stack-protector -fno-strict-aliasing -fpic -fwide-exec-charset=UCS2 -Wall -Wextra -Wsign-compare -nostdlib -std=gnu99 -ffreestanding -fshort-wchar -fvisibility=hidden -isystem /usr/include/efi -isystem /usr/include/efi/riscv64 -I /build/systemd/src/systemd-stable/src/fundamental -DSD_BOOT -DGNU_EFI_USE_MS_ABI -include src/boot/efi/efi_config.h -include version.h -flto -O2 -ffile-prefix-map=/build/systemd/src=/usr/src/debug src/boot/efi/bootspec-fundamental.c.o src/boot/efi/efivars-fundamental.c.o src/boot/efi/sha256.c.o src/boot/efi/string-util-fundamental.c.o src/boot/efi/assert.c.o src/boot/efi/devicetree.c.o src/boot/efi/disk.c.o src/boot/efi/graphics.c.o src/boot/efi/measure.c.o src/boot/efi/pe.c.o src/boot/efi/secure-boot.c.o src/boot/efi/util.c.o src/boot/efi/boot.c.o src/boot/efi/console.c.o src/boot/efi/drivers.c.o src/boot/efi/random-seed.c.o src/boot/efi/shim.c.o src/boot/efi/xbootldr.c.o -lefi -lgnuefi -lgcc
/usr/bin/ld.bfd: /tmp/ccGIW3p3.ltrans0.ltrans.o: in function `find_nonunique':
/usr/src/debug/build/../systemd-stable/src/boot/efi/boot.c:1711: undefined reference to `memset'
/usr/bin/ld.bfd: /tmp/ccGIW3p3.ltrans0.ltrans.o: in function `get_file_info_harder':
/usr/src/debug/build/../systemd-stable/src/boot/efi/util.c:581: undefined reference to `memset'
/usr/bin/ld.bfd: /tmp/ccGIW3p3.ltrans0.ltrans.o: in function `config_load_all_entries':
/usr/src/debug/build/../systemd-stable/src/boot/efi/boot.c:2332: undefined reference to `memset'
/usr/bin/ld.bfd: /tmp/ccGIW3p3.ltrans0.ltrans.o: in function `.L0 ':
/usr/src/debug/build/../systemd-stable/src/boot/efi/xbootldr.c:283: undefined reference to `memset'
collect2: error: ld returned 1 exit status
```

Turning off LTO on gnu-efi fixes this.