### PR TITLE
addpatch: tracker

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -102,6 +102,7 @@ tinyssh
 tmuxp
 tpm2-tools
 tpm2-tss
+tracker
 uutils-coreutils
 vim
 wanderlust

--- a/tracker/riscv64.patch
+++ b/tracker/riscv64.patch
@@ -1,0 +1,35 @@
+diff --git PKGBUILD PKGBUILD
+index 9f11265..2e8e85a 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -18,9 +18,11 @@ provides=(libtracker-{control,miner,sparql}-2.0.so)
+ options=(debug)
+ _commit=b2739625209c564192b339814264084046e1cf17  # tracker-2.3
+ source=("git+https://gitlab.gnome.org/GNOME/tracker.git#commit=$_commit"
+-        0001-libtracker-data-Workaround-SQLite-3.35.x-bug.patch)
++        0001-libtracker-data-Workaround-SQLite-3.35.x-bug.patch
++        tracker-fix-slow-tests.patch)
+ sha256sums=('SKIP'
+-            '2dc030fb047e99420bd330d5eee1fd70bd26a7ee0adf31f90c724bd0732ed67d')
++            '2dc030fb047e99420bd330d5eee1fd70bd26a7ee0adf31f90c724bd0732ed67d'
++            'b3478c1860a61174ce70e4d3aab54ccac3e073f47bdf6b14aa1a8af0376b2794')
+ 
+ pkgver() {
+   cd tracker
+@@ -32,6 +34,7 @@ prepare() {
+ 
+   # https://gitlab.gnome.org/GNOME/tracker/-/merge_requests/382
+   git apply -3 ../0001-libtracker-data-Workaround-SQLite-3.35.x-bug.patch
++  git apply -Np1 ../tracker-fix-slow-tests.patch
+ }
+ 
+ build() {
+@@ -40,7 +43,7 @@ build() {
+ }
+ 
+ check() {
+-  dbus-run-session meson test -C build --print-errorlogs -t 3
++  dbus-run-session meson test -C build --print-errorlogs -t 10
+ }
+ 
+ package() {

--- a/tracker/tracker-fix-slow-tests.patch
+++ b/tracker/tracker-fix-slow-tests.patch
@@ -1,0 +1,28 @@
+diff --git a/utils/trackertestutils/helpers.py b/utils/trackertestutils/helpers.py
+index 2b218e5d0..cbd9450bd 100644
+--- a/utils/trackertestutils/helpers.py
++++ b/utils/trackertestutils/helpers.py
+@@ -240,6 +240,9 @@ class StoreHelper (Helper):
+     def start(self, command_args=None, extra_env=None):
+         Helper.start(self, command_args, extra_env)
+
++        import time
++        time.sleep(5)
++
+         self.resources = Gio.DBusProxy.new_sync(
+             self.bus, Gio.DBusProxyFlags.DO_NOT_AUTO_START, None,
+             self.TRACKER_BUSNAME, self.TRACKER_OBJ_PATH, self.RESOURCES_IFACE)
+
+diff --git a/tests/libtracker-sparql/tracker-sparql-test.c b/tests/libtracker-sparql/tracker-sparql-test.c
+index 3b60d18be..3deaa5ae6 100644
+--- a/tests/libtracker-sparql/tracker-sparql-test.c
++++ b/tests/libtracker-sparql/tracker-sparql-test.c
+@@ -304,7 +304,7 @@ test_tracker_sparql_nb237150 (void)
+ 	 * never returns
+ 	 */
+ 	g_test_trap_subprocess ("/libtracker-sparql/tracker-sparql/nb237150/subprocess",
+-	                        G_USEC_PER_SEC * 2,
++	                        G_USEC_PER_SEC * 20,
+ 	                        G_TEST_SUBPROCESS_INHERIT_STDOUT |
+ 	                        G_TEST_SUBPROCESS_INHERIT_STDERR);
+


### PR DESCRIPTION
although tons of methods have been tried, the tracker test is still flaky:

among several runs, these failure combinations have been observed:

```
1.
34/43 data-sparql                           FAIL             11.08s   (exit status 133 or signal 5 SIGTRAP)
42/43 tracker-sparql-test                   FAIL              2.20s   (exit status 134 or signal 6 SIGABRT)

2.
34/43 data-sparql                           FAIL              8.78s   (exit status 133 or signal 5 SIGTRAP)
37/43 miner-miner-fs                        FAIL             39.02s   killed by signal 5 SIGTRAP
42/43 tracker-sparql-test                   FAIL              2.22s   (exit status 134 or signal 6 SIGABRT)

3.
38/43 miner-miner-fs                        FAIL             73.48s   killed by signal 5 SIGTRAP
42/43 tracker-sparql-test                   FAIL              2.20s   (exit status 134 or signal 6 SIGABRT)

4.
35/43 data-sparql                           FAIL             15.33s   (exit status 133 or signal 5 SIGTRAP)
37/43 data-ontology                         FAIL             34.73s   (exit status 133 or signal 5 SIGTRAP)
39/43 miner-miner-fs                        FAIL             76.30s   killed by signal 5 SIGTRAP
42/43 tracker-sparql-test                   FAIL              2.19s   (exit status 134 or signal 6 SIGABRT)

5.
36/43 data-sparql                           FAIL             32.33s   (exit status 133 or signal 5 SIGTRAP)
42/43 tracker-sparql-test                   FAIL              2.22s   (exit status 134 or signal 6 SIGABRT)

6.
42/43 tracker-sparql-test                   FAIL              3.79s   (exit status 134 or signal 6 SIGABRT)

7.
All PASS
```

The `tracker-sparql-test` test is VERY fragile plus it cannot be reproduced afterwards (?), this needs further investigation