### PR TITLE
addpatch: haskell-prettyprinter

### DIFF
--- a/haskell-prettyprinter/riscv64.patch
+++ b/haskell-prettyprinter/riscv64.patch
@@ -1,0 +1,16 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1328145)
++++ PKGBUILD	(working copy)
+@@ -14,6 +14,11 @@
+ source=(https://hackage.haskell.org/packages/archive/${_hkgname}/${pkgver}/${_hkgname}-${pkgver}.tar.gz)
+ sha512sums=('26289e579cc1a2826dc11daedbdfd5ce31acf4a2382f827c20194d910f05201e3f332a6544aa0c3f941188d9eaee8d6dee3cf3d319dc3c5a7bfe4f35d77b4dd9')
+ 
++prepare() {
++    cd $_hkgname-$pkgver
++    sed -i '/test-suite doctest/a \    buildable: False' $_hkgname.cabal
++}
++
+ build() {
+     cd $_hkgname-$pkgver
+     


### PR DESCRIPTION
Disable doctests until we fix our GHCi crashes.