### PR TITLE
addpkg: cpupower to blacklist

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -18,6 +18,7 @@ vivaldi
 
 # No hardware support
 amd-ucode
+cpupower
 dosemu
 i7z
 intel-gmmlib


### PR DESCRIPTION
cpupower is only compatible with x86

compare linux-tools patch 70c606f