### PR TITLE
upgpatch: pixman 0.42.0-1

### DIFF
--- a/pixman/riscv64.patch
+++ b/pixman/riscv64.patch
@@ -1,9 +1,27 @@
-Index: PKGBUILD
-===================================================================
---- PKGBUILD	(revision 391859)
-+++ PKGBUILD	(working copy)
-@@ -24,7 +24,10 @@
-     -D neon=disabled \
+--- PKGBUILD
++++ PKGBUILD
+@@ -13,10 +13,17 @@ depends=('glibc')
+ makedepends=('meson' 'libpng')
+ options=('debug')
+ provides=('libpixman-1.so')
+-source=(https://xorg.freedesktop.org/releases/individual/lib/${pkgname}-${pkgver}.tar.xz)
+-sha512sums=('43d43d1aef9b8a6167098ab68ce2cfd8c0429c4825d40a4fb468b5b51dc1a2035f8bd1b70413e4ecd77deb469b5d558f42171b423e348d5ddd8604c466ffc7d9')
++source=(https://xorg.freedesktop.org/releases/individual/lib/${pkgname}-${pkgver}.tar.xz
++        ${pkgname}-revert-changeds-in-reduce_32.patch::https://gitlab.freedesktop.org/pixman/pixman/-/merge_requests/69.patch)
++sha512sums=('43d43d1aef9b8a6167098ab68ce2cfd8c0429c4825d40a4fb468b5b51dc1a2035f8bd1b70413e4ecd77deb469b5d558f42171b423e348d5ddd8604c466ffc7d9'
++            '485be322426d43bf06bad0e5885f72ca4b2d1d056003f7c82e7592b9ee8b946f93c038b4c8ca46880748542dcda744b21994332f1fa6bd48ad8163231ab0bf38')
+ #validpgpkeys=('') # Maarten Lankhorst <maarten.lankhorst@linux.intel.com>
+ 
++prepare() {
++  cd $pkgname-$pkgver
++  patch -Np1 < ../${pkgname}-revert-changeds-in-reduce_32.patch
++}
++
+ build() {
+   arch-meson $pkgbase-$pkgver build \
+     -D loongson-mmi=disabled \
+@@ -26,7 +33,10 @@ build() {
+     -D a64-neon=disabled \
      -D iwmmxt=disabled \
      -D mips-dspr2=disabled \
 -    -D gtk=disabled


### PR DESCRIPTION
Cherry-pick an upstream unmerged MR [Revert "Fix signed-unsigned semantics in reduce_32" ](https://gitlab.freedesktop.org/pixman/pixman/-/merge_requests/69) to fix test timeout and failure.

```
30/33 scaling-test          FAIL            565.63s   exit status 1
――――――――――――――――――――――――――――――――――――― ✀  ―――――――――――――――――――――――――――――――――――――
scaling test failed! (checksum=54B264D2, expected D3589272)
――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
```