### PR TITLE
addpkg: libsecret to qemu-user blacklist

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -30,6 +30,7 @@ libdwarf
 libfbclient
 libmemcached-awesome
 liborcus
+libsecret
 libuv
 mdbook
 meilisearch


### PR DESCRIPTION
Stuck in `check()` with qemu-user.