### PR TITLE
addpkg: coreutils

### DIFF
--- a/coreutils/fix-test-getlogin.patch
+++ b/coreutils/fix-test-getlogin.patch
@@ -1,0 +1,68 @@
+--- a/gnulib-tests/test-getlogin.h
++++ b/gnulib-tests/test-getlogin.h
+@@ -18,6 +18,7 @@
+ 
+ #include <errno.h>
+ #include <stdio.h>
++#include <stdbool.h>
+ #include <stdlib.h>
+ #include <string.h>
+ #include <unistd.h>
+@@ -42,11 +43,43 @@ test_getlogin_result (const char *buf, int err)
+           exit (77);
+         }
+ 
+-      /* It fails when stdin is not connected to a tty.  */
+       ASSERT (err == ENOTTY
+               || err == EINVAL /* seen on Linux/SPARC */
+               || err == ENXIO
+              );
++
++#if defined __linux__
++      /* On Linux, it is possible to set up a chroot environment in such a way
++         that stdin is connected to a tty and nervertheless /proc/self/loginuid
++         contains the value (uid_t)(-1).  In this situation, getlogin() and
++         getlogin_r() fail; this is expected.  */
++      bool loginuid_undefined = false;
++      /* Does the special file /proc/self/loginuid contain the value
++         (uid_t)(-1)?  */
++      FILE *fp = fopen ("/proc/self/loginuid", "r");
++      if (fp != NULL)
++        {
++          char buf[21];
++          size_t n = fread (buf, 1, sizeof buf, fp);
++          if (n > 0 && n < sizeof buf)
++            {
++              buf[n] = '\0';
++              errno = 0;
++              char *endptr;
++              unsigned long value = strtoul (buf, &endptr, 10);
++              if (*endptr == '\0' && errno == 0)
++                loginuid_undefined = ((uid_t) value == (uid_t)(-1));
++            }
++          fclose (fp);
++        }
++      if (loginuid_undefined)
++        {
++          fprintf (stderr, "Skipping test: loginuid is undefined.\n");
++          exit (77);
++        }
++#endif
++
++      /* It fails when stdin is not connected to a tty.  */
+ #if !defined __hpux /* On HP-UX 11.11 it fails anyway.  */
+       ASSERT (! isatty (0));
+ #endif
+@@ -63,8 +96,10 @@ test_getlogin_result (const char *buf, int err)
+ 
+     if (!isatty (STDIN_FILENO))
+       {
+-         fprintf (stderr, "Skipping test: stdin is not a tty.\n");
+-         exit (77);
++        /* We get here, for example, when running under 'nohup' or as part of a
++           non-interactive ssh command.  */
++        fprintf (stderr, "Skipping test: stdin is not a tty.\n");
++        exit (77);
+       }
+ 
+     ASSERT (fstat (STDIN_FILENO, &stat_buf) == 0);

--- a/coreutils/riscv64.patch
+++ b/coreutils/riscv64.patch
@@ -1,0 +1,17 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -11,10 +11,12 @@ arch=('x86_64')
+ license=('GPL3')
+ url='https://www.gnu.org/software/coreutils/'
+ depends=('glibc' 'acl' 'attr' 'gmp' 'libcap' 'openssl')
+-source=("https://ftp.gnu.org/gnu/$pkgname/$pkgname-$pkgver.tar.xz"{,.sig})
++source=("https://ftp.gnu.org/gnu/$pkgname/$pkgname-$pkgver.tar.xz"{,.sig}
++        "fix-test-getlogin.patch")
+ validpgpkeys=('6C37DC12121A5006BC1DB804DF6FD971306037D9') # Pádraig Brady
+ sha256sums=('61a1f410d78ba7e7f37a5a4f50e6d1320aca33375484a3255eddf17a38580423'
+-            'SKIP')
++            'SKIP'
++            '5df5e81f5c859b7baca415a6435ea48ae5f09fa111ecd59b0d74c7fe696c3e92')
+ 
+ prepare() {
+   cd $pkgname-$pkgver

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -5,6 +5,7 @@ beatslash-lv2
 bmake
 caps
 cargo-audit
+coreutils
 datovka
 dbus
 dovecot


### PR DESCRIPTION
This package fails to build on a riscv64 real hardware due to the same
reason on x86_64. The test-getlogin doesn't handle the case
/proc/self/loginuid is -1. After being reported to the upstream gnulib,
a patch to resolve this issue has been merged on master.
Ref: https://lists.gnu.org/archive/html/bug-gnulib/2022-06/msg00001.html

I also filed a bug on ArchLinux bug tracker which backports the patch to
resolve the issue of FTBFS.
Ref: https://bugs.archlinux.org/task/75112

Currently, I'm not sure why some unit tests fail when running with
qemu-user. Failing tests are listed below.
- FAIL: tests/misc/tac-2-nonseekable.sh
- FAIL: tests/tail-2/follow-stdin.sh