### PR TITLE
addpkg: ob-xd

### DIFF
--- a/ob-xd/riscv64.patch
+++ b/ob-xd/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -67,6 +67,9 @@ prepare() {
+   # use system juce
+   sed -e 's/useGlobalPath="0"/useGlobalPath="1"/g' -i OB-Xd.jucer
+ 
++  # update arch info for rv64
++  sed -i 's/linuxArchitecture="-m64"/linuxArchitecture="-march=rv64gc"/' OB-Xd.jucer
++
+   # generate desktop file
+   gendesk -n \
+     --exec OB-Xd \

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -58,6 +58,7 @@ nodejs-lts-gallium
 notepadqq
 nuitka
 nushell
+ob-xd
 openh264
 openldap
 pangomm-2.48


### PR DESCRIPTION
Replace the build option `-m64` to `-march=rv64gc`.

* Additional Notes

  This package can't be built in qemu-user because the build file generator Projucer will stuck.

Signed-off-by: Avimitin <avimitin@gmail.com>