### PR TITLE
addpkg: link-grammar

### DIFF
--- a/link-grammar/riscv64.patch
+++ b/link-grammar/riscv64.patch
@@ -1,0 +1,21 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -9,7 +9,7 @@ arch=('x86_64')
+ url="https://www.abisource.com/projects/link-grammar/"
+ license=('LGPL')
+ depends=('hunspell' 'sqlite' 'libedit')
+-makedepends=('python' 'swig' 'apache-ant' 'java-environment=11')
++makedepends=('python' 'swig' 'apache-ant' 'java-environment=11' 'autoconf-archive')
+ options=('!makeflags')
+ source=(https://www.abisource.com/downloads/${pkgname}/${pkgver}/${pkgname}-${pkgver}.tar.gz{,.asc})
+ validpgpkeys=('6407453C98BECC19ADB03D82EB6AA534E0C0651C'
+@@ -19,7 +19,8 @@ sha256sums=('324710cd8132975ff9ccb53509732f7558473b1c19f17892000a3dedb8618aed'
+ 
+ prepare() {
+   cd "${srcdir}/${pkgname}-${pkgver}"
+-
++  autoupdate
++  autoreconf -fiv
+   # Fix build with Python 3.10
+   sed -i '/test -n "$lg_python_unusable" && PythonFound=no/d' configure
+ }


### PR DESCRIPTION
Fix `config.guess` trivial.
Notice: `m4` macros not found, so added `autoconf-archive` to `makedepends`.
