### PR TITLE
addpatch: jumpy

### DIFF
--- a/jumpy/riscv64.patch
+++ b/jumpy/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -20,7 +20,7 @@ sha512sums=('b697ece72321ca88fc0ca6732a5eee217903f6c74cd0c007b4cf045292d537a3c50
+ 
+ prepare() {
+   cd "$pkgname-$pkgver"
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  cargo fetch --locked
+ }
+ 
+ build() {


### PR DESCRIPTION
Fixed error:

```
error: failed to run `rustc` to learn about target-specific information

Caused by:
  process didn't exit successfully: `rustc - --crate-name ___ --print=file-names --target riscv64-unknown-linux-gnu --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=cfg` (exit status: 1)
  --- stderr
  error: Error loading target specification: Could not find specification for target "riscv64-unknown-linux-gnu". Run `rustc --print target-list` for a list of built-in targets
```