### PR TITLE
addpatch: nix-busybox

### DIFF
--- a/nix-busybox/riscv64.patch
+++ b/nix-busybox/riscv64.patch
@@ -1,0 +1,26 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1320766)
++++ PKGBUILD	(working copy)
+@@ -13,11 +13,9 @@
+ license=('GPL')
+ makedepends=(
+   'ncurses'
+-  'musl'
+-  'kernel-headers-musl'
+ )
+ source=(
+-  "$url/download/$_pkgname-$pkgver.tar.bz2"{,.sig}
++  "$url/downloads/$_pkgname-$pkgver.tar.bz2"{,.sig}
+   'config'
+ )
+ b2sums=('c08656bc863cd3fa8f7269032e808a30832215c36414c12f8233ab00503636ed1979541b7df42df654f1dfdfdd46fc00c8fe790bf0bed629a915b4c806c643b9'
+@@ -32,7 +30,7 @@
+ 
+   # reproducible build
+   export KCONFIG_NOTIMESTAMP=1
+-  make CC=musl-gcc
++  make
+ }
+ 
+ package() {


### PR DESCRIPTION
- Use glibc instead of musl because the kernel-headers-musl package is too old to support RISC-V

- Also fixed source url and reported at https://bugs.archlinux.org/task/76101