### PR TITLE
addpatch: haskell-pretty-simple

### DIFF
--- a/haskell-pretty-simple/riscv64.patch
+++ b/haskell-pretty-simple/riscv64.patch
@@ -1,0 +1,16 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1329015)
++++ PKGBUILD	(working copy)
+@@ -14,6 +14,11 @@
+ source=(https://hackage.haskell.org/packages/archive/${_hkgname}/${pkgver}/${_hkgname}-${pkgver}.tar.gz)
+ sha512sums=('ac2c6b7efa477109229e71adbfb287d0b697720d22eb0cbad6545622d65249149d7af9cc497042e7746571579610dce078da2e3db93e104f1161bda0ec87ccc5')
+ 
++prepare() {
++    cd $_hkgname-$pkgver
++    sed -i '/test-suite pretty-simple-doctest/a \  buildable: False' pretty-simple.cabal
++}
++
+ build() {
+     cd $_hkgname-$pkgver
+ 


### PR DESCRIPTION
Disable doctests due to our GHCi crashes.