### PR TITLE
addpkg: odin2-synthesizer to qemu-user blacklist

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -59,6 +59,7 @@ notepadqq
 nuitka
 nushell
 ob-xd
+odin2-synthesizer
 openh264
 openldap
 pangomm-2.48


### PR DESCRIPTION
Subprocess `Odin2_LV2_lv2_ttl_generator` launched by `make` will stuck in qemu-user at build stage, but will pass on real boards.