### PR TITLE
addpatch: limesuite

### DIFF
--- a/limesuite/limesuite-march-native.patch
+++ b/limesuite/limesuite-march-native.patch
@@ -1,0 +1,26 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index ef9b3b31..d7c6197f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -92,6 +92,9 @@ endif()
+ 
+ if(CMAKE_COMPILER_IS_GNUCXX)
+ 
++    # include module for check_cxx_compiler_flag
++    include(CheckCXXCompilerFlag)
++
+     #enable C++11 on older versions of cmake
+     if (CMAKE_VERSION VERSION_LESS "3.1")
+         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+@@ -118,7 +121,10 @@ if(CMAKE_COMPILER_IS_GNUCXX)
+     #default SIMD configuration uses native build flags
+     #when packaging and x86, use sse3 so the binaries work across multiple x86 variants
+     if(NOT DEFAULT_SIMD_FLAGS)
+-        set(DEFAULT_SIMD_FLAGS "native")
++        check_cxx_compiler_flag(-march=native COMPILER_SUPPORTS_MARCH_NATIVE)
++        if (COMPILER_SUPPORTS_MARCH_NATIVE)
++            set(DEFAULT_SIMD_FLAGS "native")
++        endif()
+     endif()
+     if ("${CMAKE_INSTALL_PREFIX}" STREQUAL "/usr" AND X86)
+         set(DEFAULT_SIMD_FLAGS "SSE3")

--- a/limesuite/riscv64.patch
+++ b/limesuite/riscv64.patch
@@ -1,0 +1,24 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1346003)
++++ PKGBUILD	(working copy)
+@@ -12,13 +12,17 @@
+ optdepends=('octave: Octave plugin')
+ provides=('soapylms7')
+ conflicts=('soapylms7')
+-source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
+-sha512sums=('4ff422d04bb8795463da1a3e04dd742701bca89cb9003e3a1af3a97f9aa13a167c6cafa4b36734c3c810d08cec96f4d8aced40413504660f42a9c7208bfa3264')
++source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz"
++        "limesuite-march-native.patch")
++sha512sums=('4ff422d04bb8795463da1a3e04dd742701bca89cb9003e3a1af3a97f9aa13a167c6cafa4b36734c3c810d08cec96f4d8aced40413504660f42a9c7208bfa3264'
++            '004f2ad8165445f1119e10a403d166dab3a5033837b65ab5582bf526e3d9945eb4e3b5fce79e2df5f236f2328cdc1986bc6e833dd61ce7bc11d6b1fbb2940d2c')
+ 
+ prepare() {
+   cd LimeSuite-$pkgver
+ 
+   sed -i 's|MODE="660", GROUP="plugdev"|MODE="666"|g' udev-rules/64-limesuite.rules
++
++  patch -Np1 -i ../limesuite-march-native.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
LimeSuite enables `-march=native` by default. This patch adds a check. If compiler supports `-march=native`, we can enable it by default. This patch has been merged upstream.
Upstream link: https://github.com/myriadrf/LimeSuite/pull/370