### PR TITLE
addpatch: haskell-tasty-checklist

### DIFF
--- a/haskell-tasty-checklist/riscv64.patch
+++ b/haskell-tasty-checklist/riscv64.patch
@@ -1,0 +1,12 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1309110)
++++ PKGBUILD	(working copy)
+@@ -16,6 +16,7 @@
+ 
+ prepare() {
+   cd $_hkgname-$pkgver
++  sed -i '/test-suite checklistDocTests/a \  buildable: False' $_hkgname.cabal
+   gen-setup
+   uusi -u doctest $_hkgname.cabal
+ }


### PR DESCRIPTION
Disable doctests until we figure out our GHCi crash.