### PR TITLE
addpkg: libmfx to blacklist

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -32,6 +32,7 @@ intel-mkl-static
 intel-opencl-clang
 intel-ucode
 intel-undervolt
+libmfx
 libva-intel-driver
 throttled
 tp_smapi


### PR DESCRIPTION
libmfx is part of intel-media-sdk and not compatible with riscv64