### PR TITLE
addpatch: lvm2

### DIFF
--- a/lvm2/riscv64.patch
+++ b/lvm2/riscv64.patch
@@ -1,0 +1,22 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 452715)
++++ PKGBUILD	(working copy)
+@@ -9,7 +9,7 @@
+ arch=('x86_64')
+ url='https://sourceware.org/lvm2/'
+ license=('GPL2' 'LGPL2.1')
+-makedepends=('git' 'systemd' 'thin-provisioning-tools')
++makedepends=('git' 'systemd' 'thin-provisioning-tools' 'autoconf-archive')
+ validpgpkeys=('88437EF5C077BD113D3B7224228191C1567E2C17'  # Alasdair G Kergon <agk@redhat.com>
+               'D501A478440AE2FD130A1BE8B9112431E509039F') # Marian Csontos <marian.csontos@gmail.com>
+ source=("git+https://sourceware.org/git/lvm2.git#tag=${_tag}?signed"
+@@ -41,6 +41,8 @@
+     scripts/dm_event_systemd_red_hat.socket.in \
+     scripts/lvm2_lvmpolld_systemd_red_hat.socket.in \
+     scripts/lvm2_monitoring_systemd_red_hat.service.in
++  
++  autoreconf -fiv
+ }
+ 
+ build() {


### PR DESCRIPTION
This is an issue about config.guess and config.sub. Added a dependency autoconf-archive because of AC_PYTHON_MODULE macro in configure.ac.
```
# To get this macro, install autoconf-archive package then run autoreconf
AC_PYTHON_MODULE([pyudev], [Required], python3)              
AC_PYTHON_MODULE([dbus], [Required], python3)
```
I have filed an issue to upstream bugzilla.
https://bugzilla.redhat.com/show_bug.cgi?id=2118243