### PR TITLE
noqemu: gssdp

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -32,6 +32,7 @@ glibc
 go
 gpxsee
 grep
+gssdp
 gtest
 gupnp
 gupnp-igd


### PR DESCRIPTION
Package test acquired hardware is not available in QEMU-user.

Signed-off-by: Avimitin <avimitin@gmail.com>