### PR TITLE
addpkg: openjade

### DIFF
--- a/openjade/riscv64.patch
+++ b/openjade/riscv64.patch
@@ -1,0 +1,12 @@
+diff --git PKGBUILD trunk/PKGBUILD
+index 2337cd0..fbd652d 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -21,6 +21,7 @@ sha256sums=('1d2d7996cc94f9b87d0c51cf0e028070ac177c4123ecbfd7ac1cb8d0b7d322d1'
+ prepare() {
+   cd ${pkgname}-$pkgver
+   patch -Np1 -i "$srcdir"/${pkgname}1.3_${pkgver}-${_debpatch}.diff
++  cp -v "/usr/share/autoconf/build-aux/config.guess" "/usr/share/autoconf/build-aux/config.sub" config
+   # https://bugs.archlinux.org/task/55331 / https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69534#c9
+   export CXXFLAGS+=' -fno-lifetime-dse'
+ }


### PR DESCRIPTION
This package failed to build because the config.guess and config.sub are
too old to recognize RISC-V.