### PR TITLE
addpatch: hplip

### DIFF
--- a/hplip/riscv64.patch
+++ b/hplip/riscv64.patch
@@ -1,0 +1,13 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 455744)
++++ PKGBUILD	(working copy)
+@@ -78,7 +78,7 @@
+  ./configure --prefix=/usr \
+              --enable-qt5 \
+              --disable-qt4 \
+-             --enable-hpcups-install \
++             --disable-hpcups-install \
+              --enable-cups-drv-install \
+              --disable-imageProcessor-build \
+              --enable-pp-build #--help


### PR DESCRIPTION
Failing reason is described in #1665

We can disable hpcups install to avoid libImageProcessor.