### PR TITLE
addpatch: haskell-record-dot-preprocessor

### DIFF
--- a/haskell-record-dot-preprocessor/riscv64.patch
+++ b/haskell-record-dot-preprocessor/riscv64.patch
@@ -1,0 +1,16 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1328040)
++++ PKGBUILD	(working copy)
+@@ -13,6 +13,11 @@
+ source=("https://hackage.haskell.org/packages/archive/$_hkgname/$pkgver/$_hkgname-$pkgver.tar.gz")
+ sha512sums=('2a4f6fc7798b5a2f0052084639feec1ed09d03a073a02280b4b0ddcd0862803a11349c8cea643db48dce85cf73e14e915e471a3d97916d1f57df0b075d5273ad')
+ 
++prepare() {
++  cd $_hkgname-$pkgver
++  sed -i '/test-suite record-dot-preprocessor-test/a \    buildable: False' record-dot-preprocessor.cabal
++}
++
+ build() {
+   cd $_hkgname-$pkgver
+ 


### PR DESCRIPTION
Disable tests until we fix our GHC crashes.