### PR TITLE
Remove `rust` from qemu-user blacklist

### DIFF
--- a/qemu-user-makedepends-blacklist.txt
+++ b/qemu-user-makedepends-blacklist.txt
@@ -1,3 +1,1 @@
 go
-rust
-cargo


### PR DESCRIPTION
It's been a long time not observing unrecoverable sleep under qemu-user for packages written in Rust. Try to remove it.