### PR TITLE
addpkg: iftop

### DIFF
--- a/iftop/riscv64.patch
+++ b/iftop/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -19,6 +19,8 @@ sha512sums=('abd74e8025bb82fef9ebab4997b1d018201a523d47c0128128ca37797490046538d
+ 
+ prepare() {
+   cd $pkgname-$pkgver
++  autoupdate
++  autoreconf -fiv
+   # FS#75357
+   patch -p0 -i ../mac-address-fix.patch
+ }


### PR DESCRIPTION
The upstream has maintain a self-owned gitlab instance.
And there is no entry point to approach their repo to report bug because of the lack of signing up page.
I will try my best to get another way.

Fixed `config.guess` trivial.