### PR TITLE
addpkg: libicns

### DIFF
--- a/libicns/riscv64.patch
+++ b/libicns/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD trunk/PKGBUILD
+index fb6b2675..7334e2dc 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -19,6 +19,8 @@ sha256sums=('335f10782fc79855cf02beac4926c4bf9f800a742445afbbf7729dab384555c2')
+ 
+ build() {
+     cd "$pkgname-$pkgver"
++    autoupdate
++    autoreconf -fiv
+     ./configure --prefix=/usr
+     make
+ }


### PR DESCRIPTION
Fixed `config.guess`.
The message of guess file too old will be reported to upstream.