### PR TITLE
upgpkg: libseccomp to 2.5.4

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -31,6 +31,7 @@ libdwarf
 libfbclient
 libmemcached-awesome
 liborcus
+libseccomp
 libsecret
 libuv
 mdbook


### PR DESCRIPTION
`check()` failed at 52-basic-load because qemu-user doesn't support
seccomp syscall, and `prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, )`
also failed. You can check the result by setting QEMU_STRACE. The
result is (Function not implemented) and (Invalid argument).
What's more, the package can pass `check()` in a RSIC-V board. So
I think it's proper to add libseccomp to qemu-user-blacklist.txt.