### PR TITLE
addpatch libarchive

### DIFF
--- a/libarchive/0003-libarchive-Do-not-include-sys-mount.h-when-linux-fs..patch
+++ b/libarchive/0003-libarchive-Do-not-include-sys-mount.h-when-linux-fs..patch
@@ -1,0 +1,40 @@
+From a2f68263a1da5ad227bcb9cd8fa91b93c8b6c99f Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 25 Jul 2022 10:56:53 -0700
+Subject: [PATCH] libarchive: Do not include sys/mount.h when linux/fs.h is present
+
+These headers are in conflict and only one is needed by
+archive_read_disk_posix.c therefore include linux/fs.h if it exists
+otherwise include sys/mount.h
+
+It also helps compiling with glibc 2.36
+where sys/mount.h conflicts with linux/mount.h see [1]
+
+[1] https://sourceware.org/glibc/wiki/Release/2.36
+---
+ libarchive/archive_read_disk_posix.c | 5 ++---
+ 1 file changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/libarchive/archive_read_disk_posix.c b/libarchive/archive_read_disk_posix.c
+index 2b39e672..a96008db 100644
+--- a/libarchive/archive_read_disk_posix.c
++++ b/libarchive/archive_read_disk_posix.c
+@@ -34,9 +34,6 @@ __FBSDID("$FreeBSD$");
+ #ifdef HAVE_SYS_PARAM_H
+ #include <sys/param.h>
+ #endif
+-#ifdef HAVE_SYS_MOUNT_H
+-#include <sys/mount.h>
+-#endif
+ #ifdef HAVE_SYS_STAT_H
+ #include <sys/stat.h>
+ #endif
+@@ -54,6 +51,8 @@ __FBSDID("$FreeBSD$");
+ #endif
+ #ifdef HAVE_LINUX_FS_H
+ #include <linux/fs.h>
++#elif HAVE_SYS_MOUNT_H
++#include <sys/mount.h>
+ #endif
+ /*
+  * Some Linux distributions have both linux/ext2_fs.h and ext2fs/ext2_fs.h.

--- a/libarchive/riscv64.patch
+++ b/libarchive/riscv64.patch
@@ -1,0 +1,26 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,17 +14,20 @@ options=('debug')
+ validpgpkeys=('A5A45B12AD92D964B89EEE2DEC560C81CEC2276E') # Martin Matuska <mm@FreeBSD.org>
+ source=("https://github.com/${pkgname}/${pkgname}/releases/download/v${pkgver}/${pkgname}-${pkgver}.tar.xz"{,.asc}
+         '0001-libarchive-Handle-a-calloc-returning-NULL-fixes-1754.patch'
+-        '0002-Validate-entry_bytes_remaining-in-pax_attribute.patch')
++        '0002-Validate-entry_bytes_remaining-in-pax_attribute.patch'
++        '0003-libarchive-Do-not-include-sys-mount.h-when-linux-fs..patch')
+ sha256sums=('5a411aceb978f43e626f0c2d1812ddd8807b645ed892453acabd532376c148e6'
+             'SKIP'
+             'bc52b2b2b99915894b436c97872d5d50e94c8c7483865a028fad9a710c837fa7'
+-            '38c8d9b00f3259558e67e6fdf790ccbf8ecbba2de101476c2416d87b1679bcb9')
++            '38c8d9b00f3259558e67e6fdf790ccbf8ecbba2de101476c2416d87b1679bcb9'
++            '99c85a9b8e6c16131cefaf1040d5fa15cd565ecf8c71c1f644c8fa47fe1306dc')
+ 
+ prepare() {
+   cd "${pkgname}-${pkgver}"
+ 
+   patch -Np1 < ../0001-libarchive-Handle-a-calloc-returning-NULL-fixes-1754.patch
+   patch -Np1 < ../0002-Validate-entry_bytes_remaining-in-pax_attribute.patch
++  patch -Np1 < ../0003-libarchive-Do-not-include-sys-mount.h-when-linux-fs..patch
+ }
+ 
+ build() {
+


### PR DESCRIPTION
Libarchive failed to build because of glibc 2.36 update. ArchLinux upstream fixed the issue in trunk. So, I backported the patch here. Upstream issue linked is listed below.
https://bugs.archlinux.org/task/75533