### PR TITLE
addpkg: cargo-audit

### DIFF
--- a/cargo-audit/riscv64.patch
+++ b/cargo-audit/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,7 +15,7 @@ b2sums=('1dce9dcc94c75e1df9f8d955c4f86bb08905e18de6eb875f6a4380ed55190874e512b89
+ 
+ prepare() {
+   cd rustsec-${pkgname}-v${pkgver}/${pkgname}
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  cargo fetch --locked
+ }
+ 
+ build() {

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -4,6 +4,7 @@ bazel
 beatslash-lv2
 bmake
 caps
+cargo-audit
 datovka
 dbus
 dovecot


### PR DESCRIPTION
Fixed error:
```
error: failed to run `rustc` to learn about target-specific information

Caused by:
  process didn't exit successfully: `rustc - --crate-name ___ --print=file-names --target riscv64-unknown-linux-gnu --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=cfg` (exit status: 1)
  --- stderr
  error: Error loading target specification: Could not find specification for target "riscv64-unknown-linux-gnu". Run `rustc --print target-list` for a list of built-in targets
```

and this package will stuck in test `advisories_found_exit_error` in qemu-user:
```
thread 'advisories_found_exit_error' panicked at 'error waiting for subprocess to terminate: operation timed out: operation timed out after 1800 seconds', /build/.cargo/registry/src/github.com-1ecc6299db9ec823/abscissa_core-0.6.0/src/testing/runner.rs:229:13
```
