### PR TITLE
upgpkg: terraform 1.2.2-1

### DIFF
--- a/terraform/riscv64.patch
+++ b/terraform/riscv64.patch
@@ -1,28 +1,15 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -16,18 +16,22 @@ options=('!lto')
- source=("$pkgname-$pkgver.tar.gz::https://github.com/hashicorp/terraform/archive/v$pkgver.tar.gz"
-         "terraform.bash"
-         "terraform.fish"
--        "terraform.zsh")
-+        "terraform.zsh"
-+        "$pkgname-bump-go-expect.patch::https://github.com/hashicorp/terraform/pull/31103.patch")
- sha512sums=('6a7af43744f928722f71d8ffb3401d594b250fad03df79ae403acbdd1887365de868256d47bdde42a170a4c01d76f789f52de821267db666407e42776deb0b25'
-             'ea42bfc41288e5ad741fcddfbd5c1f8ba0088be0967b820db1e12e1dc13d1ba242b9cc1c247bf29c36ec59cdce76ff6703cf6b3f76cca5ec441a4927a01afe7d'
-             '44b387fbd7b6abb8f524999d3d5f14fd4d5be54b2b34336a708c6a493c93c886a7230d3102601604f62cf95c53e91de683919213d0e1473ee84e606030d249e3'
--            'ad991daf40f68c11fa66256177a04d97bd38d6a89c554d6261489d4de703852628ffc37429d862237ca24e15f6a7c915cfa027731189ac89a27f7b20c72ab4c9')
-+            'ad991daf40f68c11fa66256177a04d97bd38d6a89c554d6261489d4de703852628ffc37429d862237ca24e15f6a7c915cfa027731189ac89a27f7b20c72ab4c9'
-+            '20950a6302d4e8f02bef41eb8a0ce06fa0ddc40589e3b58ea2c92100907a59c4d8be2f8c036ae117a5e991155595a095a394738b8d4d5af32c9dbe3f5b75928c')
- b2sums=('ff4483adefc7728089573ebd032f46f1d1b131cddee7b1e1f3bc0c07606d125991e18686fcbff637d4f5765c85dd902557122927d3d87c6e21c3e1398e96ca8d'
-         'd047735bbb006e9afbaa4b18af7a7f16a205ec528e91caa61a0b663dd6e24ec1df999216f0b7bd06e3b3c087b37f6ce3aa3cf3a20c892a9cc1962d33ce1b0bcc'
-         'd3655f23ba8893d0f8c6cd5e8b42fae473ccfbc77d97b7424aa1f0d0057bfed6cb4d2505e74dd89099c39af6bc03b92eddedae5bb2821ff905d06b5e311be1f0'
--        'd58712c8203e4a58ec68738f3d22457547a55d230018408400fd1ca433346171b72fa4a87f05efc93213c71f9757d3a8072149ca4e6894355e79f8cfae3bd55b')
-+        'd58712c8203e4a58ec68738f3d22457547a55d230018408400fd1ca433346171b72fa4a87f05efc93213c71f9757d3a8072149ca4e6894355e79f8cfae3bd55b'
-+        'e047615a9adb0c80421154a9e87ac2f281f88075fdfaa3b2fc8ee5b158403e193d72320a0dc932fb703bc71147a0d34dfa383e284d638061f937b3fcb9035c10')
+@@ -28,6 +28,12 @@
  
  prepare() {
  	cd "$pkgname-$pkgver"
-+	patch -Np1 -i $srcdir/$pkgname-bump-go-expect.patch
++
++	# upgrade dependency
++	# upstreamed at https://github.com/hashicorp/terraform/pull/31103
++	go get -u github.com/Netflix/go-expect
++	go mod tidy
++
  	go mod download
  }
  


### PR DESCRIPTION
This PR uses `go get -u` rather than patch of `go.mod` and `go.sum` to upgrade the dependency, to avoid patch fails.