### PR TITLE
Revert "Remove `rust` from qemu-user blacklist"

### DIFF
--- a/qemu-user-makedepends-blacklist.txt
+++ b/qemu-user-makedepends-blacklist.txt
@@ -1,1 +1,3 @@
 go
+rust
+cargo


### PR DESCRIPTION
Reverts felixonmars/archriscv-packages#1827

Unrecoverable sleeps still occur with *a* probability. Aggressively blacklist them from qemu-user because builds entering unrecoverable sleeps needs manual intervention to retry.