### PR TITLE
updpatch: gcc

### DIFF
--- a/gcc/riscv64.patch
+++ b/gcc/riscv64.patch
@@ -1,17 +1,17 @@
-diff --git PKGBUILD PKGBUILD
-index 1952b31..37569f0 100644
---- PKGBUILD
-+++ PKGBUILD
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 455113)
++++ PKGBUILD	(working copy)
 @@ -7,7 +7,7 @@
  # toolchain build order: linux-api-headers->glibc->binutils->gcc->glibc->binutils->gcc
  # NOTE: libtool requires rebuilt with each new gcc version
  
 -pkgname=(gcc gcc-libs lib32-gcc-libs gcc-fortran gcc-objc gcc-ada gcc-go gcc-d lto-dump libgccjit)
 +pkgname=(gcc gcc-libs gcc-fortran gcc-objc gcc-go gcc-d lto-dump libgccjit)
- pkgver=12.1.1
- _commit=681c73db9bd156f9b65a73ccc6c4a0a697fe70d6
+ pkgver=12.2.0
  _majorver=${pkgver%%.*}
-@@ -19,14 +19,10 @@ url='https://gcc.gnu.org'
+ _commit=2ee5e4300186a92ad73f1a1a64cb918dc76c8d67
+@@ -19,14 +19,10 @@
  makedepends=(
    binutils
    doxygen
@@ -26,7 +26,7 @@ index 1952b31..37569f0 100644
    python
    zstd
  )
