### PR TITLE
addpatch: haskell-validation-selective

### DIFF
--- a/haskell-validation-selective/riscv64.patch
+++ b/haskell-validation-selective/riscv64.patch
@@ -1,0 +1,12 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1328040)
++++ PKGBUILD	(working copy)
+@@ -18,6 +18,7 @@
+ prepare(){
+   cd $_hkgname-$pkgver
+   gen-setup
++  sed -i '/test-suite validation-selective-doctest/a \  buildable: False' $_hkgname.cabal
+ }
+ 
+ build() {


### PR DESCRIPTION
Disable doctests until we fix our GHCi crash.