### PR TITLE
upgpkg: cclive

### DIFF
--- a/cclive/update-configure-ac.patch
+++ b/cclive/update-configure-ac.patch
@@ -1,5 +1,5 @@
---- a/configure.ac      2022-06-17 14:04:00.757308838 +0200
-+++ b/configure.ac      2022-06-17 13:55:30.352253509 +0200
+--- a/configure.ac	2022-06-17 14:04:00.757308838 +0200
++++ b/configure.ac	2022-06-17 13:55:30.352253509 +0200
 @@ -17,7 +17,8 @@
  AC_DEFINE_UNQUOTED([CANONICAL_TARGET], "$target",
    [Define to canonical target])


### PR DESCRIPTION
Fix patch. Remove excess blank spaces to match with checksum.