### PR TITLE
addpatch: gnutls

### DIFF
--- a/gnutls/riscv64.patch
+++ b/gnutls/riscv64.patch
@@ -1,0 +1,13 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 461555)
++++ PKGBUILD	(working copy)
+@@ -43,7 +43,7 @@
+   # disable parallel tests:
+   # FAIL: serv-udp.sh
+ #  make -j1 check
+-  make check
++  make -j1 check
+ }
+ 
+ package() {


### PR DESCRIPTION
Temporarily disable parallel check because of serv-udp.sh.

Upstream report: https://bugs.archlinux.org/task/76577