### PR TITLE
addpkg: wxsqlite3

### DIFF
--- a/wxsqlite3/riscv64.patch
+++ b/wxsqlite3/riscv64.patch
@@ -1,0 +1,15 @@
+diff --git PKGBUILD trunk/PKGBUILD
+index 438ed797..23032f1e 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -16,8 +16,8 @@ sha256sums=('f093881d91ae7a600999a879ecdfb98d2059a030541393acdddc8a49cc02c704')
+ 
+ build() {
+   cd $pkgname-$pkgver
+-
+-  autoreconf
++  autoupdate
++  autoreconf -fiv
+   ./configure --prefix=/usr
+   make
+ }


### PR DESCRIPTION
Fixed `config.guess`.
The message of guess file too old will be reported to upstream.
Note:
There are some so name difference. Here is the info:
`usr/lib/libwxcode_gtk3u_wxsqlite3-3.0.so                      | usr/lib/libwxcode_gtk3u_wxsqlite3-3.2.so`
`usr/lib/libwxcode_gtk3u_wxsqlite3-3.0.so.0                    | usr/lib/libwxcode_gtk3u_wxsqlite3-3.2.so.0`
`usr/lib/libwxcode_gtk3u_wxsqlite3-3.0.so.0.0.0                | usr/lib/libwxcode_gtk3u_wxsqlite3-3.2.so.0.0.0`
`==> WARNING: Sonames differ in wxsqlite3!`
`libwxcode_gtk3u_wxsqlite3-3.0.so=0-64                         | libwxcode_gtk3u_wxsqlite3-3.2.so=0-64`