### PR TITLE
addpatch: golang-github-davecgh-go-spew 1.1.1-2

### DIFF
--- a/golang-github-davecgh-go-spew/riscv64.patch
+++ b/golang-github-davecgh-go-spew/riscv64.patch
@@ -1,0 +1,19 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -8,8 +8,14 @@ arch=('any')
+ url="https://github.com/davecgh/go-spew"
+ license=('ISC')
+ depends=('go')
+-source=("$pkgname-$pkgver.tar.gz::https://github.com/davecgh/go-spew/archive/v$pkgver.tar.gz")
+-sha512sums=('b00621d2f11c4cc858e69fda3e6975f910deb375c4f2305a45b230e2d9be73f183db5d2ce4f5e30a14b27e11e79380233ee68fceeef0d855c64fca966e68111e')
++source=("$pkgname-$pkgver.tar.gz::https://github.com/davecgh/go-spew/archive/v$pkgver.tar.gz"
++        "$pkgname-go-mod.patch::https://github.com/davecgh/go-spew/pull/126.patch")
++sha512sums=('b00621d2f11c4cc858e69fda3e6975f910deb375c4f2305a45b230e2d9be73f183db5d2ce4f5e30a14b27e11e79380233ee68fceeef0d855c64fca966e68111e'
++            'ab83c045c13bef938b7e3eb8383d406befb5bfdda1780eaea23f07e40b915405b75d945ab24a8b338c33bdc15804b65683cebafc4e50ac732fbb6f3711c72afe')
++
++prepare() {
++  patch -d "$srcdir"/go-spew-$pkgver -p1 -i "$srcdir"/$pkgname-go-mod.patch
++}
+ 
+ check() {
+   export GOPATH="$srcdir/build:/usr/share/gocode"


### PR DESCRIPTION
Arch Linux bug report: https://bugs.archlinux.org/task/73665