### PR TITLE
addpkg: grafana-agent

### DIFF
--- a/grafana-agent/riscv64.patch
+++ b/grafana-agent/riscv64.patch
@@ -1,0 +1,33 @@
+diff --git PKGBUILD trunk/PKGBUILD
+index 771067e2..484fa35b 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,16 +12,18 @@ depends=('glibc'
+ makedepends=('go' 'systemd')
+ options=('!lto')
+ source=($pkgname-$pkgver.tar.gz::https://github.com/grafana/agent/archive/v$pkgver.tar.gz
+-        grafana-agent.sysusers grafana-agent.service grafana-agent.tmpfiles)
++        grafana-agent.sysusers grafana-agent.service grafana-agent.tmpfiles support_go_1.19.patch)
+ sha512sums=('92a11ebec6a34d10a7b38f113afee229ac8b7c4204256d2ceb031cd7c0829341a712bcd8a047546b5dde001c657bede23be35ad984cf12b367f166bb352cd505'
+             '1e58f6273562fd6ddeae41bb6d223230ed301199af6bd2f85fa3d2c1e6352952c600cd4488ad769069519c42b6863be84aaa2c93c88f696e5a0bedbb93758d0e'
+             '3f8debbc4732009f54c063d70c2dce4846b81b829f495d25a431fef857077c83949d777f763de8c106fb8d1cf0bd7e874680db8387b4811704b1a303932fa090'
+-            '3a4c4896b2454272b5a2d53ba5aa7009fa5b42a573fef521afb5d9712e53119539c4195d2b149d04d086c5fa197ccf7dc9bbdc407efb55514e3c92b994121fa8')
++            '3a4c4896b2454272b5a2d53ba5aa7009fa5b42a573fef521afb5d9712e53119539c4195d2b149d04d086c5fa197ccf7dc9bbdc407efb55514e3c92b994121fa8'
++            'fa3749c6f467af0a6c05f1177350482f55581e85602ec78e38feda70ea39f754aa861c0723e69e54061f736747c304347162df59006069c14f103cbbdeadcb61')
+ 
+ prepare() {
+   cd "agent-$pkgver"
+ 
+   go mod download
++  patch -Ni "${srcdir}/support_go_1.19.patch"
+ }
+ 
+ build() {
+@@ -31,7 +33,6 @@ build() {
+   export CGO_CFLAGS="${CFLAGS}"
+   export CGO_CPPFLAGS="${CPPFLAGS}"
+   export CGO_CXXFLAGS="${CXXFLAGS}"
+-  export GOPROXY=off
+   for path in cmd/agent cmd/agentctl tools/crow; do
+     go build \
+       -trimpath \

--- a/grafana-agent/support_go_1.19.patch
+++ b/grafana-agent/support_go_1.19.patch
@@ -1,0 +1,26 @@
+diff --git a/go.mod b/go.mod
+index 1a5a321878..77e51fcec8 100644
+--- a/go.mod
++++ b/go.mod
+@@ -459,7 +459,7 @@ require (
+ 	go.opentelemetry.io/otel v1.7.0 // indirect
+ 	go.uber.org/goleak v1.1.12 // indirect
+ 	go4.org/intern v0.0.0-20210108033219-3eb7198706b2 // indirect
+-	go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37 // indirect
++	go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 // indirect
+ 	gocloud.dev v0.24.0 // indirect
+ 	golang.org/x/crypto v0.0.0-20220507011949-2cf3adece122 // indirect
+ 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
+diff --git a/go.sum b/go.sum
+index c5a7b7648c..51c88b66d3 100644
+--- a/go.sum
++++ b/go.sum
+@@ -2721,6 +2721,8 @@ go4.org/unsafe/assume-no-moving-gc v0.0.0-20201222175341-b30ae309168e/go.mod h1:
+ go4.org/unsafe/assume-no-moving-gc v0.0.0-20201222180813-1025295fd063/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
+ go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37 h1:Tx9kY6yUkLge/pFG7IEMwDZy6CS2ajFc9TvQdPCW0uA=
+ go4.org/unsafe/assume-no-moving-gc v0.0.0-20211027215541-db492cf91b37/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
++go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760 h1:FyBZqvoA/jbNzuAWLQE2kG820zMAkcilx6BMjGbL/E4=
++go4.org/unsafe/assume-no-moving-gc v0.0.0-20220617031537-928513b29760/go.mod h1:FftLjUGFEDu5k8lt0ddY+HcrH/qU/0qk+H8j9/nTl3E=
+ gocloud.dev v0.24.0 h1:cNtHD07zQQiv02OiwwDyVMuHmR7iQt2RLkzoAgz7wBs=
+ gocloud.dev v0.24.0/go.mod h1:uA+als++iBX5ShuG4upQo/3Zoz49iIPlYUWHV5mM8w8=
+ golang.org/x/crypto v0.0.0-20171113213409-9f005a07e0d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=


### PR DESCRIPTION
Here contains two patches:
One from modification of `PKGBUILD` called `riscv46`.
The other from upstream, which fixed the original error: `assume-no-moving-gc`.

Because upstream fixed this error without new release found, so I just change their modification into a patch then apply it in our packages.
Notice: in their modification, `go` need download new version, however, `build()` of `PKGBUILD` has a option `export GOPROXY=off`, which can lead this into failure, so I delete it.
If there is any wrong management, please fell free to tell me, thanks.

Build passed.

**Related issue and pull request:**
Issue: https://github.com/grafana/agent/issues/1983
PR: https://github.com/grafana/agent/pull/1985

**Original error message:**
```console
panic: Something in this program imports go4.org/unsafe/assume-no-moving-gc to declare that it assumes a non-moving garbage collector, but your version of go4.org/unsafe/assume-no-moving-gc hasn't been updated to assert that it's safe against the go1.19 runtime. If you want to risk it, run with environment variable ASSUME_NO_MOVING_GC_UNSAFE_RISK_IT_WITH=go1.19 set. Notably, if go1.19 adds a moving garbage collector, this program is unsafe to use.
```