### PR TITLE
fixpatch: golang-github-yuin-goldmark 1.4.13-2

### DIFF
--- a/golang-github-yuin-goldmark/riscv64.patch
+++ b/golang-github-yuin-goldmark/riscv64.patch
@@ -8,11 +8,11 @@
 +  cd "$srcdir"/goldmark-$pkgver
 +
 +  # Increase test timeouts with sed
-+  # We will able use GOLDMARK_TEST_TIMEOUT_MULTIPLIER=10 instead of sed
++  # We will able use GOLDMARK_TEST_TIMEOUT_MULTIPLIER=20 instead of sed
 +  # if https://github.com/yuin/goldmark/pull/337 is accepted.
 +  echo "Following test timeouts will be increased:"
 +  grep -E -nH '\(finished - started\) > ([0-9]+)' extra_test.go
-+  sed -Ei 's/\(finished - started\) > ([0-9]+)/\0*10/g' extra_test.go
++  sed -Ei 's/\(finished - started\) > ([0-9]+)/\0*20/g' extra_test.go
 +}
 +
  check() {


### PR DESCRIPTION
Increase test timeout multiplier from 10 to 20.