### PR TITLE
addpkg: cclive

### DIFF
--- a/cclive/riscv64.patch
+++ b/cclive/riscv64.patch
@@ -1,0 +1,30 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,12 +15,14 @@ source=("https://downloads.sourceforge.net/project/${pkgname}/${pkgver%.*}/${pkg
+         iostream.patch
+         reproducible-date.patch
+         boost-1.67.patch
++        update-configure-ac.patch
+         boost.m4) # https://github.com/tsuna/boost.m4
+ sha512sums=('0d8f6f870e24e2906542c1e02745009597fca2e879261bef7a81e07f8dec016ee200d8a4b37dd0f20b3ad27c12e2445fed1f6a9dc262a6c27e40222048bb5438'
+             'SKIP'
+             'dc6fb068d153e91c03533830e6d87bb292109e192b9fff7003a23fbe3ab5a786fee52a0f522788b5715511be0de55deed1b4a9b2369ac6d239074ec099e0e893'
+             'bb0c71d3e726096c2856392cef10d8b62aa1a67b30171f079bdf7bd03b64d27a32e611633298889311c88929369a40dd7c56b6560afaa8c43578682b4ff55aa8'
+             '8897a535aaa7d8acf3eea07f0e172423d59ec7ff051dbfc096661162649b589b23795f326aad7fa6370aad3174ec5b7e2125424d0425cff425f3dfa3ca660c9d'
++            'd680fba86f57b26f6a64752555a94d5dbffcd522fd819a223a9ccdc02962310df3cc41589aff9725aae22347300b731b7a8c373dad436ec167aaf1b5806e6641'
+             'fe459153907224948888dd6cf6d04b780867595e5e70661d50e3fc2976149f716b807c71d5bfed61566b069bddc955838fdcf441ba5110bea9b2bbaac5b99c84')
+ validpgpkeys=('E220FCFF9EADBA326FD6B23BBF1D59CCAD00BE50')  # Toni Gundogdu
+ 
+@@ -28,10 +30,11 @@ prepare() {
+   cd $pkgname-$pkgver
+ 
+   patch -Np1 -i ../reproducible-date.patch
++  patch -Np1 -i ../update-configure-ac.patch
+ 
+   # Update boost.m4 to support GCC > 5.1
+   cp "$srcdir"/boost.m4 m4/
+-  autoconf
++  autoreconf -fiv
+ 
+   patch -Np1 -i ../iostream.patch
+   patch -Np1 -i ../boost-1.67.patch

--- a/cclive/update-configure-ac.patch
+++ b/cclive/update-configure-ac.patch
@@ -1,0 +1,12 @@
+--- a/configure.ac      2022-06-17 14:04:00.757308838 +0200
++++ b/configure.ac      2022-06-17 13:55:30.352253509 +0200
+@@ -17,7 +17,8 @@
+ AC_DEFINE_UNQUOTED([CANONICAL_TARGET], "$target",
+   [Define to canonical target])
+ 
+-AM_INIT_AUTOMAKE([1.11.1 -Wall -Werror dist-xz no-dist-gzip tar-ustar])
++AM_INIT_AUTOMAKE([1.11.1 -Wall -Werror dist-xz no-dist-gzip tar-ustar
++                  subdir-objects])
+ AM_SILENT_RULES([yes])
+ 
+ # GNU Automake 1.12 requires this macro. Earlier versions do not


### PR DESCRIPTION
This patch does two things.
- Update configure.ac to make it compatible with autotools 1.16 in order
  to execute `autoreconf -fiv`
- Fix the trivial issue with config.guess and config.sub

The second issue is configure.ac is outdated. According to the release
notes of autotools 1.14[1]

  - The next major Automake version (2.0) will unconditionally activate
    the 'subdir-objects' option.  In order to smooth out the transition,
    we now give a warning (in the category 'unsupported') whenever a
    source file is present in a subdirectory but the 'subdir-object' is
    not enabled.

The current configure.ac lacks the 'subdir-objects' option, which will
throw an error due to '-Werror' option.

FYI, I have sent an e-mail to cclive-devel mailing list to inform the maintainers
this issue, although it haven't appeared on mail archive yet.

[1]: https://lists.gnu.org/archive/html/automake/2013-06/msg00040.html