### PR TITLE
updpatch: echoping

### DIFF
--- a/echoping/riscv64.patch
+++ b/echoping/riscv64.patch
@@ -1,8 +1,6 @@
-diff --git PKGBUILD PKGBUILD
-index a0aafb51..73aebdb5 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -6,6 +6,7 @@ pkgrel=10
+@@ -6,6 +6,7 @@ pkgrel=12
  pkgdesc="tests performance of a remote host by sending HTTP, TCP and UDP requests"
  arch=('x86_64')
  url="http://echoping.sourceforge.net/"
@@ -10,3 +8,11 @@ index a0aafb51..73aebdb5 100644
  license=('GPL')
  depends=(libidn popt libldap)
  #source=(https://sourceforge.net/projects/$pkgname/files/$pkgname/$pkgver/$pkgname-$pkgver.tar.gz)
+@@ -18,6 +19,7 @@ sha256sums=('1dfa4c45bf461b2379ff91773ed7136176e2abac9e85c26bc9654942b5155eac'
+ 
+ prepare() {
+   cd "$srcdir/$pkgname-$pkgver"
++  find . -name config.guess -exec cp -f /usr/share/libtool/build-aux/config.guess {} \;
+   patch -Np1 -i ../link-echoping-to-libm.patch
+ }
+ 


### PR DESCRIPTION
Fix config.guess issue.

FYI: echoping is no longer maintained (see https://framagit.org/bortzmeyer/echoping)