### PR TITLE
addpkg: gnuchess

### DIFF
--- a/gnuchess/riscv64.patch
+++ b/gnuchess/riscv64.patch
@@ -1,0 +1,22 @@
+diff --git PKGBUILD trunk/PKGBUILD
+index 837a8376..880df3f9 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -10,6 +10,7 @@ arch=('x86_64')
+ url="https://www.gnu.org/software/chess/chess.html"
+ license=('GPL3')
+ depends=('bash')
++makedepends=('help2man')
+ optdepends=('xboard: graphical frontend')
+ source=(https://ftp.gnu.org/pub/gnu/chess/$pkgname-$pkgver.tar.gz
+         https://ftp.gnu.org/pub/gnu/chess/$pkgname-$pkgver.tar.gz.sig)
+@@ -19,7 +20,8 @@ md5sums=('ede9af6cf29eea31179a737a21b9d1bc'
+ 
+ build() {
+   cd $pkgname-$pkgver
+-
++  autoupdate
++  autoreconf -fiv
+   ./configure --prefix=/usr
+ 
+   make  


### PR DESCRIPTION
This package's `config.guess` is too old, and the truth will be reported to upstream.

BTW, after `autoreconf`, it occurs a new error. That is lacking of `help2man` dependency, so add it to `makedepends` to avoid the same error on other machines.

Build passed.