### PR TITLE
addpatch: tracker3

### DIFF
--- a/tracker3/riscv64.patch
+++ b/tracker3/riscv64.patch
@@ -1,0 +1,25 @@
+diff --git PKGBUILD PKGBUILD
+index 22c87dd..1d0e852 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -16,8 +16,10 @@ makedepends=(gobject-introspection git hotdoc bash-completion meson asciidoc
+              systemd libsoup python-gobject python-dbus python-tappy)
+ options=(debug)
+ _commit=6e38fb55cb7cc58d8c29937db01dc8179fe15b68  # tags/3.4.0^0
+-source=("git+https://gitlab.gnome.org/GNOME/tracker.git#commit=$_commit")
+-sha256sums=('SKIP')
++source=("git+https://gitlab.gnome.org/GNOME/tracker.git#commit=$_commit"
++        tracker3-MR543.patch::https://gitlab.gnome.org/GNOME/tracker/-/merge_requests/543.patch)
++sha256sums=('SKIP'
++            '80ef5d40935e24f3e7d799ca4996d6a158f94c4dcb81cf2865466d75792357ca')
+ 
+ pkgver() {
+   cd tracker
+@@ -26,6 +28,7 @@ pkgver() {
+ 
+ prepare() {
+   cd tracker
++  patch -Np1 < ../tracker3-MR543.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
the non-NULL terminated array causes an out-of-bound read

upstream: https://gitlab.gnome.org/GNOME/tracker/-/merge_requests/543