### PR TITLE
addpkg: libopenraw

### DIFF
--- a/libopenraw/riscv64.patch
+++ b/libopenraw/riscv64.patch
@@ -1,0 +1,22 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,7 +12,7 @@ arch=('x86_64')
+ url='https://libopenraw.freedesktop.org/'
+ license=('LGPL')
+ depends=('gdk-pixbuf2')
+-makedepends=('boost' 'libxml2' 'cargo')
++makedepends=('boost' 'libxml2' 'cargo' 'autoconf-archive')
+ provides=('libopenraw.so' 'libopenrawgnome.so')
+ source=("https://libopenraw.freedesktop.org/download/${pkgname}-${pkgver}.tar.bz2"{.asc,})
+ b2sums=('SKIP'
+@@ -20,6 +20,10 @@ b2sums=('SKIP'
+ validpgpkeys=('6C44DB3E0BF3EAF5B433239A5FEE05E6A56E15A3') # Hubert Figuiere <hub@mozilla.com>
+ 
+ prepare() {
++  cd $pkgname-$pkgver
++  autoupdate
++  autoreconf -fiv
++  cd -
+ # Fix libopenraw dependency in -gnome pc file
+   sed -e 's|libopenraw-0.1|libopenraw-0.3|' -i $pkgname-$pkgver/gnome/libopenraw-gnome-0.3.pc.in
+ }


### PR DESCRIPTION
Fixed `config.guess`.
Finally made it building passed after 3 month due to `llvm 13` updated.

**Note**
Because of `m4` macros not found, its `makedepends` was added `autoconf-archive`.