### PR TITLE
addpkg: mkvtoolnix

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -45,6 +45,7 @@ libuv
 mdbook
 meilisearch
 menyoki
+mkvtoolnix
 nextcloud-client
 ninja
 nodejs-lts-gallium


### PR DESCRIPTION
This is a trivial issue. Qmake cannot run properly in qemu-user. I have successfully built this package on a real board.