### PR TITLE
addpkg: svt-hevc, svt-vp9

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -12,6 +12,8 @@ nvidia-utils
 opencl-nvidia
 opera
 reaper
+svt-hevc
+svt-vp9
 teamspeak3
 teamspeak3-server
 vivaldi


### PR DESCRIPTION
These two package have same error: `immintrin.h: No such file or directory`.

I searched some talks, blogs, bugs or issues, finally ensured that this `immintrin.h` head file is for `x86_64` architecture only.

Since I have no idea about how to avoid this troublesome error to let the package port successfully, so I just simply add these two packages to the `blacklist.txt`(below the `Binary package that don't have RISC-V support`) and REPORTED ITS UPSTREAM.

If there are any mistakes about the management, please dm me.

PERHAPS USEFUL LINKS:

- https://github.com/suijingfeng/vkQuake3/issues/14#issuecomment-674390549
- https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=262910#c3
- https://www.betamaster.us/blog/?p=1922

UPSTREAM ISSUE LINKS:

- https://github.com/OpenVisualCloud/SVT-HEVC/issues/622
- https://github.com/OpenVisualCloud/SVT-VP9/issues/159