### PR TITLE
addpkg: open-isns

### DIFF
--- a/open-isns/riscv64.patch
+++ b/open-isns/riscv64.patch
@@ -1,0 +1,12 @@
+diff --git PKGBUILD PKGBUILD
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,6 +15,8 @@ sha256sums=('9611344733c0cdf14395f60880950ea4c3c7d6b765565b6493ad3e1afbe216de')
+ build() {
+ 	cd "$srcdir"/${pkgname}-${pkgver}
+ 
++        autoreconf -fi
++
+ 	./configure \
+ 		--prefix=/usr \
+ 		--bindir=/usr/bin \


### PR DESCRIPTION
```
This script, last modified 2005-05-27, has failed to recognize
the operating system you are using. 
...
configure: error: cannot guess build type; you must specify one
```
The script can't detect the build type, thus we specify it manually by adding `--host=riscv64-unknown-linux-gnu` and  `--build=riscv64-unknown-linux-gnu` to `configure` parameters. 