### PR TITLE
addpatch: elfutils

### DIFF
--- a/elfutils/elflint.patch
+++ b/elfutils/elflint.patch
@@ -1,0 +1,329 @@
+From de209d23e5f571f03ff0efc6547a2ebbfae3828e Mon Sep 17 00:00:00 2001
+From: Andreas Schwab <schwab@suse.de>
+Date: Mon, 8 Aug 2022 13:44:08 +0200
+Subject: [PATCH 1/3] libelf: Sync elf.h from glibc
+
+Adds PT_RISCV_ATTRIBUTES, SHT_RISCV_ATTRIBUTES, PT_AARCH64_MEMTAG_MTE,
+RELR definitions, LoongArch relocations.
+
+dwelf_elf_e_machine_string was updated to handle EM_LOONGARCH, and
+ebl_dynamic_tag_name was updated to handle the new RELR dynamic tags.
+
+Signed-off-by: Andreas Schwab <schwab@suse.de>
+---
+ libdwelf/ChangeLog                    |  5 ++
+ libdwelf/dwelf_elf_e_machine_string.c |  2 +
+ libebl/ChangeLog                      |  5 ++
+ libebl/ebldynamictagname.c            |  2 +-
+ libelf/ChangeLog                      |  4 ++
+ libelf/elf.h                          | 99 ++++++++++++++++++++++++++-
+ 6 files changed, 113 insertions(+), 4 deletions(-)
+
+diff --git a/libdwelf/dwelf_elf_e_machine_string.c b/libdwelf/dwelf_elf_e_machine_string.c
+index 051c70b5..6d588ea8 100644
+--- a/libdwelf/dwelf_elf_e_machine_string.c
++++ b/libdwelf/dwelf_elf_e_machine_string.c
+@@ -398,6 +398,8 @@ dwelf_elf_e_machine_string (int machine)
+       return "BPF";
+     case EM_CSKY:
+       return "C-SKY";
++    case EM_LOONGARCH:
++      return "LoongArch";
+ 
+     case EM_ALPHA:
+       return "Alpha";
+diff --git a/libebl/ebldynamictagname.c b/libebl/ebldynamictagname.c
+index 3f8d8ee4..5d4a3a58 100644
+--- a/libebl/ebldynamictagname.c
++++ b/libebl/ebldynamictagname.c
+@@ -54,7 +54,7 @@ ebl_dynamic_tag_name (Ebl *ebl, int64_t tag, char *buf, size_t len)
+ 	      "RELENT", "PLTREL", "DEBUG", "TEXTREL", "JMPREL", "BIND_NOW",
+ 	      "INIT_ARRAY", "FINI_ARRAY", "INIT_ARRAYSZ", "FINI_ARRAYSZ",
+ 	      "RUNPATH", "FLAGS", "ENCODING", "PREINIT_ARRAY",
+-	      "PREINIT_ARRAYSZ", "SYMTAB_SHNDX"
++	      "PREINIT_ARRAYSZ", "SYMTAB_SHNDX", "RELRSZ", "RELR", "RELRENT"
+ 	    };
+ 	  eu_static_assert (sizeof (stdtags) / sizeof (const char *) == DT_NUM);
+ 
+diff --git a/libelf/elf.h b/libelf/elf.h
+index 0735f6b5..02a1b3f5 100644
+--- a/libelf/elf.h
++++ b/libelf/elf.h
+@@ -358,8 +358,9 @@ typedef struct
+ 
+ #define EM_BPF		247	/* Linux BPF -- in-kernel virtual machine */
+ #define EM_CSKY		252     /* C-SKY */
++#define EM_LOONGARCH	258	/* LoongArch */
+ 
+-#define EM_NUM		253
++#define EM_NUM		259
+ 
+ /* Old spellings/synonyms.  */
+ 
+@@ -443,7 +444,8 @@ typedef struct
+ #define SHT_PREINIT_ARRAY 16		/* Array of pre-constructors */
+ #define SHT_GROUP	  17		/* Section group */
+ #define SHT_SYMTAB_SHNDX  18		/* Extended section indices */
+-#define	SHT_NUM		  19		/* Number of defined types.  */
++#define SHT_RELR	  19            /* RELR relative relocations */
++#define	SHT_NUM		  20		/* Number of defined types.  */
+ #define SHT_LOOS	  0x60000000	/* Start OS-specific.  */
+ #define SHT_GNU_ATTRIBUTES 0x6ffffff5	/* Object attributes.  */
+ #define SHT_GNU_HASH	  0x6ffffff6	/* GNU-style hash table.  */
+@@ -662,6 +664,11 @@ typedef struct
+   Elf64_Sxword	r_addend;		/* Addend */
+ } Elf64_Rela;
+ 
++/* RELR relocation table entry */
++
++typedef Elf32_Word	Elf32_Relr;
++typedef Elf64_Xword	Elf64_Relr;
++
+ /* How to extract and insert information held in the r_info field.  */
+ 
+ #define ELF32_R_SYM(val)		((val) >> 8)
+@@ -887,7 +894,10 @@ typedef struct
+ #define DT_PREINIT_ARRAY 32		/* Array with addresses of preinit fct*/
+ #define DT_PREINIT_ARRAYSZ 33		/* size in bytes of DT_PREINIT_ARRAY */
+ #define DT_SYMTAB_SHNDX	34		/* Address of SYMTAB_SHNDX section */
+-#define	DT_NUM		35		/* Number used */
++#define DT_RELRSZ	35		/* Total size of RELR relative relocations */
++#define DT_RELR		36		/* Address of RELR relative relocations */
++#define DT_RELRENT	37		/* Size of one RELR relative relocaction */
++#define	DT_NUM		38		/* Number used */
+ #define DT_LOOS		0x6000000d	/* Start of OS-specific */
+ #define DT_HIOS		0x6ffff000	/* End of OS-specific */
+ #define DT_LOPROC	0x70000000	/* Start of processor-specific */
+@@ -2893,6 +2903,9 @@ enum
+ #define R_AARCH64_TLSDESC      1031	/* TLS Descriptor.  */
+ #define R_AARCH64_IRELATIVE	1032	/* STT_GNU_IFUNC relocation.  */
+ 
++/* MTE memory tag segment type.  */
++#define PT_AARCH64_MEMTAG_MTE	(PT_LOPROC + 2)
++
+ /* AArch64 specific values for the Dyn d_tag field.  */
+ #define DT_AARCH64_BTI_PLT	(DT_LOPROC + 1)
+ #define DT_AARCH64_PAC_PLT	(DT_LOPROC + 3)
+@@ -3918,6 +3931,8 @@ enum
+ #define EF_RISCV_FLOAT_ABI_SINGLE 	0x0002
+ #define EF_RISCV_FLOAT_ABI_DOUBLE 	0x0004
+ #define EF_RISCV_FLOAT_ABI_QUAD 	0x0006
++#define EF_RISCV_RVE			0x0008
++#define EF_RISCV_TSO			0x0010
+ 
+ /* RISC-V relocations.  */
+ #define R_RISCV_NONE		 0
+@@ -3978,6 +3993,19 @@ enum
+ 
+ #define R_RISCV_NUM		59
+ 
++/* RISC-V specific values for the st_other field.  */
++#define STO_RISCV_VARIANT_CC	0x80	/* Function uses variant calling
++					   convention */
++
++/* RISC-V specific values for the sh_type field.  */
++#define SHT_RISCV_ATTRIBUTES	(SHT_LOPROC + 3)
++
++/* RISC-V specific values for the p_type field.  */
++#define PT_RISCV_ATTRIBUTES	(PT_LOPROC + 3)
++
++/* RISC-V specific values for the d_tag field.  */
++#define DT_RISCV_VARIANT_CC	(DT_LOPROC + 1)
++
+ /* BPF specific declarations.  */
+ 
+ #define R_BPF_NONE		0	/* No reloc */
+@@ -4056,6 +4084,71 @@ enum
+ #define R_NDS32_TLS_TPOFF	102
+ #define R_NDS32_TLS_DESC	119
+ 
++/* LoongArch ELF Flags */
++#define EF_LARCH_ABI    	0x07
++#define EF_LARCH_ABI_LP64D	0x03
++
++/* LoongArch specific dynamic relocations */
++#define R_LARCH_NONE		0
++#define R_LARCH_32		1
++#define R_LARCH_64		2
++#define R_LARCH_RELATIVE	3
++#define R_LARCH_COPY		4
++#define R_LARCH_JUMP_SLOT	5
++#define R_LARCH_TLS_DTPMOD32	6
++#define R_LARCH_TLS_DTPMOD64	7
++#define R_LARCH_TLS_DTPREL32	8
++#define R_LARCH_TLS_DTPREL64	9
++#define R_LARCH_TLS_TPREL32	10
++#define R_LARCH_TLS_TPREL64	11
++#define R_LARCH_IRELATIVE	12
++
++/* Reserved for future relocs that the dynamic linker must understand.  */
++
++/* used by the static linker for relocating .text.  */
++#define R_LARCH_MARK_LA  20
++#define R_LARCH_MARK_PCREL  21
++#define R_LARCH_SOP_PUSH_PCREL  22
++#define R_LARCH_SOP_PUSH_ABSOLUTE  23
++#define R_LARCH_SOP_PUSH_DUP  24
++#define R_LARCH_SOP_PUSH_GPREL  25
++#define R_LARCH_SOP_PUSH_TLS_TPREL  26
++#define R_LARCH_SOP_PUSH_TLS_GOT  27
++#define R_LARCH_SOP_PUSH_TLS_GD  28
++#define R_LARCH_SOP_PUSH_PLT_PCREL  29
++#define R_LARCH_SOP_ASSERT  30
++#define R_LARCH_SOP_NOT  31
++#define R_LARCH_SOP_SUB  32
++#define R_LARCH_SOP_SL  33
++#define R_LARCH_SOP_SR  34
++#define R_LARCH_SOP_ADD  35
++#define R_LARCH_SOP_AND  36
++#define R_LARCH_SOP_IF_ELSE  37
++#define R_LARCH_SOP_POP_32_S_10_5  38
++#define R_LARCH_SOP_POP_32_U_10_12  39
++#define R_LARCH_SOP_POP_32_S_10_12  40
++#define R_LARCH_SOP_POP_32_S_10_16  41
++#define R_LARCH_SOP_POP_32_S_10_16_S2  42
++#define R_LARCH_SOP_POP_32_S_5_20  43
++#define R_LARCH_SOP_POP_32_S_0_5_10_16_S2  44
++#define R_LARCH_SOP_POP_32_S_0_10_10_16_S2  45
++#define R_LARCH_SOP_POP_32_U  46
++
++/* used by the static linker for relocating non .text.  */
++#define R_LARCH_ADD8  47
++#define R_LARCH_ADD16  48
++#define R_LARCH_ADD24  49
++#define R_LARCH_ADD32  50
++#define R_LARCH_ADD64  51
++#define R_LARCH_SUB8  52
++#define R_LARCH_SUB16  53
++#define R_LARCH_SUB24  54
++#define R_LARCH_SUB32  55
++#define R_LARCH_SUB64  56
++#define R_LARCH_GNU_VTINHERIT  57
++#define R_LARCH_GNU_VTENTRY  58
++
++
+ /* ARCompact/ARCv2 specific relocs.  */
+ #define R_ARC_NONE		0x0
+ #define R_ARC_8			0x1
+-- 
+2.37.1
+
+
+From d703772ee51ff9171e0b4f09e1b1d7c96369f9b9 Mon Sep 17 00:00:00 2001
+From: Andreas Schwab <schwab@suse.de>
+Date: Tue, 9 Aug 2022 09:54:28 +0200
+Subject: [PATCH 2/3] backends: Handle new RISC-V specific definitions
+
+Handle PT_RISCV_ATTRIBUTES, SHT_RISCV_ATTRIBUTES, DT_RISCV_VARIANT_CC.
+
+Signed-off-by: Andreas Schwab <schwab@suse.de>
+---
+ backends/ChangeLog      |  9 +++++++++
+ backends/riscv_init.c   |  4 ++++
+ backends/riscv_symbol.c | 45 +++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 58 insertions(+)
+
+diff --git a/backends/riscv_init.c b/backends/riscv_init.c
+index 141e0821..f2d46082 100644
+--- a/backends/riscv_init.c
++++ b/backends/riscv_init.c
+@@ -65,6 +65,10 @@ riscv_init (Elf *elf,
+   HOOK (eh, check_special_symbol);
+   HOOK (eh, machine_flag_check);
+   HOOK (eh, set_initial_registers_tid);
++  HOOK (eh, segment_type_name);
++  HOOK (eh, section_type_name);
++  HOOK (eh, dynamic_tag_name);
++  HOOK (eh, dynamic_tag_check);
+   if (eh->class == ELFCLASS64)
+     eh->core_note = riscv64_core_note;
+   else
+diff --git a/backends/riscv_symbol.c b/backends/riscv_symbol.c
+index c34b7702..c149b8ba 100644
+--- a/backends/riscv_symbol.c
++++ b/backends/riscv_symbol.c
+@@ -119,3 +119,48 @@ riscv_check_special_symbol (Elf *elf, const GElf_Sym *sym,
+ 
+   return false;
+ }
++
++const char *
++riscv_segment_type_name (int segment, char *buf __attribute__ ((unused)),
++			 size_t len __attribute__ ((unused)))
++{
++  switch (segment)
++    {
++    case PT_RISCV_ATTRIBUTES:
++      return "RISCV_ATTRIBUTES";
++    }
++  return NULL;
++}
++
++/* Return symbolic representation of section type.  */
++const char *
++riscv_section_type_name (int type,
++			 char *buf __attribute__ ((unused)),
++			 size_t len __attribute__ ((unused)))
++{
++  switch (type)
++    {
++    case SHT_RISCV_ATTRIBUTES:
++      return "RISCV_ATTRIBUTES";
++    }
++
++  return NULL;
++}
++
++const char *
++riscv_dynamic_tag_name (int64_t tag, char *buf __attribute__ ((unused)),
++			size_t len __attribute__ ((unused)))
++{
++  switch (tag)
++    {
++    case DT_RISCV_VARIANT_CC:
++      return "RISCV_VARIANT_CC";
++    }
++  return NULL;
++}
++
++bool
++riscv_dynamic_tag_check (int64_t tag)
++{
++  return tag == DT_RISCV_VARIANT_CC;
++}
+-- 
+2.37.1
+
+
+From 2f275fc12127db031592752136f077f5f3f3d273 Mon Sep 17 00:00:00 2001
+From: Andreas Schwab <schwab@suse.de>
+Date: Tue, 9 Aug 2022 10:29:53 +0200
+Subject: [PATCH 3/3] elflint: Allow zero p_memsz for PT_RISCV_ATTRIBUTES
+
+The RISCV_ATTRIBUTES segment is not meant to be loaded.
+
+Signed-off-by: Andreas Schwab <schwab@suse.de>
+---
+ src/ChangeLog | 5 +++++
+ src/elflint.c | 5 ++++-
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/src/elflint.c b/src/elflint.c
+index d919936f..b0e5415e 100644
+--- a/src/elflint.c
++++ b/src/elflint.c
+@@ -4731,7 +4731,10 @@ section [%2zu] '%s' must not be executable\n"),
+ 	}
+ 
+       if (phdr->p_filesz > phdr->p_memsz
+-	  && (phdr->p_memsz != 0 || phdr->p_type != PT_NOTE))
++	  && (phdr->p_memsz != 0
++	      || (phdr->p_type != PT_NOTE
++		  && !(ehdr->e_machine == EM_RISCV
++		       && phdr->p_type == PT_RISCV_ATTRIBUTES))))
+ 	ERROR (_("\
+ program header entry %d: file size greater than memory size\n"),
+ 	       cnt);
+-- 
+2.37.1
+

