### PR TITLE
upgpatch: charm 0.12.4-1

### DIFF
--- a/charm/riscv64.patch
+++ b/charm/riscv64.patch
@@ -1,20 +1,16 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -39,6 +39,17 @@ prepare() {
+@@ -36,6 +36,13 @@ pkgver() {
+ prepare() {
+   cd charm
+ 
++  # replace dependency with its successor to support riscv64
++  # remove after https://github.com/charmbracelet/charm/pull/178 is merged
++  sed -i "/github.com\/jacobsa\/crypto/d" go.mod
++  go get -v github.com/aperturerobotics/jacobsa-crypto
++  sed -i 's|"github.com/jacobsa/crypto/siv"|"github.com/aperturerobotics/jacobsa-crypto/siv"|' crypt/crypt.go
++  go mod tidy
++
    # create directory for build output
    mkdir build
  
-+  # bump dependencies
-+  # remove this line after https://github.com/charmbracelet/charm/pull/148 is merged
-+  go get -u modernc.org/sqlite github.com/dgraph-io/badger/v3
-+
-+  # replace dependency github.com/jacobsa/crypto with https://github.com/jacobsa/crypto/pull/14
-+  # upstream is not responding at https://github.com/charmbracelet/charm/issues/147
-+  go mod edit -replace github.com/jacobsa/crypto=github.com/piggynl/jacobsa-crypto@xorblock-generic
-+
-+  # update go.sum after the go.mod changes
-+  go mod tidy
-+
-   # download dependencies
-   go mod download
- }


### PR DESCRIPTION
The previous patch replaced an unmaintained dependency [`github.com/jacobsa/crypto`](https://github.com/jacobsa/crypto) with a reference to PR jacobsa/crypto#14 to support `linux/riscv64`. This change to the patch replaced the reference with another community-maintained successor [`github.com/aperturerobotics/jacobsa-crypto`](https://github.com/aperturerobotics/jacobsa-crypto).

FTR: upstream PR submitted at [charmbracelet/charm#178](https://github.com/charmbracelet/charm/pull/178).