### PR TITLE
addpkg: simutrans-pak128

### DIFF
--- a/simutrans-pak128/riscv64.patch
+++ b/simutrans-pak128/riscv64.patch
@@ -1,0 +1,21 @@
+diff --git PKGBUILD PKGBUILD
+index 74212cd..fd0f65d 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -3,15 +3,15 @@
+ 
+ pkgname=simutrans-pak128
+ pkgver=2.8.1
+-_pkgver='ST 120.4.1 (2.8.1, priority signals + bugfix)'
++_pkgver='ST%20120.4.1%20(2.8.1,%20priority%20signals%20+%20bugfix)'
+ pkgrel=2
+ pkgdesc="High resolution graphics set for Simutrans"
+ url="https://128.simutrans.com/"
+ license=('Artistic2.0')
+ provides=('simutrans-pak64')
+ options=('!strip')
+-source=("https://downloads.sourceforge.net/project/simutrans/pak128/pak128 for $_pkgver/pak128.zip")
++source=("https://downloads.sourceforge.net/project/simutrans/pak128/pak128%20for%20$_pkgver/pak128.zip")
+ sha256sums=('bc17793e9d64c7f56e58bc050f6f8d59cac5deb46b9d90773af8fc0cf2f1017c')
+ 
+ package() {


### PR DESCRIPTION
Fix the illegally formated URL (also FTBFS in x86_64).
Bug reported: https://bugs.archlinux.org/task/75317