### PR TITLE
addpatch: doctest 2.4.9-1

### DIFF
--- a/doctest/riscv64.patch
+++ b/doctest/riscv64.patch
@@ -1,0 +1,19 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -9,11 +9,14 @@ arch=('any')
+ url='https://github.com/onqtam/doctest'
+ license=('MIT')
+ makedepends=('cmake')
+-source=("${pkgname}-${pkgver}.tar.gz::https://github.com/${pkgname}/${pkgname}/archive/refs/tags/v${pkgver}.tar.gz")
+-sha256sums=('19b2df757f2f3703a5e63cee553d85596875f06d91a3333acd80a969ef210856')
++source=("${pkgname}-${pkgver}.tar.gz::https://github.com/${pkgname}/${pkgname}/archive/refs/tags/v${pkgver}.tar.gz"
++        "${pkgname}-fix-ptr-cmp.patch::https://github.com/doctest/doctest/pull/699.patch")
++sha256sums=('19b2df757f2f3703a5e63cee553d85596875f06d91a3333acd80a969ef210856'
++            '2e852fea05ab98c76012e93fef991f4b18ba5a9ca2a31b06c88e01c8657a240f')
+ 
+ prepare() {
+   cd "${srcdir}/${pkgname}-${pkgver}"
++  patch -Np1 < $srcdir/${pkgname}-fix-ptr-cmp.patch
+   mkdir build
+ }
+ 


### PR DESCRIPTION
Fix compile errors in downstream packages when comparing pointers.

Upstream PR: https://github.com/doctest/doctest/pull/699