### PR TITLE
addpatch: haskell-pgp-wordlist

### DIFF
--- a/haskell-pgp-wordlist/riscv64.patch
+++ b/haskell-pgp-wordlist/riscv64.patch
@@ -1,0 +1,16 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1327625)
++++ PKGBUILD	(working copy)
+@@ -14,6 +14,11 @@
+ source=(https://hackage.haskell.org/packages/archive/${_hkgname}/${pkgver}/${_hkgname}-${pkgver}.tar.gz)
+ sha512sums=('b7c6db47c1f9a0b10c5c94ea46b8eee282988e5990ef3dafa2d07a5bfc0718572b04494d23ddab063811ef2452546d6b17010c6490a89031f4b071f1a43d989b')
+ 
++prepare() {
++    cd $_hkgname-$pkgver
++    sed -i '/test-suite doctest/a \    buildable: false' $_hkgname.cabal
++}
++
+ build() {
+     cd $_hkgname-$pkgver
+     


### PR DESCRIPTION
Disable doctests because of our GHCi crashes.