### PR TITLE
upgpkg: go-ipfs 0.12.2-1

### DIFF
--- a/go-ipfs/riscv64.patch
+++ b/go-ipfs/riscv64.patch
@@ -1,5 +1,3 @@
-diff --git PKGBUILD PKGBUILD
-index 4b89dd3b..32ef4063 100644
 --- PKGBUILD
 +++ PKGBUILD
 @@ -34,6 +34,8 @@ prepare() {
@@ -7,7 +5,7 @@ index 4b89dd3b..32ef4063 100644
    cd go-ipfs
    patch -Np1 -i ../rb.patch
 +  go mod edit -replace github.com/marten-seemann/tcp=github.com/r-value/tcp@master
-+  go mod vendor
++  go mod download
  }
  
  build() {


### PR DESCRIPTION
The checksum in `go.sum` is mismatched after running `go mod edit -replace`, so `go mod download` should be run to update `go.sum`.

Also, we only need `go mod download` to download dependencies to local cache, instead of using `go mod vendor` to make a vendored copy of dependencies.