### PR TITLE
Add uutils-coreutils to qemu-user-blacklist

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -74,6 +74,7 @@ tinyssh
 tmuxp
 tpm2-tools
 tpm2-tss
+uutils-coreutils
 vim
 wayland
 xmonk.lv2


### PR DESCRIPTION
These tests fail on qemu-user, but can pass on a RISC-V board.

```text
---- common::util::tests::test_check_coreutil_version stdout ----
run: id --version
run: no test name --version
thread 'common::util::tests::test_check_coreutil_version' panicked at 'assertion failed: `(left == right)`
  left: `Err("uutils-tests-warning: no coreutils version string found for reference coreutils 'no test name --version'")`,
 right: `Err("uutils-tests-warning: 'no test name' No such file or directory (os error 2)")`', tests/common/util.rs:1738:9

---- test_install::test_install_and_strip_with_non_existent_program stdout ----
current_directory_resolved: 
run: /build/uutils-coreutils/src/coreutils-0.0.14/target/release/coreutils install -s --strip-program /usr/bin/non_existent_program helloworld_linux helloworld_installed
thread 'test_install::test_install_and_strip_with_non_existent_program' panicked at ''install: strip program failed: 
' does not contain 'No such file or directory'', tests/common/util.rs:418:9

---- test_sort::test_compress_fail stdout ----
current_directory_resolved: 
run: /build/uutils-coreutils/src/coreutils-0.0.14/target/release/coreutils sort ext_sort.txt -n --compress-program nonexistent-program -S 10
thread 'test_sort::test_compress_fail' panicked at 'assertion failed: `(left == right)`

Diff < left / right > :
<sort: 'nonexistent-program' terminated abnormally
>sort: couldn't execute compress program: errno 2

', tests/common/util.rs:326:9


failures:
    common::util::tests::test_check_coreutil_version
    test_install::test_install_and_strip_with_non_existent_program
    test_sort::test_compress_fail
```