### PR TITLE
addpatch: grafana-zabbix

### DIFF
--- a/grafana-zabbix/riscv64.patch
+++ b/grafana-zabbix/riscv64.patch
@@ -1,0 +1,23 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -7,15 +7,17 @@ arch=('any')
+ url="https://github.com/alexanderzobnin/grafana-zabbix"
+ license=('APACHE')
+ depends=('grafana')
+-makedepends=(yarn libfaketime go git nodejs-lts-gallium)
++makedepends=(yarn libfaketime go git nodejs-lts-gallium python3)
+ source=("$pkgname-$pkgver-retagged-1.tar.gz::https://github.com/alexanderzobnin/grafana-zabbix/archive/v$pkgver.tar.gz")
+ sha256sums=('79d5a637711d5aa92295494c79f6ec14b6f32f2834d0b30e62fe84beea5b0d94')
+ 
+ build() {
+ 	cd "$pkgname-$pkgver"
+ 	make install
+-	make build
+-	make dist
++	make build-frontend
++	go build -o ./dist/zabbix-plugin_linux_$CARCH ./pkg
++
++	go build -v -ldflags="-s -w" -o ./dist/zabbix-plugin_linux_$CARCH ./pkg
+ }
+ 
+ check() {


### PR DESCRIPTION
- Add dependency `python3`

Dependency node-gyp will download pre-built library in x86_64. In riscv64 it has to build itself from source which requires python3 executable. But there is no python package provided in the original PKGBUILD.

- Move the build script from Makefile to PKGBUILD

 Targets in Makefile doesn't handle all the platform. Maintainer hard code `amd64` suffix in `make build` and set environment `GOOS` to darwin, windows, openbsd...etc. It is not a proper way to run make build and make dist here.

Ref:
 - https://github.com/alexanderzobnin/grafana-zabbix/blob/master/Makefile#L45

Addtional:
  1. yarn install depends on network, so the make install command is flaky.
  2. Test will fail with signal `SIGSEGV` in QEMU-user. It is caused by test framework jest. This problem can be steadily reproduced.

Signed-off-by: Avimitin <avimitin@gmail.com>