### PR TITLE
addpatch: haskell-wreq

### DIFF
--- a/haskell-wreq/riscv64.patch
+++ b/haskell-wreq/riscv64.patch
@@ -1,0 +1,13 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1320144)
++++ PKGBUILD	(working copy)
+@@ -34,7 +34,7 @@
+     runhaskell Setup configure -O --enable-shared --enable-executable-dynamic --disable-library-vanilla \
+         --prefix=/usr --docdir=/usr/share/doc/$pkgname --datasubdir=$pkgname --enable-tests \
+         --dynlibdir=/usr/lib --libsubdir=\$compiler/site-local/\$pkgid --ghc-option=-fllvm \
+-            -fdoctest -f-aws -fhttpbin -f-developer
++            -f-doctest -f-aws -fhttpbin -f-developer
+     runhaskell Setup build $MAKEFLAGS
+     runhaskell Setup register --gen-script
+     runhaskell Setup unregister --gen-script


### PR DESCRIPTION
Disable doctests until we figure out our GHCi crash.