### PR TITLE
addpatch: cargo-c

### DIFF
--- a/cargo-c/riscv64.patch
+++ b/cargo-c/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -16,7 +16,7 @@ sha256sums=('d79c12eae1460803a1ce8b440ae213dc4df63a6f2bf39ebd49eea1d7a008bec6'
+ 
+ prepare() {
+     ln -sf "../${pkgname}-${pkgver}.Cargo.lock" "${pkgname}-${pkgver}/Cargo.lock"
+-    cargo fetch --locked --target "${CARCH}-unknown-linux-gnu" --manifest-path="${pkgname}-${pkgver}/Cargo.toml"
++    cargo fetch --locked --manifest-path="${pkgname}-${pkgver}/Cargo.toml"
+ }
+ 
+ build() {


### PR DESCRIPTION
Remove `--target` option to fix the target not found issue

Signed-off-by: Avimitin <avimitin@gmail.com>