### PR TITLE
addpatch: gstreamermm

### DIFF
--- a/gstreamermm/riscv64.patch
+++ b/gstreamermm/riscv64.patch
@@ -1,0 +1,20 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -11,12 +11,15 @@ license=('LGPL')
+ depends=('glibmm' 'gst-plugins-base')
+ makedepends=('mm-common' 'glibmm-docs' 'cairomm' 'cairomm-docs' 'pangomm' 'pangomm-docs')
+ changelog=$pkgname.changelog
+-source=(https://ftp.gnome.org/pub/GNOME/sources/gstreamermm/1.10/$pkgname-$pkgver.tar.xz)
+-sha256sums=('be58fe9ef7d7e392568ec85e80a84f4730adbf91fb0355ff7d7c616675ea8d60')
++source=(https://ftp.gnome.org/pub/GNOME/sources/gstreamermm/1.10/$pkgname-$pkgver.tar.xz
++        $pkgname-fix-build-against-glib-2.68.patch::https://gitlab.gnome.org/GNOME/gstreamermm/-/merge_requests/4.patch)
++sha256sums=('be58fe9ef7d7e392568ec85e80a84f4730adbf91fb0355ff7d7c616675ea8d60'
++            'e02fcf5d6c2d658066dd3515025b6cb2d492dbe4944c91c2475100d9c9e97ac4')
+ 
+ prepare() {
+   cd $pkgbase-$pkgver
+   NOCONFIGURE=1 ./autogen.sh
++  patch -Np1 -i ../$pkgname-fix-build-against-glib-2.68.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
Apply an upstream PR to fix error:

```
/usr/include/glib-2.0/glib/gatomic.h:113:19: error: argument 2 of ‘__atomic_load’ must not be a pointer to a ‘volatile’ type
```