### PR TITLE
addpatch: syslog-ng

### DIFF
--- a/syslog-ng/riscv64.patch
+++ b/syslog-ng/riscv64.patch
@@ -1,0 +1,24 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -29,15 +29,19 @@ backup=('etc/syslog-ng/scl.conf'
+         'etc/logrotate.d/syslog-ng'
+         'etc/default/syslog-ng@default')
+ source=(https://github.com/balabit/syslog-ng/releases/download/syslog-ng-$pkgver/$pkgname-$pkgver.tar.gz
+-        syslog-ng.conf syslog-ng.logrotate)
++        syslog-ng.conf syslog-ng.logrotate
++        syslog-ng-remove-json-c-submodule.patch)
+ sha512sums=('beebd89c54a415469dc58630ac1900d632ef351f6a13fad4a95ce7bb1760b16d6cfdcede02225a35e97ebce7dae151c6aa228f3d378463e8b873c4f71ed86ab7'
+             '36629a566a8343574dc07430e744e20ce90574be0cc856bc43340f834cd6642a8f08889b9ba15996d088aeebeee4bc3ca64411265046c17c8e125fbed8948ded'
+-            'cd39f545a6a855c866a466bf846e33940b2c2dd1fc2eaf50cce29c68e1a5753c7c4b56411e4f01c152f32e155104a98dd755a96319767f47c73a8853f720b2cc')
++            'cd39f545a6a855c866a466bf846e33940b2c2dd1fc2eaf50cce29c68e1a5753c7c4b56411e4f01c152f32e155104a98dd755a96319767f47c73a8853f720b2cc'
++            '5c08ff8560122fe68a5b06bc2aa9abbd35a413c36ebd68b5289440599e11680b1c2be5e07ce61284cde64c67f3b88228e92d9683731af32d4350f5d30fac81f0')
+ 
+ prepare() {
+   cd $pkgname-$pkgver
+   sed -i -e 's,/bin/,/usr/bin/,' -e 's,/sbin/,/bin/,' contrib/systemd/syslog-ng@.service
+   sed -i -e 's|/var/run|/run|g' contrib/systemd/syslog-ng@default
++  rm -rf lib/jsonc
++  patch -Np1 < ../syslog-ng-remove-json-c-submodule.patch
+ }
+ 
+ build() {

--- a/syslog-ng/syslog-ng-remove-json-c-submodule.patch
+++ b/syslog-ng/syslog-ng-remove-json-c-submodule.patch
@@ -1,0 +1,470 @@
+From 6ee64b465a9a6a974dd1df0bd492402af6f27ce0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?L=C3=A1szl=C3=B3=20V=C3=A1rady?=
+ <laszlo.varady@protonmail.com>
+Date: Tue, 12 Jul 2022 16:27:03 +0200
+Subject: [PATCH 1/3] submodules: remove json-c submodule
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+We've been using an old version of json-c internally as a submodule.
+
+It seems that all known distros provide json-c packages nowadays, so the
+need of embedding (and maintaning) a json-c version in our tarball is
+not really important anymore.
+
+Instead of updating the submodule, this patch removes it.
+
+Signed-off-by: László Várady <laszlo.varady@protonmail.com>
+---
+ .astylerc                         |  1 -
+ .gitmodules                       |  4 ---
+ autogen.sh                        |  2 +-
+ cmake/Makefile.am                 |  1 -
+ cmake/Modules/ExternalJSONC.cmake | 57 -------------------------------
+ configure.ac                      | 32 ++++-------------
+ dbld/packages.manifest            |  2 --
+ lib/Makefile.am                   | 16 ++-------
+ lib/jsonc                         |  1 -
+ modules/json/CMakeLists.txt       |  4 ---
+ modules/json/tests/CMakeLists.txt |  9 -----
+ packaging/debian/copyright        | 22 ------------
+ tests/collect-cov.sh              |  1 -
+ tests/copyright/policy            |  1 -
+ 14 files changed, 9 insertions(+), 144 deletions(-)
+ delete mode 100644 cmake/Modules/ExternalJSONC.cmake
+ delete mode 160000 lib/jsonc
+
+#diff --git a/.astylerc b/.astylerc
+#index 3c31431383..c62f7ec8b6 100644
+#--- a/.astylerc
+#+++ b/.astylerc
+#@@ -27,6 +27,5 @@
+# # on Travis these submodules are not checked out when cheking the style
+# --ignore-exclude-errors
+# --exclude="lib/ivykis"
+#---exclude="lib/jsonc"
+# --exclude="lib/compat/strcasestr.c"
+# --exclude="dbld"
+#diff --git a/.gitmodules b/.gitmodules
+#index 4ee81d2213..0afbb546e6 100644
+#--- a/.gitmodules
+#+++ b/.gitmodules
+#@@ -2,7 +2,3 @@
+#         path = lib/ivykis
+#         url = https://github.com/buytenh/ivykis.git
+#         ignore = dirty
+#-[submodule "lib/jsonc"]
+#-        path = lib/jsonc
+#-        url = https://github.com/json-c/json-c.git
+#-        ignore = dirty
+diff --git a/autogen.sh b/autogen.sh
+index 4887a99e65..7b78333aef 100755
+--- a/autogen.sh
++++ b/autogen.sh
+@@ -25,7 +25,7 @@
+ # This script is needed to setup build environment from checked out
+ # source tree.
+ #
+-SUBMODULES="lib/ivykis lib/jsonc"
++SUBMODULES="lib/ivykis"
+ GIT=`which git`
+ # bootstrap syslog-ng itself
+ case `uname -s` in
+diff --git a/cmake/Makefile.am b/cmake/Makefile.am
+index 3114c182a3..db67476e1a 100644
+--- a/cmake/Makefile.am
++++ b/cmake/Makefile.am
+@@ -7,7 +7,6 @@ EXTRA_DIST +=	\
+ 	cmake/Modules/CheckSockaddrStorage.cmake	\
+ 	cmake/Modules/CheckStructMember.cmake	\
+ 	cmake/Modules/ExternalIVYKIS.cmake	\
+-	cmake/Modules/ExternalJSONC.cmake	\
+ 	cmake/Modules/Findcriterion.cmake	\
+ 	cmake/Modules/FindCurl.cmake	\
+ 	cmake/Modules/FindESMTP.cmake	\
+diff --git a/cmake/Modules/ExternalJSONC.cmake b/cmake/Modules/ExternalJSONC.cmake
+deleted file mode 100644
+index 3b8c61a636..0000000000
+--- a/cmake/Modules/ExternalJSONC.cmake
++++ /dev/null
+@@ -1,57 +0,0 @@
+-#############################################################################
+-# Copyright (c) 2017 Balabit
+-# Copyright (c) 2017 Kokan
+-#
+-# This library is free software; you can redistribute it and/or
+-# modify it under the terms of the GNU Lesser General Public
+-# License as published by the Free Software Foundation; either
+-# version 2.1 of the License, or (at your option) any later version.
+-#
+-# This library is distributed in the hope that it will be useful,
+-# but WITHOUT ANY WARRANTY; without even the implied warranty of
+-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+-# Lesser General Public License for more details.
+-#
+-# You should have received a copy of the GNU Lesser General Public
+-# License along with this library; if not, write to the Free Software
+-# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+-#
+-# As an additional exemption you are allowed to compile & link against the
+-# OpenSSL libraries as published by the OpenSSL project. See the file
+-# COPYING for details.
+-#
+-#############################################################################
+-
+-set(LIB_NAME "JSONC")
+-
+-if (EXISTS ${PROJECT_SOURCE_DIR}/lib/jsonc/json.h)
+-
+-    ExternalProject_Add(
+-        ${LIB_NAME}
+-        PREFIX            ${CMAKE_CURRENT_BINARY_DIR}
+-        INSTALL_DIR       ${CMAKE_CURRENT_BINARY_DIR}
+-        SOURCE_DIR        ${PROJECT_SOURCE_DIR}/lib/jsonc/
+-        DOWNLOAD_COMMAND  echo
+-        BUILD_COMMAND     make
+-        INSTALL_COMMAND   make install
+-        CONFIGURE_COMMAND ${PROJECT_SOURCE_DIR}/lib/jsonc/configure  --prefix=${PROJECT_BINARY_DIR}
+-        STEP_TARGETS update patch configure
+-    )
+-
+-   ExternalProject_Add_Step(${LIB_NAME} autogen
+-     COMMAND ./autogen.sh
+-     COMMENT "Performing autogen step for '${LIB_NAME}'"
+-     DEPENDEES update patch
+-     DEPENDERS configure
+-     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/lib/jsonc/
+-     LOG 1
+-     )
+-
+-    set(${LIB_NAME}_INTERNAL TRUE)
+-    set(${LIB_NAME}_INTERNAL_INCLUDE_DIR "${PROJECT_BINARY_DIR}/include/json-c/")
+-    set(${LIB_NAME}_INTERNAL_LIBRARY "${PROJECT_BINARY_DIR}/lib/libjson-c${CMAKE_SHARED_LIBRARY_SUFFIX}")
+-    install(DIRECTORY ${PROJECT_BINARY_DIR}/lib/ DESTINATION lib USE_SOURCE_PERMISSIONS FILES_MATCHING PATTERN "libjson-c${CMAKE_SHARED_LIBRARY_SUFFIX}*")
+-
+-else()
+-  set(${LIB_NAME}_INTERNAL FALSE)
+-endif()
+diff --git a/configure.ac b/configure.ac
+index 8cfab2251e..eb51182a04 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -256,9 +256,9 @@ AC_ARG_ENABLE(mongodb,
+               ,,enable_mongodb="auto")
+ 
+ AC_ARG_WITH(jsonc,
+-              [  --with-jsonc=[system/internal/auto/no]
+-                                         Link against the system supplied or the built-in jsonc library or explicitly disable it. (default:auto)]
+-              ,,with_jsonc="internal")
++              [  --with-jsonc=[system/auto/no]
++                                         Link against the system supplied jsonc library or explicitly disable it. (default:auto)]
++              ,,with_jsonc="auto")
+ 
+ AC_ARG_ENABLE(json,
+              [ --enable-json=[yes/no]            Enable JSON support (default: yes)]
+@@ -1219,11 +1219,8 @@ dnl ***************************************************************************
+ 
+ enable_json="no"
+ 
+-JSON_INTERNAL_SOURCE_EXISTS="test -f $srcdir/lib/jsonc/json.h"
+-
+-if $JSON_INTERNAL_SOURCE_EXISTS; then
+-  AC_CONFIG_SUBDIRS([lib/jsonc])
+-  JSON_SUBDIRS="lib/jsonc"
++if test "x$with_jsonc" = "xinternal"; then
++   AC_MSG_ERROR([The internal (bundled) json-c library is no longer supported!])
+ fi
+ 
+ if test "x$with_jsonc" = "xsystem" -o "x$with_jsonc" = "xauto"; then
+@@ -1235,21 +1232,6 @@ if test "x$with_jsonc" = "xsystem" -o "x$with_jsonc" = "xauto"; then
+      AC_MSG_ERROR([json-c library development files cannot be not found on system!])
+    fi
+ fi
+-if test "x$with_jsonc" = "xinternal" -o "x$with_jsonc" = "xauto"; then
+-  AC_MSG_CHECKING(for JSON)
+-  if $JSON_INTERNAL_SOURCE_EXISTS; then
+-      JSON_LIBS="\$(top_builddir)/lib/jsonc/libjson-c.la"
+-      JSON_DEPENDENCY="$JSON_LIBS"
+-      JSON_CFLAGS="-I\$(top_srcdir)/lib/jsonc -I\$(top_builddir)/lib/jsonc"
+-      enable_json="yes"
+-      with_jsonc="internal"
+-  else
+-      AC_MSG_WARN([Internal jsonc sources not found in lib/jsonc])
+-      enable_json="no"
+-      with_jsonc="no"
+-  fi
+-  AC_MSG_RESULT($enable_json)
+-fi
+ 
+ dnl ***************************************************************************
+ dnl mongo-c-driver headers/libraries
+@@ -1991,7 +1973,6 @@ AM_CONDITIONAL(ENABLE_GEOIP2, [test "$enable_geoip2" = "yes"])
+ AM_CONDITIONAL(ENABLE_REDIS, [test "$enable_redis" = "yes"])
+ AM_CONDITIONAL(ENABLE_KAFKA, [test "$enable_kafka" = "yes"])
+ AM_CONDITIONAL(IVYKIS_INTERNAL, [test "x$with_ivykis" = "xinternal"])
+-AM_CONDITIONAL(JSON_INTERNAL, [test "x$with_jsonc" = "xinternal"])
+ AM_CONDITIONAL(LIBMONGO_INTERNAL, [test "x$LIBMONGO_SUBDIRS" != "x"])
+ AM_CONDITIONAL(LIBRABBITMQ_INTERNAL, [test "x$with_librabbitmq_client" = "xinternal"])
+ AM_CONDITIONAL(ENABLE_RIEMANN, [test "$enable_riemann" != "no"])
+@@ -2058,7 +2039,6 @@ AC_SUBST(LIBRABBITMQ_CFLAGS)
+ AC_SUBST(LIBRABBITMQ_SUBDIRS)
+ AC_SUBST(JSON_LIBS)
+ AC_SUBST(JSON_CFLAGS)
+-AC_SUBST(JSON_SUBDIRS)
+ AC_SUBST(JSON_DEPENDENCY)
+ AC_SUBST(IVYKIS_SUBDIRS)
+ AC_SUBST(RESOLV_LIBS)
+@@ -2103,7 +2083,6 @@ echo "  Criterion                   : ${with_criterion:=no}"
+ echo "  Unit tests                  : ${enable_tests:=no}"
+ echo " Submodules:"
+ echo "  ivykis                      : $with_ivykis"
+-echo "  jsonc                       : $with_jsonc"
+ echo " Features:"
+ echo "  Forced server mode          : ${enable_forced_server_mode:=yes}"
+ echo "  Debug symbols               : ${enable_debug:=no}"
+@@ -2116,6 +2095,7 @@ echo "  Linux capability support    : ${has_linux_caps:=no}"
+ echo "  Env wrapper support         : ${enable_env_wrapper:=no}"
+ echo "  systemd support             : ${enable_systemd:=no} (unit dir: ${systemdsystemunitdir:=none})"
+ echo "  systemd-journal support     : ${with_systemd_journal:=no}"
++echo "  JSON support                : $with_jsonc"
+ echo " Build options:"
+ echo "  Generate manual pages       : ${enable_manpages:=no}"
+ echo "  Install manual pages        : ${enable_manpages_install:=no}"
+diff --git a/dbld/packages.manifest b/dbld/packages.manifest
+index f131019af5..0240baea6a 100644
+--- a/dbld/packages.manifest
++++ b/dbld/packages.manifest
+@@ -44,8 +44,6 @@ which				[fedora]
+ #############################################################################
+ # Tarball related tools
+ #############################################################################
+-# needed to create a tarball from libjson-c
+-doxygen                         [tarball]
+ 
+ # docbook to generate man pages
+ docbook-xsl                     [tarball]
+diff --git a/lib/Makefile.am b/lib/Makefile.am
+index a021f55d52..9136dc21fc 100644
+--- a/lib/Makefile.am
++++ b/lib/Makefile.am
+@@ -1,4 +1,4 @@
+-DIST_SUBDIRS				+= @IVYKIS_SUBDIRS@ @JSON_SUBDIRS@
++DIST_SUBDIRS				+= @IVYKIS_SUBDIRS@
+ 
+ include lib/ack-tracker/Makefile.am
+ include lib/eventlog/src/Makefile.am
+@@ -84,14 +84,6 @@ UNINSTALL_HOOKS				+= uninstall-ivykis
+ endif
+ 
+ 
+-
+-if JSON_INTERNAL
+-lib/jsonc/libjson-c.la:
+-	${MAKE} CFLAGS="${CFLAGS} -Wno-error" -C lib/jsonc
+-
+-CLEAN_SUBDIRS				+= @JSON_SUBDIRS@
+-endif
+-
+ # this is intentionally formatted so conflicts are less likely to arise. one name in every line.
+ pkginclude_HEADERS			+= \
+ 	lib/afinter.h			\
+@@ -318,10 +310,6 @@ if IVYKIS_INTERNAL
+ lib/ivykis/ ivykis: lib/ivykis/src/libivykis.la
+ endif
+ 
+-if JSON_INTERNAL
+-lib/jsonc/ jsonc: lib/jsonc/libjson-c.la
+-endif
+-
+-.PHONY: lib/ libsyslog-ng ivykis lib/ivykis/ lib/jsonc/ jsonc
++.PHONY: lib/ libsyslog-ng ivykis lib/ivykis/
+ 
+ include lib/tests/Makefile.am
+#diff --git a/lib/jsonc b/lib/jsonc
+#deleted file mode 160000
+#index 2849650f11..0000000000
+#--- a/lib/jsonc
+#+++ /dev/null
+#@@ -1 +0,0 @@
+#-Subproject commit 2849650f1130f97621e39ff4cb5b6d3da0e97653
+diff --git a/modules/json/CMakeLists.txt b/modules/json/CMakeLists.txt
+index 65228cc1f1..84013ddb6a 100644
+--- a/modules/json/CMakeLists.txt
++++ b/modules/json/CMakeLists.txt
+@@ -26,8 +26,4 @@ add_module(
+   SOURCES ${JSON_SOURCES}
+ )
+ 
+-if (JSONC_INTERNAL)
+-    add_dependencies(json-plugin JSONC)
+-endif()
+-
+ add_test_subdirectory(tests)
+diff --git a/modules/json/tests/CMakeLists.txt b/modules/json/tests/CMakeLists.txt
+index 989a17952c..f0d3936607 100644
+--- a/modules/json/tests/CMakeLists.txt
++++ b/modules/json/tests/CMakeLists.txt
+@@ -1,19 +1,10 @@
+ add_unit_test(LIBTEST CRITERION TARGET test_format_json
+   DEPENDS syslogformat json-plugin ${JSONC_LIBRARY})
+-if (${JSONC_INTERNAL})
+-  add_dependencies(test_format_json JSONC)
+-endif()
+ 
+ add_unit_test(LIBTEST CRITERION TARGET test_json_parser
+   INCLUDES "${JSON_INCLUDE_DIR}"
+   DEPENDS json-plugin ${JSONC_LIBRARY})
+-if (${JSONC_INTERNAL})
+-  add_dependencies(test_json_parser JSONC)
+-endif()
+ 
+ add_unit_test(LIBTEST CRITERION TARGET test_dot_notation
+   INCLUDES "${JSON_INCLUDE_DIR}" "${JSONC_INCLUDE_DIR}"
+   DEPENDS json-plugin ${JSONC_LIBRARY})
+-if (${JSONC_INTERNAL})
+-  add_dependencies(test_dot_notation JSONC)
+-endif()
+diff --git a/packaging/debian/copyright b/packaging/debian/copyright
+index 85077cd2bc..35cf935287 100644
+--- a/packaging/debian/copyright
++++ b/packaging/debian/copyright
+@@ -117,28 +117,6 @@ License: ivykis-man
+  and in case of nontrivial modification author and date
+  of the modification is added to the header.
+ 
+-Files: lib/jsonc/*
+-Copyright: Copyright (C) Metaparadigm Pte. Ltd
+-           Copyright (C) Eric Haszlakiewicz
+-License: Expat
+-
+-Files: lib/jsonc/debug.h
+-       lib/jsonc/json.h
+-       lib/jsonc/json_object.*
+-       lib/jsonc/json_object_iterator.*
+-       lib/jsonc/linkhash.*
+-Copyright: Copyright (C) Hewlett-Packard Development Company, L.P
+-           Copyright (C) Metaparadigm Pte. Ltd
+-           Copyright (C) Eric Haszlakiewicz
+-License: Expat
+-
+-Files: lib/jsonc/json_tokener.c
+-       lib/jsonc/printbuf.*
+-Copyright: Copyright (C) Yahoo! Inc.
+-           Copyright (C) Metaparadigm Pte. Ltd
+-           Copyright (C) Eric Haszlakiewicz
+-License: Expat
+-
+ Files: modules/*
+ Copyright: Copyright (C) Balázs Scheidler
+            Copyright (C) BalaBit IT Security Ltd.
+diff --git a/tests/collect-cov.sh b/tests/collect-cov.sh
+index 0fa81d238f..55429d442e 100755
+--- a/tests/collect-cov.sh
++++ b/tests/collect-cov.sh
+@@ -25,6 +25,5 @@ set -e
+ 
+ lcov --capture --directory `pwd` --compat-libtool --output-file coverage.info
+ lcov --extract coverage.info "${top_srcdir}/*" --output-file coverage.info
+-lcov --remove coverage.info "${top_srcdir}/lib/jsonc/*" --output-file coverage.info
+ lcov --remove coverage.info "${top_srcdir}/lib/ivykis/*" --output-file coverage.info
+ genhtml coverage.info --prefix "${top_srcdir}" --output-directory coverage.html
+diff --git a/tests/copyright/policy b/tests/copyright/policy
+index f5271c274b..9e9693455f 100644
+--- a/tests/copyright/policy
++++ b/tests/copyright/policy
+@@ -11,7 +11,6 @@ scl/syslogconf/convert-syslogconf.awk$
+ .*/[^/]+-grammar\.[ch]$
+ (.*/)?(README|\.gitignore|pylintrc)$
+ lib/ivykis
+-lib/jsonc
+ lib/eventlog
+ modules/java/org_syslog_ng_[^./_-]+\.h$
+ modules/(afmongodb|afamqp)/dummy\.c$
+
+From 3b5a89843f57bd255e74ea79c9245dece7bbbdc0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?L=C3=A1szl=C3=B3=20V=C3=A1rady?=
+ <laszlo.varady@protonmail.com>
+Date: Tue, 12 Jul 2022 16:27:04 +0200
+Subject: [PATCH 2/3] configure: make json-c mandatory by default
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+It is still possible to explicitly disable JSON support with
+"--with-jsonc=no" for special cases, but since the default configuration
+depends on the JSON module, the default is going to be `system` from now
+on.
+
+Signed-off-by: László Várady <laszlo.varady@protonmail.com>
+---
+ configure.ac | 16 ++++++++++------
+ 1 file changed, 10 insertions(+), 6 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index eb51182a04..a798b5f7cd 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -256,9 +256,9 @@ AC_ARG_ENABLE(mongodb,
+               ,,enable_mongodb="auto")
+ 
+ AC_ARG_WITH(jsonc,
+-              [  --with-jsonc=[system/auto/no]
+-                                         Link against the system supplied jsonc library or explicitly disable it. (default:auto)]
+-              ,,with_jsonc="auto")
++              [  --with-jsonc=[yes/no]
++                                         Link against the system supplied jsonc library or explicitly disable it. (default: yes)]
++              ,,with_jsonc="yes")
+ 
+ AC_ARG_ENABLE(json,
+              [ --enable-json=[yes/no]            Enable JSON support (default: yes)]
+@@ -1223,12 +1223,16 @@ if test "x$with_jsonc" = "xinternal"; then
+    AC_MSG_ERROR([The internal (bundled) json-c library is no longer supported!])
+ fi
+ 
+-if test "x$with_jsonc" = "xsystem" -o "x$with_jsonc" = "xauto"; then
++if test "x$with_jsonc" = "xsystem"; then
++   with_jsonc="yes"
++fi
++
++if test "x$with_jsonc" = "xyes" -o "x$with_jsonc" = "xauto"; then
+    enable_json="yes"
+    PKG_CHECK_EXISTS(json-c, json_module_name="json-c",
+    PKG_CHECK_EXISTS(json, json_module_name="json"))
+-   PKG_CHECK_MODULES(JSON, $json_module_name >= $JSON_C_MIN_VERSION,[with_jsonc="system"], [JSON_LIBS=""; enable_json="no"])
+-   if test "x$with_jsonc" = "xsystem" -a "x$enable_json" = "xno"; then
++   PKG_CHECK_MODULES(JSON, $json_module_name >= $JSON_C_MIN_VERSION,[with_jsonc="yes"], [JSON_LIBS=""; enable_json="no"])
++   if test "x$with_jsonc" = "xyes" -a "x$enable_json" = "xno"; then
+      AC_MSG_ERROR([json-c library development files cannot be not found on system!])
+    fi
+ fi
+
+From f76de1aa89dc78bf4ba1f8ae4b83c92f46af2466 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?L=C3=A1szl=C3=B3=20V=C3=A1rady?=
+ <laszlo.varady@protonmail.com>
+Date: Mon, 18 Jul 2022 17:37:12 +0200
+Subject: [PATCH 3/3] news: add entry for #4078
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: László Várady <laszlo.varady@protonmail.com>
+---
+ news/other-4078.md | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+ create mode 100644 news/other-4078.md
+
+diff --git a/news/other-4078.md b/news/other-4078.md
+new file mode 100644
+index 0000000000..88dcb04fa3
+--- /dev/null
++++ b/news/other-4078.md
+@@ -0,0 +1,8 @@
++The `json-c` library is no longer bundled in the syslog-ng source tarball
++
++Since all known OS package managers provide json-c packages nowadays, the json-c
++submodule has been removed from the source tarball.
++
++The `--with-jsonc=internal` option of the `configure` script has been removed
++accordingly, system libraries will be used instead. For special cases, the JSON
++support can be disabled by specifying `--with-jsonc=no`.


### PR DESCRIPTION
Removed outdated submodule `json-c` in PR https://github.com/syslog-ng/syslog-ng/pull/4078.