### PR TITLE
addpatch: postgrest

### DIFF
--- a/postgrest/riscv64.patch
+++ b/postgrest/riscv64.patch
@@ -1,0 +1,12 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1329385)
++++ PKGBUILD	(working copy)
+@@ -29,6 +29,7 @@
+ 
+ prepare() {
+     cd $pkgname-$pkgver
++    sed -i '/test-suite doctests/a \  buildable: False' $pkgname.cabal
+     uusi -u aeson -u hspec -u HTTP -u jose -u lens-aeson -u optparse-applicative -u vector $pkgname.cabal
+ 
+     # Hack LD_LIBRARY_PATH


### PR DESCRIPTION
Disable doctests until we fix our GHCi crashes.