### PR TITLE
addpatch: haskell-pcg-random

### DIFF
--- a/haskell-pcg-random/riscv64.patch
+++ b/haskell-pcg-random/riscv64.patch
@@ -1,0 +1,16 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1327625)
++++ PKGBUILD	(working copy)
+@@ -13,6 +13,11 @@
+ source=("https://hackage.haskell.org/packages/archive/$_hkgname/$pkgver/$_hkgname-$pkgver.tar.gz")
+ sha256sums=('e6c8c26841b5d0d6d9e2816e952e397062730fd1a0bc13cf7c3ebcba6dc1d2d0')
+ 
++prepare() {
++  cd $_hkgname-$pkgver
++  sed -i '/test-suite doctests/a \  buildable: false' $_hkgname.cabal
++}
++
+ build() {
+   cd $_hkgname-$pkgver
+ 


### PR DESCRIPTION
Disable doctests until we fix our GHCi crashes.