### PR TITLE
addpkg: handbrake

### DIFF
--- a/handbrake/riscv64.patch
+++ b/handbrake/riscv64.patch
@@ -1,0 +1,32 @@
+diff --git PKGBUILD PKGBUILD
+index 818fee1..4fadc5d 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -29,7 +29,8 @@ build() {
+ 
+   ./configure \
+     --prefix=/usr \
+-    --enable-qsv
++    --disable-qsv \
++    --disable-nvenc
+   make -C build
+ }
+ 
+@@ -39,7 +40,6 @@ package_handbrake() {
+            "${_commondeps[@]}" "${_guideps[@]}")
+   optdepends=('gst-plugins-good: for video previews'
+               'gst-libav: for video previews'
+-              'intel-media-sdk: Intel QuickSync support'
+               'libdvdcss: for decoding encrypted DVDs')
+ 
+   cd "$srcdir/HandBrake-$pkgver/build"
+@@ -51,8 +51,7 @@ package_handbrake() {
+ package_handbrake-cli() {
+   pkgdesc="Multithreaded video transcoder (CLI)"
+   depends=("${_commondeps[@]}")
+-  optdepends=('intel-media-sdk: Intel QuickSync support'
+-              'libdvdcss: for decoding encrypted DVDs')
++  optdepends=('libdvdcss: for decoding encrypted DVDs')
+ 
+   cd "$srcdir/HandBrake-$pkgver/build"
+   install -D HandBrakeCLI "$pkgdir/usr/bin/HandBrakeCLI"


### PR DESCRIPTION
intel-media-sdk is unavailable on riscv
The nvidia video codec sdk is unavailable on riscv (including nvenc)

basically the same as ffmpeg 057be4d0c5eadc6d1df953485180ea64387f93fc