### PR TITLE
addpatch: opl-synth 2.2-1

### DIFF
--- a/opl-synth/riscv64.patch
+++ b/opl-synth/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -65,6 +65,9 @@ prepare() {
+   # disable JUCE splash screen
+   sed -e 's:\(displaySplashScreen="\)1:\10:' -i OPL.jucer
+ 
++  # RISC-V
++  sed -i "s/-m64/-march=rv64gc/g" OPL.jucer
++
+   # use global path for loading instruments
+   patch -p1 -i "$srcdir/use-global-path.patch"
+ 


### PR DESCRIPTION
Replaced `-m64` compile argument with `-march=rv64gc`.