### PR TITLE
noqemu: rz-cutter

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -74,6 +74,7 @@ razor
 rbutil
 rocksdb
 rustypaste
+rz-cutter
 shfmt
 smplayer
 smtube


### PR DESCRIPTION
This PR add rz-cutter into qemu blacklist. It build successfully without
any modification in unmatched board larvesta.

Qt program will meet "fatal error: 'stddef.h' file not found" when it is
built in qemu user. The QT QProcess spawned a llvm-config child process
during the build. But because of the qemu user only "forkfd_pidfd"
related issue, the llvm-config process will crash.

Signed-off-by: Avimitin <avimitin@gmail.com>