### PR TITLE
addpatch: jupyter_console

### DIFF
--- a/jupyter_console/riscv64.patch
+++ b/jupyter_console/riscv64.patch
@@ -1,0 +1,13 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1334699)
++++ PKGBUILD	(working copy)
+@@ -9,7 +9,7 @@
+ license=('BSD')
+ depends=('ipython' 'python-jupyter_client' 'python-ipykernel'
+          'python-pygments' 'python-prompt_toolkit')
+-makedepends=('python-build' 'python-installer' 'python-wheel')
++makedepends=('python-build' 'python-installer' 'python-wheel' 'python-setuptools')
+ #source=("$pkgname-$pkgver.tgz::https://github.com/jupyter/jupyter_console/archive/$pkgver.tar.gz")
+ source=("https://files.pythonhosted.org/packages/source/j/$pkgname/$pkgname-$pkgver.tar.gz")
+ md5sums=('a5e0426e44738c96c0a63663cdc0cfb1')


### PR DESCRIPTION
FTBFS due to lack of dependency. Upstream ArchLinux has fixed in trunk.

Upstream link: https://bugs.archlinux.org/task/76288