### PR TITLE
Remove sv57-related packages from blacklist

### DIFF
--- a/qemu-system-makedepends-blacklist.txt
+++ b/qemu-system-makedepends-blacklist.txt
@@ -1,8 +1,0 @@
-npm
-nodejs
-yarn
-java-environment
-jdk-openjdk
-jdk8-openjdk
-jdk11-openjdk
-jdk17-openjdk


### PR DESCRIPTION
After https://github.com/felixonmars/archriscv-packages/pull/1868 our qemu-system instances have sv57 disabled. These packages are buildable again.