### PR TITLE
CI perform validity check for sources

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     container: archlinux/archlinux:latest
     steps:
       - name: Install dependencies
-        run: pacman -Syu --noconfirm git patch subversion
+        run: pacman -Syu --noconfirm git patch subversion binutils
       - name: Fix git unsafe repository
         run: git config --global --add safe.directory /__w/archriscv-packages/archriscv-packages
       - uses: actions/checkout@v3

--- a/test.sh
+++ b/test.sh
@@ -50,7 +50,13 @@ for _dir in $(git diff --merge-base --name-only upstream/master | cut -d / -f 1 
   fi
 
   cp $ORIGDIR/$PKGBASE/* ./
+
   patch -p0 -i ./riscv64.patch || exit 1
+
+  # `makepkg` requires a non-root user to run, let's remove this restriction
+  sed -e 's|if (( EUID == 0 ))|if false|' -i /usr/bin/makepkg
+  makepkg --verifysource --skippgpcheck || exit 1
+
   popd
 done
 


### PR DESCRIPTION
Perform the validity check for sources to avoid merging patches with mismatched checksums.