### PR TITLE
addpkg: exiv2

### DIFF
--- a/exiv2/exiv2-fix_test_failure.patch
+++ b/exiv2/exiv2-fix_test_failure.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/bugfixes/github/test_CVE_2018_12265.py b/tests/bugfixes/github/test_CVE_2018_12265.py
+index 4ba11b46..0b73c73c 100644
+--- a/tests/bugfixes/github/test_CVE_2018_12265.py
++++ b/tests/bugfixes/github/test_CVE_2018_12265.py
+@@ -18,7 +18,6 @@ class AdditionOverflowInLoaderExifJpeg(metaclass=system_tests.CaseMeta):
+ Warning: Directory Image, entry 0x0201: Strip 0 is outside of the data area; ignored.
+ Warning: Directory Image, entry 0x0201: Strip 7 is outside of the data area; ignored.
+ Error: Offset of directory Thumbnail, entry 0x0201 is out of bounds: Offset = 0x00000000; truncating the entry
+-$uncaught_exception $addition_overflow_message
+ """
+     ]
+-    retval = [1]
++    retval = [0]

--- a/exiv2/riscv64.patch
+++ b/exiv2/riscv64.patch
@@ -1,0 +1,25 @@
+diff --git PKGBUILD PKGBUILD
+index c5c9b6d..6327e25 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,9 +12,17 @@ depends=('gcc-libs' 'zlib' 'expat' 'libexpat.so' 'gettext' 'curl' 'libcurl.so')
+ makedepends=('cmake' 'gtest' 'ninja')
+ checkdepends=('python')
+ provides=('libexiv2.so')
+-source=(https://github.com/Exiv2/exiv2/archive/v${pkgver}/${pkgname}-${pkgver}.tar.gz)
+-sha512sums=('fb7153c141502de4a3446abb49d991735aa034ef30d0ee2050cffc6c73778faa8ba2a666797565d45c11f9ae1130544b6ed854570d38351505dbb3c1610c4b7c')
+-b2sums=('97eab9341e039f11a09630f428dee77bcda699451507076f78012dc84bd57f3aa9b47ee7346aebf809788917754be0ff83b5d624ee18759155c2585026b76f1b')
++source=(https://github.com/Exiv2/exiv2/archive/v${pkgver}/${pkgname}-${pkgver}.tar.gz
++  exiv2-fix_test_failure.patch)
++sha512sums=('fb7153c141502de4a3446abb49d991735aa034ef30d0ee2050cffc6c73778faa8ba2a666797565d45c11f9ae1130544b6ed854570d38351505dbb3c1610c4b7c'
++            'e77c9963a2c4a02ae02ef6d56d2b678b48f33ed5ce77aff5b68aba79995573004510214f391fd06f55226c42d3d973aaf3320227999acb72d346a23676a986c4')
++b2sums=('97eab9341e039f11a09630f428dee77bcda699451507076f78012dc84bd57f3aa9b47ee7346aebf809788917754be0ff83b5d624ee18759155c2585026b76f1b'
++        '037735e95c4129f469e530ffa52f9d906fa416c5a54bb651e04bcccf9021291f276b8c1c1048f763027a9a030d05858067950e57553a4b4dd77d2c8146c40e56')
++
++prepare() {
++  cd ${pkgname}-${pkgver}
++  patch -Np1 < $srcdir/exiv2-fix_test_failure.patch
++}
+ 
+ build() {
+   cd ${pkgname}-${pkgver}


### PR DESCRIPTION
the `char` type on RISC-V is unsigned where the failed test assumed it to be signed[1]
apply a patch similar to what GUIX has done[2].

[1] https://github.com/Exiv2/exiv2/issues/933
[2] https://github.com/guix-mirror/guix/commit/b8df15b748024128e09cebb4d7ebae42be5df788