### PR TITLE
addpkg: libxxf86vm

### DIFF
--- a/libxxf86vm/riscv64.patch
+++ b/libxxf86vm/riscv64.patch
@@ -1,0 +1,16 @@
+diff --git PKGBUILD trunk/PKGBUILD
+index 15fc4fd..2bfe92f 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,6 +15,11 @@ sha512sums=('c5f92d86e143db02ebb36bcd25618acaa2cb2831f5a23800a06dd431cd73b6702d9
+             'SKIP')
+ validpgpkeys=('4A193C06D35E7C670FA4EF0BA2FB9E081F2D130E') # Alan Coopersmith <alan.coopersmith@oracle.com>
+ 
++prepare() {
++  cd libXxf86vm-${pkgver}
++  autoreconf -fiv
++}
++
+ build() {
+   cd libXxf86vm-${pkgver}
+   ./configure --prefix=/usr --disable-static


### PR DESCRIPTION
This package failed to build because config.guess and config.sub bundled
in release tarball are too old. So force autoreconf in prepare() should
solve this problem.

Also, a bug has been filed to upstream.
https://bugs.archlinux.org/task/74869