### PR TITLE
addpatch: borg

### DIFF
--- a/borg/riscv64.patch
+++ b/borg/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -30,7 +30,7 @@ build() {
+ }
+ 
+ check() {
+-  cd "$_pkgname-$pkgver/build/lib.linux-$CARCH-cpython-"*/
++  cd "$_pkgname-$pkgver/build/lib.linux-$CARCH"*/
+   PYTHONPATH=$PWD PYTHONDONTWRITEBYTECODE=1 pytest -k 'not benchmark'
+ }
+ 


### PR DESCRIPTION
The packager script won't generate "-cpython-" suffix for the build
directory in riscv64. The build artifacts is still the same.

Signed-off-by: Avimitin <avimitin@gmail.com>