-@@ -79,7 +75,6 @@ build() {
+@@ -79,7 +75,6 @@
        --mandir=/usr/share/man
        --infodir=/usr/share/info
        --with-bugurl=https://bugs.archlinux.org/
@@ -34,16 +34,23 @@ index 1952b31..37569f0 100644
        --with-linker-hash-style=gnu
        --with-system-zlib
        --enable-__cxa_atexit
-@@ -94,7 +89,7 @@ build() {
+@@ -94,7 +89,6 @@
        --enable-link-serialization=1
        --enable-linker-build-id
        --enable-lto
 -      --enable-multilib
-+      --disable-multilib
        --enable-plugin
        --enable-shared
        --enable-threads=posix
-@@ -112,7 +107,7 @@ build() {
+@@ -101,6 +95,7 @@
+       --disable-libssp
+       --disable-libstdcxx-pch
+       --disable-werror
++      --disable-multilib
+   )
+ 
+   cd gcc-build
+@@ -112,7 +107,7 @@
    CXXFLAGS=${CXXFLAGS/-Werror=format-security/}
  
    "$srcdir/gcc/configure" \
@@ -52,7 +59,7 @@ index 1952b31..37569f0 100644
      --enable-bootstrap \
      "${_confflags[@]:?_confflags unset}"
  
-@@ -126,6 +121,10 @@ build() {
+@@ -126,6 +121,10 @@
    # make documentation
    make -O -C $CHOST/libstdc++-v3/doc doc-man-doxygen
  
@@ -63,7 +70,7 @@ index 1952b31..37569f0 100644
    # Build libgccjit separately, to avoid building all compilers with --enable-host-shared
    # which brings a performance penalty
    cd "${srcdir}"/libgccjit-build
-@@ -160,9 +159,9 @@ check() {
+@@ -160,9 +159,9 @@
  package_gcc-libs() {
    pkgdesc='Runtime libraries shipped by GCC'
    depends=('glibc>=2.27')
@@ -75,7 +82,7 @@ index 1952b31..37569f0 100644
    replaces=($pkgname-multilib libgphobos)
  
    cd gcc-build
-@@ -173,11 +172,9 @@ package_gcc-libs() {
+@@ -173,11 +172,9 @@
               libgfortran \
               libgo \
               libgomp \
@@ -89,7 +96,7 @@ index 1952b31..37569f0 100644
      make -C $CHOST/$lib DESTDIR="$pkgdir" install-toolexeclibLTLIBRARIES
    done
  
-@@ -189,24 +186,22 @@ package_gcc-libs() {
+@@ -189,17 +186,16 @@
    rm -f "$pkgdir"/usr/lib/libgphobos.spec
  
    for lib in libgomp \
@@ -110,6 +117,7 @@ index 1952b31..37569f0 100644
  }
  
  package_gcc() {
+@@ -206,7 +202,6 @@
    pkgdesc="The GNU Compiler Collection - C and C++ frontends"
    depends=("gcc-libs=$pkgver-$pkgrel" 'binutils>=2.28' libmpc zstd libisl.so)
    groups=('base-devel')
@@ -117,7 +125,7 @@ index 1952b31..37569f0 100644
    provides=($pkgname-multilib)
    replaces=($pkgname-multilib)
    options=(!emptydirs staticlibs debug)
-@@ -220,22 +215,18 @@ package_gcc() {
+@@ -220,22 +215,18 @@
    install -m755 -t "$pkgdir/${_libdir}/" gcc/{cc1,cc1plus,collect2,lto1}
  
    make -C $CHOST/libgcc DESTDIR="$pkgdir" install
@@ -142,7 +150,7 @@ index 1952b31..37569f0 100644
  
    make DESTDIR="$pkgdir" install-fixincludes
    make -C gcc DESTDIR="$pkgdir" install-mkheaders
-@@ -246,20 +237,14 @@ package_gcc() {
+@@ -246,20 +237,14 @@
      "$pkgdir/usr/lib/bfd-plugins/"
  
    make -C $CHOST/libgomp DESTDIR="$pkgdir" install-nodist_{libsubinclude,toolexeclib}HEADERS
@@ -164,7 +172,7 @@ index 1952b31..37569f0 100644
  
    make -C libcpp DESTDIR="$pkgdir" install
    make -C gcc DESTDIR="$pkgdir" install-po
-@@ -274,9 +259,6 @@ package_gcc() {
+@@ -274,9 +259,6 @@
    # install the libstdc++ man pages
    make -C $CHOST/libstdc++-v3/doc DESTDIR="$pkgdir" doc-install-man
  
@@ -174,7 +182,7 @@ index 1952b31..37569f0 100644
    # byte-compile python libraries
    python -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
    python -O -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
-@@ -296,8 +278,6 @@ package_gcc-fortran() {
+@@ -296,8 +278,6 @@
    cd gcc-build
    make -C $CHOST/libgfortran DESTDIR="$pkgdir" install-cafexeclibLTLIBRARIES \
      install-{toolexeclibDATA,nodist_fincludeHEADERS,gfor_cHEADERS}
@@ -183,7 +191,7 @@ index 1952b31..37569f0 100644
    make -C $CHOST/libgomp DESTDIR="$pkgdir" install-nodist_fincludeHEADERS
    make -C gcc DESTDIR="$pkgdir" fortran.install-{common,man,info}
    install -Dm755 gcc/f951 "$pkgdir/${_libdir}/f951"
-@@ -327,45 +307,6 @@ package_gcc-objc() {
+@@ -327,45 +307,6 @@
      "$pkgdir/usr/share/licenses/$pkgname/"
  }
  
@@ -229,7 +237,7 @@ index 1952b31..37569f0 100644
  package_gcc-go() {
    pkgdesc='Go front-end for GCC'
    depends=("gcc=$pkgver-$pkgrel" libisl.so)
-@@ -375,11 +316,10 @@ package_gcc-go() {
+@@ -375,11 +316,10 @@
  
    cd gcc-build
    make -C $CHOST/libgo DESTDIR="$pkgdir" install-exec-am
@@ -242,7 +250,7 @@ index 1952b31..37569f0 100644
    install -Dm755 gcc/go1 "$pkgdir/${_libdir}/go1"
  
    # Install Runtime Library Exception
-@@ -388,43 +328,6 @@ package_gcc-go() {
+@@ -388,43 +328,6 @@
      "$pkgdir/usr/share/licenses/$pkgname/"
  }
  
@@ -286,7 +294,7 @@ index 1952b31..37569f0 100644
  package_gcc-d() {
    pkgdesc="D frontend for GCC"
    depends=("gcc=$pkgver-$pkgrel" libisl.so)
-@@ -440,7 +343,6 @@ package_gcc-d() {
+@@ -440,7 +343,6 @@
  
    make -C $CHOST/libphobos DESTDIR="$pkgdir" install
    rm -f "$pkgdir/usr/lib/"lib{gphobos,gdruntime}.so*


### PR DESCRIPTION
Fix rotten.

There are quite a lot of FAILs, however it seems that ArchLinux doesn't care about them.

```
make -O -k check || true
```