### PR TITLE
updpatch: glibc

### DIFF
--- a/glibc/0001-stdlib-strfrom-Remove-the-NAN-testcase-bug-29501.patch
+++ b/glibc/0001-stdlib-strfrom-Remove-the-NAN-testcase-bug-29501.patch
@@ -1,0 +1,83 @@
+From ac545294d59a868e67fe8b334d93d99bbcd9a158 Mon Sep 17 00:00:00 2001
+From: FantasqueX <fantasquex@gmail.com>
+Date: Fri, 16 Sep 2022 00:43:24 +0800
+Subject: [PATCH] stdlib/strfrom: Remove the -NAN testcase (bug 29501)
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+According to the specification of ISO/IEC TS 18661-1:2014,
+
+The strfromd, strfromf, and strfroml functions are equivalent to
+snprintf(s, n, format, fp) (7.21.6.5), except the format string contains only
+the character %, an optional precision that does not contain an asterisk *, and
+one of the conversion specifiers a, A, e, E, f, F, g, or G, which applies to
+the type (double, float, or long double) indicated by the function suffix
+(rather than  by a length modifier). Use of these functions with any other 20
+format string results in undefined behavior.
+
+strfromf will convert the arguement with type float to double first.
+
+According to the latest version of IEEE754 which is published in 2019,
+
+Conversion of a quiet NaN from a narrower format to a wider format in the same
+radix, and then back to the same narrower format, should not change the quiet
+NaN payload in any way except to make it canonical.
+
+When either an input or result is a NaN, this standard does not interpret the
+sign of a NaN. However, operations on bit strings—copy, negate, abs,
+copySign—specify the sign bit of a NaN result, sometimes based upon the sign
+bit of a NaN operand. The logical predicates totalOrder and isSignMinus are
+also affected by the sign bit of a NaN operand. For all other operations, this
+standard does not specify the sign bit of a NaN result, even when there is only
+one input NaN, or when the NaN is produced from an invalid operation.
+
+converting NAN or -NAN with type float to double doesn't need to keep
+the signbit. As a result, this test case isn't mandatory.
+
+The problem is that according to RISC-V ISA manual in chapter 11.3 of
+riscv-isa-20191213,
+
+Except when otherwise stated, if the result of a floating-point operation is
+NaN, it is the canonical NaN. The canonical NaN has a positive sign and all
+significand bits clear except the MSB, a.k.a. the quiet bit. For
+single-precision floating-point, this corresponds to the pattern 0x7fc00000.
+
+which means that conversion -NAN from float to double won't keep the signbit.
+
+As this test case isn't mandatory and may fail on some architecture, it
+is OK to remove it.
+
+Signed-off-by: Letu Ren <fantasquex@gmail.com>
+---
+ stdlib/tst-strfrom-locale.c | 1 -
+ stdlib/tst-strfrom.c        | 1 -
+ 2 files changed, 2 deletions(-)
+
+diff --git a/stdlib/tst-strfrom-locale.c b/stdlib/tst-strfrom-locale.c
+index 85907c0ce1..5fc7c4b17d 100644
+--- a/stdlib/tst-strfrom-locale.c
++++ b/stdlib/tst-strfrom-locale.c
+@@ -37,7 +37,6 @@ static const struct test tests[] = {
+   TEST ("5,900000e-16", "%e", 50, 12, 5.9e-16),
+   TEST ("1,234500e+20", "%e", 50, 12, 12.345e19),
+   TEST ("1,000000e+05", "%e", 50, 12, 1e5),
+-  TEST ("-NAN", "%G", 50, 4, -NAN_),
+   TEST ("-inf", "%g", 50, 4, -INF),
+   TEST ("inf", "%g", 50, 3, INF)
+ };
+diff --git a/stdlib/tst-strfrom.c b/stdlib/tst-strfrom.c
+index 3a447eac12..1533fb9170 100644
+--- a/stdlib/tst-strfrom.c
++++ b/stdlib/tst-strfrom.c
+@@ -37,7 +37,6 @@ static const struct test tests[] = {
+   TEST ("5.900000e-16", "%e", 50, 12, 5.9e-16),
+   TEST ("1.234500e+20", "%e", 50, 12, 12.345e19),
+   TEST ("1.000000e+05", "%e", 50, 12, 1e5),
+-  TEST ("-NAN", "%G", 50, 4, -NAN_),
+   TEST ("-inf", "%g", 50, 4, -INF),
+   TEST ("inf", "%g", 50, 3, INF)
+ };
+-- 
+2.37.3
+

--- a/glibc/riscv64.patch
+++ b/glibc/riscv64.patch
@@ -1,6 +1,6 @@
 Index: PKGBUILD
 ===================================================================
---- PKGBUILD	(revision 456080)
+--- PKGBUILD	(revision 456256)
 +++ PKGBUILD	(working copy)
 @@ -7,7 +7,7 @@
  # NOTE: valgrind requires rebuilt with each major glibc version
