### PR TITLE
addpatch: carla

### DIFF
--- a/carla/carla-riscv64-portable.patch
+++ b/carla/carla-riscv64-portable.patch
@@ -1,0 +1,31 @@
+diff --git a/source/Makefile.deps.mk b/source/Makefile.deps.mk
+index ae4f0051f..76a817625 100644
+--- a/source/Makefile.deps.mk
++++ b/source/Makefile.deps.mk
+@@ -81,6 +81,10 @@ ifneq (,$(filter aarch64%,$(TARGET_PROCESSOR)))
+ CPU_AARCH64 = true
+ CPU_ARM_OR_AARCH64 = true
+ endif
++ifneq (,$(filter riscv64%,$(TARGET_PROCESSOR)))
++CPU_RISCV64 = true
++CPU_RISCV32_OR_RISCV64 = true
++endif
+ 
+ # ---------------------------------------------------------------------------------------------------------------------
+ # Set PKG_CONFIG (can be overridden by environment variable)
+diff --git a/source/modules/ysfx/Makefile b/source/modules/ysfx/Makefile
+index b8b910c51..d921e1ffd 100644
+--- a/source/modules/ysfx/Makefile
++++ b/source/modules/ysfx/Makefile
+@@ -34,6 +34,11 @@ YSFX_FLAGS += -DEEL_TARGET_PORTABLE
+ endif
+ endif
+ 
++# RISC-V needs portable code
++ifeq ($(CPU_RISCV64),true)
++YSFX_FLAGS += -DEEL_TARGET_PORTABLE
++endif
++
+ ifeq ($(YSFX_FTS_LACKS_LFS_SUPPORT),true)
+ YSFX_FLAGS += -DYSFX_FTS_LACKS_LFS_SUPPORT
+ endif

--- a/carla/riscv64.patch
+++ b/carla/riscv64.patch
@@ -1,0 +1,26 @@
+diff --git PKGBUILD PKGBUILD
+index 917ed902a..6aa00e788 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -25,11 +25,19 @@ provides=(dssi-host ladspa-host lv2-host vst-host vst3-host)
+ options=(debug)
+ source=(
+   git+https://github.com/falkTX/$pkgname#tag=$_commit?signed
++  carla-riscv64-portable.patch
+ )
+-sha512sums=('SKIP')
+-b2sums=('SKIP')
++sha512sums=('SKIP'
++            '63f3aae704810f3b558a9280393948f249b8728aa9821e650e686c91b62aa3c79b1eb6d8a6eacf24c3f588f79d861106572716aecbf9b943da7538bb1d43293b')
++b2sums=('SKIP'
++        '382a63d0cf795f7984121e29ba9bb7276daed7d3ef843c831552c836e4abeb59b05f2ab904706002d0071c5061391c3ddd231c8eb7398adfc1c9240fb1eaaa01')
+ validpgpkeys=('62B11043D2F6EB6672D93103CDBAA37ABC74FBA0')  # falkTX <falktx@falktx.com>
+ 
++prepare() {
++  cd $pkgname
++  patch -Np1 -i $srcdir/carla-riscv64-portable.patch
++}
++
+ build() {
+   make features -C $pkgname
+   make -C $pkgname


### PR DESCRIPTION
EEL doesn't have a native RISC-V implementation, so add `EEL_TARGET_PORTABLE` to use the software-based one