### PR TITLE
updpatch: linux-tools 5.19-1.1

### DIFF
--- a/linux-tools/riscv64.patch
+++ b/linux-tools/riscv64.patch
@@ -1,14 +1,8 @@
 Index: PKGBUILD
 ===================================================================
---- PKGBUILD	(revision 1011877)
+--- PKGBUILD	(revision 1320031)
 +++ PKGBUILD	(working copy)
-@@ -4,15 +4,12 @@
- pkgname=(
-   'bpf'
-   'cgroup_event_listener'
--  'cpupower'
-   'hyperv'
-   'linux-tools-meta'
+@@ -11,9 +11,7 @@
    'perf'
  #  'python-perf'
    'tmon'
@@ -16,26 +10,28 @@ Index: PKGBUILD
    'usbip'
 -  'x86_energy_perf_policy'
  )
- pkgver=5.14
+ pkgver=5.19
  pkgrel=1
-@@ -26,8 +23,6 @@
- makedepends+=('asciidoc' 'xmlto')
- # perf deps
- makedepends+=('perl' 'python' 'slang' 'elfutils' 'libunwind' 'numactl' 'audit' 'zstd' 'libcap')
--# cpupower deps
--makedepends+=('pciutils')
- # usbip deps
- makedepends+=('glib2' 'sysfsutils' 'udev')
- # tmon deps
-@@ -88,16 +83,6 @@
-     DESTDIR="$pkgdir"
+@@ -41,6 +39,7 @@
+ makedepends+=('llvm' 'clang')
+ groups=("$pkgbase")
+ source=("git+https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git#tag=v${pkgver//_/-}?signed"
++        linux-tools-binutils-2.39.patch::https://patch-diff.githubusercontent.com/raw/kernel-patches/bpf/pull/3418.patch
+ #        "https://cdn.kernel.org/pub/linux/kernel/v5.x/patch-$pkgver.1.xz"
+         'cpupower.default'
+         'cpupower.systemd'
+@@ -54,6 +53,7 @@
+   '647F28654894E3BD457199BE38DBBDC86092693E'  # Greg Kroah-Hartman
+ )
+ sha256sums=('SKIP'
++            '7b06733566b3d64a69b6d5c4ea898f352c29d1d9fcb95d286e9c1ff8c2f097e7'
+             '4fa509949d6863d001075fa3e8671eff2599c046d20c98bb4a70778595cd1c3f'
+             'b692f4859ed3fd9831a058a450a84d8c409bf7e3e45aac1c2896a14bb83f3d7a'
+             '42d2ec9f1d9cc255ee7945a27301478364ef482f5a6ddfc960189f03725ccec2'
+@@ -97,11 +97,6 @@
+   make VERSION=$pkgver-$pkgrel
    popd
  
--  echo ':: cpupower'
--  pushd linux/tools/power/cpupower
--  make VERSION=$pkgver-$pkgrel
--  popd
--
 -  echo ':: x86_energy_perf_policy'
 -  pushd linux/tools/power/x86/x86_energy_perf_policy
 -  make
@@ -44,7 +40,7 @@ Index: PKGBUILD
    echo ':: usbip'
    pushd linux/tools/usb/usbip
    # Fix gcc compilation
-@@ -117,11 +102,6 @@
+@@ -121,11 +116,6 @@
    make
    popd
  
@@ -56,12 +52,7 @@ Index: PKGBUILD
    echo ':: hv'
    pushd linux/tools/hv
    CFLAGS+=' -DKVP_SCRIPTS_PATH=\"/usr/lib/hyperv/kvp_scripts/\"' make
-@@ -143,14 +123,11 @@
-   depends=(
-     'bpf'
-     'cgroup_event_listener'
--    'cpupower'
-     'hyperv'
+@@ -158,9 +148,7 @@
      'perf'
  #    'python-perf'
      'tmon'


### PR DESCRIPTION
- Enable cpupower (obsoletes #1766). It used to have some build failures but now works flawlessly.

- Add a patch for binutils 2.39