### PR TITLE
addpkg: typescript-language-server

### DIFF
--- a/typescript-language-server/riscv64.patch
+++ b/typescript-language-server/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -16,6 +16,9 @@ b2sums=('e38ba2e85dd06c89ebe0e1debd5354e40b8016b0907d6207f7f8fa4e20ccb29d637fa6e
+ prepare() {
+   cd $pkgname-$pkgver
+   yarn --frozen-lockfile
++
++  # Increase tests' timeout
++  sed -i 's#})\.timeout(10000)#})\.timeout(40000)#' ./src/*.spec.ts ./src/**/*.spec.ts
+ }
+ 
+ build() {


### PR DESCRIPTION
The tests no longer fail after increasing the tests' timeout.

Previous error log:
```
Error: Timeout of 10000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
```