### PR TITLE
addpatch: nextcloud-client

### DIFF
--- a/nextcloud-client/riscv64.patch
+++ b/nextcloud-client/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -77,7 +77,7 @@ check() {
+   # with a small /tmp partition.
+   # Use UTC as TestCookies is sensitive to the timezone
+   # https://github.com/nextcloud/desktop/blob/v3.2.2/test/testcookies.cpp#L24
+-  QT_QPA_PLATFORM=offscreen TMPDIR="$srcdir/tmpdir" TZ=UTC ARGS="--rerun-failed --output-on-failure" make test
++  QT_QPA_PLATFORM=offscreen QTEST_FUNCTION_TIMEOUT=3600000 TMPDIR="$srcdir/tmpdir" TZ=UTC ARGS="--rerun-failed --output-on-failure" make test
+ }
+ 
+ package_nextcloud-client() {

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -41,6 +41,7 @@ libsecret
 libuv
 mdbook
 meilisearch
+nextcloud-client
 ninja
 nodejs-lts-gallium
 notepadqq


### PR DESCRIPTION
Test `TestUtility::testVersionOfInstalledBinary()` will fail in QEMU but passed on real boards.

Increased the test timeout value for slow performance boards. 