### PR TITLE
addpkg: gtest to qemu user blacklist

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -20,6 +20,7 @@ gauche
 gdk-pixbuf2
 go
 gpxsee
+gtest
 gupnp
 gupnp-igd
 gxplugins.lv2


### PR DESCRIPTION
Test `googletest-port-test` failed in QEMU but passed on board, seems to be caused by

```cpp
// Returns the number of active threads, or 0 when there is an error.
size_t GetThreadCount() {
  const std::string filename =
      (Message() << "/proc/" << getpid() << "/stat").GetString();
  return ReadProcFileField<size_t>(filename, 19);
}
```

always returns 0 in QEMU.