### PR TITLE
addpkg: busybox

### DIFF
--- a/busybox/riscv64.patch
+++ b/busybox/riscv64.patch
@@ -1,0 +1,84 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1209968)
++++ PKGBUILD	(working copy)
+@@ -9,16 +9,17 @@
+ arch=("x86_64")
+ url="https://www.busybox.net"
+ license=('GPL')
+-makedepends=("ncurses" "musl" "kernel-headers-musl")
++depends=('glibc')
++makedepends=("ncurses" "linux-api-headers")
+ validpgpkeys=('C9E9416F76E610DBD09D040F47B70C55ACC9965B')
+ source=("$url/downloads/$pkgname-$pkgver.tar.bz2"{,.sig}
+         "config")
+ sha256sums=('415fbd89e5344c96acf449d94a6f956dbed62e18e835fc83e064db33a34bd549'
+             'SKIP'
+-            '82e934fbdf143028ffb19b195e34c2171dd3b2c17d1c5e37499068ade4d5b28f')
++            'dfd14b68b4cb71af3090060302cae979694ff469742d87a320c577f4798c7eff')
+ b2sums=('1f45f58db26ae0bae2eb728db3a7d49680d611f489c4633d1fdf2827d3c33285721e232f722ac1f80f2ad7616352df9fd6b8880bcb5fa0dc6787b70c897dd033'
+         'SKIP'
+-        'ec7ab659d02bda59be7e0eaae532e5a3e1a53f630559fe66ddadadbdebe5baf31f9f9897e73a6a6f11aa9523158331eac74803035bf84ffab27d8941c181cc61')
++        '51db786bcc96bf81c913f7e23c4aac607e44c351b073e5288959bf6fec8dd7dc19442e3d4c2622546a17336042e5b0cf2d5b550921656752dbf0541e2c105be1')
+ 
+ build() {
+   cd "$srcdir/$pkgname-$pkgver"
+@@ -26,7 +27,7 @@
+   cp "$srcdir"/config .config
+   # reproducible build
+   export KCONFIG_NOTIMESTAMP=1
+-  make CC=musl-gcc
++  make
+ }
+ 
+ package() {
+Index: config
+===================================================================
+--- config	(revision 1209968)
++++ config	(working copy)
+@@ -1,6 +1,6 @@
+ #
+ # Automatically generated make config: don't edit
+-# Busybox version: 1.33.1
++# Busybox version: 1.34.1
+ #
+ CONFIG_HAVE_DOT_CONFIG=y
+ 
+@@ -39,8 +39,8 @@
+ #
+ # Build Options
+ #
+-CONFIG_STATIC=y
+-# CONFIG_PIE is not set
++# CONFIG_STATIC is not set
++CONFIG_PIE=y
+ # CONFIG_NOMMU is not set
+ # CONFIG_BUILD_LIBBUSYBOX is not set
+ # CONFIG_FEATURE_LIBBUSYBOX_STATIC is not set
+@@ -53,7 +53,7 @@
+ CONFIG_EXTRA_LDLIBS=""
+ # CONFIG_USE_PORTABLE_CODE is not set
+ CONFIG_STACK_OPTIMIZATION_386=y
+-CONFIG_STATIC_LIBGCC=y
++# CONFIG_STATIC_LIBGCC is not set
+ 
+ #
+ # Installation Options ("make install" behavior)
+@@ -317,7 +317,6 @@
+ CONFIG_FEATURE_TEST_64=y
+ CONFIG_TIMEOUT=y
+ CONFIG_TOUCH=y
+-CONFIG_FEATURE_TOUCH_NODEREF=y
+ CONFIG_FEATURE_TOUCH_SUSV3=y
+ CONFIG_TR=y
+ CONFIG_FEATURE_TR_CLASSES=y
+@@ -1139,8 +1138,8 @@
+ # CONFIG_SHELL_HUSH is not set
+ # CONFIG_HUSH_BASH_COMPAT is not set
+ # CONFIG_HUSH_BRACE_EXPANSION is not set
++# CONFIG_HUSH_BASH_SOURCE_CURDIR is not set
+ # CONFIG_HUSH_LINENO_VAR is not set
+-# CONFIG_HUSH_BASH_SOURCE_CURDIR is not set
+ # CONFIG_HUSH_INTERACTIVE is not set
+ # CONFIG_HUSH_SAVEHISTORY is not set
+ # CONFIG_HUSH_JOB is not set


### PR DESCRIPTION
Make it dynamic for now as https://github.com/sabotage-linux/kernel-headers does not support RISC-V yet.