### PR TITLE
addpatch: qemu 7.1.0-10

### DIFF
--- a/qemu/riscv64.patch
+++ b/qemu/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index 4ba567e6..e5c19cc7 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -97,7 +97,7 @@
+   zlib
+   zstd
+ )
+-options=(debug)
++options=(debug !lto)
+ source=(
+   https://download.qemu.org/qemu-$pkgver.tar.xz{,.sig}
+   bridge.conf


### PR DESCRIPTION
Disable lto since it fails with:
```text
[1474/2930] Linking target qemu-aarch64
FAILED: qemu-aarch64 
c++  -o qemu-aarch64 libcommon.fa.p/hw_core_cpu-common.c.o libcommon.fa.p/hw_core_machine-smp.c.o libcommon.fa.p/cpus-common.c.o libcommon.fa.p/page-vary-common.c.o libcommon.fa.p/disas_riscv.c.o libcommon.fa.p/accel_accel-user.c.o libcommon.fa.p/common-user_safe-syscall.S.o libcommon.fa.p/common-user_safe-syscall-error.c.o libqemu-aarch64-linux-user.fa.p/linux-user_aarch64_signal.c.o libqemu-aarch64-linux-user.fa.p/linux-user_aarch64_cpu_loop.c.o libqemu-aarch64-linux-user.fa.p/target_arm_cpu.c.o libqemu-aarch64-linux-user.fa.p/target_arm_crypto_helper.c.o libqemu-aarch64-linux-user.fa.p/target_arm_debug_helper.c.o libqemu-aarch64-linux-user.fa.p/target_arm_gdbstub.c.o libqemu-aarch64-linux-user.fa.p/target_arm_helper.c.o libqemu-aarch64-linux-user.fa.p/target_arm_iwmmxt_helper.c.o libqemu-aarch64-linux-user.fa.p/target_arm_m_helper.c.o libqemu-aarch64-linux-user.fa.p/target_arm_mve_helper.c.o libqemu-aarch64-linux-user.fa.p/target_arm_neon_helper.c.o libqemu-aarch64-linux-user.fa.p/target_arm_op_helper.c.o libqemu-aarch64-linux-user.fa.p/target_arm_tlb_helper.c.o libqemu-aarch64-linux-user.fa.p/target_arm_translate.c.o libqemu-aarch64-linux-user.fa.p/target_arm_translate-m-nocp.c.o libqemu-aarch64-linux-user.fa.p/target_arm_translate-mve.c.o libqemu-aarch64-linux-user.fa.p/target_arm_translate-neon.c.o libqemu-aarch64-linux-user.fa.p/target_arm_translate-vfp.c.o libqemu-aarch64-linux-user.fa.p/target_arm_vec_helper.c.o libqemu-aarch64-linux-user.fa.p/target_arm_vfp_helper.c.o libqemu-aarch64-linux-user.fa.p/target_arm_cpu_tcg.c.o libqemu-aarch64-linux-user.fa.p/target_arm_kvm-stub.c.o libqemu-aarch64-linux-user.fa.p/target_arm_cpu64.c.o libqemu-aarch64-linux-user.fa.p/target_arm_gdbstub64.c.o libqemu-aarch64-linux-user.fa.p/target_arm_helper-a64.c.o libqemu-aarch64-linux-user.fa.p/target_arm_mte_helper.c.o libqemu-aarch64-linux-user.fa.p/target_arm_pauth_helper.c.o libqemu-aarch64-linux-user.fa.p/target_arm_sve_helper.c.o libqemu-aarch64-linux-user.fa.p/target_arm_sme_helper.c.o libqemu-aarch64-linux-user.fa.p/target_arm_translate-a64.c.o libqemu-aarch64-linux-user.fa.p/target_arm_translate-sve.c.o libqemu-aarch64-linux-user.fa.p/target_arm_translate-sme.c.o libqemu-aarch64-linux-user.fa.p/trace_control-target.c.o libqemu-aarch64-linux-user.fa.p/cpu.c.o libqemu-aarch64-linux-user.fa.p/disas.c.o libqemu-aarch64-linux-user.fa.p/gdbstub.c.o libqemu-aarch64-linux-user.fa.p/page-vary.c.o libqemu-aarch64-linux-user.fa.p/semihosting_guestfd.c.o libqemu-aarch64-linux-user.fa.p/semihosting_syscalls.c.o libqemu-aarch64-linux-user.fa.p/semihosting_arm-compat-semi.c.o libqemu-aarch64-linux-user.fa.p/tcg_optimize.c.o libqemu-aarch64-linux-user.fa.p/tcg_region.c.o libqemu-aarch64-linux-user.fa.p/tcg_tcg.c.o libqemu-aarch64-linux-user.fa.p/tcg_tcg-common.c.o libqemu-aarch64-linux-user.fa.p/tcg_tcg-op.c.o libqemu-aarch64-linux-user.fa.p/tcg_tcg-op-gvec.c.o libqemu-aarch64-linux-user.fa.p/tcg_tcg-op-vec.c.o libqemu-aarch64-linux-user.fa.p/fpu_softfloat.c.o libqemu-aarch64-linux-user.fa.p/accel_accel-common.c.o libqemu-aarch64-linux-user.fa.p/accel_tcg_tcg-all.c.o libqemu-aarch64-linux-user.fa.p/accel_tcg_cpu-exec-common.c.o libqemu-aarch64-linux-user.fa.p/accel_tcg_cpu-exec.c.o libqemu-aarch64-linux-user.fa.p/accel_tcg_tcg-runtime-gvec.c.o libqemu-aarch64-linux-user.fa.p/accel_tcg_tcg-runtime.c.o libqemu-aarch64-linux-user.fa.p/accel_tcg_translate-all.c.o libqemu-aarch64-linux-user.fa.p/accel_tcg_translator.c.o libqemu-aarch64-linux-user.fa.p/accel_tcg_user-exec.c.o libqemu-aarch64-linux-user.fa.p/accel_tcg_user-exec-stub.c.o libqemu-aarch64-linux-user.fa.p/linux-user_elfload.c.o libqemu-aarch64-linux-user.fa.p/linux-user_exit.c.o libqemu-aarch64-linux-user.fa.p/linux-user_fd-trans.c.o libqemu-aarch64-linux-user.fa.p/linux-user_linuxload.c.o libqemu-aarch64-linux-user.fa.p/linux-user_main.c.o libqemu-aarch64-linux-user.fa.p/linux-user_mmap.c.o libqemu-aarch64-linux-user.fa.p/linux-user_signal.c.o libqemu-aarch64-linux-user.fa.p/linux-user_strace.c.o libqemu-aarch64-linux-user.fa.p/linux-user_syscall.c.o libqemu-aarch64-linux-user.fa.p/linux-user_thunk.c.o libqemu-aarch64-linux-user.fa.p/linux-user_uaccess.c.o libqemu-aarch64-linux-user.fa.p/linux-user_uname.c.o libqemu-aarch64-linux-user.fa.p/linux-user_flatload.c.o libqemu-aarch64-linux-user.fa.p/linux-user_semihost.c.o libqemu-aarch64-linux-user.fa.p/meson-generated_.._aarch64-linux-user-gdbstub-xml.c.o -Wl,--as-needed -Wl,--no-undefined -Wl,--whole-archive libhwcore.fa libqom.fa -Wl,--start-group libevent-loop-base.a -Wl,--no-whole-archive -Wl,--warn-common -Wl,-z,relro -Wl,-z,now -static -fstack-protector-strong -march=rv64gc -mabi=lp64d -O2 -pipe -fexceptions -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security -fstack-clash-protection -Wp,-D_GLIBCXX_ASSERTIONS -g -ffile-prefix-map=/build/qemu/src=/usr/src/debug -flto=auto -Wl,-O1,--sort-common,--as-needed,-z,relro,-z,now -flto=auto libqemuutil.a libhwcore.fa libqom.fa /usr/lib/libz.a -lrt -lm -pthread -lgthread-2.0 -lglib-2.0 -lpcre2-8 -lsysprof-capture-4 -lstdc++ -Wl,--end-group
/usr/bin/ld: /usr/lib/libglib-2.0.a(gutils.c.o): in function `.LVL48':
(.text+0x252): warning: Using 'getpwuid' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /usr/lib/libglib-2.0.a(gutils.c.o): in function `.L0 ':
(.text+0xe2): warning: Using 'getpwnam_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
/usr/bin/ld: /usr/lib/libglib-2.0.a(gutils.c.o): in function `.LVL19':
(.text+0x114): warning: Using 'getpwuid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
libcommon.fa.p/common-user_safe-syscall.S.o: in function `safe_syscall_base':
/build/qemu/src/build-static/../qemu-7.1.0/common-user/host/riscv/safe-syscall.inc.S:72:(.text+0x2a): relocation truncated to fit: R_RISCV_JAL against symbol `safe_syscall_set_errno_tail' defined in .text section in /tmp/ccnnWpLe.ltrans0.ltrans.o
collect2: error: ld returned 1 exit status
```