### PR TITLE
addpkg: libmemcached-awesome

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -28,6 +28,7 @@ keepassxc
 knot
 libdwarf
 libfbclient
+libmemcached-awesome
 liborcus
 libuv
 mdbook


### PR DESCRIPTION
The test `memcached_udp` fails in QEMU, but passes on board.