### PR TITLE
updpatch: yabause-qt 0.9.15-3

### DIFF
--- a/yabause-qt/riscv64.patch
+++ b/yabause-qt/riscv64.patch
@@ -1,23 +1,24 @@
-diff --git PKGBUILD PKGBUILD
-index fd6f004..968dbd6 100755
 --- PKGBUILD
 +++ PKGBUILD
-@@ -13,8 +13,9 @@ arch=('x86_64')
- url="https://yabause.org/"
- license=('GPL')
- depends=('freeglut' 'glew' 'openal' 'qt5-base' 'qt5-multimedia' 'sdl2')
--makedepends=('cmake' 'glu' 'libxmu')
-+makedepends=('cmake' 'glu' 'libxmu' 'clang')
+@@ -17,16 +17,19 @@ makedepends=('cmake' 'glu' 'libxmu')
  conflicts=('yabause-gtk')
-+options=('!lto')
  source=("https://download.tuxfamily.org/yabause/releases/${pkgver}/yabause-${pkgver}.tar.gz"
          'qt-5.11.patch'
-         'rwx.patch')
-@@ -38,6 +39,7 @@ build() {
-   mkdir build && cd build
-
-   cmake .. \
-+    -DCMAKE_C_COMPILER=clang \
-     -DCMAKE_BUILD_TYPE='Release' \
-     -DCMAKE_INSTALL_PREFIX='/usr' \
-     -DYAB_PORTS='qt' \
+-        'rwx.patch')
++        'rwx.patch'
++        "$pkgname-c68k-compiler-optimization.patch::https://github.com/Yabause/yabause/pull/444.patch")
+ sha256sums=('4334c43fe0f3ff297bac8e91f4e059fe5fd276291faff2489e37b5b3a4ccc2b2'
+             '5c4f639478567d9a42963420bb6ab4086fd0514e8787c597c7b40804e1946ea6'
+-            'd29997d3249683081a2687f31e777f917093101d56815d22103aaaf22ac786b1')
++            'd29997d3249683081a2687f31e777f917093101d56815d22103aaaf22ac786b1'
++            'c683b1e3ecd359327ce1671b6efa8c88d17944f40cddf0e1207b59abc70109ce')
+ 
+ prepare() {
+   cd yabause-${pkgver}
+ 
+   patch -Np2 -i ../qt-5.11.patch
+   patch -Np1 -i ../rwx.patch
++  patch -Np2 -i ../$pkgname-c68k-compiler-optimization.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
Upstream used `-O0` to prevent GCC from performing strict aliasing optimizations. Without `-freorder-blocks`, GCC generates an unlinkable ELF file, causing the package fails to build. This patch substitutes `-O0` with `-fno-strict-aliasing` to make the compilation work as intended. You may refer to upstream patch Yabause/yabause#444 for details.