### PR TITLE
fixpatch: rdiff-backup

### DIFF
--- a/rdiff-backup/riscv64.patch
+++ b/rdiff-backup/riscv64.patch
@@ -6,7 +6,7 @@ diff --git PKGBUILD PKGBUILD
    cd $pkgname
    export PATH="$PWD/build/scripts-3.10:$PATH"
 -  export PYTHONPATH="$PWD/build/lib.linux-x86_64-3.10"
-+  export PYTHONPATH="$PWD/build/lib.linux-$CARCH-3.10"
++  export PYTHONPATH="$PWD/build/lib.linux-$CARCH-cpython-310"
    python testing/commontest.py
    python testing/ctest.py
    python testing/timetest.py


### PR DESCRIPTION
After python-setuptools updated, the build-lib suffix is -cpython-310 now.

Ref:
* https://github.com/pypa/setuptools/commit/1c23f5e1e4b18b50081cbabb2dea22bf345f5894
* Upstream bug report: https://bugs.archlinux.org/task/76043

Signed-off-by: Avimitin <avimitin@gmail.com>