### PR TITLE
addpatch: haskell-blaze-html

### DIFF
--- a/haskell-blaze-html/riscv64.patch
+++ b/haskell-blaze-html/riscv64.patch
@@ -1,0 +1,13 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1309110)
++++ PKGBUILD	(working copy)
+@@ -23,7 +23,7 @@
+ build() {
+     cd $_hkgname-$pkgver
+ 
+-    runghc -isrc src/Util/GenerateHtmlCombinators.hs
++    # runghc -isrc src/Util/GenerateHtmlCombinators.hs
+     
+     runhaskell Setup configure -O --enable-shared --enable-executable-dynamic --disable-library-vanilla \
+         --prefix=/usr --docdir=/usr/share/doc/$pkgname --datasubdir=$pkgname --enable-tests \


### PR DESCRIPTION
Disable HTML Combinators regeneration on packaging to workaround GHCi segfault for now.