### PR TITLE
addpkg: python-doublex-expects

### DIFF
--- a/python-doublex-expects/riscv64.patch
+++ b/python-doublex-expects/riscv64.patch
@@ -1,0 +1,11 @@
+-- PKGBUILD
++++ PKGBUILD
+@@ -9,7 +9,7 @@
+ url="https://github.com/jaimegildesagredo/doublex-expects"
+ depends=('python-doublex' 'python-expects')
+ makedepends=('python-setuptools')
+-checkdepends=('python-mamba')
++checkdepends=('python-mamba' 'python-six')
+ source=("$pkgname-$pkgver.tar.gz::https://github.com/jaimegildesagredo/doublex-expects/archive/v$pkgver.tar.gz")
+ sha512sums=('2aaff2e58556ed9eb91ebb418e65058367411e011e843afb5adb08ab69705b6bdfb478d3052aae093ad1c1a1b49ba1e084e4c5510acde4874182a658330e3448')
+ 


### PR DESCRIPTION
Fix python ModuleNotFoundError.
Bug reported: https://bugs.archlinux.org/task/75729