### PR TITLE
addpkg: freeradius

### DIFF
--- a/freeradius/riscv64.patch
+++ b/freeradius/riscv64.patch
@@ -1,0 +1,25 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -29,17 +29,20 @@ source=("ftp://ftp.freeradius.org/pub/radius/freeradius-server-$pkgver.tar.bz2"{
+         'python310.patch'
+         'freeradius-sysusers.conf'
+         'freeradius-tmpfiles.conf'
+-        'freeradius.service')
++        'freeradius.service'
++        "$pkgname-update-config-guess.patch::https://github.com/FreeRADIUS/freeradius-server/commit/ba3c2a02419cad1420d7ba3a7e9401e81dd92b22.patch")
+ sha256sums=('a3071cd78ffcb4706217561d822ee4c760daeb277a63f36a9f11d412c3c39e56'
+             'SKIP'
+             '58f415a4d05f2446d2514b98f5fd5d740d7bee400745d43a82d024a3d23ab253'
+             '8ecaca94c7d0f4806b326685312dd4e543ce9c6c183d3d7ad01c1a0197bdfb94'
+             'f536a9aa972e3e42a6b1a6d8ee17166eb721c7cba2e80f60473811497c7bd8bc'
+-            'c469e1a3f9edad769da01c324779babe783ee85a9b53ce4638d3d2d09c7c8d4b')
++            'c469e1a3f9edad769da01c324779babe783ee85a9b53ce4638d3d2d09c7c8d4b'
++            'e36146955fb87c8fd2510f7ae63053e28ed803de0223fbdc2aa096d5f04007c6')
+ 
+ prepare() {
+   cd "$srcdir"/freeradius-server-$pkgver
+   patch -Np1 -i ../python310.patch
++  patch -Np1 -i ../$pkgname-update-config-guess.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
Fixed error `checking build system type... ./config.guess: unable to guess system type` by cherry-picking an upstream unreleased commit that updated the `config.guess` file.