### PR TITLE
Lock the arch value to x86_64

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -40,7 +40,11 @@ for _dir in $(git diff --merge-base --name-only upstream/master | cut -d / -f 1 
   fi
 
   ARCH=$(. PKGBUILD; echo $arch)
-  if [ "${ARCH}" != "any" ] && ! cd ../repos/$REPO-x86_64; then
+
+  if [ "${ARCH}" == "any" ] && ! cd ../repos/$REPO-any; then
+    error "Release directory does not exist for $REPO-any."
+    exit 1
+  elif ! cd ../repos/$REPO-x86_64; then
     error "Release directory does not exist for $REPO-$ARCH."
     exit 1
   fi

--- a/test.sh
+++ b/test.sh
@@ -45,7 +45,7 @@ for _dir in $(git diff --merge-base --name-only upstream/master | cut -d / -f 1 
     error "Release directory does not exist for $REPO-any."
     exit 1
   elif ! cd ../repos/$REPO-x86_64; then
-    error "Release directory does not exist for $REPO-$ARCH."
+    error "Release directory does not exist for $REPO-x86_64."
     exit 1
   fi
 

--- a/test.sh
+++ b/test.sh
@@ -44,7 +44,7 @@ for _dir in $(git diff --merge-base --name-only upstream/master | cut -d / -f 1 
   if [ "${ARCH}" == "any" ] && ! cd ../repos/$REPO-any; then
     error "Release directory does not exist for $REPO-any."
     exit 1
-  elif ! cd ../repos/$REPO-x86_64; then
+  elif [ "${ARCH}" != "any" ] && ! cd ../repos/$REPO-x86_64; then
     error "Release directory does not exist for $REPO-x86_64."
     exit 1
   fi

--- a/test.sh
+++ b/test.sh
@@ -40,7 +40,7 @@ for _dir in $(git diff --merge-base --name-only upstream/master | cut -d / -f 1 
   fi
 
   ARCH=$(. PKGBUILD; echo $arch)
-  if ! cd ../repos/$REPO-$ARCH; then
+  if [ "${ARCH}" != "any" ] && ! cd ../repos/$REPO-x86_64; then
     error "Release directory does not exist for $REPO-$ARCH."
     exit 1
   fi


### PR DESCRIPTION
This patch update the condition logic. Script will try cd into `$REPO-x86_64` only now.