### PR TITLE
addpkg: updlockfiles

### DIFF
--- a/updlockfiles/riscv64.patch
+++ b/updlockfiles/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,7 +14,7 @@ b2sums=('913e92e5b5ce1a1f0d1bca5947b0fe740076f529782cb724a9e8bc1b2288d576c775187
+ 
+ prepare() {
+   cd "${pkgname}-${pkgver}"
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  cargo fetch --locked 
+ }
+ 
+ build() {


### PR DESCRIPTION
Fixed `--target "$CARCH-unknown-linux-gnu"`.

TinySnow
Oct 18th, 2022.