### PR TITLE
addpatch: libffado

### DIFF
--- a/libffado/riscv64.patch
+++ b/libffado/riscv64.patch
@@ -1,0 +1,13 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1266539)
++++ PKGBUILD	(working copy)
+@@ -26,6 +26,8 @@
+   sed -e 's/hi64-apps-ffado/ffado-mixer/g' -i support/xdg/ffado.org-ffadomixer.desktop
+   # fix id, so it's coherent with XDG desktop file name
+   sed -e 's/ffado.org-ffadomixer.desktop/ffado-mixer.desktop/g' -i support/xdg/ffado-mixer.appdata.xml
++
++  cp -v /usr/share/autoconf/build-aux/config.guess admin/
+ }
+ 
+ build() {


### PR DESCRIPTION
Scons build system invokes `/bin/sh admin/config.guess` directly.
```python
def ConfigGuess( context ):
    context.Message( "Trying to find the system triple: " )
    ret = check_output(("/bin/sh", "admin/config.guess")).rstrip()
    context.Result( ret )
    return ret.decode()
```
So, I replace it with config.guess bundled with system.
I also filed an issue to upstream.
https://sourceforge.net/p/ffado/mailman/ffado-devel/thread/CAEUwDuAJDjFfXuQRBrLpYd6N75ZgYj7P-EtK%2BrPupwVB3aRCSQ%40mail.gmail.com/#msg37694098
