### PR TITLE
addpatch: dhall-docs

### DIFF
--- a/dhall-docs/riscv64.patch
+++ b/dhall-docs/riscv64.patch
@@ -1,0 +1,16 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1309110)
++++ PKGBUILD	(working copy)
+@@ -16,6 +16,11 @@
+ source=("https://hackage.haskell.org/packages/archive/$pkgname/$pkgver/$pkgname-$pkgver.tar.gz")
+ sha512sums=('62b3eeaf24b305f5136dcebedf670ffe9a899953b494412c7f3517c1d52a9c1b8f99cee4fb774328ce7c275a0804e550f97ae4fa9f82b5644dfd9ee72f9f84c4')
+ 
++prepare() {
++  cd $pkgname-$pkgver
++  sed -i '/Test-Suite doctest/a \    buildable: False' $pkgname.cabal
++}
++
+ build() {
+   cd $pkgname-$pkgver
+ 


### PR DESCRIPTION
Disable doctests until we fix our GHCi crash.