### PR TITLE
addpkg: trojan

### DIFF
--- a/trojan/riscv64.patch
+++ b/trojan/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,7 +12,7 @@ depends=('boost-libs' 'openssl' 'mariadb-libs')
+ optdepends=('ca-certificates: server certificate verification'
+             'mariadb: advanced user management')
+ makedepends=('cmake' 'boost' 'openssl' 'mariadb-libs')
+-checkdepends=('openssl' 'python' 'curl' 'netcat')
++checkdepends=('openssl' 'python' 'curl' 'openbsd-netcat')
+ source=("$pkgname-$pkgver.tar.gz::https://github.com/trojan-gfw/$pkgname/archive/v$pkgver.tar.gz")
+ backup=('etc/trojan.json'
+         'etc/trojan/config.json')


### PR DESCRIPTION
Dependency `netcat` is actually `gnu-netcat`, which doesn't work properly on `RISC-V` architecture (Not related to `QEMU`). Replace it with `openbsd-netcat` could fix the problem of test `LinuxSmokeTest-basic` stuck.

MRE for `gnu-netcat` problem:

```bash
#!/bin/bash

function wait_port() {
    until nc -z 127.0.0.1 "$1"; do
        sleep 0.1
    done
}

python3 -m http.server 10081 &

wait_port 10081
```