### PR TITLE
addpkg: buddy

### DIFF
--- a/buddy/riscv64.patch
+++ b/buddy/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,6 +14,11 @@ source=("https://downloads.sourceforge.net/$pkgname/$pkgname-$pkgver.tar.gz")
+ md5sums=('3b59cb073bcb3f26efdb851d617ef2ed')
+ sha256sums=('d3df80a6a669d9ae408cb46012ff17bd33d855529d20f3a7e563d0d913358836')
+ 
++prepare() {
++  cd "$srcdir/$pkgname-$pkgver"
++  autoreconf -fiv
++  autoupdate
++}
+ build() {
+   cd "$srcdir/$pkgname-$pkgver"
+   ./configure --prefix=/usr


### PR DESCRIPTION
Fixed `config.guess`.
Uptream url: https://sourceforge.net/p/buddy/patches/7/.