### PR TITLE
addpkg: libxv

### DIFF
--- a/libxv/riscv64.patch
+++ b/libxv/riscv64.patch
@@ -1,0 +1,23 @@
+diff --git PKGBUILD trunk/PKGBUILD
+index 759ab0c..0901d4b 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -9,12 +9,17 @@ arch=('x86_64')
+ license=('custom')
+ url="https://xorg.freedesktop.org/"
+ depends=('libxext')
+-makedepends=('xorgproto')
++makedepends=('xorgproto' 'xorg-util-macros')
+ source=(${url}/releases/individual/lib/libXv-${pkgver}.tar.bz2{,.sig})
+ sha256sums=('d26c13eac99ac4504c532e8e76a1c8e4bd526471eb8a0a4ff2a88db60cb0b088'
+             'SKIP')
+ validpgpkeys=('C41C985FDCF1E5364576638B687393EE37D128F8') # Matthieu Herrb <matthieu.herrb@laas.fr>
+ 
++prepare() {
++  cd "${srcdir}/libXv-${pkgver}"
++  autoreconf -fiv
++}
++
+ build() {
+   cd "${srcdir}/libXv-${pkgver}"
+   ./configure --prefix=/usr --disable-static


### PR DESCRIPTION
This package failed to build because config.guess and config.sub bundled
in release tarball are too old. So force autoreconf in prepare() should
solve this problem. A makedepends is added due to requirements of
autoreconf.

Also, a bug has been filed to upstream.
https://bugs.archlinux.org/task/74866