### PR TITLE
updpatch: gnu-efi

### DIFF
--- a/gnu-efi/riscv64.patch
+++ b/gnu-efi/riscv64.patch
@@ -1,14 +1,13 @@
 Index: PKGBUILD
 ===================================================================
---- PKGBUILD	(revision 443903)
+--- PKGBUILD	(revision 452639)
 +++ PKGBUILD	(working copy)
-@@ -25,8 +25,7 @@
-   # NOTE: apply only minimal CFLAGS, as gnu-efi does not provide userspace
-   # libs, but may be used in unitialized machine state and should therefore not
-   # be architecture optmized
--  # NOTE: fat-lto-objects is required for non-mangled (static) object files
--  CFLAGS="-O2 -flto -ffat-lto-objects"
-+  CFLAGS="-O2"
-   make
-   make -C lib
-   make -C gnuefi
+@@ -33,7 +33,7 @@
+   make -C inc
+   # unset LDFLAGS for custom linker used in apps, as we have patched our
+   # LDFLAGS in manually in prepare()
+-  LDFLAGS=""
++  LDFLAGS="--no-warn-rwx-segments"
+   make -C apps
+ }
+ 


### PR DESCRIPTION
This is an issue caused by binutils 2.39. Binutils 2.39 introduced new warning `ld: warning: t.so has a LOAD segment with RWX permissions`. According to an [issue](https://github.com/systemd/systemd/issues/23789) of systemd, they just silent the warning. So, I think it's not a big problem and we can silent the warning as well.