### PR TITLE
addpatch: monero-gui 0.18.1.0-1

### DIFF
--- a/monero-gui/riscv64.patch
+++ b/monero-gui/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -33,6 +33,9 @@ validpgpkeys=(
+   '8777AB8F778EE89487A2F8E7F4ACA0183641E010' # luigi1111 <luigi1111w@gmail.com>
+   '487277A8BD0A209C16B700F3C64552D877C32479' # Alexander Blair (Snipa / Snipa22) <snipa@jagtech.io>
+ )
++# bypass error:
++# relocation truncated to fit: R_RISCV_JAL against symbol `mdb_stat' defined in text_env section in /tmp/ccWy6leF.ltrans22.ltrans.o
++options=(!lto)
+ 
+ prepare() {
+   cd "${pkgname}"


### PR DESCRIPTION
Disable LTO to bypass error:

```
/tmp/ccWy6leF.ltrans19.ltrans.o: in function `.L0 ':
<artificial>:(.text+0x1ad2): relocation truncated to fit: R_RISCV_JAL against symbol `mdb_stat' defined in text_env section in /tmp/ccWy6leF.ltrans22.ltrans.o
```

Just like we did for `opencv` in https://github.com/felixonmars/archriscv-packages/pull/1427.