### PR TITLE
addpkg: perl-file-rsyncp

### DIFF
--- a/perl-file-rsyncp/riscv64.patch
+++ b/perl-file-rsyncp/riscv64.patch
@@ -1,0 +1,12 @@
+diff --git PKGBUILD PKGBUILD
+index a5c6bcc..dcbc0ef 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,6 +17,7 @@ sha512sums=('b81d9ce63181605939e8aff87c9e56ab276899f019f44eb3f149e7ee0d44a94fcbe
+ 
+ prepare() {
+   cd File-RsyncP-$pkgver
++  cp -vf /usr/share/autoconf/build-aux/config.guess FileList/
+   # https://rt.cpan.org/Public/Bug/Display.html?id=141822
+   patch -Np1 -i ../gcc12.patch
+ }


### PR DESCRIPTION
Fixed config.guess.

This package contains outdated config.guess file and couldn't correctly
guess system type. This patch is a temporary workaround that copy the
local config.guess file into project.

This is the same problem as some previous packages.
Ref: https://github.com/felixonmars/archriscv-packages/pull/1313.
Build passed.