### PR TITLE
addpatch: bzip3

### DIFF
--- a/bzip3/riscv64.patch
+++ b/bzip3/riscv64.patch
@@ -1,0 +1,12 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1340051)
++++ PKGBUILD	(working copy)
+@@ -17,6 +17,7 @@
+ 
+ build() {
+ 	cd "$_archive"
++        LDFLAGS="${LDFLAGS} -Wl,-plugin-opt=-target-abi=lp64d"
+ 	./configure --prefix /usr CC=clang
+ 	make all
+ }


### PR DESCRIPTION
`/usr/bin/ld: /tmp/lto-llvm-cca3ab.o: can't link soft-float modules with double-float modules`

Solution is taken from [here](https://riscv-notes.sh1mar.in/docs/record/lto#%E5%85%B6%E4%BB%96).