### PR TITLE
Updpatch: firefox

### DIFF
--- a/firefox/riscv64.patch
+++ b/firefox/riscv64.patch
@@ -1,4 +1,4 @@
---- PKGBUILD	(revision 454659)
+--- PKGBUILD	(revision 455021)
 +++ PKGBUILD	(working copy)
 @@ -12,8 +12,7 @@
  depends=(gtk3 libxt mime-types dbus-glib ffmpeg nss ttf-font libpulse)
@@ -15,14 +15,14 @@
  source=(https://archive.mozilla.org/pub/firefox/releases/$pkgver/source/firefox-$pkgver.source.tar.xz{,.asc}
          zstandard-0.18.0.diff arc4random.diff
 +        makotokato-riscv64-support-and-zenithal-backported.patch
-+        https://raw.githubusercontent.com/alexfanqi/riscv/master/www-client/firefox/files/firefox-disable-vet-hack.patch
++        https://raw.githubusercontent.com/gentoo/riscv/master/www-client/firefox/files/firefox-riscv64-hack.patch
          $pkgname.desktop identity-icons-brand.svg)
- sha256sums=('1a294a651dc6260f9a72a3ab9f10e7792a4ab41a9cfa8527ad3dd9979cdc98ce'
+ sha256sums=('f23f4198bd9ba1bbb7420a622080301adb924fafbd6d83b00b1e6cc687e75f4e'
              'SKIP'
              'a6857ad2f2e2091c6c4fdcde21a59fbeb0138914c0e126df64b50a5af5ff63be'
              '714ca50b2ce0cac470dbd5a60e9a0101b28072f08a5e7a9bba94fef2058321c4'
 +            '95d79a8dfdd2742ce34a4194804162bdeea7060121fb4e393c4384d50ba5bd98'
-+            'cf1c1269b3dcd0f9c028d13ce11f000953c9ddafbecf53b6dfef785e8fb7347b'
++            '94ab3debdae0eda1aa8fe1c600d7ada76a4b9211ff2578632cc1fac53e75060c'
              '298eae9de76ec53182f38d5c549d0379569916eebf62149f9d7f4a7edef36abf'
              'a9b8b4a0a1f4a7b4af77d5fc70c2686d624038909263c795ecc81e0aec7711e9')
  validpgpkeys=('14F26682D0916CDD81E37B6D61B7B526D98F0353') # Mozilla Software Releases <release@mozilla.com>
@@ -30,7 +30,7 @@
    # Unbreak build with glibc 2.36
    patch -Np1 -i ../arc4random.diff
  
-+  patch -Np1 -i ../firefox-disable-vet-hack.patch
++  patch -Np1 -i ../firefox-riscv64-hack.patch
 +  patch -Np1 -i ../makotokato-riscv64-support-and-zenithal-backported.patch
 +
    echo -n "$_google_api_key" >google-api-key
@@ -83,7 +83,14 @@
  ac_add_options --disable-updater
  ac_add_options --disable-tests
  END
-@@ -110,39 +124,42 @@
+@@ -104,45 +118,48 @@
+   export MOZ_NOSPAM=1
+   export MOZBUILD_STATE_PATH="$srcdir/mozbuild"
+   export MOZ_ENABLE_FULL_SYMBOLS=1
+-  export MACH_BUILD_PYTHON_NATIVE_PACKAGE_SOURCE=system
++  export MACH_BUILD_PYTHON_NATIVE_PACKAGE_SOURCE=pip
+ 
+   # LTO needs more open files
    ulimit -n 4096
  
    # Do 3-tier PGO


### PR DESCRIPTION
1. Updpkg: firefox 104.0.1
2. Replace `firefox-disable-vet-hack.patch` with `firefox-riscv64-hack.patch`. from: https://github.com/gentoo/riscv/pull/8
3. set `MACH_BUILD_PYTHON_NATIVE_PACKAGE_SOURCE=pip` to solve the problem of failed build environment detection. from: https://bugs.archlinux.org/task/75796