### PR TITLE
addpatch: postgresql

### DIFF
--- a/postgresql/riscv64.patch
+++ b/postgresql/riscv64.patch
@@ -1,0 +1,30 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 452604)
++++ PKGBUILD	(working copy)
+@@ -11,7 +11,7 @@
+ arch=('x86_64')
+ license=('custom:PostgreSQL')
+ makedepends=('krb5' 'libxml2' 'python' 'perl' 'tcl>=8.6.0' 'openssl>=1.0.0'
+-             'pam' 'zlib' 'icu' 'systemd' 'libldap' 'llvm' 'clang' 'libxslt'
++             'pam' 'zlib' 'icu' 'systemd' 'libldap' 'libxslt'
+              'util-linux')
+ options=('debug')
+ source=(https://ftp.postgresql.org/pub/source/v${pkgver}/postgresql-${pkgver}.tar.bz2
+@@ -84,7 +84,6 @@
+     --with-icu
+     --with-systemd
+     --with-ldap
+-    --with-llvm
+     --with-libxslt
+     --enable-nls
+     --enable-thread-safety
+@@ -172,7 +171,7 @@
+   pkgdesc='Sophisticated object-relational DBMS'
+   backup=('etc/pam.d/postgresql' 'etc/logrotate.d/postgresql')
+   depends=("postgresql-libs>=${pkgver}" 'krb5' 'libxml2' 'readline>=6.0'
+-           'openssl>=1.0.0' 'pam' 'icu' 'systemd-libs' 'libldap' 'llvm-libs' 'libxslt')
++           'openssl>=1.0.0' 'pam' 'icu' 'systemd-libs' 'libldap' 'libxslt')
+   optdepends=('python: for PL/Python 3 support'
+               'perl: for PL/Perl support'
+               'tcl: for PL/Tcl support'


### PR DESCRIPTION
Disable LLVM JIT to workaround runtime errors:

FATAL:  fatal llvm error: Relocation type not implemented yet!