### PR TITLE
addpkg: slang

### DIFF
--- a/slang/riscv64.patch
+++ b/slang/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -19,6 +19,8 @@ validpgpkeys=('64083373E9E1DE997EBBE7784B82D0B82930237D')  # John E. Davis
+ 
+ build() {
+   cd ${pkgname}-${pkgver}
++  cp -fv /usr/share/autoconf/build-aux/config.guess autoconf/config.guess
++  cp -fv /usr/share/autoconf/build-aux/config.sub autoconf/config.sub
+   ./configure --prefix=/usr --sysconfdir=/etc
+   make
+ }


### PR DESCRIPTION
Fixed `config.guess`.

**Notice**
The normal fixing approach didn't work since it haven't  `configure.ac` file in its `src` directory.
Their `autotools` related files located at `autoconf` directory. In this directory, `autoreconf -fiv` went wrong.
So, copied files.

**Failed Log** (in `autoconf` dir)
```console
autoreconf: running: /usr/bin/autoheader --force
autoheader: error: cannot rename /tmp/arsWSSX0/ahvyjYuf/config.hin as src/config.hin: No such file or directory
autoreconf: error: /usr/bin/autoheader failed with exit status: 1
```
