### PR TITLE
addpatch: coin-or-cgl

### DIFF
--- a/coin-or-clp/coin-or-cgl/riscv64.patch
+++ b/coin-or-clp/coin-or-cgl/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,6 +14,12 @@ depends=(coin-or-clp)
+ source=($pkgname-$pkgver.tar.gz::https://github.com/coin-or/Cgl/archive/refs/tags/releases/$pkgver.tar.gz)
+ sha256sums=('9e2c51ffad816ab408763d6b931e2a3060482ee4bf1983148969de96d4b2c9ce')
+ 
++prepare() {
++  cd Cgl-releases-$pkgver
++  autoconf_file="/usr/share/autoconf/build-aux/config"
++  echo ". Cgl" | xargs -r -n1 cp ${autoconf_file}.{guess,sub}
++}
++
+ build() {
+   cd Cgl-releases-$pkgver
+   ./configure --prefix=/usr


### PR DESCRIPTION
Fix the config.guess issue. BTW, the coin-or-clp in current repo link
to the libcholmod.so.3 file, but the latest suitesparse package provide
libcholmod.so.4 now. So the coin-or-clp package should be built before
this package.

Signed-off-by: Avimitin <avimitin@gmail.com>
