### PR TITLE
addpatch: srs-state-thread

### DIFF
--- a/srs-state-threads/riscv-cpu-support.patch
+++ b/srs-state-threads/riscv-cpu-support.patch
@@ -1,0 +1,102 @@
+diff --git a/md.h b/md.h
+index 51e8b25..703e783 100644
+--- a/md.h
++++ b/md.h
+@@ -186,6 +186,10 @@
+             /* https://github.com/ossrs/state-threads/issues/21 */
+             #define MD_USE_BUILTIN_SETJMP
+             #define MD_GET_SP(_t) *((long *)&((_t)->context[0].__jb[0]))
++        #elif defined(__riscv)
++            /* https://github.com/ossrs/state-threads/pull/28 */
++            #define MD_USE_BUILTIN_SETJMP
++            #define MD_GET_SP(_t) *((long *)&((_t)->context[0].__jmpbuf[0]))
+ 
+         #elif defined(__loongarch__)
+             /* https://github.com/ossrs/state-threads/issues/24 */
+diff --git a/md_linux.S b/md_linux.S
+index adcee5a..2c66618 100644
+--- a/md_linux.S
++++ b/md_linux.S
+@@ -352,6 +352,82 @@
+ 
+ 
+ 
++#elif defined(__riscv)
++
++    /****************************************************************/
++    /*
++     * Internal __jmp_buf layout
++     * riscv-asm: https://github.com/riscv/riscv-asm-manual/blob/master/riscv-asm.md
++     */
++    #define JB_SP  0    /* A0, SP, Stack pointer */
++    #define JB_RA  1    /* RA, Return address */
++    #define JB_FP  2    /* FP/S0 Frame pointer */
++    #define JB_S1  3    /* S1 Saved register*/
++    #define JB_S2  4    /* S2-S11,  Saved register */
++    #define JB_S3  5    /* S2-S11,  Saved register */
++    #define JB_S4  6    /* S2-S11,  Saved register */
++    #define JB_S5  7    /* S2-S11,  Saved register */
++    #define JB_S6  8    /* S2-S11,  Saved register */
++    #define JB_S7  9    /* S2-S11,  Saved register */
++    #define JB_S8  10    /* S2-S11,  Saved register */
++    #define JB_S9  11   /* S2-S11,  Saved register */
++    #define JB_S10 12   /* S2-S11,  Saved register */
++    #define JB_S11 13   /* S2-S11,  Saved register */
++
++
++    	.file "md_linux.S"
++    	.text
++
++    	/* _st_md_cxt_save(__jmp_buf env) */ /* The env is $a0, https://en.wikipedia.org/wiki/RISC-V#Register_sets */
++    	.globl _st_md_cxt_save
++    	.type _st_md_cxt_save, %function
++    	.align 2
++    _st_md_cxt_save:
++	sd    sp,  JB_SP  * 8(a0)
++	sd    ra,  JB_RA  * 8(a0)
++	sd    s0,  JB_FP  * 8(a0)
++	sd    s1,  JB_S1  * 8(a0)
++	sd    s2,  JB_S2  * 8(a0)
++	sd    s3,  JB_S3  * 8(a0)
++	sd    s4,  JB_S4  * 8(a0)
++	sd    s5,  JB_S5  * 8(a0)
++	sd    s6,  JB_S6  * 8(a0)
++	sd    s7,  JB_S7  * 8(a0)
++	sd    s8,  JB_S8  * 8(a0)
++	sd    s9,  JB_S9  * 8(a0)
++	sd    s10, JB_S10 * 8(a0)
++	sd    s11, JB_S11 * 8(a0)
++	li    a0,  0
++	jr    ra
++    	.size _st_md_cxt_save, .-_st_md_cxt_save
++
++    /****************************************************************/
++
++    	/* _st_md_cxt_restore(__jmp_buf env, int val) */
++    	.globl _st_md_cxt_restore
++    	.type _st_md_cxt_restore, %function
++    	.align 2
++    _st_md_cxt_restore:
++	ld        sp,  JB_SP  * 8(a0)
++	ld        ra,  JB_RA  * 8(a0)
++	ld        s0,  JB_FP  * 8(a0)
++	ld        s1,  JB_S1  * 8(a0)
++	ld        s2,  JB_S2  * 8(a0)
++	ld        s3,  JB_S3  * 8(a0)
++	ld        s4,  JB_S4  * 8(a0)
++	ld        s5,  JB_S5  * 8(a0)
++	ld        s6,  JB_S6  * 8(a0)
++	ld        s7,  JB_S7  * 8(a0)
++	ld        s8,  JB_S8  * 8(a0)
++	ld        s9,  JB_S9  * 8(a0)
++	ld        s10, JB_S10 * 8(a0)
++	ld        s11, JB_S11 * 8(a0)
++	li        a0,  1
++	jr        ra
++    	.size _st_md_cxt_restore, .-_st_md_cxt_restore
++
++    /****************************************************************/
++
+ 
+ 
+ 

--- a/srs-state-threads/riscv64.patch
+++ b/srs-state-threads/riscv64.patch
@@ -1,0 +1,23 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -10,13 +10,18 @@ arch=('x86_64')
+ url="https://github.com/ossrs/state-threads/"
+ license=('GPL2' 'MPL')
+ makedepends=('git')
+-source=("git+https://github.com/ossrs/state-threads/#commit=${_pkgcommit}")
+-sha256sums=('SKIP')
++source=("git+https://github.com/ossrs/state-threads/#commit=${_pkgcommit}"
++        "riscv-cpu-support.patch")
++sha256sums=('SKIP'
++            '87fe9d0a5fd988d2f6458b35a0d644a58e8399f691e082d6f5d5a3844e0d98fb')
+ 
+ prepare() {
+   cd "${srcdir}"/state-threads
+   ldFlags="$(echo "$LDFLAGS" | sed 's|-Wl,||;s|,| |g') -z noexecstack"
+   sed -ie "s|LDFLAGS     =|LDFLAGS     = ${ldFlags}|" Makefile
++
++  # add riscv support
++  patch -Ni "$srcdir/riscv-cpu-support.patch"
+ }
+ 
+ build() {


### PR DESCRIPTION
This patch adds RISC-V CPU support from upstream:
https://github.com/ossrs/state-threads/pull/28.

The README.md file was changed after the latest version and the
original patch can't be applied on it, so a modified local patch is also
submit here.

Signed-off-by: Avimitin <avimitin@gmail.com>