### PR TITLE
addpatch: libluv

### DIFF
--- a/libluv/riscv64.patch
+++ b/libluv/riscv64.patch
@@ -1,0 +1,32 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1346534)
++++ PKGBUILD	(working copy)
+@@ -11,7 +11,7 @@
+ url='https://github.com/luvit/luv'
+ license=('APACHE')
+ depends=('libuv')
+-makedepends=('cmake' 'libuv' 'ninja' 'luajit' 'lua>=5.4.0' 'lua<5.5.0' 'lua51' 'lua52' 'lua53')
++makedepends=('cmake' 'libuv' 'ninja' 'lua>=5.4.0' 'lua<5.5.0' 'lua51' 'lua52' 'lua53')
+ source=("https://github.com/luvit/luv/releases/download/${pkgver//_/-}/luv-${pkgver//_/-}.tar.gz")
+ sha256sums=('3eb5c7bc44f61fbc4148ea30e3221d410263e0ffa285672851fc19debf9e5c30')
+ 
+@@ -43,12 +43,17 @@
+     -DBUILD_MODULE=OFF \
+     -DBUILD_SHARED_LIBS=ON \
+     -DCMAKE_INSTALL_PREFIX=/usr \
++    -DLUA=/usr/bin/lua5.1 \
++    -DLIBDIR=/usr/lib \
++    -DLUA_LIBDIR=/usr/lib \
++    -DLUA_LIBFILE=liblua5.1.so \
++    -DLUA_INCDIR=/usr/include/lua5.1 \
+     "luv-${pkgver//_/-}"
+   ninja -C "build"
+ }
+ 
+ package_libluv() {
+-  depends+=('luajit')
++  depends+=('lua51')
+   provides+=('libluv')
+   DESTDIR="${pkgdir}" ninja -C "build" install
+ }

--- a/libluv/riscv64.patch
+++ b/libluv/riscv64.patch
@@ -1,6 +1,6 @@
 Index: PKGBUILD
 ===================================================================
---- PKGBUILD	(revision 1346534)
+--- PKGBUILD	(revision 1346561)
 +++ PKGBUILD	(working copy)
 @@ -11,7 +11,7 @@
  url='https://github.com/luvit/luv'
@@ -27,6 +27,6 @@ Index: PKGBUILD
  package_libluv() {
 -  depends+=('luajit')
 +  depends+=('lua51')
-   provides+=('libluv')
    DESTDIR="${pkgdir}" ninja -C "build" install
  }
+ 


### PR DESCRIPTION
Use lua51 instead of luajit because it doesn't support RISC-V (https://github.com/LuaJIT/LuaJIT/issues/628)

Unfortunately we are not getting flags correctly from luarocks. Setting all variables to avoid using default (5.4) lua installation.