### PR TITLE
addpatch: ppsspp

### DIFF
--- a/ppsspp/riscv64.patch
+++ b/ppsspp/riscv64.patch
@@ -1,0 +1,38 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1267291)
++++ PKGBUILD	(working copy)
+@@ -15,6 +15,7 @@
+ arch=(x86_64)
+ url=https://www.ppsspp.org/
+ license=(GPL2)
++options=(!lto)
+ makedepends=(
+   clang
+   cmake
+@@ -46,6 +47,7 @@
+   armips-tinyformat::git+https://github.com/Kingcom/tinyformat.git
+   ppsspp-sdl.desktop
+   ppsspp-qt.desktop
++  fix-riscv-build.patch::https://github.com/hrydgard/ppsspp/pull/15862.patch
+ )
+ b2sums=('SKIP'
+         'SKIP'
+@@ -58,7 +60,8 @@
+         'SKIP'
+         'SKIP'
+         'c6bcdfedee866dfdcc82a8c333c31ff73ed0beec65b63acec8bc8186383c0bc9f0912f21bb9715b665e8dc1793b1a85599761f9037856fa54ad8aa3bfdbfd468'
+-        '328e2ba47b78d242b0ec6ba6bfa039c77a36d1ef7246e5c2c2432d8e976e9360baf505eb05f48408ede1a30545cbbb7f875bf5ebd0252cef35523d449b8254a0')
++        '328e2ba47b78d242b0ec6ba6bfa039c77a36d1ef7246e5c2c2432d8e976e9360baf505eb05f48408ede1a30545cbbb7f875bf5ebd0252cef35523d449b8254a0'
++        '17067b4eecc5914b6d7743763c4ecea15a26e049d7853a238426e941f97e8af2f7cf25739289834cb6f463c3d241d1562fe2bdeb198a11bb420b1afe6f5b1387')
+ 
+ pkgver() {
+   cd ppsspp
+@@ -67,6 +70,7 @@
+ 
+ prepare() {
+   cd ppsspp
++  patch -p1 -i ../fix-riscv-build.patch
+ 
+   for submodule in assets/lang ext/{glslang,miniupnp} ffmpeg; do
+     git submodule init ${submodule}


### PR DESCRIPTION
LTO is disabled because the follow errors are present with our
`-Wl,-plugin-opt=-target-abi=lp64d` hack:

```
/usr/bin/ld: error: LLVM gold plugin: linking module flags
'SmallDataLimit': IDs have conflicting values in
'lib/libspirv-cross-glsl.a.llvm.105712.spirv_glsl.cpp' and 'ld-temp.o'
```

Build patch upstreamed at https://github.com/hrydgard/ppsspp/pull/15862