### PR TITLE
addpkg: cargo-hakari

### DIFF
--- a/cargo-hakari/riscv64.patch
+++ b/cargo-hakari/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,7 +15,7 @@ sha512sums=('83fd807c65554fa2ad17ebea05286bb97951c370bdf1301ae993e6c6d48930e24ba
+ prepare() {
+   mv "cargo-guppy-$pkgname-$pkgver" "$pkgname-$pkgver"
+   cd "$pkgname-$pkgver/tools/$pkgname"
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  cargo fetch --locked
+ }
+ 
+ build() {


### PR DESCRIPTION
Fixed error:
```
error: failed to run `rustc` to learn about target-specific information

Caused by:
  process didn't exit successfully: `rustc - --crate-name ___ --print=file-names --target riscv64-unknown-linux-gnu --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=cfg` (exit status: 1)
  --- stderr
  error: Error loading target specification: Could not find specification for target "riscv64-unknown-linux-gnu". Run `rustc --print target-list` for a list of built-in targets
```