### PR TITLE
updpatch: glibc

### DIFF
--- a/glibc/riscv64.patch
+++ b/glibc/riscv64.patch
@@ -1,6 +1,6 @@
 Index: PKGBUILD
 ===================================================================
---- PKGBUILD	(revision 452986)
+--- PKGBUILD	(revision 454535)
 +++ PKGBUILD	(working copy)
 @@ -7,7 +7,7 @@
  # NOTE: valgrind requires rebuilt with each major glibc version
@@ -9,8 +9,8 @@ Index: PKGBUILD
 -pkgname=(glibc lib32-glibc)
 +pkgname=(glibc)
  pkgver=2.36
- _commit=c804cd1c00adde061ca51711f63068c103e94eef
- pkgrel=2
+ _commit=e982657073c4db21459ffd9e17bc505b1d64b876
+ pkgrel=3
 @@ -14,7 +14,7 @@
  arch=(x86_64)
  url='https://www.gnu.org/software/libc'


### PR DESCRIPTION
Update to glibc 2.36-3.

As ArchLinux upstream bump to commit e982657073c4db21459ffd9e17bc505b1d64b876 which includes a fix of misc/tst-glibcsyscalls in fccadcdf5bed7ee67a6cef4714e0b477d6c8472c, there are 13 test failures in this build.

11 of them are timeout
FAIL: locale/tst-localedef-path-norm                                                                                                                                                              
FAIL: malloc/tst-malloc-too-large-malloc-hugetlb2
FAIL: nss/tst-nss-files-hosts-getent
FAIL: nss/tst-nss-files-hosts-multi
FAIL: stdio-common/tst-vfprintf-width-prec
FAIL: stdio-common/tst-vfprintf-width-prec-mem
FAIL: stdlib/test-bz22786
FAIL: stdlib/tst-arc4random-fork
FAIL: string/test-memcpy
FAIL: string/test-mempcpy
FAIL: string/test-strncasecmp

2 of them are issues with `-NAN`, glibc upstream link https://sourceware.org/bugzilla/show_bug.cgi?id=29501
FAIL: stdlib/tst-strfrom
FAIL: stdlib/tst-strfrom-locale

This package still needs `no check`