### PR TITLE
addpatch: python-nodeenv

### DIFF
--- a/python-nodeenv/riscv64.patch
+++ b/python-nodeenv/riscv64.patch
@@ -1,0 +1,20 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -10,8 +10,15 @@ arch=('any')
+ depends=('python-setuptools' 'make')
+ optdepends=('nodejs: for --node=system')
+ checkdepends=('nodejs' 'python-pytest-runner' 'python-coverage' 'python-mock')
+-source=("$pkgname-$pkgver.tar.gz::https://github.com/ekalinin/nodeenv/archive/$pkgver.tar.gz")
+-sha512sums=('1e3e4068591d51d8915de73ab0f82f04620ca628152ec5a454e7ad18001ff20b698f9818353c44b80200ab529d95fa3196a3dbc85f0c497ea49f60eaa5dc9ea7')
++source=("$pkgname-$pkgver.tar.gz::https://github.com/ekalinin/nodeenv/archive/$pkgver.tar.gz"
++        $pkgname-riscv64-support.patch::https://github.com/ekalinin/nodeenv/pull/313.patch)
++sha512sums=('1e3e4068591d51d8915de73ab0f82f04620ca628152ec5a454e7ad18001ff20b698f9818353c44b80200ab529d95fa3196a3dbc85f0c497ea49f60eaa5dc9ea7'
++            'fd5cbfb4cc6870ab9e5678ee213e15ee9442fb555bcdb2ea555c1aa338371a482f1a4be69e6546427ca2ce6a28308b9c7f9e5e39c701046ac4b0fcc6fade03a0')
++
++prepare() {
++  cd nodeenv-$pkgver
++  patch -p1 -Ni "$srcdir/$pkgname-riscv64-support.patch"
++}
+ 
+ build() {
+   cd nodeenv-$pkgver


### PR DESCRIPTION
This patch applied a RISC-V support patch from [upstream] to fix the
path glob error.

[Upstream]: https://github.com/ekalinin/nodeenv/pull/313

Signed-off-by: Avimitin <avimitin@gmail.com>