### PR TITLE
upgpatch: cargo-pgx 0.5.0-1

### DIFF
--- a/cargo-pgx/riscv64.patch
+++ b/cargo-pgx/riscv64.patch
@@ -1,10 +1,11 @@
-diff --git PKGBUILD PKGBUILD
-index e5cf5cd4..7655edca 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -25,7 +25,7 @@ prepare() {
-   cd "$pkgname-$pkgver"
+@@ -26,8 +26,10 @@ pkgver() {
+ prepare() {
+   cd "$pkgname"
  
++  echo -e "[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
++  cargo update -p ring
    # download dependencies
 -  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
 +  cargo fetch --locked


### PR DESCRIPTION
Replace dependency `ring` with our patched version.