### PR TITLE
addpkg: libc++

### DIFF
--- a/libc++/libc++abi-fix-demangler-for-long-double.patch
+++ b/libc++/libc++abi-fix-demangler-for-long-double.patch
@@ -1,0 +1,12 @@
+diff --git a/libcxxabi/src/demangle/ItaniumDemangle.h b/libcxxabi/src/demangle/ItaniumDemangle.h
+--- a/libcxxabi/src/demangle/ItaniumDemangle.h
++++ b/libcxxabi/src/demangle/ItaniumDemangle.h
+@@ -5099,7 +5099,7 @@
+ struct FloatData<long double>
+ {
+ #if defined(__mips__) && defined(__mips_n64) || defined(__aarch64__) || \
+-    defined(__wasm__)
++    defined(__wasm__) || defined(__riscv)
+     static const size_t mangled_size = 32;
+ #elif defined(__arm__) || defined(__mips__) || defined(__hexagon__)
+     static const size_t mangled_size = 16;

--- a/libc++/riscv64.patch
+++ b/libc++/riscv64.patch
@@ -1,0 +1,31 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,14 +15,16 @@ makedepends=('clang' 'cmake' 'llvm' 'libunwind' 'ninja' 'python')
+ options=(!lto)
+ source=("https://github.com/llvm/llvm-project/releases/download/llvmorg-$pkgver/llvm-$pkgver.src.tar.xz"{,.sig}
+         "https://github.com/llvm/llvm-project/releases/download/llvmorg-$pkgver/libcxx-$pkgver.src.tar.xz"{,.sig}
+-        "https://github.com/llvm/llvm-project/releases/download/llvmorg-$pkgver/libcxxabi-$pkgver.src.tar.xz"{,.sig})
++        "https://github.com/llvm/llvm-project/releases/download/llvmorg-$pkgver/libcxxabi-$pkgver.src.tar.xz"{,.sig}
++        "libc++abi-fix-demangler-for-long-double.patch")
+ noextract=("${source[@]##*/}")
+ sha512sums=('05fbe8708ac3d0dfef3a9135ee88185a95ed492095429a97d33b8aadb0187e59ad42d1a7184f02b5c84fdd31f3d7227c65bd292ed0aa039b29522e59cf90a965'
+             'SKIP'
+             '72970fbb3db44a652e89ace7843e992b4f118c978fa0fa7035bf5825cb6958cf71f7c80b56c1970977177bb3bcbf81309d4f01c29b3ac1cd057be54baf55e56f'
+             'SKIP'
+             '1a7c032ee34643518be01edddc16b1c872f339ed2944d31573438d38a018abc801a53f3fbd97e6a3d6ee58a6ed55d9703a8531ac7290c1d6e3e5593b97186749'
+-            'SKIP')
++            'SKIP'
++            'bac4a928f0dab60623f1931eb99d4d495a0c4bd40a03bff024b25c2c5b6a4d4ada21ffd5df351149cecafd0b26282156baf11b7dac66e6a66278b1d3df261745')
+ validpgpkeys=('474E22316ABF4785A88C6E8EA2C794A986419D8A' # Tom Stellard <tstellar@redhat.com> (.1 releases)
+               'B6C8F98282B944E3B0D5C2530FC3042E345AD05D') # Hans Wennborg <hans@chromium.org> (.0 releases)
+  
+@@ -32,6 +34,9 @@ prepare() {
+   bsdtar --strip-components 1 -zxf "${source[2]##*/}" -C llvm/projects/libcxx
+   bsdtar --strip-components 1 -zxf "${source[4]##*/}" -C llvm/projects/libcxxabi
+   sed -i 's/CREDITS.TXT/CREDITS/' llvm/projects/libcxx/LICENSE.TXT llvm/projects/libcxxabi/LICENSE.TXT
++
++  # patch modified from https://reviews.llvm.org/D126480
++  patch -d llvm/projects -Np1 -i $srcdir/libc++abi-fix-demangler-for-long-double.patch
+ }
+  
+ build() {


### PR DESCRIPTION
This patch fixes the test failure in libc++abi's demangler.