### PR TITLE
addpkg: iperf

### DIFF
--- a/iperf/riscv64.patch
+++ b/iperf/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index e48f5c9..bf6afb4 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -28,6 +28,8 @@ prepare() {
+     echo "Applying patch $src..."
+     patch -Np1 < "../$src"
+   done
++  # get current config.guess and config.sub to recognize riscv64
++  cp /usr/share/autoconf/build-aux/config.{guess,sub} .
+   :
+ }
+ 


### PR DESCRIPTION
config.guess and config.sub shipped by iperf are from 2015 and don't recognize riscv.

[Bug report has been submitted upstream](https://sourceforge.net/p/iperf2/discussion/general/thread/185790844e/)