### PR TITLE
added ninja to qemu-user-blacklist.

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -36,6 +36,7 @@ libsecret
 libuv
 mdbook
 meilisearch
+ninja
 nodejs-lts-gallium
 notepadqq
 nuitka


### PR DESCRIPTION
The ninja package can be passed on the real RISC-V board.
It's the problem of qemu-user.
So added it to the blacklist.

Details:
I attempted run the PKGBUILD, and failed in the `check()` function.
`[15/22] CXX build/missing_deps_test.o`
`[16/22] CXX build/manifest_parser_test.o`
`[17/22] CXX build/graph_test.o`
`[18/22] CXX build/util_test.o`
`[19/22] CXX build/subprocess_test.o`
`[20/22] CXX build/test.o`
`[21/22] CXX build/build_test.o`
`[22/22] LINK ninja_test`
`==> ERROR: A failure occurred in check().`
`    Aborting...`
`==> ERROR: Build failed, check /var/lib/archbuild/extra-riscv64/tinysnow/build`


Then, I read the `check()` function, its content as below:
`check() {`
`   cd ninja-$pkgver `
`   python ./configure.py`
`   ./ninja ninja_test`
`   ./ninja_test`
`}`

Then I located the problem: runing `./ninja_test` failed.
I entered into RISC-V qemu-user visual environment, and run ninja_test singly, finally, it failed.
The info belows:
`[root@tinysnow ninja-1.11.0]# ./ninja_test`
`[15/385] SubprocessTest.InterruptParent`
`*** Failure in src/subprocess_test.cc:98`
`"We should have been interrupted"`

So I think it's the qemu-user's problem.