### PR TITLE
addpatch: bitwarden-cli

### DIFF
--- a/bitwarden-cli/riscv64.patch
+++ b/bitwarden-cli/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -20,7 +20,8 @@ prepare() {
+ 	export npm_config_build_from_source=true
+ 	export npm_config_cache="$srcdir/npm_cache"
+ 
+-	npm ci
++	sed -i '/electron/d' package.json
++	npm ci --ignore-scripts
+ }
+ 
+ build() {


### PR DESCRIPTION
This patch remove all the electron dependencies and the husky installer.

Bitwarden-cli is part of the bitwarden/client project. It share
dependencies with other application. And the electron dependencies is
for desktop/Android version. Besides, electron is currently unusable on
RISC-V platform.

The husky installer is a git hook util implemented by nodejs. It is only
used for dev environment.

Signed-off-by: Avimitin <avimitin@gmail.com>
