### PR TITLE
addpatch: alltray 0.7.5.1dev-7

### DIFF
--- a/alltray/riscv64.patch
+++ b/alltray/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -16,6 +16,7 @@ sha256sums=('09dad447b85ecb57debcb423f34381db7f112a010fbc83e4f65b3b31cf416514')
+ 
+ build() {
+   cd "$srcdir"/${pkgname}-${pkgver}
++  autoreconf -fiv
+   ./configure --prefix=/usr
+   make
+ }


### PR DESCRIPTION
Fix error:

```
checking build system type... ./config.guess: unable to guess system type

This script, last modified 2009-12-30, has failed to recognize
the operating system you are using. It is advised that you
download the most up to date version of the config scripts from

  http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD
and
  http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD

If the version you run (./config.guess) is already up to date, please
send the following data and any information you think might be
pertinent to <config-patches@gnu.org> in order to provide the needed
information to handle your system.

config.guess timestamp = 2009-12-30

uname -m = riscv64
uname -r = 6.0.6-arch1-1
uname -s = Linux
uname -v = #1 SMP PREEMPT_DYNAMIC Sat, 29 Oct 2022 14:08:39 +0000

/usr/bin/uname -p = unknown
/bin/uname -X     = 

hostinfo               = 
/bin/universe          = 
/usr/bin/arch -k       = 
/bin/arch              = 
/usr/bin/oslevel       = 
/usr/convex/getsysinfo = 

UNAME_MACHINE = riscv64
UNAME_RELEASE = 6.0.6-arch1-1
UNAME_SYSTEM  = Linux
UNAME_VERSION = #1 SMP PREEMPT_DYNAMIC Sat, 29 Oct 2022 14:08:39 +0000
configure: error: cannot guess build type; you must specify one
```

The upstream was inactive for a long time, so I didn't report it.