### PR TITLE
addpkg: cargo-tauri

### DIFF
--- a/cargo-tauri/riscv64.patch
+++ b/cargo-tauri/riscv64.patch
@@ -1,0 +1,15 @@
+diff --git PKGBUILD trunk/PKGBUILD
+index b61d5881..835abd92 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -16,7 +16,9 @@ options=('!lto')
+ 
+ prepare() {
+   cd "$_pkgname-$pkgver/tooling/cli"
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
++  cargo update -p ring
++  cargo fetch --locked 
+ }
+ 
+ build() {


### PR DESCRIPTION
Removed `--target "$CARCH-unknown-linux-gnu"`.

After fixing, it occurred `ring` dependency error, so this patch contains two fixing places.

Build passed.