### PR TITLE
addpatch: shotgun

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -70,7 +70,6 @@ razor
 rbutil
 rustypaste
 shfmt
-shotgun
 smplayer
 smtube
 sudo

--- a/shotgun/riscv64.patch
+++ b/shotgun/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,7 +17,7 @@ b2sums=('410a88cf3750b695a59c1079a345d57c3d32c3e83f6cc2aa3f04079198aa20fe9dbf946
+ 
+ prepare() {
+   cd shotgun-$pkgver
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  cargo fetch --locked
+ }
+ 
+ build() {


### PR DESCRIPTION
Fixed error:

```
error: failed to run `rustc` to learn about target-specific information

Caused by:
  process didn't exit successfully: `rustc - --crate-name ___ --print=file-names --target riscv64-unknown-linux-gnu --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=cfg` (exit status: 1)
  --- stderr
  error: Error loading target specification: Could not find specification for target "riscv64-unknown-linux-gnu". Run `rustc --print target-list` for a list of built-in targets
```

and removed it from qemu-black-list as it can now be built in QEMU.