### PR TITLE
qemu-user-blacklist: add memcached

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -53,6 +53,7 @@ libsecret
 libuv
 mdbook
 meilisearch
+memcached
 menyoki
 mkvtoolnix
 nextcloud-client


### PR DESCRIPTION
This package is exactly the same with libseccomp.

The error log under qemu-user is
```
Failed to set a seccomp profile on a worker thread
Failed to set a seccomp profile on a worker thread
Failed to connect to unix socket: memcached not running at t/misbehave.t line 17.
# Looks like your test exited with 10 before it could output anything.
t/misbehave.t ............... 
Dubious, test returned 10 (wstat 2560, 0xa00)
Failed 1/1 subtests 
```
Some strace results
```
11864 seccomp(0,1,0,0,0,115)-1 errno=38 (Function not implemented)
= -1 errno=38 (Function not implemented)
11864 seccomp(0,1,0,0,0,115) = -1 errno=38 (Function not implemented)
= 0
11864 mprotect(0x0000004020000000,135168,PROT_READ|PROT_WRITE) = 0
11864 mmap(NULL,135168,PROT_READ|PROT_WRITE,MAP_PRIVATE|MAP_ANONYMOUS,-1,0) = 0x0000004025379000
11864 prctl(38,1,0,0,0,274948237176) = 0
11864 prctl(38,1,0,0,0,274939844472)11864 prctl(38,1,0,0,0,275225065336) = 0
11864 prctl(38,1,0,0,0,275233458040) = 0
= 0
11864 prctl(22,2,275146417328,0,0,274948237176) = -1 errno=22 (Invalid argument)
11864 prctl(22,2,275280635056,0,0,275225065336) = 11864 prctl(22,2,275414852784,0,0,275233458040) = 11864 prctl(22,2,275012199600,0,0,274939844472) = -1 errno=22 (Invalid argument)
-1 errno=22 (Invalid argument)
-1 errno=22 (Invalid argument)
11864 write(2,0x49368,51)Failed to set a seccomp profile on a worker thread
= 51
```
Well, Function not implemented :(

It works well on real hardware.