### PR TITLE
noqemu: wanderlust

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -90,6 +90,7 @@ tpm2-tools
 tpm2-tss
 uutils-coreutils
 vim
+wanderlust
 wayland
 xmonk.lv2
 zram-generator


### PR DESCRIPTION
Package can't be built in QEMU user due to the incorrect argv issue:
`Lisp error: (wrong-number-of-arguments (3 . 4) 2)`.

Signed-off-by: Avimitin <avimitin@gmail.com>