### PR TITLE
addpatch: rhythmbox

### DIFF
--- a/rhythmbox/riscv64.patch
+++ b/rhythmbox/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -53,7 +53,7 @@ check() (
+   export GSETTINGS_SCHEMA_DIR GSETTINGS_BACKEND=memory CK_TIMEOUT_MULTIPLIER=3
+ 
+   xvfb-run -s '-nolisten local' \
+-    meson test -C build --print-errorlogs
++    meson test -C build --print-errorlogs -t 5
+ )
+ 
+ package() {


### PR DESCRIPTION
Package rhythmbox needs 40secs(qemu-user)~52secs(VisionFive) to finish
the test on our RISC-V machine. The default 30secs timeout is not
enough. This patch add timeout multiplier option `-t` to increase
timeout by 5 times.

Signed-off-by: Avimitin <avimitin@gmail.com>
