### PR TITLE
addpatch: cjs

### DIFF
--- a/cjs/riscv64.patch
+++ b/cjs/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -33,7 +33,7 @@ check() {
+     cd ${pkgname}-${pkgver}/builddir
+ 
+     # Needs a display
+-    xvfb-run meson test --print-errorlogs
++    xvfb-run meson test --print-errorlogs -t 5
+ }
+ 
+ package() {


### PR DESCRIPTION
One of the test from the cjs package require 28secs(qemu-user 5950x) ~
33secs(VisionFive) to finish, and the default timeout(30secs) is not
enough. This patch add timeout multiplier with `-t` option to increase
timeout by 5 times.

Signed-off-by: Avimitin <avimitin@gmail.com>
