### PR TITLE
addpatch: haskell-prettyprinter-ansi-terminal

### DIFF
--- a/haskell-prettyprinter-ansi-terminal/riscv64.patch
+++ b/haskell-prettyprinter-ansi-terminal/riscv64.patch
@@ -1,0 +1,16 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1328530)
++++ PKGBUILD	(working copy)
+@@ -13,6 +13,11 @@
+ source=(https://hackage.haskell.org/packages/archive/${_hkgname}/${pkgver}/${_hkgname}-${pkgver}.tar.gz)
+ sha512sums=('985e965f78c767234b9f30e9cc1590d037e00d211385ebfa833b96f9b9aa092840e2587236d848c66ff1c58c97748f6ae9bd5cc02ea5175aa66d2654392ea1b6')
+ 
++prepare() {
++    cd $_hkgname-$pkgver
++    sed -i '/test-suite doctest/a \    buildable: False' prettyprinter-ansi-terminal.cabal
++}
++
+ build() {
+     cd $_hkgname-$pkgver
+     


### PR DESCRIPTION
Disable doctest because of our GHCi crash.