### PR TITLE
addpkg: tpm2-tools

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -68,6 +68,7 @@ texstudio
 tiled
 tinyssh
 tmuxp
+tpm2-tools
 tpm2-tss
 vim
 wayland

--- a/tpm2-tools/riscv64.patch
+++ b/tpm2-tools/riscv64.patch
@@ -1,0 +1,31 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD    (revision 1235733)
++++ PKGBUILD    (working copy)
+@@ -11,12 +11,24 @@
+          'libtss2-mu.so' 'libtss2-rc.so' 'libtss2-sys.so' 'libtss2-tctildr.so')
+ checkdepends=('cmocka' 'expect' 'iproute2' 'python-yaml' 'swtpm' 'tpm2-abrmd' 'xxd')
+ optdepends=('tpm2-abrmd: user space resource manager')
+-source=("$url/releases/download/$pkgver/$pkgname-$pkgver.tar.gz"{,.asc})
++options=('debug' '!lto')
++source=("$url/releases/download/$pkgver/$pkgname-$pkgver.tar.gz"{,.asc}
++        "tpm2-tools-5.2_fix_tests_libtpms_0.9.0.patch::$url/commit/0789bf264a108c4718875a050d00b1fdee4478b7.patch"
++        "tpm2-tools-5.2_fix_tests_tpm2-tss_3.2.0.patch::$url/commit/3b1f00301350848e9454c7adf0487c1a14738236.patch")
+ sha512sums=('9fb5dc298717a8a57c89d286e3590370a096c81b14d2d8d4eb5fca140d66148a8e24727ee04fb02057bbfcc3ede50e93ba0ef22396888c9df48bf6f42a5d6e6b'
+-            'SKIP')
++            'SKIP'
++            'fad196293b281d435893f9059140faf1198537ddab7c39a964cc50f72d06a7efd79dbde6add17f4f53545de71a2d76b2a151aa4eda6c87e627822f8d0847730d'
++            'd0d70408e0e8f1e332761b49553473dd1600d67b0e26fe6a2fe57d5fe502ecf88b9582d5eea3e24ccebb73a425b5fb79be628e77871fac6cdcd0c7ad14a273d9')
+ validpgpkeys=('5B482B8E3E19DA7C978E1D016DE2E9078E1F50C1'  # William Roberts (Bill Roberts) <william.c.roberts@intel.com>
+               '6313E6DC41AAFC315A8760A414986F6944B1F72B') # Desai, Imran (idesai-github-gpg) <imran.desai@intel.com>
+ 
++prepare() {
++       cd "$pkgname-$pkgver"
++       patch --forward --strip=1 --input="$srcdir/tpm2-tools-5.2_fix_tests_libtpms_0.9.0.patch"
++       patch --forward --input="$srcdir/tpm2-tools-5.2_fix_tests_tpm2-tss_3.2.0.patch" test/integration/fapi/fapi-quote-verify.sh
++       patch --forward --input="$srcdir/tpm2-tools-5.2_fix_tests_tpm2-tss_3.2.0.patch" test/integration/fapi/fapi-quote-verify_ecc.sh
++}
++
+ build() {
+        cd "$pkgname-$pkgver"
+        ./configure --prefix=/usr $( ((CHECKFUNC)) && echo --enable-unit)


### PR DESCRIPTION
This patch backports changes which has been made in trunk. Those changes
disable lto, backport 2 patches to fix unit tests and other improvement.
This patch also add tpm2-tools to qemu-user-blacklists because of error
listed below.
```
Starting the simulator
Attempting to start simulator on port: 63821
swtpm: seccomp_load failed with errno 125: Operation canceled
Could not start simulator at port: 63821
```
It seems that this error occurred because qemu-user didn't support
seccomp.