### PR TITLE
addpatch: ansible-lint

### DIFF
--- a/ansible-lint/riscv64.patch
+++ b/ansible-lint/riscv64.patch
@@ -1,0 +1,13 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1333136)
++++ PKGBUILD	(working copy)
+@@ -15,7 +15,7 @@
+ optdepends=('ansible: check official ansible collections')
+ source=(https://github.com/ansible/ansible-lint/archive/v${pkgver}/${pkgname}-${pkgver}.tar.gz
+         disable_use_scm_version.patch)
+-b2sums=('932c03eef82cf96af54f5595e9c34ed4badc7ad3f7a9f94312380e7ae4215c2f611688d9b857894958107f48f067301cc1a86393be2a9b2c48370d92f41a0e52'
++b2sums=('4ae9c344d834a3d69a05689df296c7915e6eb7cb2a85b773f3adcc4efd898c3e1c9f32d8b1efda31afb7a5466d1966aa754cd5529c7dcfd6c1f45517d39e1750'
+         'cf911567b040c8938ca589fde3c93b39cfba29ca1a373b8af354450a4f880d475463b0c81440fb9bfacc7b1f93736a5ae5ab58c7fdb30d8f03d1996754a738f3')
+ 
+ prepare() {


### PR DESCRIPTION
Validity check fails.

ArchLinux upstream link https://bugs.archlinux.org/task/76261