### PR TITLE
Fix test from GitHub Action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,9 @@ jobs:
         run: pacman -Syu --noconfirm git patch subversion
       - name: Fix git unsafe repository
         run: git config --global --add safe.directory /__w/archriscv-packages/archriscv-packages
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Add remote
         run: |
           git remote add upstream https://github.com/felixonmars/archriscv-packages.git


### PR DESCRIPTION
`actions/checkout` fetch 1 commit only by default, so that git will unable to determine the merge base of `upstream/master` and `HEAD`.