### PR TITLE
addpkg: httrack

### DIFF
--- a/httrack/riscv64.patch
+++ b/httrack/riscv64.patch
@@ -1,0 +1,21 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,11 +14,18 @@ arch=('x86_64')
+ url="https://www.httrack.com/"
+ license=('GPL3')
+ depends=('bash' 'xdg-utils' 'hicolor-icon-theme' 'openssl')
++makedepends=('autoconf-archive')
+ source=(https://mirror.httrack.com/historical/$pkgname-$pkgver.tar.gz{,.asc})
+ validpgpkeys=('BB71C7E6CB1AD8FAF53FE42A60C3AA7180598EFB') # Xavier Roche
+ sha256sums=('3477a0e5568e241c63c9899accbfcdb6aadef2812fcce0173688567b4c7d4025'
+             'SKIP')
+ 
++prepare() {
++  cd "${srcdir}"/$pkgname-$pkgver
++  autoupdate
++  autoreconf -fiv
++}
++
+ build() {
+   cd "${srcdir}"/$pkgname-$pkgver
+ 


### PR DESCRIPTION
Fixed `config.guess`.

Notice: used `autoconf-archive` makedepends.

Upstream URL: https://forum.httrack.com/readmsg/41135/index.html.