### PR TITLE
addpatch: hplip

### DIFF
--- a/hplip/0028-Remove-ImageProcessor-binary-installs.patch
+++ b/hplip/0028-Remove-ImageProcessor-binary-installs.patch
@@ -1,0 +1,38 @@
+diff '--color=auto' -ur a/Makefile.am b/Makefile.am
+--- a/Makefile.am	2022-09-10 23:10:43.591993064 +0200
++++ b/Makefile.am	2022-09-10 23:14:34.395559134 +0200
+@@ -167,7 +167,7 @@
+ dist_hplip_SCRIPTS = hpssd.py __init__.py hpdio.py
+ endif #HPLIP_CLASS_DRIVER
+ 
+-dist_noinst_DATA += prnt/drv/hpijs.drv.in.template prnt/drv/hpcups.drv.in.template prnt/hpcups/libImageProcessor-x86_64.so prnt/hpcups/libImageProcessor-x86_32.so
++dist_noinst_DATA += prnt/drv/hpijs.drv.in.template prnt/drv/hpcups.drv.in.template
+ 
+ dist_noinst_DATA += prnt/ipp-usb/HPLIP.conf
+ dist_noinst_SCRIPTS += dat2drv.py install.py  hplip-install init-suse-firewall init-iptables-firewall class_rpm_build.sh hplipclassdriver.spec createPPD.sh Makefile_dat2drv hpijs-drv
+@@ -597,7 +597,7 @@
+ 	prnt/hpcups/ImageProcessor.h
+ 
+ hpcups_CXXFLAGS = $(APDK_ENDIAN_FLAG) $(DBUS_CFLAGS)
+-hpcups_LDADD = -L./prnt/hpcups/ -ljpeg -ldl -lImageProcessor -lcups -lcupsimage -lz $(DBUS_LIBS)
++hpcups_LDADD = -L./prnt/hpcups/ -ljpeg -ldl -lcups -lcupsimage -lz $(DBUS_LIBS)
+ #else
+ #hpcupsdir = $(cupsfilterdir)
+ #hpcups_PROGRAMS = hpcups
+@@ -687,16 +687,6 @@
+ 
+ install-data-hook:
+ if HPLIP_BUILD
+-	if [ \( "$(UNAME)" = "x86_64" -a  -d "$(libdir)/" \) ]; then \
+-		cp prnt/hpcups/libImageProcessor-x86_64.so $(libdir)/ ; \
+-		chmod 775 $(libdir)/libImageProcessor-x86_64.so ; \
+-		ln -sf $(libdir)/libImageProcessor-x86_64.so $(libdir)/libImageProcessor.so ; \
+-	fi; \
+-	if [ \( \( "$(UNAME)" = "i686" -o "$(UNAME)" = "i386" \) -a -d "$(libdir)/" \) ]; then \
+-		cp prnt/hpcups/libImageProcessor-x86_32.so $(libdir)/ ; \
+-		chmod 775 $(libdir)/libImageProcessor-x86_32.so ; \
+-		ln -sf $(libdir)/libImageProcessor-x86_32.so $(libdir)/libImageProcessor.so ; \
+-	fi
+ 	if [ -d "/usr/share/ipp-usb/quirks/" ]; then \
+ 		echo "ipp-usb directory exists"; \
+ 		cp prnt/ipp-usb/HPLIP.conf /usr/share/ipp-usb/quirks/ ; \

--- a/hplip/riscv64.patch
+++ b/hplip/riscv64.patch
@@ -1,0 +1,39 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 455744)
++++ PKGBUILD	(working copy)
+@@ -33,7 +33,8 @@
+         # use the one from Fedora
+         hplip-configure-python.patch
+         python3.diff
+-        reproducible-gzip.patch)
++        reproducible-gzip.patch
++        0028-Remove-ImageProcessor-binary-installs.patch)
+ sha512sums=('cb25c07c767d3d8921468429ef154401a4df9d2fdf87ead3ab18f0d06e1bd3de610843b8131641a1af8d920c7e15e290a0923405bf609cdc0a3fba9df93ddb5e'
+             'SKIP'
+             'ee0bd240568a7dbb4dc6ef64dba28ea84c4bedf7d688d054960c686666f8f0bc4562961c40845107ef0c936e60d3e676bffb2a1ba708039690bb0520cda3a525'
+@@ -43,11 +44,13 @@
+             'b7e67bccb2516f4d98e4c5ea55f7d2299d95bfdc341dbc0149af1423169bedcd8bcfdb125c92f373e9e7be57ea284fef80a8343035fb42572b9cb927929cd257'
+             '089c102357ea5fd55d81ae76aaff62713f780fd84500c3b92ecd6b2bb11ccdc3a162978548e9a5f9e98a8354a5be3997e416c52daa18eda4621ed79a29d6fea8'
+             'b8a4c860e90a52ec566ca5a9c7f3a5ecb7386ae76e17b2c6c878073e60eeaf0cb63883b740b4725794be9914e1ab8fc91313efb288395f3095f599c07f54cf14'
+-            '379fcbe9dc2986da828a174a0ac4e71a1da43a98408894d5e713e09d7d9cba1e9fac30f9602b81d48d992abe6b65b6402b8a07664efe97400c5d839be33cf15f')
++            '379fcbe9dc2986da828a174a0ac4e71a1da43a98408894d5e713e09d7d9cba1e9fac30f9602b81d48d992abe6b65b6402b8a07664efe97400c5d839be33cf15f'
++            'ff2bd84cb620141304d09c60ffb5ee160a8a1955ce855db7f3711877ee0a6e75380a9041adb7f104a3cbdd5b8b0a595fb16bea4eb7b05265376738be3feb852e')
+ validpgpkeys=('4ABA2F66DBD5A95894910E0673D770CDA59047B9') # HPLIP (HP Linux Imaging and Printing) <hplip@hp.com>
+ 
+ prepare() {
+  cd "$pkgname"-$pkgver
++ rm -v prnt/hpcups/libImageProcessor*
+ 
+  # disable insecure update - https://bugs.archlinux.org/task/38083
+  patch -Np0 -i "${srcdir}"/disable_upgrade.patch
+@@ -69,6 +72,9 @@
+  # make gzip creation reproducible by removing the timestamp
+  patch -Np1 -i ../reproducible-gzip.patch
+ 
++ # don't link unnecessary prebuilt ImageProcessor library
++ patch -Np1 -i ../0028-Remove-ImageProcessor-binary-installs.patch
++
+  export AUTOMAKE='automake --foreign'
+  autoreconf --force --install
+ }


### PR DESCRIPTION
This patch is taken from https://salsa.debian.org/printing-team/hplip/-/blob/debian/main/debian/patches/0028-Remove-ImageProcessor-binary-installs.patch

Since not linking this library won't cause any link error, I think it's safe to do so.