### PR TITLE
addpatch: elinks

### DIFF
--- a/elinks/riscv64.patch
+++ b/elinks/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -22,6 +22,7 @@ md5sums=('5a55aceb06d6cfee0dd0520103a23c3b')
+ build() {
+   cd elinks-$pkgver
+   sed -i 's/Terminal=1/Terminal=true/' "contrib/debian/$pkgname.desktop"
++  autoreconf -fiv
+   [ -x configure ] || sh autogen.sh
+   ./configure --prefix=/usr --mandir=/usr/share/man \
+               --sysconfdir=/etc \


### PR DESCRIPTION
Fixed error:

```
checking build system type... ./config/config.guess: unable to guess system type

This script, last modified 2004-09-07, has failed to recognize
the operating system you are using. It is advised that you
download the most up to date version of the config scripts from

    ftp://ftp.gnu.org/pub/gnu/config/

If the version you run (./config/config.guess) is already up to date, please
send the following data and any information you think might be
pertinent to <config-patches@gnu.org> in order to provide the needed
information to handle your system.

config.guess timestamp = 2004-09-07

uname -m = riscv64
uname -r = 5.18.6-arch1-1
uname -s = Linux
uname -v = #1 SMP PREEMPT_DYNAMIC Wed, 22 Jun 2022 18:10:56 +0000

/usr/bin/uname -p = unknown
/bin/uname -X     = 

hostinfo               = 
/bin/universe          = 
/usr/bin/arch -k       = 
/bin/arch              = 
/usr/bin/oslevel       = 
/usr/convex/getsysinfo = 

UNAME_MACHINE = riscv64
UNAME_RELEASE = 5.18.6-arch1-1
UNAME_SYSTEM  = Linux
UNAME_VERSION = #1 SMP PREEMPT_DYNAMIC Wed, 22 Jun 2022 18:10:56 +0000
configure: error: cannot guess build type; you must specify one
```

Upstream PR: https://github.com/rkd77/elinks/pull/181