### PR TITLE
addpkg: nettle

### DIFF
--- a/nettle/riscv64.patch
+++ b/nettle/riscv64.patch
@@ -1,0 +1,12 @@
+diff --git PKGBUILD trunk/PKGBUILD
+index b7e8664..f3861a5 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -10,7 +10,6 @@ url="https://www.lysator.liu.se/~nisse/nettle"
+ license=('GPL2')
+ depends=('gmp')
+ provides=('libnettle.so' 'libhogweed.so')
+-checkdepends=('valgrind')
+ options=('debug')
+ source=(https://ftp.gnu.org/gnu/$pkgname/$pkgname-$pkgver.tar.gz{,.sig})
+ sha256sums=('7576c68481c198f644b08c160d1a4850ba9449e308069455b5213319f234e8e6'


### PR DESCRIPTION
This package previously failed because of Valgrind. According to #896,
Valgrind is premature. So we can disable Valgrind temporarily.