### PR TITLE
upgpatch: libafterimage

### DIFF
--- a/libafterimage/riscv64.patch
+++ b/libafterimage/riscv64.patch
@@ -1,30 +1,11 @@
-diff --git PKGBUILD PKGBUILD
-index aa43cc4..0aef92d 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -13,11 +13,13 @@ arch=('x86_64')
- source=("https://downloads.sourceforge.net/project/afterstep/libAfterImage/$pkgver/libAfterImage-$pkgver.tar.bz2"
-         libafterimage-libpng15.patch
-         libafterimage-ldflags.patch
--        header-install.patch)
-+        header-install.patch
-+        libafterimage-ar.patch::"https://gitweb.gentoo.org/repo/gentoo.git/plain/media-libs/libafterimage/files/libafterimage-ar.patch?id=b22db36af30264f2cde7c55e627cae4a125c0af9")
- sha256sums=('6e233253f4d1dd22dfce9f9a245cc036d814fc99ba7f6732f4e345de62cfe458'
-             'bbf95bcddc4c48dcde88745dc9cb772ca53b625e8e466b9d565e4183ce71dbe3'
-             'a38f2e46bb69f6749c5e48cff60f51fae6bda19d268f0c7f16dfbd74d34d2f64'
--            '6e1c5fd8acbbbc1c83f0ca490f08b7602d37a2295cb4741eef6f3b88fb638203')
-+            '6e1c5fd8acbbbc1c83f0ca490f08b7602d37a2295cb4741eef6f3b88fb638203'
-+            '50dfe442abcdf68843f0d83309e9cbeb886d30414c88bed2e8ff072da0034749')
- 
- prepare() {
-   cd libAfterImage-$pkgver
-@@ -30,6 +32,9 @@ prepare() {
+@@ -30,6 +30,8 @@ prepare() {
  
    # Make sure LDFLAGS are passed to lib
    patch < ../libafterimage-ldflags.patch
 +
-+  # Drop non-standard 'l' from ar args (https://bugs.gentoo.org/784182)
-+  patch -p1 -i ../libafterimage-ar.patch
++  autoreconf -fiv
  }
  
  build() {


### PR DESCRIPTION
Fixed error:

```
checking build system type... ./config.guess: unable to guess system type

This script, last modified 2005-02-10, has failed to recognize
the operating system you are using. It is advised that you
download the most up to date version of the config scripts from

    ftp://ftp.gnu.org/pub/gnu/config/

If the version you run (./config.guess) is already up to date, please
send the following data and any information you think might be
pertinent to <config-patches@gnu.org> in order to provide the needed
information to handle your system.

config.guess timestamp = 2005-02-10

uname -m = riscv64
uname -r = 5.18.7-arch1-1
uname -s = Linux
uname -v = #1 SMP PREEMPT_DYNAMIC Sat, 25 Jun 2022 20:22:01 +0000

/usr/bin/uname -p = unknown
/bin/uname -X     = 

hostinfo               = 
/bin/universe          = 
/usr/bin/arch -k       = 
/bin/arch              = 
/usr/bin/oslevel       = 
/usr/convex/getsysinfo = 

UNAME_MACHINE = riscv64
UNAME_RELEASE = 5.18.7-arch1-1
UNAME_SYSTEM  = Linux
UNAME_VERSION = #1 SMP PREEMPT_DYNAMIC Sat, 25 Jun 2022 20:22:01 +0000
configure: error: cannot guess build type; you must specify one
```

The upstream is inactive (last modified on 2011-01-18), so this issue was not reported.