### PR TITLE
addpatch: dummyhttp 0.5.0-1

### DIFF
--- a/dummyhttp/riscv64.patch
+++ b/dummyhttp/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,6 +15,8 @@ sha512sums=('913d913a1d4cb29e1668a5cdf7029a46351142d0b93180199c5c42f039a961ace1a
+ build() {
+   cd "$srcdir/$pkgname-$pkgver"
+ 
++  echo -e "[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
++  cargo update -p ring
+   cargo build --release --locked
+ }
+ 


### PR DESCRIPTION
Fix error:

```
error: failed to run custom build command for `ring v0.16.20`

Caused by:
  process didn't exit successfully: `/build/dummyhttp/src/dummyhttp-0.5.0/target/release/build/ring-86c85cc89dc3d48a/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', /build/.cargo/registry/src/github.com-1ecc6299db9ec823/ring-0.16.20/build.rs:358:10
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```