### PR TITLE
addpatch: dhall

### DIFF
--- a/dhall/riscv64.patch
+++ b/dhall/riscv64.patch
@@ -1,0 +1,16 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1309110)
++++ PKGBUILD	(working copy)
+@@ -27,6 +27,11 @@
+ source=("https://hackage.haskell.org/packages/archive/${pkgname}/${pkgver}/${pkgname}-${pkgver}.tar.gz")
+ sha512sums=('d2d1b0f513f02f8eb9bc25d0e01a1e749c09eb4089a0982b1ea20f18ff598932b62c898e764167f74718dc71aabe5760ce2e0abe0fe550cb7f1b3ac773219f9a')
+ 
++prepare() {
++    cd $pkgname-$pkgver
++    sed -i '/Test-Suite doctest/a \    buildable: False' $pkgname.cabal
++}
++
+ build() {
+     cd $pkgname-$pkgver
+ 


### PR DESCRIPTION
Disable doctests until we fix our GHCi crash.