### PR TITLE
updpatch: netcdf-openmpi-bootstrap

### DIFF
--- a/netcdf-openmpi-bootstrap/PKGBUILD
+++ b/netcdf-openmpi-bootstrap/PKGBUILD
@@ -15,8 +15,8 @@ depends=("hdf5-${_mpi}" curl libxml2 libzip)
 makedepends=(cmake)
 optdepends=('netcdf-fortran: fortran bindings' 'netcdf-cxx: c++ bindings')
 checkdepends=(inetutils unzip)
-provides=("${_pkg}")
-conflicts=("${_pkg}")
+provides=("${_pkg}" "${_pkg}-${_mpi}")
+conflicts=("${_pkg}" "${_pkg}-${_mpi}")
 options=(!makeflags)
 source=(https://github.com/Unidata/netcdf-c/archive/v${pkgver}/${pkgname}-${pkgver}.tar.gz
         netcdf-4.9.0-fix-cmake-typo.patch::https://github.com/Unidata/netcdf-c/pull/2412.patch


### PR DESCRIPTION
Provides the original package to satisfy dependency.