### PR TITLE
addpatch: maven

### DIFF
--- a/maven/riscv64.patch
+++ b/maven/riscv64.patch
@@ -1,0 +1,40 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1340439)
++++ PKGBUILD	(working copy)
+@@ -10,7 +10,7 @@
+ arch=('any')
+ license=('APACHE')
+ depends=('java-environment>=8' 'bash' 'procps-ng')
+-makedepends=('maven' 'java-environment=8')
++makedepends=('maven' 'java-environment>=8')
+ backup=('opt/maven/conf/settings.xml')
+ source=(https://downloads.apache.org/maven/maven-3/${pkgver}/source/apache-maven-${pkgver}-src.tar.gz{,.asc}
+         # both bin artifacts are only used for reproducible builds from source
+@@ -42,9 +42,7 @@
+ build() {
+   cd apache-maven-${pkgver}
+ 
+-  export PATH="/usr/lib/jvm/java-8-openjdk/bin:${PATH}"
+   mvn package \
+-    -DbuildNumber="$(_buildnumber)" \
+     -Dline.separator=$'\r\n' \
+     -Dproject.build.sourceEncoding=UTF-8 -e \
+     -Dmaven.repo.local="${srcdir}/repo" \
+@@ -55,14 +53,13 @@
+   # technically free to use the static build number in our build env. On top we
+   # ensure bit by bit identical upstream signed binary dist against our variant
+   # via diff exiting non-successful on mismatch.
+-  sha512sum -c <(printf "$(cat ${srcdir}/apache-maven-${pkgver}-bin.tar.gz.sha512) apache-maven/target/apache-maven-${pkgver}-bin.tar.gz")
+-  diff "${srcdir}/apache-maven-${pkgver}-bin.tar.gz" apache-maven/target/apache-maven-${pkgver}-bin.tar.gz
++  # sha512sum -c <(printf "$(cat ${srcdir}/apache-maven-${pkgver}-bin.tar.gz.sha512) apache-maven/target/apache-maven-${pkgver}-bin.tar.gz")
++  # diff "${srcdir}/apache-maven-${pkgver}-bin.tar.gz" apache-maven/target/apache-maven-${pkgver}-bin.tar.gz
+ }
+ 
+ check() {
+   cd apache-maven-${pkgver}
+ 
+-  export PATH="/usr/lib/jvm/java-8-openjdk/bin:${PATH}"
+   mvn test \
+     -Dmaven.repo.local="${srcdir}/repo"
+ }


### PR DESCRIPTION
Use newer openjdk and give up the build number hack, until we have openjdk 8.