### PR TITLE
addpkg: x86_energy_perf_policy to blacklist

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -38,6 +38,7 @@ tp_smapi
 tp_smapi-lts
 tpacpi-bat
 vulkan-intel
+x86_energy_perf_policy
 xf86-video-intel
 xf86-video-openchrome
 


### PR DESCRIPTION
x86_energy_perf_policy is only compatible with x86

compare linux-tools patch 70c606f