### PR TITLE
updpatch: mkinitcpio

### DIFF
--- a/mkinitcpio/riscv64.patch
+++ b/mkinitcpio/riscv64.patch
@@ -2,24 +2,27 @@ Index: PKGBUILD
 ===================================================================
 --- PKGBUILD	(revision 454173)
 +++ PKGBUILD	(working copy)
-@@ -20,20 +20,23 @@
+@@ -20,20 +20,27 @@
  provides=('initramfs')
  backup=('etc/mkinitcpio.conf')
  source=("https://sources.archlinux.org/other/$pkgname/$pkgname-$pkgver.tar.gz"{,.sig}
 -       0001-Fix-the-warning-about-missing-modules.builtin.modinf.patch)
 +       0001-Fix-the-warning-about-missing-modules.builtin.modinf.patch
-+       mkinitcpio-generic-gzip-kernel.patch::https://github.com/archlinux/mkinitcpio/pull/112.patch)
++       mkinitcpio-generic-gzip-kernel.patch::https://github.com/archlinux/mkinitcpio/pull/112.patch
++       mkinitcpio-include-spi-modules.patch::https://github.com/archlinux/mkinitcpio/pull/113.patch)
  install=mkinitcpio.install
  sha512sums=('4ef87c2e4f579b292c38f9c487e78b3b99f6db77909cab322e860e5ca70aca3747fcfc272e2e15c9a3605c924ab178057b8b23151f98debc5d96e65f3c0c49d5'
              'SKIP'
 -            'fd348d6fcff249672b495db50fa67ce06d5d9a0c8f749c8b488bc1e4b43c9b850a5ad87392230fbe8b715422bb14e760bb0ad219cfcf1d7e132c6a7e4dd118a6')
 +            'fd348d6fcff249672b495db50fa67ce06d5d9a0c8f749c8b488bc1e4b43c9b850a5ad87392230fbe8b715422bb14e760bb0ad219cfcf1d7e132c6a7e4dd118a6'
-+            '2c396e6139991bb8ffa478c86748ee7b6d94e76d75de6e7035561d1c8adef44eb3bb7443ea5d9f97dc1ba9289f9139b50577484de5e7c96c7e0003d5092c9d1d')
++            '2c396e6139991bb8ffa478c86748ee7b6d94e76d75de6e7035561d1c8adef44eb3bb7443ea5d9f97dc1ba9289f9139b50577484de5e7c96c7e0003d5092c9d1d'
++            'bab1e8b7ec2ed16158dea573270c891bd3a04bb309543304ca6539dd1770e2f7cfe085ad43d0639b82998db803cb4c5c266976f7894c191d4261483476f71aa0')
  b2sums=('0113e288906e3b5fa485c29c00e7df60d85addd96718c45531031a686f18c739fa18303b6cac374d35b85edb7b663e221c8dc9158dff08c75858a4ed4dd154bf'
          'SKIP'
 -        '5a05cee0382284d6cc0a2033e872b7c4c9f01ddfe6d3550974b5eab9a8a18690d1115b57d8d08153497fed08fd55b69f8b4a4cbcbe67795d615cc06ea7c86618')
 +        '5a05cee0382284d6cc0a2033e872b7c4c9f01ddfe6d3550974b5eab9a8a18690d1115b57d8d08153497fed08fd55b69f8b4a4cbcbe67795d615cc06ea7c86618'
-+        '18da70dec57bdee27e610a05abce223bff348627d4c1fc14a070572ea78a7924e4f86654ba599152874bf3f5820c3bf8d78d40cbb726cf3a139326aa52f92d51')
++        '18da70dec57bdee27e610a05abce223bff348627d4c1fc14a070572ea78a7924e4f86654ba599152874bf3f5820c3bf8d78d40cbb726cf3a139326aa52f92d51'
++        '48dee9b1ee225a17b39ad3c539b7c09db661fffc0ce3fa7d098ee297cdf36dff8f1b106fd2f99c59b25758324f3b51d235440db7823f543e785ff5a410f4c52e')
  validpgpkeys=('ECCAC84C1BA08A6CC8E63FBBF22FB1D78A77AEAB')    # Giancarlo Razzolini
  
  prepare() {
@@ -27,6 +30,7 @@ Index: PKGBUILD
    patch -Np1 < "$srcdir"/0001-Fix-the-warning-about-missing-modules.builtin.modinf.patch  
 -   
 +  patch -Np1 < "$srcdir"/mkinitcpio-generic-gzip-kernel.patch
++  patch -Np1 < "$srcdir"/mkinitcpio-include-spi-modules.patch
  }
  
  check() {


### PR DESCRIPTION
Add another [patch](https://github.com/archlinux/mkinitcpio/pull/113) to include spi modules for `block` hook. This fixes SD
card boot for Hifive Unmatched board.