### PR TITLE
addpkg: libixion

### DIFF
--- a/libixion/riscv64.patch
+++ b/libixion/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -16,6 +16,7 @@ sha256sums=('53c97139223f3b786d498f86512a20ee878fab0ef981947647aa116df7c4101e')
+ 
+ build() {
+   cd ${pkgname}-${pkgver}
++  autoreconf -fiv
+   ./configure --prefix=/usr \
+     --disable-static
+ #  sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool # doesn't fix it


### PR DESCRIPTION
Fixed error:

```
checking build system type... upstream/config.guess: unable to guess system type

This script, last modified 2014-03-23, has failed to recognize
the operating system you are using. It is advised that you
download the most up to date version of the config scripts from

  http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD
and
  http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD

If the version you run (upstream/config.guess) is already up to date, please
send the following data and any information you think might be
pertinent to <config-patches@gnu.org> in order to provide the needed
information to handle your system.

config.guess timestamp = 2014-03-23

uname -m = riscv64
uname -r = 5.18.1-arch1-1
uname -s = Linux
uname -v = #1 SMP PREEMPT_DYNAMIC Mon, 30 May 2022 17:53:11 +0000

/usr/bin/uname -p = unknown
/bin/uname -X     = 

hostinfo               = 
/bin/universe          = 
/usr/bin/arch -k       = 
/bin/arch              = 
/usr/bin/oslevel       = 
/usr/convex/getsysinfo = 

UNAME_MACHINE = riscv64
UNAME_RELEASE = 5.18.1-arch1-1
UNAME_SYSTEM  = Linux
UNAME_VERSION = #1 SMP PREEMPT_DYNAMIC Mon, 30 May 2022 17:53:11 +0000
configure: error: cannot guess build type; you must specify one
```

by running `autoreconf`.

Bug reported to upstream: https://gitlab.com/ixion/ixion/-/issues/50