### PR TITLE
addpkg: prometheus-wireguard-exporter

### DIFF
--- a/prometheus-wireguard-exporter/riscv64.patch
+++ b/prometheus-wireguard-exporter/riscv64.patch
@@ -1,0 +1,23 @@
+diff --git PKGBUILD PKGBUILD
+index a573d5d..e11db13 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -23,7 +23,17 @@ sha512sums=('9ff42deaf28a45be26cf0211b11878be873467bee0bdb128efec3c1a9d4f7214f53
+ 
+ prepare() {
+   cd "prometheus_wireguard_exporter-${pkgver}"
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++
++  # RISC-V Patches:
++
++  # The upstream `ring' package does not support riscv yet.
++  # This workaround comes from https://github.com/felixonmars/archriscv-packages/wiki/%E6%88%91%E4%BB%AC%E7%9A%84%E5%B7%A5%E4%BD%9C%E4%B9%A0%E6%83%AF
++  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
++  cargo update -p ring
++
++  # rustc(1) recognizes `riscv64gc' instead of `riscv64'. Thus,
++  # as the convention, we removed `--target'.
++  cargo fetch --locked
+ }
+ 
+ build() {


### PR DESCRIPTION
The PKGBUILD patch fixes two issues:

 1. rustc(1) recognizes `riscv64gc' instead of `riscv64'. It fixes the issue by substituting `riscv64' with `riscv64gc' in the `--target' argument if $CARCH is `riscv64'.

 2. This package depends on `ring', which is not yet riscv64 ready. This patch works around this issue by forcing Cargo to use felixonmars/ring.

The patched version passes compiling and testing.

References:

 1. https://github.com/felixonmars/archriscv-packages/commit/1e0a422d3e1a1b879b31988aada28441c5f25223

 2. https://wiki.archlinux.org/title/Rust_package_guidelines#Prepare

 3. https://github.com/felixonmars/archriscv-packages/wiki/%E6%88%91%E4%BB%AC%E7%9A%84%E5%B7%A5%E4%BD%9C%E4%B9%A0%E6%83%AF