### PR TITLE
addpatch: pythia8

### DIFF
--- a/pythia8/riscv64.patch
+++ b/pythia8/riscv64.patch
@@ -1,0 +1,33 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1309223)
++++ PKGBUILD	(working copy)
+@@ -14,7 +14,7 @@
+ url="http://home.thep.lu.se/Pythia/"
+ license=('GPL')
+ depends=('python' 'openmp')
+-makedepends=('fastjet' 'hepmc' 'hepmc2' 'lhapdf>=6.2' 'root')
++makedepends=('fastjet' 'hepmc' 'hepmc2' 'lhapdf>=6.2')
+ source=("https://pythia.org/download/pythia${_pkgpre}/${_pkgid}.tgz"
+         'pythia8.sh'
+         'fix_python_lib_paths.patch')
+@@ -70,9 +70,6 @@
+         --with-python \
+         --with-python-include="/usr/include/python${_pyver}" \
+         --with-python-lib="/usr/lib/python${_pyver}" \
+-        --with-root \
+-        --with-root-include=/usr/include/root \
+-        --with-root-lib=/usr/lib/root \
+         --with-openmp \
+         --with-openmp-include=${_inc} \
+         --with-openmp-lib=${_lib}
+@@ -83,8 +80,7 @@
+     optdepends=('fastjet: fast jet finding in pp and e+e- collisions'
+                 'hepmc: storing collisions from Monte Carlo'
+                 'hepmc2: storing collisions from Monte Carlo (old interface)'
+-                'lhapdf: evaluate PDFs from discretised data files'
+-                'root: integrated examples with CERN ROOT data analysis framework')
++                'lhapdf: evaluate PDFs from discretised data files')
+ 
+     cd "${srcdir}/${_pkgid}"
+ 


### PR DESCRIPTION
Disable `root` support because it vendors LLVM 9. Revisit this when `root` got an updated LLVM:
https://github.com/root-project/root/pull/10294