### PR TITLE
addpatch: haskell-network-byte-order

### DIFF
--- a/haskell-network-byte-order/riscv64.patch
+++ b/haskell-network-byte-order/riscv64.patch
@@ -1,0 +1,16 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1327625)
++++ PKGBUILD	(working copy)
+@@ -13,6 +13,11 @@
+ source=(https://hackage.haskell.org/packages/archive/${_hkgname}/${pkgver}/${_hkgname}-${pkgver}.tar.gz)
+ sha512sums=('bfb15f6e1aa863af7f81dc35518273e936d04f5f9decf6a0938a972dc9780ab5c9c10ed062ea027d1e92aa1e61dfb0059dcbc38324dbd4124f89d08017a2ae97')
+ 
++prepare() {
++    cd $_hkgname-$pkgver
++    sed -i '/test-suite doctest/a \  buildable: false' $_hkgname.cabal
++}
++
+ build() {
+     cd $_hkgname-$pkgver
+     


### PR DESCRIPTION
Disable doctests because of our GHCi crashes