### PR TITLE
upgpatch: tbb

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -69,6 +69,7 @@ sudo
 sweep
 swtpm
 systemd
+tbb
 texstudio
 tiled
 tinyssh

--- a/tbb/riscv64.patch
+++ b/tbb/riscv64.patch
@@ -1,21 +1,21 @@
-diff --git PKGBUILD PKGBUILD
-index 38ab1a15..153fbc11 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -16,8 +16,14 @@
- conflicts=('intel-tbb')
+@@ -17,13 +17,16 @@ conflicts=('intel-tbb')
  provides=("intel-tbb=$pkgver")
  replaces=('intel-tbb')
--source=(https://github.com/oneapi-src/oneTBB/archive/v$pkgver/$pkgname-$pkgver.tar.gz)
--sha512sums=('0e7b71022e397a6d7abb0cea106847935ae79a1e12a6976f8d038668c6eca8775ed971202c5bd518f7e517092b67af805cc5feb04b5c3a40e9fbf972cc703a46')
-+source=(https://github.com/oneapi-src/oneTBB/archive/v$pkgver/$pkgname-$pkgver.tar.gz
+ source=(https://github.com/oneapi-src/oneTBB/archive/v$pkgver/$pkgname-$pkgver.tar.gz
+-        retry-pthread_create.patch::https://github.com/oneapi-src/oneTBB/pull/824.patch)
++        retry-pthread_create.patch::https://github.com/oneapi-src/oneTBB/pull/824.patch
 +        tbb-riscv.patch::https://github.com/oneapi-src/oneTBB/pull/550.patch)
-+sha512sums=('0e7b71022e397a6d7abb0cea106847935ae79a1e12a6976f8d038668c6eca8775ed971202c5bd518f7e517092b67af805cc5feb04b5c3a40e9fbf972cc703a46'
+ sha512sums=('0e7b71022e397a6d7abb0cea106847935ae79a1e12a6976f8d038668c6eca8775ed971202c5bd518f7e517092b67af805cc5feb04b5c3a40e9fbf972cc703a46'
+-            '62c1535a3888f27f1af5f472c57b8e22dc6977a0a64edb84d9ea84e4a967169d2c79a2b20654c4aa3da2891fec9538c22c6e5d8a5f296947b8760c6f97e02d98')
++            '62c1535a3888f27f1af5f472c57b8e22dc6977a0a64edb84d9ea84e4a967169d2c79a2b20654c4aa3da2891fec9538c22c6e5d8a5f296947b8760c6f97e02d98'
 +            'dfba52da2bd6f463adf658e95a41912c60f12f33b3cdc8e15097dd88c0306fb09c8e269862fda74bbb07cd5091491f611086fb011c79ca762f2be8521cb2fc0b')
-+
-+prepare() {
+ 
+ prepare() {
+   # Patch for mold:
+   patch -d oneTBB-$pkgver -p1 -i ../retry-pthread_create.patch
 +  patch -d oneTBB-$pkgver -p1 < tbb-riscv.patch
-+}
+ }
  
  build() {
-   cd oneTBB-$pkgver


### PR DESCRIPTION
Fixed rotten patch.

Test 23 `test_task_group` will get stuck in QEMU, but pass on real boards.