### PR TITLE
addpatch: efivar

### DIFF
--- a/efivar/riscv64.patch
+++ b/efivar/riscv64.patch
@@ -1,0 +1,33 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 454545)
++++ PKGBUILD	(working copy)
+@@ -18,11 +18,17 @@
+ source=(
+   "git+https://github.com/rhinstaller/efivar.git#tag=${pkgver}?signed"
+   "${pkgname}-38-ld_t.patch::https://github.com/rhboot/efivar/pull/201/commits/197a0874ea4010061b98b4b55eff65b33b1cd741.patch"
++  "${pkgname}-38-march-native.patch::https://github.com/rhboot/efivar/commit/aab4e9b10ac9e98588a1b19771cf6f4c8c0a3096.patch"
++  "${pkgname}-38-glibc-mount.patch::https://github.com/rhboot/efivar/commit/bc65d63ebf8fe6ac8a099ff15ca200986dba1565.patch"
+ )
+ sha512sums=('SKIP'
+-            '568bc88b182875c37479c49b3dbf5b8ee6edf8090f940176e67c9aa28dd2ff6f417c70b2bef6b5df99ada2afa33db3efd295ba9de5d68b3ecc5ce1dc3361d042')
++            '568bc88b182875c37479c49b3dbf5b8ee6edf8090f940176e67c9aa28dd2ff6f417c70b2bef6b5df99ada2afa33db3efd295ba9de5d68b3ecc5ce1dc3361d042'
++            'SKIP'
++            'SKIP')
+ b2sums=('SKIP'
+-        'ccddc04ab83d4dcf570d5a89e43fc27d36e2010513b36d9eb2fcdea71ceb5dba96a064a1cbca9ffdecf17fb5b9cb22cfe89eae4ee3a188547a4ab6fa6b4e2983')
++        'ccddc04ab83d4dcf570d5a89e43fc27d36e2010513b36d9eb2fcdea71ceb5dba96a064a1cbca9ffdecf17fb5b9cb22cfe89eae4ee3a188547a4ab6fa6b4e2983'
++        'SKIP'
++        'SKIP')
+ validpgpkeys=('B00B48BC731AA8840FED9FB0EED266B70F4FEF10') # Peter Jones <pjones@redhat.com>
+ 
+ prepare() {
+@@ -29,6 +35,8 @@
+   cd "${pkgname}"
+   # fix issues with linker scripts: https://github.com/rhboot/efivar/pull/201
+   patch -Np1 -i ../"${pkgname}-38-ld_t.patch"
++  patch -Np1 -i ../"${pkgname}-38-march-native.patch"
++  patch -Np1 -i ../"${pkgname}-38-glibc-mount.patch"
+ }
+ 
+ build() {


### PR DESCRIPTION
Add two patches from upstream. One is to fix build issue with RISCV64, the other is to fix build issue with glibc 2.36. The later one is also needed in ArchLinux official repository. So, I also sent a patch to ArchLinux.

https://bugs.archlinux.org/task/75702

