### PR TITLE
noqemu: fulcio

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -21,6 +21,7 @@ fd
 findutils
 fish
 foot
+fulcio
 gauche
 gdk-pixbuf2
 glib-perl


### PR DESCRIPTION
Test "cmd/app/http_test" fail to pass on qemu-user.
But it successfully passes on RISC-V board.
It fails to create a new server due to the invalid listen address.
The address was created correctly but turned into the string
"passthrough:///:0\x00\x00\x00\x00\x00\x00" in [line 58].

The strings.Replace function has some unknown problem in qemu-user.
And it can work as expect if we flush the stdout:

```diff
+	os.Stdout.Sync()
	grpcServer.grpcServerEndpoint = strings.Replace(grpcServer.grpcServerEndpoint, "::", "localhost", 1)
```

I am still digging the reason and trying to make a minimal reproducible code.

[line 58]: https://github.com/sigstore/fulcio/blob/v0.5.2/cmd/app/http_test.go#L58

Signed-off-by: Avimitin <avimitin@gmail.com>