### PR TITLE
addpatch: cifs-utils

### DIFF
--- a/cifs-utils/cifs-utils.patch
+++ b/cifs-utils/cifs-utils.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -23,7 +23,7 @@ build() {
+   cd "$srcdir/$pkgname-$pkgver"
+   # systemd support is broken in mount.cifs
+   # https://bugs.archlinux.org/task/30958
+-  autoreconf -i
++  autoreconf -fiv
+   # https://www.spinics.net/lists/linux-cifs/msg21550.html
+   # change back to libcap-ng depend when upstream is fixed
+   ./configure --prefix=/usr --with-libcap=yes --sbindir=/usr/bin --disable-systemd 


### PR DESCRIPTION
invoke autoreconf with the `-f` option to update `config.guess` and `config.sub`