### PR TITLE
addpkg: ncnn

### DIFF
--- a/ncnn/riscv64.patch
+++ b/ncnn/riscv64.patch
@@ -1,0 +1,13 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1255016)
++++ PKGBUILD	(working copy)
+@@ -28,7 +28,7 @@
+         -DNCNN_SYSTEM_GLSLANG=ON \
+         -DNCNN_BUILD_EXAMPLES=OFF \
+         -DGLSLANG_TARGET_DIR=/usr/lib/cmake/ \
+-        -Wno-dev
++        -Wno-dev -DNCNN_RVV=OFF
+     ninja -C build
+ }
+ 


### PR DESCRIPTION
Disable RVV as upstream recommended for now. NCNN doesn't have proper
support for latest mainline GCC or Clang yet.

For GCC:
```
In file included from /build/ncnn/src/ncnn-20220721/src/layer.h:18,
                 from /build/ncnn/src/ncnn-20220721/src/layer/absval.h:18,
                 from /build/ncnn/src/build/src/layer/riscv/absval_riscv_rvv.h:18,
                 from /build/ncnn/src/build/src/layer/riscv/absval_riscv_rvv.cpp:15:
/build/ncnn/src/ncnn-20220721/src/mat.h:36:10: fatal error: riscv_vector.h: No such file or directory
   36 | #include <riscv_vector.h>
      |          ^~~~~~~~~~~~~~~~
```

For Clang:
```
In file included from /build/ncnn/src/build/src/layer/riscv/absval_riscv_rvv.cpp:15:
In file included from /build/ncnn/src/build/src/layer/riscv/absval_riscv_rvv.h:18:
In file included from /build/ncnn/src/ncnn-20220721/src/layer/absval.h:18:
In file included from /build/ncnn/src/ncnn-20220721/src/layer.h:18:
/build/ncnn/src/ncnn-20220721/src/mat.h:1078:11: error: unknown type name 'word_type'
    const word_type vl = vsetvl_e32m1(packn);
          ^
/build/ncnn/src/ncnn-20220721/src/mat.h:1092:11: error: unknown type name 'word_type'
    const word_type vl = vsetvl_e16m1(packn);
          ^
/build/ncnn/src/ncnn-20220721/src/mat.h:1106:11: error: unknown type name 'word_type'
    const word_type vl = vsetvl_e8m1(packn);
          ^
/build/ncnn/src/ncnn-20220721/src/mat.h:1120:11: error: unknown type name 'word_type'
    const word_type vl = vsetvl_e16m1(packn);
          ^
/build/ncnn/src/build/src/layer/riscv/absval_riscv_rvv.cpp:73:13: error: unknown type name 'word_type'
            word_type vl = vsetvl_e32m8(n);
            ^
/build/ncnn/src/build/src/layer/riscv/absval_riscv_rvv.cpp:113:13: error: unknown type name 'word_type'
            word_type vl = vsetvl_e16m8(n);
            ^
```