### PR TITLE
addpkg: cups

### DIFF
--- a/cups/riscv64.patch
+++ b/cups/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -51,6 +51,9 @@ prepare() {
+   # FS#56818 - https://github.com/apple/cups/issues/5236
+   patch -Np1 -i "${srcdir}"/guid.patch
+ 
++  # Fix unable to guess system type issue
++  cp /usr/share/autoconf/build-aux/config.{sub,guess} .
++
+   # Rebuild configure script
+   aclocal -I config-scripts
+   autoconf -I config-scripts


### PR DESCRIPTION
The current config.guess file is outdated. This patch is a temporary
workaround. And it should be removed after the [upstream] update the guess
file.

ref:
[upstream]: https://github.com/OpenPrinting/cups/issues/404

Signed-off-by: Avimitin <avimitin@gmail.com>