### PR TITLE
addpatch: haskell-foldl

### DIFF
--- a/haskell-foldl/riscv64.patch
+++ b/haskell-foldl/riscv64.patch
@@ -1,0 +1,12 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1328069)
++++ PKGBUILD	(working copy)
+@@ -18,6 +18,7 @@
+ 
+ prepare() {
+     cd $_hkgname-$pkgver
++    sed -i '/Test-Suite doctest/a \    buildable: False' $_hkgname.cabal
+     uusi -u hashable -u vector $_hkgname.cabal
+ }
+ 


### PR DESCRIPTION
Disable doctests because of our GHCi crashes.