### PR TITLE
addpkg: mesa-amber

### DIFF
--- a/mesa-amber/riscv64.patch
+++ b/mesa-amber/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD trunk/PKGBUILD
+index cb2e3db..e62edcd 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -30,7 +30,7 @@ build() {
+     -D b_ndebug=true \
+     -D amber=true \
+     -D platforms=auto \
+-    -D dri-drivers=i915,i965,r100,r200,nouveau \
++    -D dri-drivers=r100,r200,nouveau \
+     -D gallium-drivers=swrast \
+     -D vulkan-drivers=auto \
+     -D dri3=enabled \


### PR DESCRIPTION
This package failed because intel dri drivers cannot be used in riscv64,
reference: #1326 . After disabling intel dri drivers, mesa-amber can be
built normally.