### PR TITLE
addpkg: mumble

### DIFF
--- a/mumble/riscv64.patch
+++ b/mumble/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -18,7 +18,7 @@ depends=('gcc-libs' 'glibc' 'openssl' 'qt5-base')
+ makedepends=('avahi' 'boost' 'cmake' 'poco' 'protobuf' 'python' 'qt5-tools' 'speech-dispatcher')
+ # mumble makedepends
+ makedepends+=('alsa-lib' 'hicolor-icon-theme' 'jack' 'libpulse' 'libsndfile'
+-'libspeechd' 'libx11' 'libxi' 'mesa' 'opus' 'qt5-svg' 'speex' 'xdg-utils' 'lib32-gcc-libs')
++'libspeechd' 'libx11' 'libxi' 'mesa' 'opus' 'qt5-svg' 'speex' 'xdg-utils')
+ # murmur makedepends
+ makedepends+=('grpc' 'libcap' 'zeroc-ice')
+ source=(


### PR DESCRIPTION
lib32-gcc-libs is not available in riscv64 arch. Delete this dependency will not affect the build process.