### PR TITLE
fixpatch: qt6-quick3dphysics

### DIFF
--- a/qt6-quick3dphysics/riscv64.patch
+++ b/qt6-quick3dphysics/riscv64.patch
@@ -7,10 +7,10 @@ index 659838f..673f6b9 100644
  options=(debug)
  _pkgfn=${pkgname/6-/}-everywhere-src-$_qtver
 -source=(https://download.qt.io/official_releases/qt/${pkgver%.*}/$_qtver/submodules/$_pkgfn.tar.xz)
--sha256sums=('dc59443434d1255fb0cfc50c28ccf391e50745d67014b4aa787cd7571c28fd07')
+-sha256sums=('1dd4a81e671436c8f468f84dfc52fa2fb54bde043598cdb7c6fc69d0511badbb')
 +source=(https://download.qt.io/official_releases/qt/${pkgver%.*}/$_qtver/submodules/$_pkgfn.tar.xz
 +    physx-rv64.patch)
-+sha256sums=('dc59443434d1255fb0cfc50c28ccf391e50745d67014b4aa787cd7571c28fd07'
++sha256sums=('1dd4a81e671436c8f468f84dfc52fa2fb54bde043598cdb7c6fc69d0511badbb'
 +            '76e430885958c5680818de9c4a0f9e4bf5ec43a3c537e3e7aa45fb7542853570')
 +
 +prepare() {


### PR DESCRIPTION
fix a rotten patch (its sha256sums has changed)