### PR TITLE
addpatch: dsniff

### DIFF
--- a/dsniff/riscv64.patch
+++ b/dsniff/riscv64.patch
@@ -1,0 +1,28 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1328567)
++++ PKGBUILD	(working copy)
+@@ -14,13 +14,11 @@
+ makedepends=('rpcsvc-proto')
+ options=('!makeflags')
+ source=(https://www.monkey.org/~dugsong/${pkgname}/beta/${pkgname}-${pkgver}.tar.gz
+-        http://ftp.de.debian.org/debian/pool/main/d/${pkgname}/${pkgname}_2.4b1+debian-29.debian.tar.xz
+-        dsniff-rpc.patch
++        http://ftp.de.debian.org/debian/pool/main/d/${pkgname}/${pkgname}_2.4b1+debian-30.debian.tar.xz
+         dsniff-macof-size-calculation.patch
+         dsniff-httppostfix.patch)
+ sha256sums=('a9803a7a02ddfe5fb9704ce86f0ffc48453c321e88db85810db411ba0841152a'
+-            '3f2263452facf9f0a402497b34c7a2573da0700005bb3c7940df9c5e099b5835'
+-            '21b37ba4c386aa576d6829c298bdd62df6fa227e44164d9e96675e66b93bb134'
++            '5fcdcc4525e1b4c2aa0208a8543024735bc07096ff1ee6f895eee4e2cf453144'
+             'd8f5cc5d14a614410a84a8eaba5a4212ee03466c4fe2fd4a634f5d7c3f688ec7'
+             '3efd6ca2267540016e843af3e8d7720d888fd17a73cba410e2c68022fd3a7baf')
+ 
+@@ -48,7 +46,6 @@
+ build() {
+   cd ${pkgname}-2.4
+   ./configure \
+-    --with-libtirpc \
+     --prefix=/usr \
+     --sbindir=/usr/bin
+   make


### PR DESCRIPTION
Dsniff also fails to build from source on x86_64. So, I updated debian patch and removed one redundant patch of ArchLinux. "--with-libtirpc" won't be needed because of updated debian patches.

When reporting to ArchLinux Upstream, I noticed loqs reported the problem before. Our ideas are just the same. So, I added my patch to flyspray.

Link to flyspray: https://bugs.archlinux.org/task/72121