### PR TITLE
addpatch: ocaml

### DIFF
--- a/ocaml/riscv64.patch
+++ b/ocaml/riscv64.patch
@@ -1,0 +1,13 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 452604)
++++ PKGBUILD	(working copy)
+@@ -20,7 +20,7 @@
+   cd "${srcdir}/${pkgname}-${pkgver}"
+   CFLAGS+=' -ffat-lto-objects'
+   CXXFLAGS+=' -ffat-lto-objects'
+-  ./configure --prefix /usr --mandir /usr/share/man --disable-force-safe-string --enable-frame-pointers
++  ./configure --prefix /usr --mandir /usr/share/man --disable-force-safe-string
+   make --debug=v world.opt
+ }
+ 


### PR DESCRIPTION
frame pointers are x86_64 only.

Ref: https://github.com/ocaml/ocaml/blob/98392895940cc1c18534280ae001b70fa5bf24c2/configure.ac#L1925