### PR TITLE
addpkg: python-pbr

### DIFF
--- a/python-pbr/riscv64.patch
+++ b/python-pbr/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index 93ed6b9a..7bb9946f 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -25,7 +25,7 @@
+ check() {
+   cd pbr-$pkgver
+   # TODO: find out this failure
+-  stestr run --exclude-regex "pbr.tests.test_packaging.TestPackagingWheels.test_metadata_directory_has_pbr_json"
++  OS_TEST_TIMEOUT=60 stestr run --exclude-regex "pbr.tests.test_packaging.TestPackagingWheels.test_metadata_directory_has_pbr_json"
+ }
+ 
+ package() {


### PR DESCRIPTION
set default `OS_TEST_TIMEOUT=60` suggested in upstream `tox.ini`.

https://github.com/openstack/pbr/blob/5.9.0/tox.ini#L16
