### PR TITLE
addpatch: freeipmi 1.6.10-1

### DIFF
--- a/freeipmi/riscv64.patch
+++ b/freeipmi/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -37,7 +37,7 @@ validpgpkeys=('A865A9FB6F0387624468543A3EFB7C4BE8303927') # Albert Chu <chu11@ll
+ prepare() {
+   cd "$pkgname-$pkgver"
+ 
+-  autoreconf -vi
++  autoreconf -vif
+ 
+   ./configure \
+     --prefix=/usr \


### PR DESCRIPTION
Fix error:

```
checking build system type... ./config/config.guess: unable to guess system type

This script, last modified 2013-06-10, has failed to recognize
the operating system you are using. It is advised that you
download the most up to date version of the config scripts from

  http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD
and
  http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD

If the version you run (./config/config.guess) is already up to date, please
send the following data and any information you think might be
pertinent to <config-patches@gnu.org> in order to provide the needed
information to handle your system.

config.guess timestamp = 2013-06-10

uname -m = riscv64
uname -r = 5.19.2-arch1-2
uname -s = Linux
uname -v = #1 SMP PREEMPT_DYNAMIC Sat, 20 Aug 2022 16:11:19 +0000

/usr/bin/uname -p = unknown
/bin/uname -X     = 

hostinfo               = 
/bin/universe          = 
/usr/bin/arch -k       = 
/bin/arch              = 
/usr/bin/oslevel       = 
/usr/convex/getsysinfo = 

UNAME_MACHINE = riscv64
UNAME_RELEASE = 5.19.2-arch1-2
UNAME_SYSTEM  = Linux
UNAME_VERSION = #1 SMP PREEMPT_DYNAMIC Sat, 20 Aug 2022 16:11:19 +0000
configure: error: cannot guess build type; you must specify one
```