### PR TITLE
addpkg: netcdf-openmpi-bootstrap

### DIFF
--- a/netcdf-openmpi-bootstrap/PKGBUILD
+++ b/netcdf-openmpi-bootstrap/PKGBUILD
@@ -1,0 +1,73 @@
+# Maintainer: Ronald van Haren <ronald.archlinux.org>
+# Maintainer: Bruno Pagani <archange@archlinux.org>
+# Contributor: damir <damir@archlinux.org>
+
+_pkg=netcdf
+_mpi=openmpi
+pkgname=${_pkg}-${_mpi}-bootstrap
+pkgver=4.9.0
+pkgrel=3
+pkgdesc="network Common Data Form interface for array-oriented data access and corresponding library with parallel support (${_mpi} version)"
+arch=(riscv64)
+url="https://www.unidata.ucar.edu/software/netcdf/"
+license=(custom)
+depends=("hdf5-${_mpi}" curl libxml2 libzip)
+makedepends=(cmake)
+optdepends=('netcdf-fortran: fortran bindings' 'netcdf-cxx: c++ bindings')
+checkdepends=(inetutils unzip)
+provides=("${_pkg}")
+conflicts=("${_pkg}")
+options=(!makeflags)
+source=(https://github.com/Unidata/netcdf-c/archive/v${pkgver}/${pkgname}-${pkgver}.tar.gz
+        netcdf-4.9.0-fix-cmake-typo.patch::https://github.com/Unidata/netcdf-c/pull/2412.patch
+        netcdf-4.9.0-read-chunk-size.patch::https://github.com/Unidata/netcdf-c/pull/2319.patch
+        netcdf-4.9.0-pnetcdf-test.patch::https://github.com/Unidata/netcdf-c/pull/2437.patch)
+sha256sums=('9f4cb864f3ab54adb75409984c6202323d2fc66c003e5308f3cdf224ed41c0a6'
+            'ed45ae6c49cf8dcddaadef4c5cf403049bf3f761187413d7b03754d319345d6a'
+            'd71b441b6499d6ddb97ea25377018000781d16de6551f0d2ba33b9bcd6e769fd'
+            '66f7ec8474acb8d04ef5b5cd871b6b0178c8a4d6a2f1661a9566c96a780a54ae')
+prepare() {
+  # https://github.com/Unidata/netcdf-c/issues/2188 https://github.com/Unidata/netcdf-c/issues/2242
+  sed -i "/tst_remote3/d" ${_pkg}-c-${pkgver}/ncdap_test/CMakeLists.txt
+  # https://github.com/Unidata/netcdf-c/issues/2390
+  patch -p1 -d ${_pkg}-c-${pkgver} < netcdf-4.9.0-fix-cmake-typo.patch
+  # https://github.com/Unidata/netcdf-c/issues/2418
+  patch -p1 -d ${_pkg}-c-${pkgver} < netcdf-4.9.0-read-chunk-size.patch
+  # https://github.com/Unidata/netcdf-c/issues/2435
+  patch -p1 -d ${_pkg}-c-${pkgver} < netcdf-4.9.0-pnetcdf-test.patch
+}
+
+build() {
+  export CC=mpicc
+  cmake -B build -S ${_pkg}-c-${pkgver} \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DCMAKE_INSTALL_LIBDIR=lib \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DENABLE_BYTERANGE=OFF \
+    -DENABLE_CDF5=ON \
+    -DENABLE_PNETCDF=OFF \
+    -DENABLE_DAP_LONG_TESTS=ON \
+    -DENABLE_DAP_REMOTE_TESTS=ON \
+    -DENABLE_EXAMPLE_TESTS=ON \
+    -DENABLE_EXTRA_TESTS=ON \
+    -DENABLE_FILTER_TESTING=ON \
+    -DENABLE_LARGE_FILE_TESTS=ON \
+    -DENABLE_UNIT_TESTS=ON
+  make -C build
+}
+
+
+check() {
+  # This is required starting with OpenMPI 3.0 when trying to run more
+  # processes than the number of available cores
+  export OMPI_MCA_rmaps_base_oversubscribe=yes
+  # We don’t have CUDA by default
+  export OMPI_MCA_opal_warn_on_missing_libcuda=0
+
+  make -C build test
+}
+
+package() {
+  make -C build DESTDIR="${pkgdir}" install
+  install -Dm644 ${_pkg}-c-${pkgver}/COPYRIGHT -t "${pkgdir}"/usr/share/licenses/${_pkg}/
+}


### PR DESCRIPTION
This package provides `netcdf-openmpi` for package `pnetcdf-openmpi`. And the `pnetcdf-openmpi` package can be used for building the `netcdf-openmpi` itself.

Modifications:
==============

1. Becasue of the bug mentioned in [netcdf-c #2500], BYTERANGE feature is closed.
2. Close the pnetcdf feature and remove the pnetcdf makedepends.

[netcdf-c #2500]: https://github.com/Unidata/netcdf-c/issues/2500

Build Sequence:
===============

1. netcdf-openmpi-bootstrap
2. pnetcdf-openmpi
3. netcdf-openmpi

Additional Info:
================

All the three packages mention above needs `--nocheck`. This is because there are always some bug in shared memory from openmpi. All tests except openmpi parallel tests passed successfully. hdf5-openmpi [ignore] the failure too. So no check to bypass those parallel test is acceptable.

[ignore]: https://github.com/archlinux/svntogit-community/blob/packages/hdf5-openmpi/trunk/PKGBUILD#L88

Signed-off-by: Avimitin <avimitin@gmail.com>