### PR TITLE
add makedepends based blacklists

### DIFF
--- a/qemu-system-makedepends-blacklist.txt
+++ b/qemu-system-makedepends-blacklist.txt
@@ -1,0 +1,8 @@
+npm
+nodejs
+yarn
+java-environment
+jdk-openjdk
+jdk8-openjdk
+jdk11-openjdk
+jdk17-openjdk

--- a/qemu-user-makedepends-blacklist.txt
+++ b/qemu-user-makedepends-blacklist.txt
@@ -1,0 +1,3 @@
+go
+rust
+cargo


### PR DESCRIPTION
qemu-system-makedepends-blacklist: all because of sv57 at the moment. remove when sv57 is disabled in our kernels.

qemu-user-makedepends-blacklist: random deadlocks.