### PR TITLE
addpatch: haskell-swagger2

### DIFF
--- a/haskell-swagger2/riscv64.patch
+++ b/haskell-swagger2/riscv64.patch
@@ -1,0 +1,12 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1320144)
++++ PKGBUILD	(working copy)
+@@ -22,6 +22,7 @@
+ 
+ prepare() {
+     cd $_hkgname-$pkgver
++    sed -i '/test-suite doctests/a \  buildable: False' $_hkgname.cabal
+     uusi -u hspec $_hkgname.cabal
+ }
+ 


### PR DESCRIPTION
Disable doctests until we fix our GHCi crash.