### PR TITLE
updpatch: gnuradio

### DIFF
--- a/gnuradio/riscv64.patch
+++ b/gnuradio/riscv64.patch
@@ -1,12 +1,13 @@
-diff --git PKGBUILD PKGBUILD
-index 14f7aba..a9c350c 100644
---- PKGBUILD
-+++ PKGBUILD
-@@ -10,6 +10,7 @@ pkgdesc="General purpose DSP and SDR toolkit.  With drivers for usrp and fcd."
- arch=('x86_64')
- url="https://gnuradio.org"
- license=('GPL')
-+options=(!lto)
- depends=('python-numpy' 'gsl' 'blas' 'libuhd' 'libvolk' 'log4cpp' 'python-yaml'
-     'gmp' 'gsm' 'codec2' 'python-mako' 'python-click-plugins' 'soapysdr'
-     'pybind11')
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1294153)
++++ PKGBUILD	(working copy)
+@@ -15,7 +15,7 @@
+     'pybind11' 'libsndfile' 'spdlog')
+ makedepends=('alsa-lib' 'boost' 'cmake' 'fftw' 'glu' 'gtk3' 'jack' 'pango'
+     'portaudio' 'python-gobject' 'python-lxml' 'python-pyqt5' 'python-cairo'
+-    'python-jsonschema' 'qwt' 'zeromq')
++    'python-jsonschema' 'qwt' 'zeromq' 'python-packaging')
+ 
+ # todo
+ # split the gui components?


### PR DESCRIPTION
This package fails to build on x86_64 as well. The problem is the same which is lacking a makedepends.
More details here: https://bugs.archlinux.org/task/75819