### PR TITLE
addpkg: clang

### DIFF
--- a/clang/riscv64.patch
+++ b/clang/riscv64.patch
@@ -1,0 +1,33 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -22,7 +22,8 @@ source=($_source_base/clang-$pkgver.src.tar.xz{,.sig}
+         $_source_base/llvm-$pkgver.src.tar.xz{,.sig}
+         clang-coroutines-ubsan.patch
+         clang-tidy-fix-standalone-build.patch
+-        enable-fstack-protector-strong-by-default.patch)
++        enable-fstack-protector-strong-by-default.patch
++        add-R_RISCV_SUB6-relocation.patch::https://reviews.llvm.org/D120001?download=true)
+ sha256sums=('2b5847b6a63118b9efe5c85548363c81ffe096b66c3b3675e953e26342ae4031'
+             'SKIP'
+             '7cf3b8ff56c65c4d1eae3c56883fc4a6cbc3ff9f3a1530a74d66e45d27271866'
+@@ -31,7 +32,8 @@ sha256sums=('2b5847b6a63118b9efe5c85548363c81ffe096b66c3b3675e953e26342ae4031'
+             'SKIP'
+             '2c25ddf0ba6be01949842873fef4d285456321aaccd4ba95db61b69a4c580106'
+             '081a7ebc1ae524b13fc6be3dc73feb2c9eb7cf4b99f7f13d9ed37a688311f58a'
+-            '7a9ce949579a3b02d4b91b6835c4fb45adc5f743007572fb0e28e6433e48f3a5')
++            '7a9ce949579a3b02d4b91b6835c4fb45adc5f743007572fb0e28e6433e48f3a5'
++            '0b8056b7786e7426cedcc9a5aa13e67d44fc360d22f3400f3048dfea53344c2f')
+ validpgpkeys=('474E22316ABF4785A88C6E8EA2C794A986419D8A') # Tom Stellard <tstellar@redhat.com>
+ 
+ # Utilizing LLVM_DISTRIBUTION_COMPONENTS to avoid
+@@ -57,6 +59,10 @@ _get_distribution_components() {
+ }
+ 
+ prepare() {
++  pushd llvm-$pkgver.src
++  patch -Np2 -i ../add-R_RISCV_SUB6-relocation.patch
++  popd
++
+   cd clang-$pkgver.src
+   mkdir build
+   mv "$srcdir/clang-tools-extra-$pkgver.src" tools/extra


### PR DESCRIPTION
Adding a patch that is necessary for further compiling & testing the `mesa` package.

Still, 4 tests are failing, remaining unaffected by this patch. They may need more investigation if keep occuring when we upgrade to clang 15.

```
FAIL: Clang-Unit :: Interpreter/./ClangReplInterpreterTests/IncrementalProcessing.InstantiateTemplate (25720 of 29882)
******************** TEST 'Clang-Unit :: Interpreter/./ClangReplInterpreterTests/IncrementalProcessing.InstantiateTemplate' FAILED ********************
Script:
--
/build/clang/src/clang-14.0.6.src/build/unittests/Interpreter/./ClangReplInterpreterTests --gtest_filter=IncrementalProcessing.InstantiateTemplate
--
Note: Google Test filter = IncrementalProcessing.InstantiateTemplate
[ RUN      ] IncrementalProcessing.InstantiateTemplate
Hard-float 'd' ABI can't be used for a target that doesn't support the D instruction set extension (ignoring target-abi)
LLVM ERROR: Relocation type not implemented yet!
#0 0x0000004004db53be (/usr/lib/libLLVM-14.so+0xc513be)
```

```
FAIL: Clang-Unit :: Interpreter/ExceptionTests/./ClangReplInterpreterExceptionTests/InterpreterTest.CatchException (25740 of 29882)
******************** TEST 'Clang-Unit :: Interpreter/ExceptionTests/./ClangReplInterpreterExceptionTests/InterpreterTest.CatchException' FAILED ********************
Script:
--
/build/clang/src/clang-14.0.6.src/build/unittests/Interpreter/ExceptionTests/./ClangReplInterpreterExceptionTests --gtest_filter=InterpreterTest.CatchException
--
Note: Google Test filter = InterpreterTest.CatchException
[ RUN      ] InterpreterTest.CatchException
Hard-float 'd' ABI can't be used for a target that doesn't support the D instruction set extension (ignoring target-abi)
JIT session error: Symbols not found: [ DW.ref.__gxx_personality_v0 ]
#0 0x0000004004db63be (/usr/lib/libLLVM-14.so+0xc513be)
```

```
FAIL: Clang :: OpenMP/declare_variant_device_isa_codegen_1.c (9416 of 29882)
******************** TEST 'Clang :: OpenMP/declare_variant_device_isa_codegen_1.c' FAILED ********************
Command Output (stderr):
--
/build/clang/src/clang-14.0.6.src/test/OpenMP/declare_variant_device_isa_codegen_1.c:51:14: error: GENERIC: expected string not found in input
 // GENERIC: call void @{{.*}}avx512_saxpy
             ^
<stdin>:337:38: note: scanning from here
define dso_local void @variant_caller(i32 noundef signext %n, float noundef %s, float* noundef %x, float* noundef %y) #0 {
                                     ^
<stdin>:351:2: note: possible intended match here
 call void @base_saxpy(i32 noundef signext %0, float noundef %1, float* noundef %2, float* noundef %3)
 ^
Input file: <stdin>
Check file: /build/clang/src/clang-14.0.6.src/test/OpenMP/declare_variant_device_isa_codegen_1.c
```

```
[1/2] Running the Clang regression tests
FAIL: Clang :: Interpreter/execute.cpp (8583 of 29882)
******************** TEST 'Clang :: Interpreter/execute.cpp' FAILED ********************
Script:
--
: 'RUN: at line 1';   /build/clang/src/clang-14.0.6.src/build/bin/clang-repl "int i = 10;" 'extern "C" int printf(const char*,...);'             'auto r1 = printf("i = %d\n", i);' | /usr/bin/FileCheck --check-prefix=CHECK-DRIVER /build/clang/src/clang-14.0.6.src/test/Interpreter/execute.cpp
: 'RUN: at line 6';   cat /build/clang/src/clang-14.0.6.src/test/Interpreter/execute.cpp | /build/clang/src/clang-14.0.6.src/build/bin/clang-repl | /usr/bin/FileCheck /build/clang/src/clang-14.0.6.src/test/Interpreter/execute.cpp
--
Exit Code: 2
Command Output (stderr):
--
Hard-float 'd' ABI can't be used for a target that doesn't support the D instruction set extension (ignoring target-abi)
fatal error: error in backend: Relocation type not implemented yet!
FileCheck error: '<stdin>' is empty.
FileCheck command line:  /usr/bin/FileCheck --check-prefix=CHECK-DRIVER /build/clang/src/clang-14.0.6.src/test/Interpreter/execute.cpp
```

```
Failed Tests (4):
  Clang :: Interpreter/execute.cpp
  Clang :: OpenMP/declare_variant_device_isa_codegen_1.c
  Clang-Unit :: Interpreter/./ClangReplInterpreterTests/IncrementalProcessing.InstantiateTemplate
  Clang-Unit :: Interpreter/ExceptionTests/./ClangReplInterpreterExceptionTests/InterpreterTest.CatchException
```