### PR TITLE
addpatch: python-pytest-plugins

### DIFF
--- a/python-pytest-plugins/riscv64.patch
+++ b/python-pytest-plugins/riscv64.patch
@@ -1,0 +1,21 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1307649)
++++ PKGBUILD	(working copy)
+@@ -7,15 +7,12 @@
+ arch=('any')
+ license=('BSD')
+ url='https://github.com/manahl/pytest-plugins'
+-makedepends=('python-pytest' 'python-setuptools-git' 'python-pypandoc' 'python-execnet' 'python-path.py'
++makedepends=('python-pytest' 'python-setuptools-git' 'python-execnet' 'python-path.py'
+              'python-mock' 'python-virtualenv' 'python-termcolor')
+ source=("$pkgbase-$pkgver.tar.gz::https://github.com/manahl/pytest-plugins/archive/v$pkgver.tar.gz")
+ sha512sums=('6ce64f554359ae8b4e8b1cdab9908226501bad1d6bcdec9d7968133bbf0b3530842883cf3ea7ef14e09372fd1454d685d4b1bf4e8d95498b69a8b0f20177e2be')
+ 
+ prepare() {
+-  # New pypandoc?
+-  sed -i "s/'rst')/'rst', format='markdown')/" pytest-plugins-$pkgver/common_setup.py
+-
+   # Our /bin is a symlink
+   sed -i "s|'/bin'|'/usr/bin'|" pytest-plugins-$pkgver/pytest-shutil/tests/integration/test_cmdline_integration.py
+ 


### PR DESCRIPTION
Disable pypandoc as we currently cannot fix pandoc.