### PR TITLE
upgpkg: trivy 0.27.0-1

### DIFF
--- a/trivy/riscv64.patch
+++ b/trivy/riscv64.patch
@@ -6,10 +6,10 @@ diff --git PKGBUILD PKGBUILD
  provides=('trivy')
  conflicts=('trivy')
 -source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/v${pkgver}.tar.gz")
--b2sums=('736d55b342dce653f2e73c6f0c08ab9707d22a03c99a8d9fce9a61f5681c3f23450d7e698d9e2b63c8e2a6d79d42763ec454461d5837673a973fd4e82fe3cb54')
+-b2sums=('8267fb66afc7951b16d65d3abaab4af6cdf3f1c3d1dc7cbadeb47624b498e240341d558570912b41765a0e574ce93baf35af0480e29c500a816c158c255dcfd9')
 +source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/v${pkgver}.tar.gz"
 +        fix-libc.patch)
-+b2sums=('736d55b342dce653f2e73c6f0c08ab9707d22a03c99a8d9fce9a61f5681c3f23450d7e698d9e2b63c8e2a6d79d42763ec454461d5837673a973fd4e82fe3cb54'
++b2sums=('a4e409b34d91fc8ea3d0efab069518179ed7195ee956064255d14044c7115ea7cfbff72a77a7bdd18c45fd13e6769bef31997079e67916fee16b34fc433e42a7'
 +        '385c02c2e8d6e783b2718aa53340094ef7444a2567f294f0e0f1399c0982df87c12f2fccb6c35fe1cf8ae8a896268e1e30c8bc211b40ece0a712c1c40f7c4b27')
  
  prepare() {


### PR DESCRIPTION
It's recommended to build this package on board, since the go build process often falls asleep in QEMU and never wake up.