### PR TITLE
addpatch: hepmc

### DIFF
--- a/hepmc/riscv64.patch
+++ b/hepmc/riscv64.patch
@@ -1,0 +1,23 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1309223)
++++ PKGBUILD	(working copy)
+@@ -11,7 +11,7 @@
+ url="http://hepmc.web.cern.ch/"
+ license=('GPL3')
+ depends=('bash')
+-makedepends=('cmake' 'doxygen' 'hepmc2' 'gcc-fortran' 'graphviz' 'root' 'pythia8' 'python')
++makedepends=('cmake' 'doxygen' 'hepmc2' 'gcc-fortran' 'graphviz' 'pythia8' 'python')
+ optdepends=('root: ROOT I/O'
+             'pythia8: Pythia support'
+             'python: Python interface')
+@@ -30,7 +30,8 @@
+       -DHEPMC3_BUILD_EXAMPLES=ON \
+       -DHEPMC3_INSTALL_INTERFACES=ON \
+       -DUSE_INTERFACE_FROM_PYTHIA8=ON \
+-      -DPYTHIA8_XMLDOC_DIR=/usr/share/pythia8/xmldoc
++      -DPYTHIA8_XMLDOC_DIR=/usr/share/pythia8/xmldoc \
++      -DHEPMC3_ENABLE_ROOTIO=OFF
+     make
+ }
+ 


### PR DESCRIPTION
Disable `root` support because it vendors LLVM 9. Revisit this when `root` got an updated LLVM:
https://github.com/root-project/root/pull/10294