### PR TITLE
addpkg: turbostat to blacklist

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -37,6 +37,7 @@ throttled
 tp_smapi
 tp_smapi-lts
 tpacpi-bat
+turbostat
 vulkan-intel
 xf86-video-intel
 xf86-video-openchrome


### PR DESCRIPTION
turbostat is only compatible with x86

compare linux-tools patch 70c606f