--- a/elfutils/riscv64.patch
+++ b/elfutils/riscv64.patch
@@ -1,0 +1,32 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -13,11 +13,17 @@ url="https://sourceware.org/elfutils/"
+ license=(LGPL3 GPL3)
+ makedepends=(bzip2 curl gcc-libs libarchive libmicrohttpd sqlite xz zlib zstd)
+ options=(debug staticlibs)
+-source=(https://sourceware.org/$pkgbase/ftp/$pkgver/$pkgbase-$pkgver.tar.bz2{,.sig})
++source=(https://sourceware.org/$pkgbase/ftp/$pkgver/$pkgbase-$pkgver.tar.bz2{,.sig}
++        skip-run-backtrace-native.patch
++        elflint.patch)
+ sha512sums=('a9b9e32b503b8b50a62d4e4001097ed2721d3475232a6380e6b9853bd1647aec016440c0ca7ceb950daf1144f8db9814ab43cf33cc0ebef7fc91e9e775c9e874'
+-            'SKIP')
++            'SKIP'
++            'f36fa06ea2806694669580611c0a8c18e499a375e4421a378ad073cb5a2f23f9336d3ecb13222b7d958de5ca1d7b17d20650517abfd706f3205273688a42e2f8'
++            'f67a3e1ae01d8b34568525bd483344ce6cf4103e43d388dfb375cb5d0c129a407f2683845c648ecc5cdd72626bd2dc1c2230acfab1c5187c52d075a34565538a')
+ b2sums=('00ba3efa689d137808f5f53ecda93fd006be0c18d690ce76616ed1dba442281098579fa4b9a9e91b8ba865a3de15968f0ae06703a7b50b15c48a4beb5c970a46'
+-        'SKIP')
++        'SKIP'
++        '4ed05c6e03a7f7da03a7cbb77a00e6b9bdd3d69e3c2dea42db59189f6600895570ac48d0de8f129fd14e2e689a121524df6d1bf666faa5f241d069761d2e2a57'
++        '4cba064fadc4f01ad8312f619722fe0104c9fe6480c82917053f02e46dd0aaa92a053c9900f6a99816038b1220eaca29f7f2359ba6242346e5e536298f59a773')
+ validpgpkeys=(
+   '47CC0331081B8BC6D0FD4DA08370665B57816A6A'  # Mark J. Wielaard <mark@klomp.org>
+   'EC3CFE88F6CA0788774F5C1D1AA44BE649DE760A'  # Mark Wielaard <mjw@gnu.org>
+@@ -36,6 +42,8 @@ _pick() {
+ prepare() {
+   (
+   cd $pkgbase-$pkgver
++  patch -p1 -i ../skip-run-backtrace-native.patch
++  patch -p1 -i ../elflint.patch
+   autoreconf -fiv
+   )
+ 

--- a/elfutils/skip-run-backtrace-native.patch
+++ b/elfutils/skip-run-backtrace-native.patch
@@ -1,0 +1,11 @@
+--- a/tests/Makefile.am	2022-05-31 22:31:31.821402012 +0800
++++ b/tests/Makefile.am	2022-05-31 22:32:07.482224764 +0800
+@@ -199,6 +199,8 @@
+ 	run-nvidia-extended-linemap-libdw.sh run-nvidia-extended-linemap-readelf.sh \
+ 	run-readelf-dw-form-indirect.sh run-strip-largealign.sh
+ 
++XFAIL_TESTS = run-backtrace-native.sh
++
+ if !BIARCH
+ export ELFUTILS_DISABLE_BIARCH = 1
+ endif

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -12,6 +12,7 @@ dbus
 dovecot
 dqlite
 element
+elfutils
 ell
 ethtool
 fd


### PR DESCRIPTION
First, I met an issue recorded in https://sourceware.org/bugzilla/show_bug.cgi?id=29073. After backporting three mentioned commits, the issue is fixed.

Next, I met an issue recorded in https://sourceware.org/bugzilla/show_bug.cgi?id=29176. This issue also appears in x86_64 architecture. And I opened an issue https://bugs.archlinux.org/task/74875. In this PR, I just add a patch to make the test expected to fail.

Last, building failed with qemu-user because of three FAIL listed below.

```
FAIL: run-backtrace-dwarf.sh
============================

PTRACE_TRACEME failed: Function not implemented
/build/elfutils/src/elfutils-test-0.187/tests/backtrace-dwarf: unexpected wait status 65280
dwarf: no main
FAIL run-backtrace-dwarf.sh (exit status: 1)

FAIL: run-deleted.sh                                                                                                                                                
====================    
                                              
PID 88033 - process
TID 88033:                 
TID 88034:                 
/build/elfutils/src/elfutils-test-0.187/src/stack: dwfl_thread_getframes tid 88033: Function not implemented
/build/elfutils/src/elfutils-test-0.187/src/stack: dwfl_thread_getframes tid 88034: Function not implemented
/build/elfutils/src/elfutils-test-0.187/src/stack: Couldn't show any frames.
FAIL run-deleted.sh (exit status: 1)
                            
FAIL: dwfl-proc-attach      
======================
                                               
./dwfl-proc-attach: dwfl_linux_proc_attach pid 88470: Couldn't find architecture of any ELF
FAIL dwfl-proc-attach (exit status: 255)
```

