### PR TITLE
addpkg: python-green to qemu-user black list

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -72,6 +72,7 @@ pyqt6-webengine
 pyside2
 pyside6
 python
+python-green
 python-prctl
 qalculate-qt
 qconf


### PR DESCRIPTION
A test will timeout in qemu-user but pass on real boards.

```
Error in green.test.test_integration.TestFinalizer.test_finalizer
Traceback (most recent call last):
  File "/usr/lib/python3.10/unittest/case.py", line 59, in testPartExecutor
    yield
  File "/usr/lib/python3.10/unittest/case.py", line 591, in run
    self._callTestMethod(testMethod)
  File "/usr/lib/python3.10/unittest/case.py", line 549, in _callTestMethod
    method()
  File "/build/python-green/src/green-3.4.3/green/test/test_integration.py", line 55, in test_finalizer
    output = subprocess.run(
  File "/usr/lib/python3.10/subprocess.py", line 503, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
  File "/usr/lib/python3.10/subprocess.py", line 1152, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
  File "/usr/lib/python3.10/subprocess.py", line 2004, in _communicate
    self._check_timeout(endtime, orig_timeout, stdout, stderr)
  File "/usr/lib/python3.10/subprocess.py", line 1196, in _check_timeout
    raise TimeoutExpired(
subprocess.TimeoutExpired: Command '['/usr/bin/python3', '-m', 'green.cmdline', '--finalizer=test_finalizer0.msg', '--maxtasksperchild=1']' timed out after 10 seconds
```