### PR TITLE
addpatch: consul

### DIFF
--- a/consul/riscv64.patch
+++ b/consul/riscv64.patch
@@ -1,0 +1,13 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1320744)
++++ PKGBUILD	(working copy)
+@@ -9,7 +9,7 @@
+ url="https://www.consul.io"
+ license=('MPL2')
+ depends=('glibc')
+-makedepends=('git' 'go' 'go-bindata-assetfs' 'go-bindata-hashicorp' 'procps-ng' 'zip' 'yarn' 'bower' 'nodejs-lts-fermium' 'npm' 'zip' 'gox' 'go-tools')
++makedepends=('git' 'go' 'go-bindata-assetfs' 'go-bindata-hashicorp' 'procps-ng' 'zip' 'zip' 'gox' 'go-tools')
+ source=("${pkgname}-${pkgver}.tar.gz::https://github.com/hashicorp/consul/archive/v${pkgver}.tar.gz"
+         'consul.service'
+         'consul.default'


### PR DESCRIPTION
Remove nodejs dependencies because they appear to be unused at the moment (and we don't have nodejs-lts-fermium).