### PR TITLE
upgpkg: nushell

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -39,6 +39,7 @@ meilisearch
 nodejs-lts-gallium
 notepadqq
 nuitka
+nushell
 openldap
 pangomm-2.48
 perl


### PR DESCRIPTION
Some tests fail in qemu-user, because they try to execute a non-existent command and expect an error occur, but since the implementation bug of qemu-user, spawning a non-existent command returns a `Ok` instead of a `Err`.

MRE:

```rust
fn main() {
    let mut process = std::process::Command::new("nonexistcommand");
    println!("result: {:?}", process.spawn());
}
```

qemu-user RISC-V returns: `result: Ok(Child { stdin: None, stdout: None, stderr: None, .. })`
x86_64 returns: `result: Err(Os { code: 2, kind: NotFound, message: "No such file or directory" })`
Board RISC-V returns: `result: Err(Os { code: 2, kind: NotFound, message: "No such file or directory" })`

<details><summary><b>Failed tests</b></summary>

```
failures:

---- overlays::remove_overlay_discard_decl stdout ----
=== stderr
Error: ]8;;https://docs.rs/nu-protocol/0.63.1/nu_protocol/enum.ShellError.html#variant.ExternalCommand\nu::shell::external_command (link)]8;;\

  × External command
   ╭─[source:1:1]
 1 │ overlay add samples/spam.nu; def bagr [] { "bagr" }; overlay remove spam; bagr
   ·                                                                           ──┬─
   ·                                                                             ╰── can't run executable
   ╰────
  help: No such file or directory (os error 2)


thread 'overlays::remove_overlay_discard_decl' panicked at 'assertion failed: !actual_repl.err.is_empty()', tests/overlays/mod.rs:272:5

---- overlays::remove_last_overlay stdout ----
=== stderr
Error: ]8;;https://docs.rs/nu-parser/0.63.1/nu_parser/enum.ParseError.html#variant.CantRemoveDefaultOverlay\nu::parser::cant_remove_default_overlay (link)]8;;\

  × Cannot remove default overlay.
   ╭─[source:1:1]
 1 │ module spam { export def foo [] { "foo" } }; overlay add spam; overlay remove; foo
   ·                                                                ───────┬──────
   ·                                                                       ╰── can't remove overlay
   ╰────
  help: 'zero' is a default overlay. Default overlays cannot be removed.


thread 'overlays::remove_last_overlay' panicked at 'assertion failed: !actual_repl.err.is_empty()', tests/overlays/mod.rs:164:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- overlays::remove_overlay_keep_discard_overwritten_alias stdout ----
=== stderr
Error: ]8;;https://docs.rs/nu-protocol/0.63.1/nu_protocol/enum.ShellError.html#variant.ExternalCommand\nu::shell::external_command (link)]8;;\

  × External command
   ╭─[source:1:1]
 1 │ overlay add samples/spam.nu; alias bar = 'baz'; overlay remove --keep-custom spam; bar
   ·                                                                                    ─┬─
   ·                                                                                     ╰── can't run executable
   ╰────
  help: No such file or directory (os error 2)


thread 'overlays::remove_overlay_keep_discard_overwritten_alias' panicked at 'assertion failed: !actual_repl.err.is_empty()', tests/overlays/mod.rs:393:5

---- overlays::remove_overlay_keep_discard_overwritten_decl stdout ----
=== stderr
Error: ]8;;https://docs.rs/nu-protocol/0.63.1/nu_protocol/enum.ShellError.html#variant.ExternalCommand\nu::shell::external_command (link)]8;;\

  × External command
   ╭─[source:1:1]
 1 │ overlay add samples/spam.nu; def foo [] { 'bar' }; overlay remove --keep-custom spam; foo
   ·                                                                                       ─┬─
   ·                                                                                        ╰── can't run executable
   ╰────
  help: No such file or directory (os error 2)


thread 'overlays::remove_overlay_keep_discard_overwritten_decl' panicked at 'assertion failed: !actual_repl.err.is_empty()', tests/overlays/mod.rs:374:5

---- overlays::remove_overlay stdout ----
=== stderr
Error: ]8;;https://docs.rs/nu-protocol/0.63.1/nu_protocol/enum.ShellError.html#variant.ExternalCommand\nu::shell::external_command (link)]8;;\

  × External command
   ╭─[source:1:1]
 1 │ module spam { export def foo [] { "foo" } }; overlay add spam; overlay remove spam; foo
   ·                                                                                     ─┬─
   ·                                                                                      ╰── can't run executable
   ╰────
  help: No such file or directory (os error 2)


thread 'overlays::remove_overlay' panicked at 'assertion failed: !actual_repl.err.is_empty()', tests/overlays/mod.rs:145:5

---- overlays::remove_overlay_discard_alias stdout ----
=== stderr
Error: ]8;;https://docs.rs/nu-protocol/0.63.1/nu_protocol/enum.ShellError.html#variant.ExternalCommand\nu::shell::external_command (link)]8;;\

  × External command
   ╭─[source:1:1]
 1 │ overlay add samples/spam.nu; alias bagr = "bagr"; overlay remove spam; bagr
   ·                                                                        ──┬─
   ·                                                                          ╰── can't run executable
   ╰────
  help: No such file or directory (os error 2)


thread 'overlays::remove_overlay_discard_alias' panicked at 'assertion failed: !actual_repl.err.is_empty()', tests/overlays/mod.rs:291:5


failures:
    overlays::remove_last_overlay
    overlays::remove_overlay
    overlays::remove_overlay_discard_alias
    overlays::remove_overlay_discard_decl
    overlays::remove_overlay_keep_discard_overwritten_alias
    overlays::remove_overlay_keep_discard_overwritten_decl

test result: FAILED. 218 passed; 6 failed; 20 ignored; 0 measured; 0 filtered out; finished in 6.63s
```
</details>
