### PR TITLE
qemu-user-blacklist: add glib-perl

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -20,6 +20,7 @@ fish
 foot
 gauche
 gdk-pixbuf2
+glib-perl
 go
 gpxsee
 gtest


### PR DESCRIPTION
`t/9.t:233:13` called fork() 🍴 while qemu-user hates forking.
`fork()` was reported successful but actually, it's not.