### PR TITLE
addpatch: haskell-xml-conduit

### DIFF
--- a/haskell-xml-conduit/riscv64.patch
+++ b/haskell-xml-conduit/riscv64.patch
@@ -1,0 +1,16 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1309149)
++++ PKGBUILD	(working copy)
+@@ -16,6 +16,11 @@
+ source=("https://hackage.haskell.org/packages/archive/${_hkgname}/${pkgver}/${_hkgname}-${pkgver}.tar.gz")
+ sha512sums=('4d75960eb400a4ac8cb13bb70f59b554659fa2a6165906f73097a2bc564505a1efa78e72b121d9ed0fd8b424ff25cd1d8368e6c1f2b6ffa4b0aa36f584727687')
+ 
++prepare() {
++    cd $_hkgname-$pkgver
++    sed -i '/test-suite doctest/a \    buildable: False' $_hkgname.cabal
++}
++
+ build() {
+     cd $_hkgname-$pkgver
+ 


### PR DESCRIPTION
Disable doctest to workaround our GHCi crash