### PR TITLE
addpatch: ophcrack

### DIFF
--- a/ophcrack/riscv64.patch
+++ b/ophcrack/riscv64.patch
@@ -1,0 +1,9 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -21,6 +21,7 @@ sha256sums=('048a6df57983a3a5a31ac7c4ec12df16aa49e652a29676d93d4ef959d50aeee0'
+ 
+ build() {
+   cd $pkgname-$pkgver
++  autoreconf -fiv
+ 
+   ./configure --prefix=/usr --enable-gui --enable-graph


### PR DESCRIPTION
Fix config.guess issue. Reported to upstream at https://gitlab.com/objectifsecurite/ophcrack/-/issues/9