### PR TITLE
addpatch: xorg-fonts-75dpi

### DIFF
--- a/xorg-fonts-75dpi/riscv64.patch
+++ b/xorg-fonts-75dpi/riscv64.patch
@@ -1,0 +1,20 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -27,6 +27,17 @@ sha256sums=('c6024a1e4a1e65f413f994dd08b734efd393ce0a502eb465deb77b9a36db4d09'
+             '4ac16afbe205480cc5572e2977ea63488c543d05be0ea8e5a94c845a6eebcb31'
+             'ba3f5e4610c07bd5859881660753ec6d75d179f26fc967aa776dbb3d5d5cf48e')
+ 
++prepare() {
++  cd "${srcdir}"
++  for dir in *; do
++    if [ -d "${dir}" ]; then
++      pushd "${dir}"
++      autoreconf -fiv 
++      popd
++    fi
++  done
++}
++
+ build() {
+   cd "${srcdir}"
+   for dir in *; do


### PR DESCRIPTION
Fix config.guess issue. Upstream report:
https://gitlab.freedesktop.org/xorg/font/adobe-75dpi/-/issues/1

Signed-off-by: Avimitin <avimitin@gmail.com>
