### PR TITLE
upgpatch: rustup

### DIFF
--- a/rustup/riscv64.patch
+++ b/rustup/riscv64.patch
@@ -1,15 +1,10 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -19,10 +19,12 @@ replaces=('cargo-tree')
- install='post.install'
- source=("rustup-${pkgver}.tar.gz::https://github.com/rust-lang/rustup.rs/archive/${pkgver}.tar.gz")
- sha512sums=('43e85f1e653d451a2555a7ae9a3f47c4b9eb8e0fea0cd9cdcf381728ac933b56aaa25366ca2e1b12f20f9190b77d407a00a3f559ced6ad9c4f51fcef9efe67d7')
-+options=('!lto')
- _binlinks=('cargo' 'rustc' 'rustdoc' 'rust-gdb' 'rust-lldb' 'rls' 'rustfmt' 'cargo-fmt' 'cargo-clippy' 'clippy-driver' 'cargo-miri')
+@@ -24,6 +24,7 @@ _binlinks=('cargo' 'rustc' 'rustdoc' 'rust-gdb' 'rust-lldb' 'rls' 'rustfmt' 'car
  
  build() {
-     cd "$pkgname-${pkgver}"
-+    echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
-     cargo build --release --features no-self-update --bin rustup-init
+   cd "$pkgname-${pkgver}"
++  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
+   cargo build --release --features no-self-update --bin rustup-init
  }
  


### PR DESCRIPTION
Fix rotten patch.

This package can now be built without disabling LTO.