### PR TITLE
addpatch: haskell-email-validate

### DIFF
--- a/haskell-email-validate/riscv64.patch
+++ b/haskell-email-validate/riscv64.patch
@@ -1,0 +1,12 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1328016)
++++ PKGBUILD	(working copy)
+@@ -17,6 +17,7 @@
+ prepare() {
+     cd $_hkgname-$pkgver
+     uusi -u doctest -u hspec $_hkgname.cabal
++    sed -i '/test-suite doctests/a \    buildable: False' $_hkgname.cabal
+ }
+ 
+ build() {


### PR DESCRIPTION
Disable doctests until we fix our GHCi crashes.