### PR TITLE
addpkg: cargo-nextest

### DIFF
--- a/cargo-nextest/riscv64.patch
+++ b/cargo-nextest/riscv64.patch
@@ -1,10 +1,12 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -17,7 +17,7 @@ b2sums=('e983a9f0da490b46dca5819b920e9dbc7ed2afbc95f519d09c72b5b8884c6c25b63a615
+@@ -18,7 +18,9 @@ options=('!lto')
  prepare() {
    mv "nextest-$pkgname-$pkgver" "$pkgname-$pkgver"
    cd "$pkgname-$pkgver"
 -  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  echo -e "[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
++  cargo update -p ring
 +  cargo fetch --locked
  }
  

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -5,6 +5,7 @@ beatslash-lv2
 bmake
 caps
 cargo-audit
+cargo-nextest
 coreutils
 datovka
 dbus


### PR DESCRIPTION
Replace dependency `ring`, and add this package to QEMU-user black list since tests `tests_integration::test_run` and `tests_integration::test_run_after_build` will be stuck in QEMU-user but pass on real board.