### PR TITLE
addpkg: arti

### DIFF
--- a/arti/riscv64.patch
+++ b/arti/riscv64.patch
@@ -1,0 +1,13 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -16,7 +16,9 @@ options=('!lto')
+ prepare() {
+   mv "$pkgname-$pkgname-v$pkgver" "$pkgname-$pkgver"
+   cd "$pkgname-$pkgver"
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
++  cargo update -p ring
++  cargo fetch --locked 
+ }
+ 
+ build() {


### PR DESCRIPTION
Fixed `--target "$CARCH-unknown-linux-gnu"`, and after this it occurred `ring` fault, so fixed in passing.