### PR TITLE
addpkg: python-doit-py-bootstrap

### DIFF
--- a/python-doit-py-bootstrap/PKGBUILD
+++ b/python-doit-py-bootstrap/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: David Runge <dvzrv@archlinux.org>
 
 _name=doit-py
-pkgname=python-doit-py
+pkgname=python-doit-py-bootstrap
 pkgver=0.5.0
 pkgrel=5
 pkgdesc="doit tasks for python stuff"

--- a/python-doit-py-bootstrap/PKGBUILD
+++ b/python-doit-py-bootstrap/PKGBUILD
@@ -1,0 +1,43 @@
+# Maintainer: David Runge <dvzrv@archlinux.org>
+
+_name=doit-py
+pkgname=python-doit-py
+pkgver=0.5.0
+pkgrel=5
+pkgdesc="doit tasks for python stuff"
+arch=('any')
+url="https://github.com/pydoit/doit-py"
+license=('MIT')
+depends=('python-configclass')
+makedepends=('python-setuptools')
+checkdepends=('hunspell' 'hunspell-en_US' 'python-pyflakes' 'python-pytest')
+# pypi sdist is missing tests:
+# https://github.com/pydoit/doit-py/issues/4
+# source=("https://files.pythonhosted.org/packages/source/${_name::1}/${_name}/${_name}-${pkgver}.tar.gz")
+source=("$pkgname-$pkgver.tar.gz::https://github.com/pydoit/${_name}/archive/${pkgver}.tar.gz")
+sha512sums=('f9e70be30f47b7251bdb479762dabe655be898f9fe37fc5ac6608110a82863a08002271620569745f9ec2f47c03529c044a6ea74244b8bb6438b3fbe7e4c28f7')
+b2sums=('092f21549d3c088baf8a96b8dd7575304d08c7ae7b0472e7a890159247422060af06c1cc14064cd608bd59e71788067c5374953b16f4511971bb3018c0245cd4')
+
+prepare() {
+  mv -v "$_name-$pkgver" "$pkgname-$pkgver"
+}
+
+build() {
+  cd "$pkgname-$pkgver"
+  python setup.py build
+}
+
+check() {
+  cd "$pkgname-$pkgver"
+  export PYTHONPATH="build:${PYTHONPATH}"
+  pytest -v
+}
+
+package() {
+  cd "$pkgname-$pkgver"
+  python setup.py install --skip-build \
+                          --optimize=1 \
+                          --root="${pkgdir}"
+  install -vDm 644 LICENSE -t "${pkgdir}/usr/share/licenses/${pkgname}"
+  install -vDm 644 {CHANGES,README.rst} -t "${pkgdir}/usr/share/doc/${pkgname}"
+}


### PR DESCRIPTION
1. `pyton-doit-py` depends on `python-doit`, and `python-doit`  checkdepends on `python-doit-py`
2. build order: ` python-doit-py` -> `python-doit` -> `python-doit-py`