### PR TITLE
addpkg: distrobuilder

### DIFF
--- a/distrobuilder/fix-static-declaration-of-lxd.patch
+++ b/distrobuilder/fix-static-declaration-of-lxd.patch
@@ -1,0 +1,106 @@
+From d83f061a21f509d42b7a334b97403d2a019a7b52 Mon Sep 17 00:00:00 2001
+From: Christian Brauner <brauner@kernel.org>
+Date: Tue, 9 Aug 2022 12:02:58 +0200
+Subject: [PATCH] cgo: ensure that lxd wrappers don't conflict with libc
+ provided wrapper
+
+Fixes: #10738
+Signed-off-by: Christian Brauner (Microsoft) <brauner@kernel.org>
+---
+ lxd/include/process_utils.h    |  8 ++++----
+ lxd/include/syscall_wrappers.h | 11 ++++++-----
+ lxd/main_checkfeature.go       |  8 ++++----
+ lxd/main_forkmount.go          |  2 +-
+ lxd/main_forksyscall.go        |  2 +-
+ lxd/main_nsexec.go             |  6 +++---
+ lxd/seccomp/seccomp.go         |  2 +-
+ shared/idmap/shift_linux.go    |  4 ++--
+ shared/util_linux_cgo.go       |  4 ++--
+ 9 files changed, 24 insertions(+), 23 deletions(-)
+
+diff --git a/lxd/include/process_utils.h b/lxd/include/process_utils.h
+index da6774a7ebac..2544aea80132 100644
+--- a/lxd/include/process_utils.h
++++ b/lxd/include/process_utils.h
+@@ -18,20 +18,20 @@
+ #include "memory_utils.h"
+ #include "syscall_numbers.h"
+ 
+-static inline int pidfd_open(pid_t pid, unsigned int flags)
++static inline int lxd_pidfd_open(pid_t pid, unsigned int flags)
+ {
+ 	return syscall(__NR_pidfd_open, pid, flags);
+ }
+ 
+-static inline int pidfd_send_signal(int pidfd, int sig, siginfo_t *info,
+-				    unsigned int flags)
++static inline int lxd_pidfd_send_signal(int pidfd, int sig, siginfo_t *info,
++					unsigned int flags)
+ {
+ 	return syscall(__NR_pidfd_send_signal, pidfd, sig, info, flags);
+ }
+ 
+ static inline bool process_still_alive(int pidfd)
+ {
+-	return pidfd_send_signal(pidfd, 0, NULL, 0) == 0;
++	return lxd_pidfd_send_signal(pidfd, 0, NULL, 0) == 0;
+ }
+ 
+ static inline int wait_for_pid(pid_t pid)
+diff --git a/lxd/include/syscall_wrappers.h b/lxd/include/syscall_wrappers.h
+index 0802352d97f7..d05604b4b25e 100644
+--- a/lxd/include/syscall_wrappers.h
++++ b/lxd/include/syscall_wrappers.h
+@@ -27,7 +27,7 @@ static inline int lxd_close_range(unsigned int fd, unsigned int max_fd, unsigned
+ 	return syscall(__NR_close_range, fd, max_fd, flags);
+ }
+ 
+-static inline int open_tree(int dfd, const char *filename, unsigned int flags)
++static inline int lxd_open_tree(int dfd, const char *filename, unsigned int flags)
+ {
+ 	return syscall(__NR_open_tree, dfd, filename, flags);
+ }
+@@ -42,14 +42,15 @@ struct lxc_mount_attr {
+ 	__u64 userns_fd;
+ };
+ 
+-static inline int mount_setattr(int dfd, const char *path, unsigned int flags,
+-				struct lxc_mount_attr *attr, size_t size)
++static inline int lxd_mount_setattr(int dfd, const char *path, unsigned int flags,
++				    struct lxc_mount_attr *attr, size_t size)
+ {
+ 	return syscall(__NR_mount_setattr, dfd, path, flags, attr, size);
+ }
+ 
+-static inline int move_mount(int from_dfd, const char *from_pathname, int to_dfd,
+-			     const char *to_pathname, unsigned int flags)
++static inline int lxd_move_mount(int from_dfd, const char *from_pathname,
++				 int to_dfd, const char *to_pathname,
++				 unsigned int flags)
+ {
+ 	return syscall(__NR_move_mount, from_dfd, from_pathname, to_dfd,
+ 		       to_pathname, flags);
+ 	*bpf_prog_type = attr.prog_type;
+ 
+diff --git a/shared/util_linux_cgo.go b/shared/util_linux_cgo.go
+index 9e53a2413e62..9b3f691c8c0a 100644
+--- a/shared/util_linux_cgo.go
++++ b/shared/util_linux_cgo.go
+@@ -78,7 +78,7 @@ func unCloexec(fd int) error {
+ }
+ 
+ func PidFdOpen(Pid int, Flags uint32) (*os.File, error) {
+-	pidFd, errno := C.pidfd_open(C.int(Pid), C.uint32_t(Flags))
++	pidFd, errno := C.lxd_pidfd_open(C.int(Pid), C.uint32_t(Flags))
+ 	if errno != nil {
+ 		return nil, errno
+ 	}
+@@ -92,7 +92,7 @@ func PidFdOpen(Pid int, Flags uint32) (*os.File, error) {
+ }
+ 
+ func PidfdSendSignal(Pidfd int, Signal int, Flags uint32) error {
+-	ret, errno := C.pidfd_send_signal(C.int(Pidfd), C.int(Signal), nil, C.uint32_t(Flags))
++	ret, errno := C.lxd_pidfd_send_signal(C.int(Pidfd), C.int(Signal), nil, C.uint32_t(Flags))
+ 	if ret != 0 {
+ 		return errno
+ 	}

--- a/distrobuilder/riscv64.patch
+++ b/distrobuilder/riscv64.patch
@@ -1,0 +1,25 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -26,15 +26,19 @@ optdepends=(
+   'hivex: for repack-windows command'
+   'wimlib: for repack-windows command'
+ )
+-source=("$url/releases/download/$pkgname-$pkgver/$pkgname-$pkgver.tar.gz"{,.asc})
++source=("$url/releases/download/$pkgname-$pkgver/$pkgname-$pkgver.tar.gz"{,.asc}
++        "fix-static-declaration-of-lxd.patch")
+ sha512sums=('80184d27305f5659f1367563161220b966b1957810da61e8f3b9f32cf408795319b43dd650bc9f867b3ac73ef2b3251972bb11999d92feb34bfd9cdae7ff7b7b'
+-            'SKIP')
++            'SKIP'
++            '04f5bbdcb4643de97fca51c7272f04cf5518d62ca7f09d4e559ba103c8639ac8cfcd84c5bb4405447364522e42cae9dac9c3b412bc89561472f0524cbd73969f')
+ b2sums=('90e82a20a3ef61d13148951956bb1f74cc3494ca86e339c188a1c9009dcb27c0cb9a298c639c6de891df67915b48d107557f6b698a45cbe35c54d41a45bac1ab'
+-        'SKIP')
++        'SKIP'
++        '1935f38101344ac803d70352afde9f5e0b95352cfd74cf95b87630562731bc2bd2704e73a82fb786e7beb28971d2bde74a7093c9b8b16ca36de4798a5e919b85')
+ validpgpkeys=('602F567663E593BCBD14F338C638974D64792D67') # Stéphane Graber <stgraber@stgraber.org>
+ 
+ prepare() {
+   cd "$pkgname-$pkgver"
++  patch -p1 -i ${srcdir}/fix-static-declaration-of-lxd.patch -d ${srcdir}/distrobuilder-2.1/vendor/github.com/lxc/lxd
+ 
+   # create folder for build output
+   mkdir build


### PR DESCRIPTION
Tough work. Build passed.

1. The `fix-static-declaration-of-lxd` patch is from the upstream of `lxd`, which is really crashed in `distrobuilder` building proeessing.
2. Delete the exceeded and needless change in upstream's patch.
  _i.e._ `lxd/main_checkfeature.go`(In `distrobuilder`, this file doesn't exist.)
3. Patch and this PR.

### Notice

The patch file is altered by TinySnow.
Patch from origin upstream doesn't work.

### Perhaps Useful Links

- `lxd` issue: https://github.com/lxc/lxd/issues/10738
- `lxd` PR: https://github.com/lxc/lxd/pull/10756