### PR TITLE
addpkg: libxtst

### DIFF
--- a/libxtst/riscv64.patch
+++ b/libxtst/riscv64.patch
@@ -1,0 +1,16 @@
+diff --git PKGBUILD trunk/PKGBUILD
+index 2b929d3..18e15d0 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,6 +15,11 @@ sha256sums=('4655498a1b8e844e3d6f21f3b2c4e2b571effb5fd83199d428a6ba7ea4bf5204'
+             'SKIP')
+ validpgpkeys=('C41C985FDCF1E5364576638B687393EE37D128F8') # Matthieu Herrb <matthieu.herrb@laas.fr>
+ 
++prepare() {
++  cd "${srcdir}/libXtst-${pkgver}"
++  autoreconf -fiv
++}
++
+ build() {
+   cd "${srcdir}/libXtst-${pkgver}"
+   ./configure --prefix=/usr --disable-static


### PR DESCRIPTION
This package failed to build because config.guess and config.sub bundled
in release tarball are too old. So force autoreconf in prepare() should
solve this problem.

Also, a bug has been filed to upstream.
https://bugs.archlinux.org/task/74868