### PR TITLE
addpkg: cloud-init to qemu-user blacklist

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -7,6 +7,7 @@ bmake
 caps
 cargo-audit
 cargo-nextest
+cloud-init
 coreutils
 datovka
 dbus


### PR DESCRIPTION
```
______________________ TestGetProcEnv.test_get_proc_ppid _______________________

self = <tests.unittests.test_util.TestGetProcEnv testMethod=test_get_proc_ppid>

    def test_get_proc_ppid(self):
        """get_proc_ppid returns correct parent pid value."""
        my_pid = os.getpid()
        my_ppid = os.getppid()
>       self.assertEqual(my_ppid, util.get_proc_ppid(my_pid))
E       AssertionError: 7 != 0

tests/unittests/test_util.py:2465: AssertionError
------------------------------ Captured log call -------------------------------
2022-09-24 01:16:47 DEBUG     cloudinit.util:util.py:1474 Reading from /proc/3005/stat (quiet=True)
2022-09-24 01:16:47 DEBUG     cloudinit.util:util.py:1485 Read 117 bytes from /proc/3005/stat
2022-09-24 01:16:47 WARNING   cloudinit.util:util.py:2903 Unable to match parent pid of process pid=3005 input: 3005 (python) 0 7 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 446652017 0 0 0 0 0 274919864608 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
```

The test will fail in qemu-user but pass on real boards. (Subprocess related issue)