### PR TITLE
updpatch: go 2:1.19.1-1

### DIFF
--- a/go/riscv64.patch
+++ b/go/riscv64.patch
@@ -1,10 +1,25 @@
-diff --git PKGBUILD PKGBUILD
-index 4f2645b4..61fc88d9 100644
---- PKGBUILD
-+++ PKGBUILD
-@@ -30,8 +30,7 @@
-             'SKIP')
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1313120)
++++ PKGBUILD	(working copy)
+@@ -24,14 +24,20 @@
+ replaces=(go-pie)
+ provides=(go-pie)
+ options=(!strip staticlibs)
+-source=(https://go.dev/dl/go${pkgver}.src.tar.gz{,.asc})
++source=(https://go.dev/dl/go${pkgver}.src.tar.gz{,.asc}
++        go-riscv64-sv57.patch::https://github.com/golang/go/commit/1e3c19f3fee12e5e2b7802a54908a4d4d03960da.patch)
+ validpgpkeys=('EB4C1BFD4F042F6DDDCCEC917721F63BD38B4796')
+ sha256sums=('27871baa490f3401414ad793fba49086f6c855b1c584385ed7771e1204c7e179'
+-            'SKIP')
++            'SKIP'
++            'a571c0fbf71afc121cd663f9a21924dc99acc9d8d1e6e0004751d9604ab298f9')
  
++prepare() {
++  cd go/src
++  patch -p2 -i "${srcdir}/go-riscv64-sv57.patch"
++}
++
  build() {
 -  export GOARCH=amd64
 -  export GOAMD64=v1 # make sure we're building for the right x86-64 version
@@ -12,7 +27,7 @@ index 4f2645b4..61fc88d9 100644
    export GOROOT_FINAL=/usr/lib/go
    export GOROOT_BOOTSTRAP=/usr/lib/go
  
-@@ -50,7 +49,7 @@
+@@ -50,7 +56,7 @@
    cd "$pkgname"
  
    install -d "$pkgdir/usr/bin" "$pkgdir/usr/lib/go" "$pkgdir/usr/share/doc/go" \
@@ -20,4 +35,4 @@ index 4f2645b4..61fc88d9 100644
 +    "$pkgdir/usr/lib/go/pkg/linux_riscv64_"{dynlink,race}
  
    cp -a bin pkg src lib misc api test "$pkgdir/usr/lib/go"
-   cp -r doc/* "$pkgdir/usr/share/doc/go"
+   # We can't strip all binaries and libraries,


### PR DESCRIPTION
Add a patch to fix go programs crashes under qemu-system due to sv57 incompatibilities.