### PR TITLE
addpkg: dnssec-tools

### DIFF
--- a/dnssec-tools/riscv64.patch
+++ b/dnssec-tools/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -44,6 +44,8 @@ prepare() {
+       -e 's:/usr/sbin/dnssec-signzone:/usr/bin/dnssec-signzone:' \
+       -i tools/etc/dnssec-tools/dnssec-tools.conf
+ 
++  autoreconf -fi
++
+ }
+ 
+ build() {


### PR DESCRIPTION
This packages contains outdated config.guess file. And the command
`autoreconf -fi` can fix it properly. This command is being used by
other distro like Debian, AOSC OS.

Signed-off-by: Avimitin <avimitin@gmail.com>