### PR TITLE
addpkg: taplo-cli.

### DIFF
--- a/taplo-cli/riscv64.patch
+++ b/taplo-cli/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD trunk/PKGBUILD
+index bffa4d30..85379e78 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -18,7 +18,7 @@ b2sums=('764a56e50473d50f72c9141838b20771e1c4e07d85edf9fc997ca2786eb6c5982afee13
+ 
+ prepare() {
+   cd $pkgname-$pkgver
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  cargo fetch --locked 
+ }
+ 
+ build() {


### PR DESCRIPTION
Fix `cargo`.
Removed the parameter `--target "$CARCH-unknown-linux-gnu"`

There is a confusion after successfully packed a binary package.
That is the end of std out lying some error info, and I dont know if it has a problem.
The wiki also guides us to remove the parameter.

If something needs to be improved, can ask me directly.
Please check.
Build passed.

Std out end lines:
`Checking taplo-cli-0.6.7-1-riscv64.pkg.tar.zst`
`==> Running checkpkg`
`error: target not found: taplo-cli`
`==> WARNING: Skipped checkpkg due to missing repo packages`