### PR TITLE
updpatch: qemu

### DIFF
--- a/qemu/riscv64.patch
+++ b/qemu/riscv64.patch
@@ -1,7 +1,7 @@
-diff --git PKGBUILD PKGBUILD
-index 4ba567e6..e5c19cc7 100644
---- PKGBUILD
-+++ PKGBUILD
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 459941)
++++ PKGBUILD	(working copy)
 @@ -97,7 +97,7 @@
    zlib
    zstd
@@ -11,3 +11,69 @@ index 4ba567e6..e5c19cc7 100644
  source=(
    https://download.qemu.org/qemu-$pkgver.tar.xz{,.sig}
    bridge.conf
+@@ -367,13 +367,6 @@
+   # remove unneeded files
+   find "$pkgdir" -name .buildinfo -delete
+ 
+-  # remove files provided by seabios
+-  rm -fv "$pkgdir/usr/share/$pkgbase/"{bios,vgabios}*
+-
+-  # remove files provided by edk2-{armvirt,ovmf}
+-  rm -fv "$pkgdir/usr/share/$pkgbase/"edk2-*
+-  rm -frv "$pkgdir/usr/share/$pkgbase/firmware"
+-
+   (
+     # create man page symlinks for all system emulators
+     cd "$pkgdir/usr/share/man/man1"
+@@ -433,6 +426,9 @@
+ 
+     _pick qemu-system-aarch64 usr/bin/qemu-system-aarch64
+     _pick qemu-system-aarch64 usr/share/man/man1/qemu-system-aarch64.1*
++    # NOTE: needs to be replaced by edk2, not buildable on riscv64 yet
++    _pick qemu-system-aarch64 usr/share/qemu/firmware/*-aarch64*
++    _pick qemu-system-aarch64 usr/share/qemu/edk2-aarch64-*
+ 
+     _pick qemu-system-alpha usr/bin/qemu-system-alpha
+     _pick qemu-system-alpha usr/share/man/man1/qemu-system-alpha.1*
+@@ -443,6 +439,9 @@
+     _pick qemu-system-arm usr/share/man/man1/qemu-system-arm.1*
+ 
+     _pick qemu-system-arm-firmware usr/share/qemu/npcm7xx_bootrom.bin
++    # NOTE: needs to be replaced by edk2, not buildable on riscv64 yet
++    _pick qemu-system-arm-firmware usr/share/qemu/firmware/*-arm*
++    _pick qemu-system-arm-firmware usr/share/qemu/edk2-arm-*
+ 
+     _pick qemu-system-avr usr/bin/qemu-system-avr
+     _pick qemu-system-avr usr/share/man/man1/qemu-system-avr.1*
+@@ -522,6 +521,13 @@
+     _pick qemu-system-x86-firmware usr/share/qemu/qboot.rom
+     # NOTE: needs to be replaced by sgabios
+     _pick qemu-system-x86-firmware usr/share/qemu/sgabios.bin
++    # NOTE: needs to be replaced by seabios/edk2, not buildable on riscv64 yet
++    _pick qemu-system-x86-firmware usr/share/qemu/firmware/*-i386*
++    _pick qemu-system-x86-firmware usr/share/qemu/firmware/*-x86_64*
++    _pick qemu-system-x86-firmware usr/share/qemu/edk2-i386-*
++    _pick qemu-system-x86-firmware usr/share/qemu/edk2-x86_64-*
++    _pick qemu-system-x86-firmware usr/share/qemu/bios*
++    _pick qemu-system-x86-firmware usr/share/qemu/vgabios*
+ 
+     _pick qemu-system-xtensa usr/bin/qemu-system-xtensa{,eb}
+     _pick qemu-system-xtensa usr/share/man/man1/qemu-system-xtensa{,eb}.1*
+@@ -716,7 +722,7 @@
+ 
+ package_qemu-system-aarch64() {
+   pkgdesc="QEMU system emulator for AARCH64"
+-  depends=("${_qemu_system_deps[@]}" edk2-armvirt systemd-libs libudev.so)
++  depends=("${_qemu_system_deps[@]}" systemd-libs libudev.so)
+   mv -v $pkgname/* "$pkgdir"
+ }
+ 
+@@ -879,7 +885,7 @@
+ 
+ package_qemu-system-x86() {
+   pkgdesc="QEMU system emulator for x86"
+-  depends=("${_qemu_system_deps[@]}" edk2-ovmf qemu-system-x86-firmware=$pkgver-$pkgrel seabios systemd-libs libudev.so)
++  depends=("${_qemu_system_deps[@]}" qemu-system-x86-firmware=$pkgver-$pkgrel systemd-libs libudev.so)
+   mv -v $pkgname/* "$pkgdir"
+ }
+ 


### PR DESCRIPTION
Restore bundled seabios & edk2 files and put them into corresponding subpackages, because they don't build on riscv64 currently.