### PR TITLE
addpkg: i7z to blacklist

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -18,6 +18,7 @@ vivaldi
 
 # No hardware support
 amd-ucode
+i7z
 intel-gmmlib
 intel-gpu-tools
 intel-graphics-compiler


### PR DESCRIPTION
The package i7z does not have hardware support for RISC-V.
It is a Intel/x86-specific CPU power state reporting tool.