### PR TITLE
addpkg: wolfssl

### DIFF
--- a/wolfssl/riscv64.patch
+++ b/wolfssl/riscv64.patch
@@ -1,0 +1,12 @@
+diff --git PKGBUILD PKGBUILD
+index 186a0aaa..a0a61694 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -31,6 +31,7 @@
+     -DWOLFSSL_CURVE448=ON \
+     -DWOLFSSL_ED25519=ON \
+     -DWOLFSSL_ED448=ON \
++    -DWOLFSSL_SHA3=ON \
+     -DWOLFSSL_REPRODUCIBLE_BUILD=ON \
+     -Wno-dev \
+     -B build \


### PR DESCRIPTION
EdDSA448 requires SHAKE256 which requires SHA-3.

SHA-3 is default enabled in x86_64/aarch64 but not enabled in riscv64 by the CMakeLists.

https://github.com/wolfSSL/wolfssl/blob/v5.3.0-stable/CMakeLists.txt#L506-L513
