### PR TITLE
qemu-user-blacklist: add ctags

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -7,6 +7,7 @@ bmake
 caps
 cargo-audit
 cargo-nextest
+ctags
 coreutils
 datovka
 dbus


### PR DESCRIPTION
cannot be built on qemu-user because several `stdout` and `exit` tests fail