### PR TITLE
addpatch: gawk

### DIFF
--- a/gawk/0001-Fix-negative-NaN-issue-on-RiscV.patch
+++ b/gawk/0001-Fix-negative-NaN-issue-on-RiscV.patch
@@ -1,0 +1,67 @@
+From a3799ae3f5dd6648040d499224cc6dea61b355dd Mon Sep 17 00:00:00 2001
+From: "Arnold D. Robbins" <arnold@skeeve.com>
+Date: Mon, 19 Sep 2022 18:51:28 +0300
+Subject: [PATCH] Fix negative NaN issue on RiscV.
+
+---
+ eval.c      | 19 +++++++++++++++++++
+ interpret.h |  2 ++
+ 2 files changed, 21 insertions(+)
+
+diff --git a/eval.c b/eval.c
+index 1069570b..3bfff0ca 100644
+--- a/eval.c
++++ b/eval.c
+@@ -39,6 +39,8 @@ static int num_exec_hook = 0;
+ static Func_pre_exec pre_execute[MAX_EXEC_HOOKS];
+ static Func_post_exec post_execute = NULL;
+ 
++static double fix_nan_sign(double left, double right, double result);
++
+ extern void frame_popped();
+ 
+ int OFSlen;
+@@ -1901,3 +1903,20 @@ elem_new_to_scalar(NODE *n)
+ 
+ 	return n;
+ }
++
++/* fix_nan_sign --- fix NaN sign on RiscV */
++
++// See the thread starting at
++// https://lists.gnu.org/archive/html/bug-gawk/2022-09/msg00005.html
++// for why we need this function.
++
++static double
++fix_nan_sign(double left, double right, double result)
++{
++	if (isnan(left) && signbit(left))
++		return copysign(result, -1.0);
++	else if (isnan(right) && signbit(right))
++		return copysign(result, -1.0);
++	else
++		return result;
++}
+diff --git a/interpret.h b/interpret.h
+index 26010ada..955d918f 100644
+--- a/interpret.h
++++ b/interpret.h
+@@ -583,6 +583,7 @@ uninitialized_scalar:
+ plus:
+ 			t1 = TOP_NUMBER();
+ 			r = make_number(t1->numbr + x2);
++			r->numbr = fix_nan_sign(t1->numbr, x2, r->numbr);
+ 			DEREF(t1);
+ 			REPLACE(r);
+ 			break;
+@@ -597,6 +598,7 @@ plus:
+ minus:
+ 			t1 = TOP_NUMBER();
+ 			r = make_number(t1->numbr - x2);
++			r->numbr = fix_nan_sign(t1->numbr, x2, r->numbr);
+ 			DEREF(t1);
+ 			REPLACE(r);
+ 			break;
+-- 
+2.37.3
+

--- a/gawk/riscv64.patch
+++ b/gawk/riscv64.patch
@@ -1,0 +1,29 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 456595)
++++ PKGBUILD	(working copy)
+@@ -13,11 +13,13 @@
+ provides=('awk')
+ options=('debug')
+ source=(https://ftp.gnu.org/pub/gnu/${pkgname}/${pkgname}-${pkgver}.tar.gz{,.sig}
+-        0001-Add-missing-UPREF.patch)
++        0001-Add-missing-UPREF.patch
++        0001-Fix-negative-NaN-issue-on-RiscV.patch)
+ validpgpkeys=('D1967C63788713177D861ED7DF597815937EC0D2') # Arnold Robbins
+ sha256sums=('ef5af4449cb0269faf3af24bf4c02273d455f0741bf3c50f86ddc09332d6cf56'
+             'SKIP'
+-            'd39fa487f89c743ba55ed0b5eeb9fe33db4bd7010bf5f61f8aa1a9541a18775e')
++            'd39fa487f89c743ba55ed0b5eeb9fe33db4bd7010bf5f61f8aa1a9541a18775e'
++            '530aad2d2155ff01c817cd491dfae6ccb57b9a6164bb178f25f8240d3fc4859a')
+ 
+ prepare() {
+   cd ${pkgname}-${pkgver}
+@@ -24,6 +26,8 @@
+ 
+   # https://bugs.gentoo.org/868567
+   patch -Np1 -i ../0001-Add-missing-UPREF.patch
++
++  patch -Np1 -i ../0001-Fix-negative-NaN-issue-on-RiscV.patch
+ }
+ 
+ build() {

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -23,6 +23,7 @@ fish
 foot
 fulcio
 gauche
+gawk
 gdk-pixbuf2
 glib-perl
 glibc


### PR DESCRIPTION
Backport one patch related to -NAN from upstream https://git.savannah.gnu.org/cgit/gawk.git/commit/?id=a3799ae3f5dd6648040d499224cc6dea61b355dd

Add gawk to qemu-user-blacklists.txt because of following failures:
```
make[3]: *** [Makefile:2219: pma] Error 137
make[3]: Leaving directory '/build/gawk/src/gawk-5.2.0/test'
make[2]: *** [Makefile:2206: pma-tests] Error 2
make[2]: Leaving directory '/build/gawk/src/gawk-5.2.0/test'
make[1]: *** [Makefile:805: check-recursive] Error 1
```