### PR TITLE
addpkg: reaper to black list

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -11,6 +11,7 @@ nvidia-lts
 nvidia-utils
 opencl-nvidia
 opera
+reaper
 teamspeak3
 teamspeak3-server
 vivaldi


### PR DESCRIPTION
This package is distributed as binary only, no source code available.