### PR TITLE
addpkg: wayland

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -62,6 +62,7 @@ tiled
 tinyssh
 tmuxp
 vim
+wayland
 x2goclient
 zram-generator
 zsh


### PR DESCRIPTION
The test `sanity-test` fails in QEMU, but passes on board.