### PR TITLE
addpatch: algol68g

### DIFF
--- a/algol68g/fix-build-host.patch
+++ b/algol68g/fix-build-host.patch
@@ -1,0 +1,13 @@
+diff --git configure.ac configure.ac
+index 52f976c..419842f 100644
+--- configure.ac
++++ configure.ac
+@@ -201,7 +201,7 @@ case "$host" in
+ # Linux.
+ #
+ # aarch64*-*-linux* is for RaspberryPi-4 on ARM-64 - otherwise http/tcp isnt found
+-*86-*-gnu | *86_64-*-gnu | *86-*-linux* | *86_64-*-linux* | arm*-*-linux* | aarch*-*-linux*) 
++*86-*-gnu | *86_64-*-gnu | *86-*-linux* | *86_64-*-linux* | arm*-*-linux* | aarch*-*-linux* | riscv64-*-linux*)
+   AC_DEFINE(BUILD_LINUX, 1, [Define this if LINUX was detected]) 
+   AC_DEFINE(HAVE_IEEE_754, 1, [Define this if IEEE_754 compliant])
+   AC_MSG_RESULT([linux])

--- a/algol68g/riscv64.patch
+++ b/algol68g/riscv64.patch
@@ -1,0 +1,22 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,9 +12,17 @@ depends=(gsl plotutils)
+ optdepends=('postgresql-libs: for postgresql support')
+ # This URL was removed:
+ source=("https://jmvdveer.home.xs4all.nl/algol68g-$pkgver.tar.gz"
+-        'https://ftp.tw.freebsd.org/distfiles/a68g-doc.pdf')
++        'https://ftp.tw.freebsd.org/distfiles/a68g-doc.pdf'
++        'fix-build-host.patch')
+ b2sums=('37a0c0e7386f31dd9b986e9c6da0f21a762dc099d5ece48dbdd1bad7789f38bf131e23ffe20596e2d874f71a0bd3a8045739e794f75bd8b5316fd7bf8e99e91e'
+-        'f8ca710d9a4f611873de41785e70359bd566645268ebb848803d3cd2e9a9f873f8ac423e3e08699998083444b7f6d98df32fdb7a4c6b36692462ee50ddb1e410')
++        'f8ca710d9a4f611873de41785e70359bd566645268ebb848803d3cd2e9a9f873f8ac423e3e08699998083444b7f6d98df32fdb7a4c6b36692462ee50ddb1e410'
++        'ca6affc2f633dd788a2b127256aaf47fb89bf9e954e408ae30595a2e01a1d6f5406d40109fe7ad081a7c452b38f0fdf9438f8455f36f5b75bc288777f5107c1b')
++
++prepare() {
++  cd $pkgname-$pkgver
++  patch -Ni $srcdir/fix-build-host.patch
++  autoreconf -fiv
++}
+ 
+ build() {
+   cd $pkgname-$pkgver


### PR DESCRIPTION
Package algol68g have an old configure.ac file that doesn't recognize
riscv. This patch add a new prepare step to patch and reconfigure the
build script.

Signed-off-by: Avimitin <avimitin@gmail.com>