### PR TITLE
addpkg: balsa

### DIFF
--- a/balsa/riscv64.patch
+++ b/balsa/riscv64.patch
@@ -1,0 +1,16 @@
+diff --git PKGBUILD PKGBUILD
+index cf5b255..5c6fe4d 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,6 +17,11 @@
+ source=(https://pawsa.fedorapeople.org/balsa/$pkgname-$pkgver.tar.xz)
+ sha256sums=('befa5984511db33d41f2b1ecbfc99e22a15d45d08efe5d737b5174a1a6ac8fc1')
+ 
++prepare() {
++  cd "${srcdir}"/$pkgname-$pkgver
++  autoreconf -fiv 
++}
++
+ build() {
+   cd "${srcdir}"/$pkgname-$pkgver
+ 


### PR DESCRIPTION
`config.guess` and `config.sub` shipped in upstream released tar are from 2015 and can not recognize riscv.

This has been reported to upstream's [mailing list](https://mail.gnome.org/mailman/listinfo/balsa-list).

But it is now being held until the list moderator can review it for approval.
