### PR TITLE
blacklist: remove dmidecode

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -18,7 +18,6 @@ vivaldi
 
 # No hardware support
 amd-ucode
-dmidecode
 intel-gmmlib
 intel-gpu-tools
 intel-graphics-compiler


### PR DESCRIPTION
Although it's not relevant for RISC-V, it's mostly harmless to have a 50KiB package around to satisfy dependencies and it compiles just fine.

Just for reference, Arch Linux ARM also has this package.