### PR TITLE
upgpkg: selene-linter

### DIFF
--- a/selene-linter/riscv64.patch
+++ b/selene-linter/riscv64.patch
@@ -1,11 +1,12 @@
-diff --git PKGBUILD PKGBUILD
 --- PKGBUILD
 +++ PKGBUILD
-@@ -15,7 +15,7 @@ b2sums=('d322c76ee4fe81d33641741d2f012b048b7bcb60c7722d6e1914004a4528a9ba9b24876
+@@ -16,7 +16,9 @@ b2sums=('bfd66c9cbe77edbceb617d6acc83dad9a42bdc541be381b87883fedb0e185d4c4459862
  
  prepare() {
    cd $_name-$pkgver
 -  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
++  cargo update -p ring
 +  cargo fetch --locked
  }
  


### PR DESCRIPTION
Fixed error:

```
error: failed to run custom build command for `ring v0.16.20`

Caused by:
  process didn't exit successfully: `/build/selene-linter/src/selene-0.18.1/target/release/build/ring-64bec00ece0b4e9b/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', /build/.cargo/registry/src/github.com-1ecc6299db9ec823/ring-0.16.20/build.rs:358:10
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```