### PR TITLE
upgpkg: opencv

### DIFF
--- a/opencv/riscv64.patch
+++ b/opencv/riscv64.patch
@@ -1,5 +1,3 @@
-diff --git PKGBUILD PKGBUILD
-index 62b04ee4..51700b20 100644
 --- PKGBUILD
 +++ PKGBUILD
 @@ -3,7 +3,7 @@
@@ -8,19 +6,28 @@ index 62b04ee4..51700b20 100644
  pkgbase=opencv
 -pkgname=(opencv opencv-samples python-opencv opencv-cuda)
 +pkgname=(opencv opencv-samples python-opencv)
- pkgver=4.5.5
+ pkgver=4.6.0
  pkgrel=3
  pkgdesc='Open Source Computer Vision Library'
 @@ -11,7 +11,7 @@ arch=(x86_64)
  license=(BSD)
  url='https://opencv.org/'
- depends=(tbb openexr gst-plugins-base libdc1394 cblas lapack libgphoto2 openjpeg2 ffmpeg4.4 protobuf)
+ depends=(tbb openexr gst-plugins-base libdc1394 cblas lapack libgphoto2 openjpeg2 ffmpeg protobuf)
 -makedepends=(cmake python-numpy python-setuptools mesa eigen hdf5 lapacke qt5-base vtk glew ant java-environment pugixml openmpi cudnn fmt)
 +makedepends=(cmake python-numpy python-setuptools mesa eigen hdf5 lapacke qt5-base vtk glew ant java-environment pugixml openmpi fmt)
  optdepends=('opencv-samples: samples'
              'vtk: for the viz module'
              'glew: for the viz module'
-@@ -48,7 +48,6 @@ build() {
+@@ -25,6 +25,8 @@ source=(https://github.com/opencv/opencv/archive/$pkgver/$pkgname-$pkgver.tar.gz
+ sha256sums=('1ec1cba65f9f20fe5a41fda1586e01c70ea0c9a6d7b67c9e13edf0cfe2239277'
+             '1777d5fd2b59029cf537e5fd6f8aa68d707075822f90bde683fcde086f85f7a7'
+             'f35a2d4ea0d6212c7798659e59eda2cb0b5bc858360f7ce9c696c77d3029668e')
++# fix error 'relocation truncated to fit: R_RISCV_PCREL_HI20 against `.LC19''
++options=(!lto)
+ 
+ prepare() {
+   patch -d $pkgname-$pkgver -p1 < vtk9.patch # Don't require all vtk optdepends
+@@ -48,7 +50,6 @@ build() {
           -DINSTALL_PYTHON_EXAMPLES=ON \
           -DCMAKE_INSTALL_PREFIX=/usr \
           -DCPU_BASELINE_DISABLE=SSE3 \
@@ -28,7 +35,7 @@ index 62b04ee4..51700b20 100644
           -DOPENCV_EXTRA_MODULES_PATH=$srcdir/opencv_contrib-$pkgver/modules \
           -DOPENCV_SKIP_PYTHON_LOADER=ON \
           -DLAPACK_LIBRARIES=/usr/lib/liblapack.so;/usr/lib/libblas.so;/usr/lib/libcblas.so \
-@@ -62,12 +61,6 @@ build() {
+@@ -62,12 +63,6 @@ build() {
   
    cmake -B build -S $pkgname-$pkgver $_opts
    cmake --build build
@@ -41,7 +48,7 @@ index 62b04ee4..51700b20 100644
  }
  
  package_opencv() {
-@@ -109,25 +102,3 @@ package_python-opencv() {
+@@ -109,25 +104,3 @@ package_python-opencv() {
    # install license file
    install -Dm644 $pkgbase-$pkgver/LICENSE -t "$pkgdir"/usr/share/licenses/$pkgname
  }


### PR DESCRIPTION
Fixed rotten patch. Disable LTO as it will cause error

```
/tmp/ccMBUcPI.ltrans3.ltrans.o: in function `.L1231':
<artificial>:(.text._ZN2cv8datasets9TR_svtImp8xmlParseERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEERSt6vectorINS_3PtrINS0_6ObjectEEESaISD_EE.constprop.0+0x394): relocation truncated to fit: R_RISCV_PCREL_HI20 against `.LC19'
collect2: error: ld returned 1 exit status
```

This problem will be reported to upstream `gcc` later.