### PR TITLE
updpatch: marisa

### DIFF
--- a/marisa/riscv64-marisa_word_size.patch
+++ b/marisa/riscv64-marisa_word_size.patch
@@ -1,0 +1,13 @@
+diff --git a/include/marisa/base.h b/include/marisa/base.h
+index ffcdc5b..f04df91 100644
+--- a/include/marisa/base.h
++++ b/include/marisa/base.h
+@@ -31,7 +31,7 @@ typedef uint64_t marisa_uint64;
+ #if defined(_WIN64) || defined(__amd64__) || defined(__x86_64__) || \
+     defined(__ia64__) || defined(__ppc64__) || defined(__powerpc64__) || \
+     defined(__sparc64__) || defined(__mips64__) || defined(__aarch64__) || \
+-    defined(__s390x__)
++    defined(__s390x__) || (defined(__riscv) && (__riscv_xlen == 64))
+  #define MARISA_WORD_SIZE 64
+ #else  // defined(_WIN64), etc.
+  #define MARISA_WORD_SIZE 32

--- a/marisa/riscv64.patch
+++ b/marisa/riscv64.patch
@@ -1,8 +1,29 @@
 diff --git PKGBUILD PKGBUILD
-index 4c6617d..7a6ff36 100644
+index 4c6617d..1eeb278 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -25,7 +25,8 @@ prepare() {
+@@ -10,9 +10,11 @@
+ license=('BSD' 'LGPL')
+ makedepends=('python' 'ruby' 'perl' 'swig')
+ source=("marisa-trie-$pkgver.tar.gz::https://github.com/s-yata/marisa-trie/archive/v$pkgver.tar.gz"
+-        fix-format-security.patch)
++        fix-format-security.patch
++        riscv64-marisa_word_size.patch)
+ sha512sums=('c094e4b22e1457efdd20f2b978ee421b53e36ed94e4fdbd8944136c0ba23da4f6ba9fe3a2c64729c1426aee4dbe8098bfa5eebb943ae7fdaa4eec760485c564d'
+-            '3583f23c55ccd46cefbd757ef3f82dc7a90f14c64ecf69a99ab3467ca1e6aeddf9822be4c4dffcdbb8841d79fe116cfb8eff0e9b44abaadbcbf8d50a10ab1ec9')
++            '3583f23c55ccd46cefbd757ef3f82dc7a90f14c64ecf69a99ab3467ca1e6aeddf9822be4c4dffcdbb8841d79fe116cfb8eff0e9b44abaadbcbf8d50a10ab1ec9'
++            'f22e2feb3db75d64a6ac9a60574450bf69cf970027edd4827aab132bf1ed827bcc1c7bf37137f055ea25eb06945cbd04811b19818a459985375b9b8d4bef3a51')
+ 
+ prepare() {
+   cd marisa-trie-$pkgver
+@@ -20,12 +22,15 @@
+ 
+   # https://github.com/s-yata/marisa-trie/pull/45
+   patch -Np1 -i ../fix-format-security.patch
++  # https://github.com/s-yata/marisa-trie/issues/40
++  patch -Np1 -i ../riscv64-marisa_word_size.patch
+ }
+ 
  build() {
    cd marisa-trie-$pkgver
    # sse2 is part of amd64


### PR DESCRIPTION
update patch for https://github.com/s-yata/marisa-trie/issues/40

It can not pass test (`make check`) in riscv64 without the patch.

```
========================================
   marisa 0.2.6: tests/test-suite.log
========================================

# TOTAL: 5
# PASS:  4
# SKIP:  0
# XFAIL: 0
# FAIL:  1
# XPASS: 0
# ERROR: 0

.. contents:: :depth: 2

FAIL: base-test
===============

base-test.cc:14: TestTypes(): 21: Assertion `MARISA_WORD_SIZE == (sizeof(std::size_t) * 8)' failed.
FAIL base-test (exit status: 255)

```