### PR TITLE
addpatch: vmpk

### DIFF
--- a/vmpk/riscv64.patch
+++ b/vmpk/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -11,7 +11,7 @@ license=(GPL3)
+ groups=(pro-audio)
+ depends=(gcc-libs glibc libxcb qt6-base)
+ makedepends=(cmake docbook-xsl drumstick qt6-tools)
+-options=(debug)
++options=(debug !lto)
+ source=(https://downloads.sourceforge.net/project/$pkgname/$pkgname/${pkgver/a/}/$pkgname-$pkgver.tar.bz2)
+ sha512sums=('e010e52174ba7f267f6c140d9dcb731c9e58f09504c7dab446fa79bccf513da4d37da5f7878f5b58a5d83c964f80f333e84a3c85edd778d11a6eeba07ca6b6bb')
+ b2sums=('b41978b98be242badaa576d6d9420f96ea172a5391c25e81a09e099d32a1b06999098b25ff14fc1d62f9ad050722bf7a4c4369a287c9d9e7140330f5a1b04e2d')


### PR DESCRIPTION
This PR remove the lto option because ld can't correctly found symbol with "lto" option on.

Signed-off-by: Avimitin <avimitin@gmail.com>