### PR TITLE
addpatch: haskell-rank2classes

### DIFF
--- a/haskell-rank2classes/riscv64.patch
+++ b/haskell-rank2classes/riscv64.patch
@@ -1,0 +1,16 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1328013)
++++ PKGBUILD	(working copy)
+@@ -14,6 +14,11 @@
+ source=(https://hackage.haskell.org/packages/archive/${_hkgname}/${pkgver}/${_hkgname}-${pkgver}.tar.gz)
+ sha512sums=('8a4bf5ffd889d9ca18142703711539035b0d124de0d2e0e9906c361a47036854a32795c71bf1a9e50d99b46fd1f23d9534f743226f1cad0f827a6faa9789bb38')
+ 
++prepare() {
++    cd $_hkgname-$pkgver
++    sed -i '/test-suite doctests/a \  buildable: False' rank2classes.cabal
++}
++
+ build() {
+     cd $_hkgname-$pkgver
+ 


### PR DESCRIPTION
Disable doctests because of our GHCi crashes.