### PR TITLE
upgpatch: maturin

### DIFF
--- a/maturin/add-riscv64-support.patch
+++ b/maturin/add-riscv64-support.patch
@@ -1,0 +1,88 @@
+commit 4ca5505845cebb078e21fd965423663a51f01fcc
+Author: Felix Yan <felixonmars@archlinux.org>
+Date:   Sun Jul 10 03:30:33 2022 +0300
+
+    Add 64-bit RISC-V support
+    
+    Tested with `orjson` and it built fine with all tests passed on a
+    riscv64 machine.
+    
+    This change is not sufficient though, because `ring` doesn't support
+    riscv64 yet. I was building `maturin` against a custom version of `ring`
+    to verify this change.
+    
+    Please let me know what could be done to move forward :)
+
+diff --git a/src/auditwheel/policy.rs b/src/auditwheel/policy.rs
+index 3d72b2a..65292ea 100644
+--- a/src/auditwheel/policy.rs
++++ b/src/auditwheel/policy.rs
+@@ -104,6 +104,7 @@ impl Policy {
+                 Arch::X86 => "libc.musl-x86.so.1",
+                 Arch::X86_64 => "libc.musl-x86_64.so.1",
+                 Arch::S390X => "libc.musl-s390x.so.1",
++                Arch::Riscv64 => "libc.musl-riscv64.so.1",
+             };
+             if !new_soname.is_empty() {
+                 self.lib_whitelist.insert(new_soname.to_string());
+diff --git a/src/target.rs b/src/target.rs
+index 6e3481f..42c068c 100644
+--- a/src/target.rs
++++ b/src/target.rs
+@@ -57,6 +57,7 @@ pub enum Arch {
+     X86,
+     X86_64,
+     S390X,
++    Riscv64,
+ }
+ 
+ impl fmt::Display for Arch {
+@@ -70,6 +71,7 @@ impl fmt::Display for Arch {
+             Arch::X86 => write!(f, "i686"),
+             Arch::X86_64 => write!(f, "x86_64"),
+             Arch::S390X => write!(f, "s390x"),
++            Arch::Riscv64 => write!(f, "riscv64"),
+         }
+     }
+ }
+@@ -86,6 +88,7 @@ fn get_supported_architectures(os: &Os) -> Vec<Arch> {
+             Arch::S390X,
+             Arch::X86,
+             Arch::X86_64,
++            Arch::Riscv64,
+         ],
+         Os::Windows => vec![Arch::X86, Arch::X86_64, Arch::Aarch64],
+         Os::Macos => vec![Arch::Aarch64, Arch::X86_64],
+@@ -163,6 +166,7 @@ impl Target {
+             target_lexicon::Architecture::Powerpc64 => Arch::Powerpc64,
+             target_lexicon::Architecture::Powerpc64le => Arch::Powerpc64Le,
+             target_lexicon::Architecture::S390x => Arch::S390X,
++            target_lexicon::Architecture::Riscv64(_) => Arch::Riscv64,
+             unsupported => bail!("The architecture {} is not supported", unsupported),
+         };
+ 
+@@ -324,6 +328,7 @@ impl Target {
+             Arch::X86 => "i386",
+             Arch::X86_64 => "x86_64",
+             Arch::S390X => "s390x",
++            Arch::Riscv64 => "riscv64",
+         }
+     }
+ 
+@@ -349,14 +354,14 @@ impl Target {
+                 PlatformTag::manylinux2014()
+             }
+             Arch::X86 | Arch::X86_64 => PlatformTag::manylinux2010(),
+-            Arch::Armv6L => PlatformTag::Linux,
++            Arch::Armv6L | Arch::Riscv64 => PlatformTag::Linux,
+         }
+     }
+ 
+     /// Returns whether the platform is 64 bit or 32 bit
+     pub fn pointer_width(&self) -> usize {
+         match self.arch {
+-            Arch::Aarch64 | Arch::Powerpc64 | Arch::Powerpc64Le | Arch::X86_64 | Arch::S390X => 64,
++            Arch::Aarch64 | Arch::Powerpc64 | Arch::Powerpc64Le | Arch::X86_64 | Arch::S390X | Arch::Riscv64 => 64,
+             Arch::Armv6L | Arch::Armv7L | Arch::X86 => 32,
+         }
+     }

--- a/maturin/riscv64.patch
+++ b/maturin/riscv64.patch
@@ -1,13 +1,28 @@
 Index: PKGBUILD
 ===================================================================
---- PKGBUILD	(revision 1015165)
+--- PKGBUILD	(revision 1249264)
 +++ PKGBUILD	(working copy)
-@@ -16,6 +16,8 @@
+@@ -11,13 +11,19 @@
+ makedepends=(bzip2 git)
+ # disable LTO until ring can be built with it: https://github.com/briansmith/ring/issues/1444
+ options=(!lto)
+-source=($pkgname-$pkgver.tar.gz::https://github.com/PyO3/$pkgname/archive/refs/tags/v$pkgver.tar.gz)
+-sha512sums=('e221711509d6c3997df49e934e73f41df3c7cdd975db9fd13a22fc9d6a2f2bb9aed33763c70f8516665918537a032e113b55d69936f65e72bb2ac5e46b45be89')
+-b2sums=('f509401b4b32a6700e08b72ec9ae49d5593df9b55e26ce3f44d62c9755429ef785a60442b540fe05159ed0ea6fae72c3230dcf517cef7e5085184ce99d0d0032')
++source=($pkgname-$pkgver.tar.gz::https://github.com/PyO3/$pkgname/archive/refs/tags/v$pkgver.tar.gz
++        add-riscv64-support.patch)
++sha512sums=('e221711509d6c3997df49e934e73f41df3c7cdd975db9fd13a22fc9d6a2f2bb9aed33763c70f8516665918537a032e113b55d69936f65e72bb2ac5e46b45be89'
++            '92ce57d6b1409538246a727fe86823ab6b84673d934aa38cef2154d8712aa5eeb1d45588a6661924583ca7d7124c7dbd2ac697810f3a2763406b0ad1cf36605b')
++b2sums=('f509401b4b32a6700e08b72ec9ae49d5593df9b55e26ce3f44d62c9755429ef785a60442b540fe05159ed0ea6fae72c3230dcf517cef7e5085184ce99d0d0032'
++        '0f5eb9ec1e867620c2675ebfe11323fdb13b607f6d572b5c92887a958b8f9db9a5807ca567e1987103adea6bc3862b4bd058621d8020c9920b699f8db216d653')
  
- build() {
-   cd maturin
+ prepare() {
+   cd $pkgname-$pkgver
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  patch -p1 -i ../add-riscv64-support.patch || :
 +  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
 +  cargo update -p ring
-   cargo build --release --locked --all-features
++  cargo fetch --locked
  }
  
+ build() {


### PR DESCRIPTION
add-riscv64-support.patch was backported from
https://github.com/PyO3/maturin/pull/1001