### PR TITLE
upgpkg: git-cliff 0.7.0-1

### DIFF
--- a/git-cliff/riscv64.patch
+++ b/git-cliff/riscv64.patch
@@ -1,11 +1,12 @@
-diff --git PKGBUILD PKGBUILD
 --- PKGBUILD
 +++ PKGBUILD
-@@ -16,7 +16,7 @@ sha512sums=('35bad914979e2241d1e9b6a0784af72712a071e65a1a6bbe0c53d5dfbc119252bf5
- prepare() {
+@@ -17,7 +17,9 @@ prepare() {
    cd "$pkgname-$pkgver"
    mkdir completions/
+   mkdir man/
 -  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  echo -e '[patch.crates-io]\nring={git="https://github.com/felixonmars/ring", branch="0.16.20"}' >> Cargo.toml
++  cargo update -p ring
 +  cargo fetch --locked
  }
  


### PR DESCRIPTION
This package require `ring` in 0.7.0. This patch replace the `ring` crate with riscv64 compatible version.