### PR TITLE
addpkg: dosemu to blacklist

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -18,6 +18,7 @@ vivaldi
 
 # No hardware support
 amd-ucode
+dosemu
 i7z
 intel-gmmlib
 intel-gpu-tools


### PR DESCRIPTION
dosemu is a x86-only DOS emulator for linux.
Because it uses the host x86 processor for running the programs, only x86 and x86_64 processors are supported.
https://sourceforge.net/p/dosemu/code/ci/master/tree/INSTALL