### PR TITLE
qemu-user-blacklist: add pyqt6 family

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -55,6 +55,13 @@ pyside2
 pyside6
 python
 python-prctl
+python-pyqt6-sip
+python-pyqt6
+python-pyqt6-3d
+python-pyqt6-charts
+python-pyqt6-datavisualization
+python-pyqt6-networkauth
+python-pyqt6-webengine
 qalculate-qt
 qconf
 qxmledit


### PR DESCRIPTION
pyqt6 needs qmake, this is broken in qemu-user