### PR TITLE
addpkg: cargo-binstall

### DIFF
--- a/cargo-binstall/riscv64.patch
+++ b/cargo-binstall/riscv64.patch
@@ -1,0 +1,13 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,7 +14,9 @@ sha256sums=('defc1900a9a2c05a3427e2a895c781e54df0c11fa89d00f53dd3318fcdf1e7d7')
+ 
+ prepare() {
+   cd "$pkgname-$pkgver"
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
++  cargo update -p ring
++  cargo fetch --locked 
+ }
+ 
+ build() {


### PR DESCRIPTION
Fixed `--target "$CARCH-unknown-linux-gnu"` and `ring` dependency error.