### PR TITLE
qemu-user-blacklist: add gnutls

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -29,6 +29,7 @@ gawk
 gdk-pixbuf2
 glib-perl
 glibc
+gnutls
 go
 gpxsee
 grep


### PR DESCRIPTION
One test fails in qemu-user.
```
FAIL: serv-udp
==============
Checking whether UDP server works
reserved port 50147
*** Fatal error: Error in the push function.
Could not connect to 127.0.0.1:50147: Connection refused
Failure: 1. handshake should have succeeded!
unreserved port 50147
FAIL serv-udp.sh (exit status: 1)
```

Build successfully on reshiram.