### PR TITLE
upgpkg: mold

### DIFF
--- a/mold/riscv64.patch
+++ b/mold/riscv64.patch
@@ -1,13 +1,14 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -41,7 +41,18 @@ check() {
+@@ -42,7 +42,19 @@ check() {
    cd "$pkgname"
-
+ 
    # temporarily remove failing tests
 -  for failing_test in exception; do
 +  # some tests contain x86-64 assembly
 +  # some tests use gcc despite CC=clang, see https://github.com/rui314/mold/issues/358
 +  for failing_test in exception \
++                      debug-macro-section \
 +                      discard \
 +                      dynamic-list2 \
 +                      gc-sections \
@@ -19,11 +20,13 @@
 +  do
      rm -vf "test/elf/$failing_test.sh"
    done
-
-@@ -51,5 +62,7 @@ check() {
+ 
+@@ -51,6 +63,8 @@ check() {
+     LTO=1 \
      SYSTEM_MIMALLOC=1 \
      SYSTEM_TBB=1 \
 +    CC=clang \
 +    CXX=clang++ \
      check
  }
+ 


### PR DESCRIPTION
Fixed error:
```
Testing debug-macro-section ... mold: fatal: library not found: gcc_s
collect2: error: ld returned 1 exit status
make[1]: *** [Makefile.linux:6: elf/debug-macro-section.sh] Error 1
make[1]: *** Waiting for unfinished jobs....
```

Based on the previous patch, this PR disabled the test `debug-macro-section`.