### PR TITLE
addpatch: fq

### DIFF
--- a/fq/riscv64.patch
+++ b/fq/riscv64.patch
@@ -1,0 +1,21 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -11,11 +11,16 @@ license=('MIT')
+ depends=('glibc')
+ checkdepends=('expect')
+ makedepends=('go' 'git')
+-source=(${pkgname}-${pkgver}.tar.gz::"${url}/archive/v${pkgver}.tar.gz")
+-sha256sums=('abcc1292af007b8405cc924e3db0dc4e1838c6a851661f6388dce1a35fa7e8b6')
++source=(${pkgname}-${pkgver}.tar.gz::"${url}/archive/v${pkgver}.tar.gz"
++        ${pkgname}-makefile-go-test-race.patch::https://github.com/wader/fq/pull/420.patch)
++sha256sums=('abcc1292af007b8405cc924e3db0dc4e1838c6a851661f6388dce1a35fa7e8b6'
++            '0774908f5f9ddcade8f3f7506159d959256bcbd27674866b13f13746fa3c282a')
+ 
+ prepare() {
+   cd "${pkgname}-${pkgver}"
++
++  patch -Np1 -i ${srcdir}/${pkgname}-makefile-go-test-race.patch
++
+   mkdir -p dist/
+ }
+ 


### PR DESCRIPTION
Upstream PR: wader/fq#420

This would prevent running `go test` with `-race` via `make test`, which is not supported on `linux/riscv64`.