### PR TITLE
ci: create pr for dropped packages in Arch

### DIFF
--- a/.github/workflows/rotten.yml
+++ b/.github/workflows/rotten.yml
@@ -1,5 +1,5 @@
 on:
-  workflow_dispatch: {}
+  workflow_dispatch: { }
   schedule:
     - cron: '0 0 * * *'
 
@@ -9,9 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     container: archlinux/archlinux:latest
     steps:
-      - uses: actions/checkout@v2
       - name: Install dependencies
-        run: pacman -Syu --noconfirm asp patch python python-sh
+        run: pacman -Syu --noconfirm asp patch python python-sh python-gitpython python-pygithub
+      - name: Fix git unsafe repository
+        run: git config --global --add safe.directory /__w/archriscv-packages/archriscv-packages
+      - uses: actions/checkout@v3
+      - uses: fregante/setup-git-user@v1
       - name: Check for rotten patches
         run: python find-rotten
-
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPO: ${{ github.repository }}

--- a/find-rotten
+++ b/find-rotten
@@ -8,14 +8,22 @@ import shutil
 import tempfile
 
 import sh
+from git import Repo
+from github import Github
 
 logging.basicConfig(level=logging.WARNING)
 logger = logging.getLogger(__name__)
 
 ENV = os.environ.copy()
 ENV["LANG"] = "C"
+
 RE_HUNK_FAILED = re.compile(r"^\d+ out of \d+ hunks? FAILED", re.MULTILINE)
 RE_REVERSED = re.compile(r"^Reversed \(or previously applied\) patch detected")
+RE_PR_RM_PACKAGE = re.compile(r"^(rm|rmv)(pkg|patch): ([^ ]+)")
+
+repo = Repo()
+g = Github(ENV["GITHUB_TOKEN"])
+gh_repo = g.get_repo(ENV["GITHUB_REPO"])
 
 
 def is_rotten(package):
@@ -51,6 +59,18 @@ def done_callback(futures, future):
         return
 
 
+# call this after making changes to repo index
+def commit_rm_package_push_pr(package):
+    repo.index.commit(f"rmvpatch: {package}")
+    branch_name = repo.active_branch.name
+    repo.git.push("origin", branch_name)
+    gh_repo.create_pull(title=f"rmvpatch: {package}",
+                        body="This package has been removed in Arch.",
+                        base="master",
+                        head=branch_name)
+    logger.info(f"created rmvpatch PR for {package}")
+
+
 def main():
     packages = set()
     for dirent in os.scandir():
@@ -62,8 +82,24 @@ def main():
 
     all_packages = set(sh.asp("list-all").stdout.decode("ascii").strip().split())
 
+    pulls = gh_repo.get_pulls(state='open', sort='created', base='master')
+    rm_package_in_pr = set()
+    for pr in pulls:
+        if match := RE_PR_RM_PACKAGE.match(pr.title):
+            rm_package_in_pr.add(match.group(3))
+
     if ghosts := packages - all_packages:
         logger.warning("nonexistent packages: \n{}\n".format("\n".join(sorted(ghosts))))
+
+        for ghost in ghosts:
+            if ghost in rm_package_in_pr:
+                continue
+            current_branch = repo.active_branch
+            new_branch = repo.create_head(f"actions-rm-{ghost}")
+            new_branch.checkout()
+            repo.index.remove(ghost, working_tree=True, r=True)
+            commit_rm_package_push_pr(ghost)
+            current_branch.checkout()
 
     with open('qemu-user-blacklist.txt') as qemu_user_blacklist:
         qemu_user_blacklist_packages = set(qemu_user_blacklist.read().split())


### PR DESCRIPTION
Permission of default actions token needs to be rw.
![image](https://user-images.githubusercontent.com/13995937/178404394-6ad1d726-d3c0-45ed-a11a-5db0f51f1c09.png)

A demo is at https://github.com/Xeonacid/archriscv-packages/pull/3. It includes the commit of this CI change because the action ran on the `actions-rmvpatch` branch (head branch of this PR) for the test instead of `master`. The action should work fine on `master`.

I leave `qemu-user-blacklist.txt` unchanged for now since it's not easy to examine whether there has been a rmvpatch PR for the package, and it may cause many conflicts if multiple packages are to be removed at the same time.