### PR TITLE
addpkg: edac-utils

### DIFF
--- a/edac-utils/riscv64.patch
+++ b/edac-utils/riscv64.patch
@@ -1,0 +1,20 @@
+diff --git PKGBUILD PKGBUILD
+index 403fec3..feba894 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -10,9 +10,14 @@ license=('GPL2')
+ makedepends=('git')
+ depends=('perl' 'sysfsutils' 'dmidecode')
+ backup=('etc/edac/labels.db')
+-source=(git://github.com/grondo/edac-utils.git#tag=${pkgver}
++source=(git+https://github.com/grondo/edac-utils.git#tag=${pkgver}
+         edac.service)
+ 
++prepare() {
++  cd "$srcdir/$pkgname"
++  autoreconf -fiv
++}
++
+ build() {
+   cd "$srcdir/$pkgname"
+   ./configure --prefix=/usr --sbindir=/usr/bin --sysconfdir=/etc --mandir=/usr/share/man --infodir=/usr/share/info


### PR DESCRIPTION
upstream's autoconf scripts are too old (from 2004), do `autoreconf` before compiling 

ref: https://github.com/grondo/edac-utils/pull/16