### PR TITLE
addpatch: wasmtime 2.0.1-1

### DIFF
--- a/wasmtime/riscv64.patch
+++ b/wasmtime/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -33,7 +33,7 @@ prepare() {
+   git config submodule.crates/wasi-nn/spec.src "${srcdir}"/wasi-nn
+   git config submodule.crates/wasi-crypto/spec.src "${srcdir}"/wasi-crypto
+   git submodule update
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  cargo fetch --locked
+ }
+ 
+ build() {


### PR DESCRIPTION
This patch fixes the following issue:

```
error: failed to run `rustc` to learn about target-specific information

Caused by:
  process didn't exit successfully: `rustc - --crate-name ___ --print=file-names --target riscv64-unknown-linux-gnu --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=cfg` (exit status: 1)
  --- stderr
  error: Error loading target specification: Could not find specification for target "riscv64-unknown-linux-gnu". Run `rustc --print target-list` for a list of built-in targets
```