### PR TITLE
upgpkg: glibc

### DIFF
--- a/glibc/riscv64.patch
+++ b/glibc/riscv64.patch
@@ -1,31 +1,47 @@
---- PKGBUILD
-+++ PKGBUILD
-@@ -7,13 +7,13 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD    (revision 448151)
++++ PKGBUILD    (working copy)
+@@ -7,7 +7,7 @@
  # NOTE: valgrind requires rebuilt with each major glibc version
  
  pkgbase=glibc
 -pkgname=(glibc lib32-glibc)
 +pkgname=(glibc)
  pkgver=2.35
- pkgrel=2
+ _commit=d7d1eebd4d5806be55ffacbf18917ad68d4ae7fd
+ pkgrel=6
+@@ -14,13 +14,11 @@
  arch=(x86_64)
  url='https://www.gnu.org/software/libc'
  license=(GPL LGPL)
 -makedepends=(git gd lib32-gcc-libs python)
 +makedepends=(git gd python)
- optdepends=('perl: for mtrace')
- options=(!strip staticlibs !lto)
- #_commit=3de512be7ea6053255afed6154db9ee31d4e557a
-@@ -36,7 +36,7 @@ b2sums=('623c728884f070cd87ffeb9203f74206197c52405ac9bc44f3dd519a3468b8e8ae2536c
+ options=(debug staticlibs !lto)
+ source=(git+https://sourceware.org/git/glibc.git#commit=${_commit}
+         locale.gen.txt
+         locale-gen
+-        lib32-glibc.conf
+-        sdt.h sdt-config.h
+         disable-clone3.diff
+ )
+ validpgpkeys=(7273542B39962DF7B299931416792B4EA25340F8 # Carlos O'Donell
+@@ -28,13 +26,10 @@
+ b2sums=('SKIP'
+         '46d533d25c7a2ce4ae75d452eee7ebb8e3ce4d191af9be3daa43718b78cb81d33cfd8046a117a15d87de9f5e940448c66005b0490515bf731c9e4691c53908d6'
+         '04fbb3b0b28705f41ccc6c15ed5532faf0105370f22133a2b49867e790df0491f5a1255220ff6ebab91a462f088d0cf299491b3eb8ea53534cb8638a213e46e3'
+-        '7c265e6d36a5c0dff127093580827d15519b6c7205c2e1300e82f0fb5b9dd00b6accb40c56581f18179c4fbbc95bd2bf1b900ace867a83accde0969f7b609f8a'
+-        'a6a5e2f2a627cc0d13d11a82458cfd0aa75ec1c5a3c7647e5d5a3bb1d4c0770887a3909bfda1236803d5bc9801bfd6251e13483e9adf797e4725332cd0d91a0e'
+-        '214e995e84b342fe7b2a7704ce011b7c7fc74c2971f98eeb3b4e677b99c860addc0a7d91b8dc0f0b8be7537782ee331999e02ba48f4ccc1c331b60f27d715678'
          'edef5f724f68ea95c6b0127bd13a10245f548afc381b2d0a6d1d06ee9f87b7dd89c6becd35d5ae722bf838594eb870a747f67f07f46e7d63f8c8d1a43cce4a52')
  
  prepare() {
 -  mkdir -p glibc-build lib32-glibc-build
 +  mkdir -p glibc-build
  
-   [[ -d glibc-$pkgver ]] && ln -s glibc-$pkgver glibc 
+   [[ -d glibc-$pkgver ]] && ln -s glibc-$pkgver glibc
    cd glibc
-@@ -57,12 +57,11 @@ build() {
+@@ -54,9 +49,7 @@
        --enable-bind-now
        --enable-cet
        --enable-kernel=4.4
@@ -35,33 +51,10 @@
        --disable-profile
        --disable-crypt
        --disable-werror
-+      --disable-experimental-malloc
-   )
+@@ -91,30 +84,6 @@
+   # build info pages manually for reproducibility
+   make info
  
-   cd "$srcdir/glibc-build"
-@@ -76,46 +75,13 @@ build() {
-   # https://github.com/allanmcrae/toolchain/blob/f18604d70c5933c31b51a320978711e4e6791cf1/glibc/PKGBUILD
-   # remove fortify for building libraries
-   CFLAGS=${CFLAGS/-Wp,-D_FORTIFY_SOURCE=2/}
-+  CPPFLAGS=${CPPFLAGS/-D_FORTIFY_SOURCE=2/}
- 
-   "$srcdir/glibc/configure" \
-       --libdir=/usr/lib \
-       --libexecdir=/usr/lib \
-       "${_configure_flags[@]}"
- 
--  # build libraries with fortify disabled
--  echo "build-programs=no" >> configparms
--  make -O
--
--  # re-enable fortify for programs
--  sed -i "/build-programs=/s#no#yes#" configparms
--  echo "CFLAGS += -Wp,-D_FORTIFY_SOURCE=2" >> configparms
--  make -O
--
--  # build info pages manually for reprducibility
--  make info
--
 -  cd "$srcdir/lib32-glibc-build"
 -  export CC="gcc -m32 -mstackrealign"
 -  export CXX="g++ -m32 -mstackrealign"
@@ -84,10 +77,12 @@
 -  # re-enable fortify for programs
 -  sed -i "/build-programs=/s#no#yes#" configparms
 -  echo "CFLAGS += -Wp,-D_FORTIFY_SOURCE=2" >> configparms
-   make -O
- 
- }
-@@ -152,7 +118,7 @@ check() {
+-  make -O
+-
+   # pregenerate C.UTF-8 locale until it is built into glibc
+   # (https://sourceware.org/glibc/wiki/Proposals/C.UTF-8, FS#74864)
+   locale/localedef -c -f ../glibc/localedata/charmaps/UTF-8 -i ../glibc/localedata/locales/C ../C.UTF-8/
+@@ -152,7 +121,7 @@
    make -O check
  }
  
@@ -95,18 +90,16 @@
 +package() {
    pkgdesc='GNU C Library'
    depends=('linux-api-headers>=4.10' tzdata filesystem)
-   optdepends=('gd: for memusagestat')
-@@ -200,48 +166,6 @@ package_glibc() {
-       -name '*.so*' -type f -exec strip $STRIP_SHARED {} + 2> /dev/null || true
-   fi
- 
+   optdepends=('gd: for memusagestat'
+@@ -189,33 +158,4 @@
+   install -dm755 "$pkgdir/usr/lib/locale"
+   cp -r "$srcdir/C.UTF-8" -t "$pkgdir/usr/lib/locale"
+   sed -i '/#C\.UTF-8 /d' "$pkgdir/etc/locale.gen"
+-
 -  # Provide tracing probes to libstdc++ for exceptions, possibly for other
 -  # libraries too. Useful for gdb's catch command.
 -  install -Dm644 "$srcdir/sdt.h" "$pkgdir/usr/include/sys/sdt.h"
 -  install -Dm644 "$srcdir/sdt-config.h" "$pkgdir/usr/include/sys/sdt-config.h"
--
-   # Provided by libxcrypt; keep the old shared library for backwards compatibility
-   rm -f "$pkgdir"/usr/include/crypt.h "$pkgdir"/usr/lib/libcrypt.{a,so}
  }
 -
 -package_lib32-glibc() {
@@ -131,17 +124,4 @@
 -
 -  # Symlink /usr/lib32/locale to /usr/lib/locale
 -  ln -s ../lib/locale "$pkgdir/usr/lib32/locale"
--
--  if check_option 'debug' n; then
--    find "$pkgdir"/usr/lib32 -name '*.a' -type f -exec strip $STRIP_STATIC {} + 2> /dev/null || true
--    find "$pkgdir"/usr/lib32 \
--      -not -name 'ld-*.so*' \
--      -not -name 'libc.so*' \
--      -not -name 'libpthread.so*' \
--      -not -name 'libthread_db.so*' \
--      -name '*.so*' -type f -exec strip $STRIP_SHARED {} + 2> /dev/null || true
--  fi
--
--  # Provided by lib32-libxcrypt; keep the old shared library for backwards compatibility
--  rm -f "$pkgdir"/usr/lib32/libcrypt.{a,so}
 -}


### PR DESCRIPTION
This patch isn't a trivial Fix rotten one, and it does three things:
1. Remove multiarch. We don't need to support RV32.
2. Remove Systemtap. This feature needs assembly modification which can
   be dealt later.
3. Add glibc to qemu-user-black. I only tested this one on a real board.

There are 17 failure in testsuite.
Five of them also failed in [release notes](https://sourceware.org/glibc/wiki/Release/2.35) on glibc wiki. We can treat them as expected to fail.
- FAIL: math/test-float-j0
- FAIL: math/test-float32-j0
- FAIL: stdlib/tst-strfrom
- FAIL: stdlib/tst-strfrom-locale
- FAIL: stdlib/test-bz22786

Eleven of them failed because timeout. We can explicitly set TIMEOUTFACTOR to solve these problems.
- FAIL: nss/tst-nss-files-hosts-getent
- FAIL: nss/tst-nss-files-hosts-multi
- FAIL: string/test-memcpy
- FAIL: string/test-memcpy-large
- FAIL: string/test-mempcpy
- FAIL: stdio-common/tst-vfprintf-width-prec
- FAIL: stdio-common/tst-vfprintf-width-prec-mem
- FAIL: resolv/tst-resolv-res\_init-multi
- FAIL: malloc/tst-malloc-too-large-malloc-hugetlb2
- FAIL: nptl/tst-mutex10
- FAIL: locale/tst-localedef-path-norm 

Last one failed because of a long-unfixed [issue](https://sourceware.org/bugzilla/show_bug.cgi?id=24816). If there is only loop back IPv6 address, nss/tst-nss-files-hosts-long will fail. Release notes mentioned this issue as "need to enable kernel IPV6". I think it's imprecise.
- FAIL: nss/tst-nss-files-hosts-long

The problem is I don't know how to set TIMEOUTFACTOR for some specific unit tests. Setting a large one may not be appropriate. What's more, I don't know how to skip tests. ArchLinux official skips tests using sed. However, for example, test-float-j0 doesn't appear in Makefile explicitly. So we cannot sed directly. The last issue with nss seems unimportant. A normal machine should have at least one IPv6 address.

This PR is a record of my progress about glibc. Hope someone can leave some comments to help me improve this patch.