### PR TITLE
addpatch: autotiling-rs 0.1.3-1

### DIFF
--- a/autotiling-rs/riscv64.patch
+++ b/autotiling-rs/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,7 +15,7 @@ b2sums=('3bffa4f9beef917c1ac731507e61ac716164829b1ce038e20708ca8d0511dd9a4382716
+ 
+ prepare() {
+   cd ${pkgname}-${pkgver}
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  cargo fetch --locked
+ }
+ 
+ build() {


### PR DESCRIPTION
Fix error:

```
error: failed to run `rustc` to learn about target-specific information

Caused by:
  process didn't exit successfully: `rustc - --crate-name ___ --print=file-names --target riscv64-unknown-linux-gnu --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=cfg` (exit status: 1)
  --- stderr
  error: Error loading target specification: Could not find specification for target "riscv64-unknown-linux-gnu". Run `rustc --print target-list` for a list of built-in targets
```