### PR TITLE
addpatch: haskell-relude

### DIFF
--- a/haskell-relude/riscv64.patch
+++ b/haskell-relude/riscv64.patch
@@ -1,0 +1,12 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1328040)
++++ PKGBUILD	(working copy)
+@@ -17,6 +17,7 @@
+ prepare(){
+   cd $_hkgname-$pkgver
+   gen-setup
++  sed -i '/test-suite relude-doctest/a \  buildable: False' $_hkgname.cabal
+   uusi -u base -u ghc-prim -u hashable -u hedgehog $_hkgname.cabal
+ }
+ 


### PR DESCRIPTION
Disable doctest until we fix our GHCi crashes.