### PR TITLE
addpatch: haskell-gi

### DIFF
--- a/haskell-gi/riscv64.patch
+++ b/haskell-gi/riscv64.patch
@@ -1,0 +1,16 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1309110)
++++ PKGBUILD	(working copy)
+@@ -16,6 +16,11 @@
+ source=("https://hackage.haskell.org/packages/archive/${_hkgname}/${pkgver}/${_hkgname}-${pkgver}.tar.gz")
+ sha512sums=('b6133c360f1d64805eb09d444536e1c7c582f26e3d723470b9245c14effac8423ab29d220eed5b438b2d9480dbad7c23b5c46c1e6bc5ec874d24b6a836766d31')
+ 
++prepare() {
++    cd $_hkgname-$pkgver
++    sed -i '/test-suite doctests/a \  buildable: False' $_hkgname.cabal
++}
++
+ build() {
+     cd $_hkgname-$pkgver
+ 


### PR DESCRIPTION
Disable doctests until we fix our GHCi crash