### PR TITLE
updpatch: glibc

### DIFF
--- a/glibc/riscv64.patch
+++ b/glibc/riscv64.patch
@@ -26,7 +26,7 @@
  
    [[ -d glibc-$pkgver ]] && ln -s glibc-$pkgver glibc
    cd glibc
-@@ -54,12 +54,11 @@ build() {
+@@ -54,9 +54,7 @@ build() {
        --enable-bind-now
        --enable-cet
        --enable-kernel=4.4
@@ -36,33 +36,10 @@
        --disable-profile
        --disable-crypt
        --disable-werror
-+      --disable-experimental-malloc
-   )
+@@ -91,30 +89,6 @@ build() {
+   # build info pages manually for reproducibility
+   make info
  
-   cd "$srcdir/glibc-build"
-@@ -73,46 +72,13 @@ build() {
-   # https://github.com/allanmcrae/toolchain/blob/f18604d70c5933c31b51a320978711e4e6791cf1/glibc/PKGBUILD
-   # remove fortify for building libraries
-   CFLAGS=${CFLAGS/-Wp,-D_FORTIFY_SOURCE=2/}
-+  CPPFLAGS=${CPPFLAGS/-D_FORTIFY_SOURCE=2/}
- 
-   "$srcdir/glibc/configure" \
-       --libdir=/usr/lib \
-       --libexecdir=/usr/lib \
-       "${_configure_flags[@]}"
- 
--  # build libraries with fortify disabled
--  echo "build-programs=no" >> configparms
--  make -O
--
--  # re-enable fortify for programs
--  sed -i "/build-programs=/s#no#yes#" configparms
--  echo "CFLAGS += -Wp,-D_FORTIFY_SOURCE=2" >> configparms
--  make -O
--
--  # build info pages manually for reproducibility
--  make info
--
 -  cd "$srcdir/lib32-glibc-build"
 -  export CC="gcc -m32 -mstackrealign"
 -  export CXX="g++ -m32 -mstackrealign"
@@ -85,10 +62,12 @@
 -  # re-enable fortify for programs
 -  sed -i "/build-programs=/s#no#yes#" configparms
 -  echo "CFLAGS += -Wp,-D_FORTIFY_SOURCE=2" >> configparms
-   make -O
- 
+-  make -O
+-
    # pregenerate C.UTF-8 locale until it is built into glibc
-@@ -153,7 +119,7 @@ check() {
+   # (https://sourceware.org/glibc/wiki/Proposals/C.UTF-8, FS#74864)
+   locale/localedef -c -f ../glibc/localedata/charmaps/UTF-8 -i ../glibc/localedata/locales/C ../C.UTF-8/
+@@ -153,7 +127,7 @@ check() {
    make -O check
  }
  
@@ -97,7 +76,7 @@
    pkgdesc='GNU C Library'
    depends=('linux-api-headers>=4.10' tzdata filesystem)
    optdepends=('gd: for memusagestat'
-@@ -190,33 +156,4 @@ package_glibc() {
+@@ -190,33 +164,4 @@ package_glibc() {
    install -dm755 "$pkgdir/usr/lib/locale"
    cp -r "$srcdir/C.UTF-8" -t "$pkgdir/usr/lib/locale"
    sed -i '/#C\.UTF-8 /d' "$pkgdir/etc/locale.gen"

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -21,6 +21,7 @@ foot
 gauche
 gdk-pixbuf2
 glib-perl
+glibc
 go
 gpxsee
 gtest


### PR DESCRIPTION
This PR does two things.
- Remove changes "--disable-experimental-malloc" and "CPPFLAGS=${CPPFLAGS/-D_FORTIFY_SOURCE=2/}"
- Add glibc to qemu-user-black-list

The reason of first one is nobody can tell why we add those two changes, and if we delete those two changes, testsuite results are promising.

The reason of second one is there are 51 Failures when building in qemu-user while there are 18 Failures when building on real hardware.

14 of 18 failures are timeout.

- locale/tst-localedef-path-norm: timeout
- malloc/tst-malloc-too-large-malloc-hugetlb2: timeout
- nptl/tst-mutex10: timeout
- nss/tst-nss-files-hosts-getent: timeout
- nss/tst-nss-files-hosts-multi: timeout
- stdio-common/tst-vfprintf-width-prec: timeout
- stdio-common/tst-vfprintf-width-prec-alloc: timeout
- stdlib/test-bz22786: timeout
- stdlib/tst-arc4random-fork: timeout
- string/test-memcpy: timeout
- string/test-mempcpy: timeout
- string/test-strcasecmp: timeout
- string/test-strncasecmp: timeout
- string/test-strncmp: timeout

1 of 18 Failures is flaky, pass when I give another try
- stdio-common/tst-vfprintf-width-prec-mem

1 of 18 failures is due to our toolchain.
- misc/tst-glibcsyscalls: 5.18 memfd_secret unknown
    - error: kernel syscall 'memfd_secret' (447) not known to glibc
    - info: glibc tables are based on kernel version 5.18
    - info: installed kernel headers are version 5.18

2 of 18 failures are included in 2.36 release notes, I think they are expected to fail.
- stdlib/tst-strfrom
- stdlib/tst-strfrom-locale

This is an initial work on glibc 2.36. Let's look forward to @moodyhunter 's subsequent work 