@@ -20,8 +20,21 @@ Index: PKGBUILD
  options=(debug staticlibs !lto)
  source=(git+https://sourceware.org/git/glibc.git#commit=${_commit}
          locale.gen.txt
-@@ -34,7 +34,7 @@
-         '5fdd133c367af2f5454ea1eea7907de12166fb95eb59dbe33eae16aa9e26209b6585972bc1c80e36a0af4bfb04296acaf940ee78cd624cdcbab9669dff46c051')
+@@ -22,6 +22,7 @@
+         lib32-glibc.conf
+         sdt.h sdt-config.h
+         reenable_DT_HASH.patch
++        0001-stdlib-strfrom-Remove-the-NAN-testcase-bug-29501.patch
+ )
+ validpgpkeys=(7273542B39962DF7B299931416792B4EA25340F8 # Carlos O'Donell
+               BC7C7372637EC10C57D7AA6579C43DFBF1CF2187) # Siddhesh Poyarekar
+@@ -31,10 +32,11 @@
+         '7c265e6d36a5c0dff127093580827d15519b6c7205c2e1300e82f0fb5b9dd00b6accb40c56581f18179c4fbbc95bd2bf1b900ace867a83accde0969f7b609f8a'
+         'a6a5e2f2a627cc0d13d11a82458cfd0aa75ec1c5a3c7647e5d5a3bb1d4c0770887a3909bfda1236803d5bc9801bfd6251e13483e9adf797e4725332cd0d91a0e'
+         '214e995e84b342fe7b2a7704ce011b7c7fc74c2971f98eeb3b4e677b99c860addc0a7d91b8dc0f0b8be7537782ee331999e02ba48f4ccc1c331b60f27d715678'
+-        '5fdd133c367af2f5454ea1eea7907de12166fb95eb59dbe33eae16aa9e26209b6585972bc1c80e36a0af4bfb04296acaf940ee78cd624cdcbab9669dff46c051')
++        '5fdd133c367af2f5454ea1eea7907de12166fb95eb59dbe33eae16aa9e26209b6585972bc1c80e36a0af4bfb04296acaf940ee78cd624cdcbab9669dff46c051'
++        'e3e17f784dd668a1bba6128a5a25616657d848ccd67668f0246e06aac36572e34935a8937639b527f28d755335bca153cadfd9e7daecfe8d5536f76b7ab0f9c0')
  
  prepare() {
 -  mkdir -p glibc-build lib32-glibc-build
@@ -29,17 +42,26 @@ Index: PKGBUILD
  
    [[ -d glibc-$pkgver ]] && ln -s glibc-$pkgver glibc
    cd glibc
-@@ -53,9 +53,7 @@
+@@ -43,6 +45,10 @@
+   # which relies on DT_HASH to be present in these libs.
+   # reconsider 2023-01
+   patch -Np1 -i "${srcdir}"/reenable_DT_HASH.patch
++
++  # Skip the nan test case which leverages undefined behavior
++  # full analysis at https://github.com/felixonmars/archriscv-packages/issues/1704
++  patch -Np1 -i "${srcdir}"/0001-stdlib-strfrom-Remove-the-NAN-testcase-bug-29501.patch
+ }
+ 
+ build() {
+@@ -53,7 +59,6 @@
        --enable-bind-now
        --enable-cet
        --enable-kernel=4.4
 -      --enable-multi-arch
        --enable-stack-protector=strong
--      --enable-systemtap
+       --enable-systemtap
        --disable-profile
-       --disable-crypt
-       --disable-werror
-@@ -90,30 +88,6 @@
+@@ -90,30 +95,6 @@
    # build info pages manually for reproducibility
    make info
  
@@ -70,8 +92,12 @@ Index: PKGBUILD
    # pregenerate C.UTF-8 locale until it is built into glibc
    # (https://sourceware.org/glibc/wiki/Proposals/C.UTF-8, FS#74864)-
    elf/ld.so --library-path "$PWD" locale/localedef -c -f ../glibc/localedata/charmaps/UTF-8 -i ../glibc/localedata/locales/C ../C.UTF-8/
-@@ -152,7 +126,7 @@
-   make -O check
+@@ -149,10 +130,10 @@
+   skip_test tst-adjtime             time/Makefile
+   skip_test tst-clock2              time/Makefile
+ 
+-  make -O check
++  TIMEOUTFACTOR=20 make -O check
  }
  
 -package_glibc() {
@@ -79,7 +105,7 @@ Index: PKGBUILD
    pkgdesc='GNU C Library'
    depends=('linux-api-headers>=4.10' tzdata filesystem)
    optdepends=('gd: for memusagestat'
-@@ -198,27 +172,3 @@
+@@ -198,27 +179,3 @@
    install -Dm644 "${srcdir}"/sdt.h "${pkgdir}"/usr/include/sys/sdt.h
    install -Dm644 "${srcdir}"/sdt-config.h "${pkgdir}"/usr/include/sys/sdt-config.h
  }


### PR DESCRIPTION
This update contains three things.

1. Reenable systemtap
2. Add a patch to skip nan test case in tst-strfrom
3. Add TIMEOUTFACTOR to enlarge timeout limit.

The patch has been sent to [upstream](https://sourceware.org/pipermail/libc-alpha/2022-September/142011.html). However, I'm not sure how to properly tweak the test case.

Now, glibc doesn't need `nocheck` 🎉