### PR TITLE
addpatch: mkinitcpio

### DIFF
--- a/mkinitcpio/riscv64.patch
+++ b/mkinitcpio/riscv64.patch
@@ -1,0 +1,32 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 454173)
++++ PKGBUILD	(working copy)
+@@ -20,20 +20,23 @@
+ provides=('initramfs')
+ backup=('etc/mkinitcpio.conf')
+ source=("https://sources.archlinux.org/other/$pkgname/$pkgname-$pkgver.tar.gz"{,.sig}
+-       0001-Fix-the-warning-about-missing-modules.builtin.modinf.patch)
++       0001-Fix-the-warning-about-missing-modules.builtin.modinf.patch
++       mkinitcpio-generic-gzip-kernel.patch::https://github.com/archlinux/mkinitcpio/pull/112.patch)
+ install=mkinitcpio.install
+ sha512sums=('4ef87c2e4f579b292c38f9c487e78b3b99f6db77909cab322e860e5ca70aca3747fcfc272e2e15c9a3605c924ab178057b8b23151f98debc5d96e65f3c0c49d5'
+             'SKIP'
+-            'fd348d6fcff249672b495db50fa67ce06d5d9a0c8f749c8b488bc1e4b43c9b850a5ad87392230fbe8b715422bb14e760bb0ad219cfcf1d7e132c6a7e4dd118a6')
++            'fd348d6fcff249672b495db50fa67ce06d5d9a0c8f749c8b488bc1e4b43c9b850a5ad87392230fbe8b715422bb14e760bb0ad219cfcf1d7e132c6a7e4dd118a6'
++            '2c396e6139991bb8ffa478c86748ee7b6d94e76d75de6e7035561d1c8adef44eb3bb7443ea5d9f97dc1ba9289f9139b50577484de5e7c96c7e0003d5092c9d1d')
+ b2sums=('0113e288906e3b5fa485c29c00e7df60d85addd96718c45531031a686f18c739fa18303b6cac374d35b85edb7b663e221c8dc9158dff08c75858a4ed4dd154bf'
+         'SKIP'
+-        '5a05cee0382284d6cc0a2033e872b7c4c9f01ddfe6d3550974b5eab9a8a18690d1115b57d8d08153497fed08fd55b69f8b4a4cbcbe67795d615cc06ea7c86618')
++        '5a05cee0382284d6cc0a2033e872b7c4c9f01ddfe6d3550974b5eab9a8a18690d1115b57d8d08153497fed08fd55b69f8b4a4cbcbe67795d615cc06ea7c86618'
++        '18da70dec57bdee27e610a05abce223bff348627d4c1fc14a070572ea78a7924e4f86654ba599152874bf3f5820c3bf8d78d40cbb726cf3a139326aa52f92d51')
+ validpgpkeys=('ECCAC84C1BA08A6CC8E63FBBF22FB1D78A77AEAB')    # Giancarlo Razzolini
+ 
+ prepare() {
+   cd $pkgname-$pkgver
+   patch -Np1 < "$srcdir"/0001-Fix-the-warning-about-missing-modules.builtin.modinf.patch  
+-   
++  patch -Np1 < "$srcdir"/mkinitcpio-generic-gzip-kernel.patch
+ }
+ 
+ check() {


### PR DESCRIPTION
Add a [patch](https://github.com/archlinux/mkinitcpio/pull/112) to support our gzipped kernel. Tested to work fine on both
qemu-system-riscv64 and HiFive Unmatched boards.