### PR TITLE
updpatch: mold

### DIFF
--- a/mold/riscv64.patch
+++ b/mold/riscv64.patch
@@ -3,8 +3,8 @@
 @@ -42,11 +42,20 @@ build() {
  check() {
    cd "$pkgname"
-
-+  for failing_test in lto-gcc gnu-unique package-metadata tls-common
+ 
++  for failing_test in lto-gcc gnu-unique package-metadata tls-common riscv-norvc tail-call
 +  do
 +    rm -vf "test/elf/$failing_test.sh"
 +  done
@@ -20,3 +20,4 @@
 +    TEST_GXX=clang++ \
      check
  }
+ 


### PR DESCRIPTION
clang 14.0.6 accidentally dismissed -mrelax option on riscv64, resulting in unexpected failure of the two new test cases