### PR TITLE
addpatch: meson

### DIFF
--- a/meson/riscv64.patch
+++ b/meson/riscv64.patch
@@ -1,0 +1,22 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 459439)
++++ PKGBUILD	(working copy)
+@@ -10,12 +10,12 @@
+ arch=('any')
+ license=('Apache')
+ depends=('python-setuptools' 'ninja')
+-checkdepends=('gcc-objc' 'vala' 'rust' 'gcc-fortran' 'mono' 'boost' 'qt5-base' 'git' 'cython'
++checkdepends=('gcc-objc' 'vala' 'rust' 'gcc-fortran' 'boost' 'qt5-base' 'git' 'cython'
+               'gtkmm3' 'gtest' 'gmock' 'protobuf' 'wxgtk3' 'python-gobject' 'gobject-introspection'
+-              'itstool' 'gtk3' 'java-environment=8' 'gtk-doc' 'llvm' 'clang' 'sdl2' 'graphviz'
+-              'doxygen' 'vulkan-validation-layers' 'openssh' 'mercurial' 'gtk-sharp-2' 'qt5-tools'
+-              'libwmf' 'valgrind' 'cmake' 'netcdf-fortran' 'openmpi' 'nasm' 'gnustep-base' 'libelf'
+-              'python-pytest-xdist' 'ldc' 'rust-bindgen' 'cuda' 'hotdoc')
++              'itstool' 'gtk3' 'gtk-doc' 'llvm' 'clang' 'sdl2' 'graphviz'
++              'doxygen' 'vulkan-validation-layers' 'openssh' 'mercurial' 'qt5-tools'
++              'libwmf' 'cmake' 'netcdf-fortran' 'openmpi' 'nasm' 'gnustep-base' 'libelf'
++              'python-pytest-xdist' 'ldc' 'rust-bindgen' 'hotdoc')
+ source=(https://github.com/mesonbuild/meson/releases/download/${pkgver}/meson-${pkgver}.tar.gz{,.asc}
+         0001-Skip-broken-tests.patch
+         arch-meson)


### PR DESCRIPTION
Remove not ported checkdeps on jdk8, mono, cuda; and valgrind because the port is incomplete and breaks here.

Still require `--nocheck` for now because rustc crashes:

```
FAILED: rust-program
rustc -C linker=cc --color=always --crate-type bin -g --crate-name
rust_program --emit dep-info=rust-program.d --emit link -C lto -o
rust-program '../test cases/rust/1 basic/prog.rs'
/usr/lib/librustc_driver-14b3d28b40883067.so(+0x720538)[0x4002f55538]
[0x4002826000]
/usr/lib/libLLVM-14.so(+0x10c62cc)[0x40075122cc]
ninja: build stopped: subcommand failed.
```