### PR TITLE
addpkg: python

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -50,6 +50,7 @@ procs
 pueue
 pyside2
 pyside6
+python
 python-prctl
 qalculate-qt
 qconf


### PR DESCRIPTION
This package can be built successfully on a real board without any patch. When
building with qemu-user, failing tests are listed below.
- test_cmd_line
    - test_no_std_streams
    - test_no_stdin
- test_faulthandler
    - test_register_chain
- test_posix
    - test_chown
    - test_fchown
    - test_lchown
    - test_close_file
    - test_fexecve
- test_subprocess
    - test_restore_signals
I'm not sure why they fail currently.