### PR TITLE
addpkg: openslide

### DIFF
--- a/openslide/riscv64.patch
+++ b/openslide/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,6 +15,7 @@
+ 
+ build() {
+   cd $pkgname-$pkgver
++  autoreconf -fi # Update config.guess
+   ./configure --prefix=/usr
+   make
+ }


### PR DESCRIPTION
Update config.guess to identify riscv64 platform.
Issue reported: https://github.com/openslide/openslide/issues/374