### PR TITLE
addpkg: backuppc

### DIFF
--- a/backuppc/riscv64.patch
+++ b/backuppc/riscv64.patch
@@ -1,0 +1,13 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -52,6 +52,10 @@ prepare() {
+     fi
+   done
+   :
++
++  # Fix unable to guess system type issue
++  cd "$srcdir"/rsync-bpc-$_rbpcver
++  cp /usr/share/autoconf/build-aux/config.{sub,guess} .
+ }
+ 
+ build() {


### PR DESCRIPTION
This package contains outdated config.guess file and couldn't correctly
guess system type. This patch is a temporary workaround that copy the
local config.guess file into project.

Signed-off-by: Avimitin <avimitin@gmail.com>