### PR TITLE
addpatch: xorg-fonts-cyrillic

### DIFF
--- a/xorg-fonts-cyrillic/riscv64.patch
+++ b/xorg-fonts-cyrillic/riscv64.patch
@@ -1,0 +1,29 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -9,7 +9,7 @@ arch=(any)
+ url="https://xorg.freedesktop.org/"
+ license=('custom')
+ depends=('xorg-fonts-alias-cyrillic')
+-makedepends=('xorg-util-macros' 'xorg-mkfontscale' 'xorg-bdftopcf')
++makedepends=('xorg-util-macros' 'xorg-mkfontscale' 'xorg-bdftopcf' 'xorg-font-util')
+ source=(${url}/releases/individual/font/font-cronyx-cyrillic-${pkgver}.tar.bz2
+         ${url}/releases/individual/font/font-misc-cyrillic-${pkgver}.tar.bz2
+         ${url}/releases/individual/font/font-screen-cyrillic-1.0.4.tar.bz2
+@@ -23,6 +23,17 @@ sha256sums=('6e8631936157677c77ba032b5c7b1fb3cb2ee872dbcea0444f12cd602cd9212a'
+             '824231e8dffe15299454e47259f29d98001c9cf8ad3d6b5171399e4d71705e79'
+             'abd13b63d02fcaec488686c23683e5cf640b43bd32f8ca22eeae6f84df0a36a0')
+ 
++prepare() {
++  cd "${srcdir}"
++  for dir in *; do
++    if [ -d "${dir}" ]; then
++      pushd "${dir}"
++      autoreconf -fiv
++      popd
++    fi
++  done
++}
++
+ build() {
+   cd "${srcdir}"
+   for dir in *; do


### PR DESCRIPTION
Fix config.guess issue. Upstream report:
https://gitlab.freedesktop.org/xorg/font/winitzki-cyrillic/-/issues/1.

This patch add additional make-depends: xorg-font-util. It is required
when we run autogen.

Signed-off-by: Avimitin <avimitin@gmail.com>
