### PR TITLE
addpatch: openh264

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -55,6 +55,7 @@ nodejs-lts-gallium
 notepadqq
 nuitka
 nushell
+openh264
 openldap
 pangomm-2.48
 perl


### PR DESCRIPTION
This package can be built successfully on larvesta. While it fails to be with qemu-user.

Test ThreadDecodeFile/ThreadDecoderOutputTest failed.