### PR TITLE
upgpkg: kubie

### DIFF
--- a/kubie/riscv64.patch
+++ b/kubie/riscv64.patch
@@ -1,8 +1,12 @@
-diff --git PKGBUILD PKGBUILD
-index 4e304b8f..eee2242d 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -19,6 +19,8 @@ prepare() {
+@@ -15,11 +15,13 @@ options=('!lto')
+ 
+ prepare() {
+   cd "$pkgname-$pkgver"
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  cargo fetch --locked
+ }
  
  build() {
    cd "$pkgname-$pkgver"


### PR DESCRIPTION
Fixed error:
```
error: failed to run `rustc` to learn about target-specific information

Caused by:
  process didn't exit successfully: `rustc - --crate-name ___ --print=file-names --target riscv64-unknown-linux-gnu --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=cfg` (exit status: 1)
  --- stderr
  error: Error loading target specification: Could not find specification for target "riscv64-unknown-linux-gnu". Run `rustc --print target-list` for a list of built-in targets

```