### PR TITLE
addpkg: system-config-printer

### DIFF
--- a/system-config-printer/riscv64.patch
+++ b/system-config-printer/riscv64.patch
@@ -1,0 +1,24 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -10,7 +10,7 @@ arch=('x86_64')
+ license=('GPL')
+ depends=('python-pycups' 'python-dbus' 'python-pycurl' 'libnotify'
+          'python-gobject' 'gtk3' 'python-cairo')
+-makedepends=('xmlto' 'docbook-xsl' 'desktop-file-utils' 'libsecret')
++makedepends=('xmlto' 'docbook-xsl' 'desktop-file-utils' 'libsecret' 'autoconf-archive')
+ optdepends=('libsecret: password management'
+             'python-pysmbc: SMB browser support'
+             'cups-pk-helper: PolicyKit helper to configure cups with fine-grained privileges')
+@@ -20,6 +20,12 @@ sha256sums=('dc9c8ad03f7983962ddf0ef05621c948370bd1763cd90c3dcff672280aa2d6e6')
+ #            'SKIP')
+ #validpgpkeys=('7ADB58203CA5F046F28025B215AA6A7F4D4227D7') # "Zdenek Dohnal (Associate Software Engineer) <zdohnal@redhat.com>"
+ 
++prepare() {
++  cd ${pkgname}-${pkgver}
++  autoupdate
++  autoreconf -fiv
++}
++
+ build() {
+   cd ${pkgname}-${pkgver}
+ 


### PR DESCRIPTION
Fix `config.guess`.
But here is one point needs to be noticed:

After `autoupdate` and `autoreconf -fiv` it occurred the same error as `libopenraw`. That is lack of some m4 macros due to the old `config.guess`. 

So I referred the suggestion of `libopenraw`'s upstream: added `autoconf-archive`.
After this pull request I will issue the upstream to update files.

I don't know my management is correct or not.
If it is right, I think it can be added to the wiki to notify the later packagers: how to fix the bash script errors (If is m4 macros related) after `autoreconf -fiv`.

Build passed.

### Perhaps useful links:
[Blog of fixing `libopenraw`](https://tinysnow.github.io/%E6%8A%80%E6%9C%AF/ArchRISC-V/Packages/libopenraw.html)
[`libopenraw's upstream`](https://gitlab.freedesktop.org/libopenraw/libopenraw/-/issues/11#note_1457831)