### PR TITLE
addpatch: libva 2.15.0-6

### DIFF
--- a/libva/riscv64.patch
+++ b/libva/riscv64.patch
@@ -1,0 +1,20 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -38,12 +38,14 @@ provides=(
+ backup=(etc/libva.conf)
+ options=(debug)
+ _tag=b095d10bf355110352e75c22e581018a7ea7de5a
+-source=(git+https://github.com/intel/libva.git#tag=${_tag})
+-sha256sums=(SKIP)
++source=(git+https://github.com/intel/libva.git#tag=${_tag}
++        set-HAVE_VA_X11-when-applicable.patch::https://github.com/intel/libva/pull/612.patch)
++sha256sums=('SKIP'
++            '2fc470682aa8f643240882c1296b889e213f9667d5eefbbfc532106d02fc1700')
+ 
+ prepare() {
+   cd libva
+-  git cherry-pick -n c49f7ea61116b030c9df251f111fffbc3235d224 # https://bugs.archlinux.org/task/75312
++  patch -Np1 -i "${srcdir}/set-HAVE_VA_X11-when-applicable.patch" # https://bugs.archlinux.org/task/75312
+ }
+ 
+ pkgver() {


### PR DESCRIPTION
Fixed outdated cherry-pick commit ID.

Upstream bug report: https://bugs.archlinux.org/task/75914