### PR TITLE
updpatch: libffi

### DIFF
--- a/libffi/riscv64.patch
+++ b/libffi/riscv64.patch
@@ -1,25 +1,26 @@
-diff --git PKGBUILD PKGBUILD
-index 172b7568..278e460e 100644
---- PKGBUILD
-+++ PKGBUILD
-@@ -14,9 +14,17 @@ depends=('glibc')
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 457546)
++++ PKGBUILD	(working copy)
+@@ -14,10 +14,18 @@
  checkdepends=('dejagnu')
  provides=('libffi.so')
  options=('debug')
 -source=(https://github.com/libffi/libffi/releases/download/v$pkgver/libffi-$pkgver.tar.gz)
--sha256sums=('540fb721619a6aba3bdeef7d940d8e9e0e6d2c193595bc243241b77ff9e93620')
--b2sums=('a8137bc895b819f949fd7705e405be627219c6d1fdef280253330f7407d4a548bb057d7bb0e9225d1767d42f9bf5f0ab3c455db1c3470d7cc876bb7b7d55d308')
+-sha256sums=('4416dd92b6ae8fcb5b10421e711c4d3cb31203d77521a77d85d0102311e6c3b8')
+-b2sums=('5e751c53a6b65316e438723810fbafe7f27732feb50466f1459d086c35a519f460b57968721212496a7502b0a5860546c84b22ec269e979728f18d0731fc918a')
 +source=(https://github.com/libffi/libffi/releases/download/v$pkgver/libffi-$pkgver.tar.gz
-+        'libffi-fix-riscv-ffi_arg-size.patch::https://patch-diff.githubusercontent.com/raw/libffi/libffi/pull/680.patch')
-+sha256sums=('540fb721619a6aba3bdeef7d940d8e9e0e6d2c193595bc243241b77ff9e93620'
-+            'ccb83f3e8dda59977d3f36c33fc38e727830a29966f619dc0424f78ad6d51b83')
-+b2sums=('a8137bc895b819f949fd7705e405be627219c6d1fdef280253330f7407d4a548bb057d7bb0e9225d1767d42f9bf5f0ab3c455db1c3470d7cc876bb7b7d55d308'
-+        '6f5117afa110cfe18163576113b4a1467cfa1027ea80f061f2a1dbd745a9a8f91d42f95d9c42d9b05a55882e479cfe48218f36d36b493071433379ca1462e4e4')
-+
++        fix-struct-reference.patch::https://github.com/libffi/libffi/commit/4b0c358e28fae22164bf0d423f183dfed8a1ba10.patch)
++sha256sums=('4416dd92b6ae8fcb5b10421e711c4d3cb31203d77521a77d85d0102311e6c3b8'
++            'b14d9a6fa17b46f85249c74fb6ddcd1c6a3af30526ea6400641566e39c17861f')
++b2sums=('5e751c53a6b65316e438723810fbafe7f27732feb50466f1459d086c35a519f460b57968721212496a7502b0a5860546c84b22ec269e979728f18d0731fc918a'
++        'cb41a382a327f7d59d155e49aeb47c8cb5a20212d0e7310387b8aecadd08d9afba180d351d04f267a4af1f626af8d5b22da6859b75ff3aa02447d7381585be5f')
+ 
 +prepare() {
 +  cd $pkgname-$pkgver
-+  patch  -Np1 -i $srcdir/libffi-fix-riscv-ffi_arg-size.patch
++  patch -Np1 -i ../fix-struct-reference.patch
 +}
- 
++
  build() {
    cd $pkgname-$pkgver
+   # remove --disable-exec-static-tramp once ghc and gobject-introspection


### PR DESCRIPTION
Upgrade to 3.4.3 and backport one patch to resolve check failures.
https://github.com/libffi/libffi/pull/738