### PR TITLE
addpatch: libretro-mupen64plus-next

### DIFF
--- a/libretro-mupen64plus-next/riscv64.patch
+++ b/libretro-mupen64plus-next/riscv64.patch
@@ -1,0 +1,16 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -37,10 +37,11 @@ pkgver() {
+ }
+ 
+ build() {
++  export CFLAGS="$CFLAGS -DNO_ASM"
++  export CXXFLAGS="$CXXFLAGS -DNO_ASM"
+   make \
+-    WITH_DYNAREC=x86_64 \
+     HAVE_PARALLEL_RDP=1 \
+-    HAVE_PARALLEL_RSP=1 \
++    HAVE_PARALLEL_RSP=0 \
+     HAVE_THR_AL=1 \
+     SYSTEM_LIBPNG=1 \
+     SYSTEM_MINIZIP=1 \


### PR DESCRIPTION
Fixed: #1715 

* Fix no `-msse` and `-msse2` option on RISC-V issue
* Drop module `mupen64plus-rsp-paraLLEl` because it contains x64 specific simd code
* Add `-DNO_ASM` option into CFLAGS & CXXFLAGS to fix the link error

Signed-off-by: Avimitin <avimitin@gmail.com>