### PR TITLE
addpkg: lprint

### DIFF
--- a/lprint/riscv64.patch
+++ b/lprint/riscv64.patch
@@ -1,0 +1,29 @@
+diff --git PKGBUILD PKGBUILD
+index 279ca36..3e256eb 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -11,16 +11,22 @@ license=('Apache' 'custom')
+ depends=('pappl' 'libcups' 'libpng' 'libusb' 'pam')
+ options=('debug')
+ source=("https://github.com/michaelrsweet/lprint/releases/download/v${pkgver}/${pkgname}-${pkgver}.tar.gz"{,.sig}
+-        fix-systemd-installdir.patch)
++        fix-systemd-installdir.patch
++        updated-config.sub::https://raw.githubusercontent.com/michaelrsweet/lprint/master/config.sub
++        updated-config.guess::https://raw.githubusercontent.com/michaelrsweet/lprint/master/config.guess)
+ #validpgpkeys=('845464660B686AAB36540B6F999559A027815955')  # "Michael R Sweet <michael.r.sweet@gmail.com>"
+ validpgpkeys=('9086C3CDC66C3F563CF8F405BE67C75EC81F3244') # "Michael R Sweet <msweet@msweet.org>"
+ sha256sums=('d40e353ac9f6b0de96974717255fa1df0f9655d37ef3f9a6f35b6391992daf73'
+             'SKIP'
+-            '5afaf8dad1e766f0c99a27095e56face16d2eae681d576c395db5d3c3761d182')
++            '5afaf8dad1e766f0c99a27095e56face16d2eae681d576c395db5d3c3761d182'
++            'deb02c26f43b2ea64276c9ede77ec0f53d08e6256710f3c0a12275712085c348'
++            '05a24a2cb33bddf1c8962423b04ee824a1c2763613ac48da5a087f7f2624a9e6')
+ 
+ prepare() {
+   cd ${pkgname}-${pkgver}
+   patch -Np1 -i ../fix-systemd-installdir.patch
++  cp -v ../updated-config.sub ./config.sub
++  cp -v ../updated-config.guess ./config.guess
+ }
+ 
+ build() {


### PR DESCRIPTION
The commit has been upstreamed but not released (yet).
Given its lastest release on 23 Dec, 2021, it seems unlikely that a new release may come in the near future. 