### PR TITLE
addpkg: dracut-hook

### DIFF
--- a/dracut-hook/60-dracut-remove.hook
+++ b/dracut-hook/60-dracut-remove.hook
@@ -1,0 +1,10 @@
+[Trigger]
+Type = Path
+Operation = Remove
+Target = usr/lib/modules/*/pkgbase
+
+[Action]
+Description = Removing initramfs...
+When = PreTransaction
+Exec = /usr/share/libalpm/scripts/dracut-remove
+NeedsTargets

--- a/dracut-hook/90-dracut-install.hook
+++ b/dracut-hook/90-dracut-install.hook
@@ -1,0 +1,13 @@
+[Trigger]
+Type = Path
+Operation = Install
+Operation = Upgrade
+Target = usr/lib/modules/*/vmlinuz
+Target = usr/lib/dracut/*
+Target = usr/lib/systemd/systemd
+
+[Action]
+Description = Updating initramfs...
+When = PostTransaction
+Exec = /usr/share/libalpm/scripts/dracut-install
+NeedsTargets

--- a/dracut-hook/PKGBUILD
+++ b/dracut-hook/PKGBUILD
@@ -1,0 +1,29 @@
+# Maintainer: Leonidas P. <jpegxguy at outlook dot com>
+# Contributor: Franklyn Tackitt <franklyn@tackitt.net>
+# Contributor: Kevin Del Castillo <quebin31@gmail.com>
+
+pkgname=dracut-hook
+pkgver=0.5.3
+pkgrel=1
+pkgdesc="Install/remove hooks for dracut"
+url=https://dracut.wiki.kernel.org/index.php/Main_Page
+arch=('any')
+license=('BSD')
+depends=('dracut')
+source=(
+	"dracut-install"
+	"dracut-remove"
+	"90-dracut-install.hook"
+	"60-dracut-remove.hook"
+)
+sha256sums=('4539f8b4e4caef233b39a308891cf448de546efaad61579e9332e312e8c4ea3a'
+            '8d7fe6622dcbe5fb8a4b0df33265e82bd895e328d202a841a46859c1dd99d47e'
+            'de09e8e65837b189aec0a8c9a067143880faff14467a5573949f772f39c053b3'
+            'e79f8e9572c5d1af6052104eac7ff956754f7a191b52b16adf12b65a38e9b4ed')
+
+package() {
+	install -Dm644 "${srcdir}/90-dracut-install.hook" "${pkgdir}/usr/share/libalpm/hooks/90-dracut-install.hook"
+	install -Dm644 "${srcdir}/60-dracut-remove.hook"  "${pkgdir}/usr/share/libalpm/hooks/60-dracut-remove.hook"
+	install -Dm755 "${srcdir}/dracut-install"         "${pkgdir}/usr/share/libalpm/scripts/dracut-install"
+	install -Dm755 "${srcdir}/dracut-remove"          "${pkgdir}/usr/share/libalpm/scripts/dracut-remove"
+}

--- a/dracut-hook/dracut-install
+++ b/dracut-hook/dracut-install
@@ -1,0 +1,39 @@
+#!/bin/bash -e
+
+all=0
+lines=()
+
+while read -r line; do
+	if [[ "${line}" != */vmlinuz ]]; then
+		# triggers when it's a change to dracut files
+		all=1
+		continue
+	fi
+
+	lines+=("/${line%/vmlinuz}")
+
+	pkgbase="$(<"${lines[-1]}/pkgbase")"
+	install -Dm644 "/${line}" "/boot/vmlinuz-${pkgbase}"
+done
+
+if (( all )); then
+	lines=(/usr/lib/modules/*)
+fi
+
+for line in "${lines[@]}"; do
+	if ! pacman -Qqo "${line}/pkgbase" &> /dev/null; then
+		# if pkgbase does not belong to any package then skip this kernel
+		continue
+	fi
+
+	pkgbase="$(<"${line}/pkgbase")"
+	kver="${line##*/}"
+	dracut_restore_img="/usr/lib/modules/${kver}/initrd"
+
+	echo ":: Building initramfs for ${pkgbase} (${kver})"
+	dracut --force --hostonly --no-hostonly-cmdline ${dracut_restore_img} "${kver}"
+	install -Dm644 ${dracut_restore_img} "/boot/initramfs-${pkgbase}.img"
+
+	echo ":: Building fallback initramfs for ${pkgbase} (${kver})"
+	dracut --force --no-hostonly "/boot/initramfs-${pkgbase}-fallback.img" "${kver}"
+done

--- a/dracut-hook/dracut-remove
+++ b/dracut-hook/dracut-remove
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+while read -r line; do
+	if [[ "${line}" == */pkgbase ]]; then
+		pkgbase="$(<"/${line}")"
+		kver="$(echo ${line} | cut -d/ -f4)"
+
+		rm -rf "/usr/lib/modules/${kver}" "/boot/vmlinuz-${pkgbase}" "/boot/initramfs-${pkgbase}.img" "/boot/initramfs-${pkgbase}-fallback.img"
+	fi
+done


### PR DESCRIPTION
We need this pacman hook to generate initramfs by dracut automatically.
Get from AUR (https://aur.archlinux.org/packages/dracut-hook).
Test in rootfs and qemu-img generator.