### PR TITLE
addpatch: glib2

### DIFF
--- a/glib2/0001-increase-test-timeout-limit.patch
+++ b/glib2/0001-increase-test-timeout-limit.patch
@@ -1,0 +1,27 @@
+From 018ebd2f2c2ef4d25034851c9dc37543795a1686 Mon Sep 17 00:00:00 2001
+From: Letu Ren <fantasquex@gmail.com>
+Date: Sat, 24 Sep 2022 12:56:41 +0200
+Subject: [PATCH] increase test timeout limit
+
+---
+ meson.build | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/meson.build b/meson.build
+index 3aa1a10a2..a0d12d658 100644
+--- a/meson.build
++++ b/meson.build
+@@ -2371,8 +2371,8 @@ if want_systemtap and enable_dtrace
+   enable_systemtap = true
+ endif
+ 
+-test_timeout = 60
+-test_timeout_slow = 180
++test_timeout = 600
++test_timeout_slow = 1800
+ 
+ pkg = import('pkgconfig')
+ windows = import('windows')
+-- 
+2.37.3
+

--- a/glib2/riscv64.patch
+++ b/glib2/riscv64.patch
@@ -1,0 +1,30 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 456698)
++++ PKGBUILD	(working copy)
+@@ -17,12 +17,14 @@
+ _commit=30bd57ecf8aa051de9848ba5a2b140f4810401ff  # tags/2.74.0^0
+ source=("git+https://gitlab.gnome.org/GNOME/glib.git#commit=$_commit"
+         0001-glib-compile-schemas-Remove-noisy-deprecation-warnin.patch
+-        glib-compile-schemas.hook gio-querymodules.{hook,script})
++        glib-compile-schemas.hook gio-querymodules.{hook,script}
++        0001-increase-test-timeout-limit.patch)
+ sha256sums=('SKIP'
+             '6d51eb5856268d79eee01b97a299fa9f99db18b2abb4df56f2ed9e641a09138a'
+             '64ae5597dda3cc160fc74be038dbe6267d41b525c0c35da9125fbf0de27f9b25'
+             '2a9f9b8235f48e3b7d0f6cfcbc76cd2116c45f28692cac4bd61074c495bd5eb7'
+-            '92d08db5aa30bda276bc3d718e7ff9dd01dc40dcab45b359182dcc290054e24e')
++            '92d08db5aa30bda276bc3d718e7ff9dd01dc40dcab45b359182dcc290054e24e'
++            'SKIP')
+ 
+ pkgver() {
+   cd glib
+@@ -34,6 +36,8 @@
+ 
+   # Suppress noise from glib-compile-schemas.hook
+   git apply -3 ../0001-glib-compile-schemas-Remove-noisy-deprecation-warnin.patch
++
++  patch -Np1 -i ../0001-increase-test-timeout-limit.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
Increase test timeout limit. However, sometimes tests still fail. I don't know why now :(