### PR TITLE
addpatch: desmume

### DIFF
--- a/desmume/detect-arm-rather-than-exclude-x86-for-arm-specific-code.patch
+++ b/desmume/detect-arm-rather-than-exclude-x86-for-arm-specific-code.patch
@@ -1,0 +1,23 @@
+diff --git a/desmume/src/libretro-common/features/features_cpu.c b/desmume/src/libretro-common/features/features_cpu.c
+index 0980821f..1b3f0a50 100644
+--- a/desmume/src/libretro-common/features/features_cpu.c
++++ b/desmume/src/libretro-common/features/features_cpu.c
+@@ -232,6 +232,9 @@ retro_time_t cpu_features_get_time_usec(void)
+ 
+ #if defined(__x86_64__) || defined(__i386__) || defined(__i486__) || defined(__i686__)
+ #define CPU_X86
++#elif defined(__ARM_ARCH) || defined(__TARGET_ARCH_ARM) || defined(_M_ARM) || defined(__arm__) || \
++      defined(__arm64) || defined(_M_ARM64) || defined(__aarch64__) || defined(__AARCH64EL__)
++#define CPU_ARM
+ #endif
+ 
+ #if defined(_MSC_VER) && !defined(_XBOX)
+@@ -310,7 +313,7 @@ static void arm_enable_runfast_mode(void)
+ }
+ #endif
+ 
+-#if defined(__linux__) && !defined(CPU_X86)
++#if defined(__linux__) && defined(CPU_ARM)
+ #if __ARM_ARCH
+ #include <sys/auxv.h>
+ #endif

--- a/desmume/riscv64.patch
+++ b/desmume/riscv64.patch
@@ -1,0 +1,20 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -37,8 +37,15 @@ makedepends=(
+   meson
+ )
+ _tag=08b6fade0bc95749acc9820cb9688aaf39d00c87
+-source=(git+https://github.com/TASEmulators/desmume.git#tag=${_tag})
+-b2sums=(SKIP)
++source=(git+https://github.com/TASEmulators/desmume.git#tag=${_tag}
++        detect-arm-rather-than-exclude-x86-for-arm-specific-code.patch)
++b2sums=('SKIP'
++        'a8cca6cb154295150b1fc643c41107c665e39e9f6e9708a0b38eb303806374f4d9d43f52f3def6311e2ed795631492fc560ee661612e6f3876c03d38d9ef684d')
++
++prepare() {
++  cd desmume
++  patch -Np1 -i ../detect-arm-rather-than-exclude-x86-for-arm-specific-code.patch
++}
+ 
+ pkgver() {
+   cd desmume


### PR DESCRIPTION
Fixed errors:

```
../desmume/desmume/src/libretro-common/features/features_cpu.c:321:31: error: ‘AT_HWCAP’ undeclared (first use in this function)
  321 |    uint64_t hwcap = getauxval(AT_HWCAP);
      |                               ^~~~~~~~
../desmume/desmume/src/libretro-common/features/features_cpu.c:321:31: note: each undeclared identifier is reported only once for each function it appears in
../desmume/desmume/src/libretro-common/features/features_cpu.c:323:23: error: ‘HWCAP_ARM_NEON’ undeclared (first use in this function)
  323 |       return (hwcap & HWCAP_ARM_NEON) != 0;
      |                       ^~~~~~~~~~~~~~
../desmume/desmume/src/libretro-common/features/features_cpu.c:325:23: error: ‘HWCAP_ARM_VFPv3’ undeclared (first use in this function)
  325 |       return (hwcap & HWCAP_ARM_VFPv3) != 0;
      |                       ^~~~~~~~~~~~~~~
../desmume/desmume/src/libretro-common/features/features_cpu.c:327:23: error: ‘HWCAP_ARM_VFPv4’ undeclared (first use in this function)
  327 |       return (hwcap & HWCAP_ARM_VFPv4) != 0;
      |                       ^~~~~~~~~~~~~~~
```

Upstream PR: https://github.com/libretro/libretro-common/pull/200