### PR TITLE
addpatch: gap

### DIFF
--- a/gap/riscv64.patch
+++ b/gap/riscv64.patch
@@ -1,0 +1,18 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -51,6 +51,15 @@ prepare() {
+   cd CddInterface-*
+   sed -e 's|/usr/include/cdd|/usr/include/cddlib|' -i configure.ac # Fix build with cddlib 0.94k
+   rm configure
++  cd ..
++
++# Update the config.guess file
++  vendors=( "xgap-4.30" "DeepThought-1.0.2" "ZeroMQInterface-0.12" )
++  for v in "${vendors[@]}"; do
++      pushd $v
++      autoreconf -fiv
++      popd
++  done
+ }
+ 
+ build() {


### PR DESCRIPTION
There are three vendor libraries using old config.guess file. This patch
add a batch update script for those config.guess file before building
the gap project.

Signed-off-by: Avimitin <avimitin@gmail.com>