### PR TITLE
addpatch: crun

### DIFF
--- a/crun/riscv64.patch
+++ b/crun/riscv64.patch
@@ -1,0 +1,13 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1320583)
++++ PKGBUILD	(working copy)
+@@ -9,7 +9,7 @@
+ license=('LGPL')
+ arch=('x86_64')
+ provides=('oci-runtime')
+-depends=('yajl' 'systemd-libs' 'libcap' 'libseccomp' 'criu')
++depends=('yajl' 'systemd-libs' 'libcap' 'libseccomp')
+ makedepends=('libtool' 'python' 'go-md2man' 'systemd' 'git')
+ source=("https://github.com/containers/crun/releases/download/$pkgver/$pkgname-$pkgver.tar.xz"{,.asc})
+ validpgpkeys=('AC404C1C0BF735C63FF4D562263D6DF2E163E1EA')


### PR DESCRIPTION
Disable criu support until upstream has support
(https://github.com/checkpoint-restore/criu/issues/1702)