### PR TITLE
addpkg: libcuckoo

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -31,6 +31,7 @@ haxe
 hyperfine
 keepassxc
 knot
+libcuckoo
 libdwarf
 libfbclient
 libmemcached-awesome


### PR DESCRIPTION
Tests pass on u62.

Log of the failing test with qemu is listed below.

9/10 Testing: insert_expansion
9/10 Test: insert_expansion
Command: "/build/libcuckoo/src/build/tests/universal-benchmark/universal_benchmark" "--inserts" "100" "--initial-capacity" "4" "--total-ops" "13107200"
Directory: /build/libcuckoo/src/build/tests/universal-benchmark
"insert_expansion" start time: Jul 05 09:49 CEST
Output:
----------------------------------------------------------
Generating keys
Pre-filling table
Running operations
<end of output>
Test time =   0.44 sec
----------------------------------------------------------
Test Failed.
"insert_expansion" end time: Jul 05 09:49 CEST
"insert_expansion" time elapsed: 00:00:00
----------------------------------------------------------