### PR TITLE
updpatch: krita

### DIFF
--- a/krita/riscv64.patch
+++ b/krita/riscv64.patch
@@ -1,16 +1,11 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -19 +19,2 @@ optdepends=('poppler-qt5: PDF filter' 'ffmpeg: to save animations'
--source=(https://download.kde.org/stable/krita/$_pkgver/$pkgname-$_pkgver.tar.gz{,.sig})
-+source=(https://download.kde.org/stable/krita/$_pkgver/$pkgname-$_pkgver.tar.gz{,.sig}
-+        $pkgname-support-compiling-on-risc-v.patch::https://invent.kde.org/graphics/krita/-/merge_requests/1416.patch)
-@@ -21 +22,2 @@ sha256sums=('ed1d1fa5073ee0c4150e1fde9e109382980ea94d32e5845286bbff20b6bf5e45'
--            'SKIP')
-+            'SKIP'
-+            '475048d165fed3408e90382aabe846fef4a63a1eb1ea1639caf9f67512c062ad')
-@@ -26,0 +29,5 @@ options=(debug)
-+prepare() {
-+  cd $pkgname-$_pkgver
-+  patch -Np1 -i ../$pkgname-support-compiling-on-risc-v.patch
-+}
-+
+@@ -11,7 +11,7 @@ license=(GPL3)
+ depends=(kitemviews kitemmodels ki18n kcompletion kguiaddons kcrash qt5-svg qt5-multimedia quazip
+          gsl libraw exiv2 openexr fftw openjpeg2 opencolorio libwebp hicolor-icon-theme)
+ makedepends=(extra-cmake-modules kdoctools boost eigen poppler-qt5 python-pyqt5 libheif
+-             qt5-tools sip kseexpr libmypaint libjxl xsimd)
++             qt5-tools sip kseexpr libmypaint libjxl)
+ optdepends=('poppler-qt5: PDF filter' 'ffmpeg: to save animations'
+             'python-pyqt5: for the Python plugins' 'libheif: HEIF filter'
+             'kseexpr: SeExpr generator layer' 'kimageformats: PSD support' 'libmypaint: support for MyPaint brushes'


### PR DESCRIPTION
The RISC-V support MR is merged and release in new version: https://invent.kde.org/graphics/krita/-/merge_requests/1416.

This patch also remove the make-depend XSIMD. XSIMD is an optional dependency for krita. And its RISC-V support is still under progress: https://github.com/xtensor-stack/xsimd/issues/503. Krita can work without it so it is fine to remove it.

Signed-off-by: Avimitin <avimitin@gmail.com>