### PR TITLE
addpkg: bigsh0t

### DIFF
--- a/bigsh0t/remove-march-and-disable-sse.patch
+++ b/bigsh0t/remove-march-and-disable-sse.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 9942ba4..7bffbab 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -29,8 +29,7 @@ endif()
+ 
+ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+     string(TOLOWER ${CMAKE_SYSTEM_NAME} DIST_PLATFORM)
+-    add_compile_options(-std=c++11 -fopenmp -march=native)
+-    add_compile_definitions(USE_SSE)
++    add_compile_options(-std=c++11 -fopenmp)
+     set (PREPROCESSOR_COMMAND gcc -E -P -I${PROJECT_SOURCE_DIR}/src/main/shotcut/bigsh0t_transform_360/ - <)
+ endif()
+ 

--- a/bigsh0t/riscv64.patch
+++ b/bigsh0t/riscv64.patch
@@ -1,0 +1,23 @@
+--- PKGBUILD	(revision 1229934)
++++ PKGBUILD	(working copy)
+@@ -9,10 +9,17 @@
+ license=(GPL)
+ depends=(gcc-libs)
+ makedepends=(cmake python)
+-source=($pkgname-$pkgver::https://bitbucket.org/leo_sutic/bigsh0t/get/$pkgver.tar.gz)
+-sha256sums=('7808e1ebd6329f3f52f66c76f3db65571f2422247a1e654f1617efcad3aaa484')
++source=($pkgname-$pkgver::https://bitbucket.org/leo_sutic/bigsh0t/get/$pkgver.tar.gz
++        'remove-march-and-disable-sse.patch')
++sha256sums=('7808e1ebd6329f3f52f66c76f3db65571f2422247a1e654f1617efcad3aaa484'
++            'd5312d660b4c102e41757a1f4450c0746e0d6dbfe5be5573ae251cdd25dedbe9')
+ 
+-build() {
++prepare(){
++  cd leo_sutic-$pkgname-dd6b0f7f2977
++  patch -Np1 -i  '../remove-march-and-disable-sse.patch'
++}
++
++build() { 
+   cmake -B build -S leo_sutic-$pkgname-* \
+     -DCMAKE_INSTALL_PREFIX=/usr
+   cmake --build build

--- a/bigsh0t/riscv64.patch
+++ b/bigsh0t/riscv64.patch
@@ -1,6 +1,6 @@
 --- PKGBUILD	(revision 1229934)
 +++ PKGBUILD	(working copy)
-@@ -9,10 +9,17 @@
+@@ -9,9 +9,16 @@
  license=(GPL)
  depends=(gcc-libs)
  makedepends=(cmake python)
@@ -11,13 +11,11 @@
 +sha256sums=('7808e1ebd6329f3f52f66c76f3db65571f2422247a1e654f1617efcad3aaa484'
 +            'd5312d660b4c102e41757a1f4450c0746e0d6dbfe5be5573ae251cdd25dedbe9')
  
--build() {
 +prepare(){
 +  cd leo_sutic-$pkgname-dd6b0f7f2977
 +  patch -Np1 -i  '../remove-march-and-disable-sse.patch'
 +}
 +
-+build() { 
+ build() {
    cmake -B build -S leo_sutic-$pkgname-* \
      -DCMAKE_INSTALL_PREFIX=/usr
-   cmake --build build


### PR DESCRIPTION
1. Bigsh0t package's [rel-2.5](https://bitbucket.org/leo_sutic/bigsh0t/commits/dd6b0f7f29775e896bc526570240f39a3860ae19#chg-CMakeLists.txt) defined options --march=navite and enabled SSE. 
2. The main branch has code that checks the intel CPU, Used to determine if the SSE option should be turned on.

PS: just wait for a new rel and this patch will be obsolete.