### PR TITLE
updpatch: glibc

### DIFF
--- a/glibc/riscv64.patch
+++ b/glibc/riscv64.patch
@@ -1,6 +1,6 @@
 Index: PKGBUILD
 ===================================================================
---- PKGBUILD	(revision 456256)
+--- PKGBUILD	(revision 457406)
 +++ PKGBUILD	(working copy)
 @@ -7,7 +7,7 @@
  # NOTE: valgrind requires rebuilt with each major glibc version
@@ -9,8 +9,8 @@ Index: PKGBUILD
 -pkgname=(glibc lib32-glibc)
 +pkgname=(glibc)
  pkgver=2.36
- _commit=645d94808aaa90fb1b20a25ff70bb50d9eb1d55b
- pkgrel=4
+ _commit=2bd815d8347851212b9a91dbdca8053f4dbdac87
+ pkgrel=6
 @@ -14,7 +14,7 @@
  arch=(x86_64)
  url='https://www.gnu.org/software/libc'
@@ -28,7 +28,7 @@ Index: PKGBUILD
  )
  validpgpkeys=(7273542B39962DF7B299931416792B4EA25340F8 # Carlos O'Donell
                BC7C7372637EC10C57D7AA6579C43DFBF1CF2187) # Siddhesh Poyarekar
-@@ -31,10 +32,11 @@
+@@ -31,7 +32,8 @@
          '7c265e6d36a5c0dff127093580827d15519b6c7205c2e1300e82f0fb5b9dd00b6accb40c56581f18179c4fbbc95bd2bf1b900ace867a83accde0969f7b609f8a'
          'a6a5e2f2a627cc0d13d11a82458cfd0aa75ec1c5a3c7647e5d5a3bb1d4c0770887a3909bfda1236803d5bc9801bfd6251e13483e9adf797e4725332cd0d91a0e'
          '214e995e84b342fe7b2a7704ce011b7c7fc74c2971f98eeb3b4e677b99c860addc0a7d91b8dc0f0b8be7537782ee331999e02ba48f4ccc1c331b60f27d715678'
@@ -37,11 +37,7 @@ Index: PKGBUILD
 +        'e3e17f784dd668a1bba6128a5a25616657d848ccd67668f0246e06aac36572e34935a8937639b527f28d755335bca153cadfd9e7daecfe8d5536f76b7ab0f9c0')
  
  prepare() {
--  mkdir -p glibc-build lib32-glibc-build
-+  mkdir -p glibc-build
- 
-   [[ -d glibc-$pkgver ]] && ln -s glibc-$pkgver glibc
-   cd glibc
+   mkdir -p glibc-build lib32-glibc-build
 @@ -43,6 +45,10 @@
    # which relies on DT_HASH to be present in these libs.
    # reconsider 2023-01
@@ -60,7 +56,7 @@ Index: PKGBUILD
 -      --enable-multi-arch
        --enable-stack-protector=strong
        --enable-systemtap
-       --disable-profile
+       --disable-crypt
 @@ -90,30 +95,6 @@
    # build info pages manually for reproducibility
    make info
@@ -105,7 +101,7 @@ Index: PKGBUILD
    pkgdesc='GNU C Library'
    depends=('linux-api-headers>=4.10' tzdata filesystem)
    optdepends=('gd: for memusagestat'
-@@ -198,27 +179,3 @@
+@@ -199,27 +180,3 @@
    install -Dm644 "${srcdir}"/sdt.h "${pkgdir}"/usr/include/sys/sdt.h
    install -Dm644 "${srcdir}"/sdt-config.h "${pkgdir}"/usr/include/sys/sdt-config.h
  }


### PR DESCRIPTION
Update glibc to 2.36-6.

The progress of strfrom patch is [here v5](https://sourceware.org/pipermail/libc-alpha/2022-October/142544.html). Since I'm still not confident with this patch, I just skip the test case.