### PR TITLE
fixpkg: add rocksdb to qemu-user-blacklist

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -71,6 +71,7 @@ qconf
 qxmledit
 razor
 rbutil
+rocksdb
 rustypaste
 shfmt
 smplayer


### PR DESCRIPTION
Shouldn't revert until qemu-user has its `/proc/cpuinfo` fixed.

Ref: https://github.com/facebook/rocksdb/pull/9366