### PR TITLE
addpkg: openipmi

### DIFF
--- a/openipmi/riscv64.patch
+++ b/openipmi/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index 70e2a3e..ba03dcb 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -19,6 +19,8 @@ sha512sums=('e409f32e6bbf26756338ada386fa394d48d734b4d6ba4beca700ce60bc3af3d0f41
+ 
+ prepare() {
+ 	cd "${srcdir}/${_pkgname}-${pkgver}"
++	autoupdate
++	autoreconf -fi
+ 	sed \
+ 		-e '/Requires:/s/pthread//' \
+ 		-e '/Libs:/s/$/ -lpthread/' \


### PR DESCRIPTION
Fixed config.guess.

This package contains outdated config.guess file and couldn't correctlyguess system type. 
This patch is a temporary workaround that copy the local config.guess file into project.

This is the same problem as some previous packages.
Ref: https://github.com/felixonmars/archriscv-packages/pull/1313.
Build passed.