### PR TITLE
addpatch: progpick

### DIFF
--- a/progpick/riscv64.patch
+++ b/progpick/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -16,7 +16,7 @@ validpgpkeys=("64B13F7117D6E07D661BBCE0FE763A64F5E54FD6")
+ 
+ prepare() {
+   cd "${pkgname}-${pkgver}"
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  cargo fetch --locked
+ }
+ 
+ build() {


### PR DESCRIPTION
`rustc` recognizes target `riscv64gc-unknown-linux-gnu` instead of `riscv64-unknown-linux-gnu`. This patch prevents the specified target triple from being passed to `cargo` to build this package.