### PR TITLE
addpkg: elfutils

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -10,6 +10,7 @@ dbus
 dovecot
 dqlite
 element
+elfutils
 ell
 ethtool
 fd


### PR DESCRIPTION
I got only three test suite failures when building on boards which are much
less than building by qemu-user. Those three failures are known to upstream and
this issue has been confirmed and assigned. Since it's tedious to investigate
why each tests failed, I just simply add elfutils to qemu-user-blacklists.txt.

Ref: https://sourceware.org/bugzilla/show_bug.cgi?id=29073