### PR TITLE
ignore: hplip

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -4,6 +4,7 @@ cudnn
 dart
 discord
 discord-canary
+hplip
 nvidia
 nvidia-cg-toolkit
 nvidia-dkms


### PR DESCRIPTION
Failing logs:
```
/usr/bin/ld: skipping incompatible ./prnt/hpcups//libImageProcessor.so when searching for -lImageProcessor
/usr/bin/ld: cannot find -lImageProcessor: No such file or directory
/usr/bin/ld: skipping incompatible ./prnt/hpcups//libImageProcessor.so when searching for -lImageProcessor
collect2: error: ld returned 1 exit status
make: *** [Makefile:6156: hpcups] Error 1
```

This package can be built on x86 because there are two prebuilt .so files `prnt/hpcups/libImageProcessor-x86_{32|64}.so`. I have filed an [issue](https://bugs.launchpad.net/hplip/+bug/1988824) to upstream. However, there is an [issue](https://bugs.launchpad.net/hplip/+bug/1815899) to request a prebuilt .so for ARM[2], and still no response yet. I think it is appropriate to blacklist hplip.