### PR TITLE
addpatch: arrow

### DIFF
--- a/arrow/riscv64.patch
+++ b/arrow/riscv64.patch
@@ -1,0 +1,30 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1266205)
++++ PKGBUILD	(working copy)
+@@ -13,6 +13,7 @@
+          snappy thrift uriparser xsimd zlib zstd)
+ provides=(parquet-cpp)
+ conflicts=(parquet-cpp)
++options=(!lto)
+ makedepends=(boost cmake flatbuffers gmock python-numpy git clang)
+ source=(https://archive.apache.org/dist/${pkgname}/${pkgname}-${pkgver}/apache-${pkgname}-${pkgver}.tar.gz{,.asc}
+         git+https://github.com/apache/parquet-testing.git
+@@ -51,7 +52,6 @@
+     -DARROW_PLASMA=ON \
+     -DARROW_PYTHON=ON \
+     -DARROW_TENSORFLOW=ON \
+-    -DARROW_SIMD_LEVEL=AVX2 \
+     -DARROW_USE_GLOG=ON \
+     -DARROW_WITH_BROTLI=ON \
+     -DARROW_WITH_BZ2=ON \
+@@ -59,7 +59,8 @@
+     -DARROW_WITH_SNAPPY=ON \
+     -DARROW_WITH_ZLIB=ON \
+     -DARROW_WITH_ZSTD=ON \
+-    -DPARQUET_REQUIRE_ENCRYPTION=ON
++    -DPARQUET_REQUIRE_ENCRYPTION=ON \
++    -DARROW_CPU_FLAG=riscv64
+   make -C build
+ }
+ 

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -1,3 +1,4 @@
+arrow
 asio
 bat
 bear


### PR DESCRIPTION
- LTO is disabled for similar reason as #1620

- The `-DARROW_CPU_FLAG=riscv64` is no longer needed in a future version
  containing https://github.com/apache/arrow/pull/13902

- Added to qemu-user-blacklist because QEMU doesn't support
  madvise(WILLNEED) properly (this includes qemu-system, actually)

- `nocheck` is needed for now as `arrow-flight-test` is failing with the
  current version but not on git master. Recheck on next release!