### PR TITLE
addpatch: js102

### DIFF
--- a/js102/riscv64.patch
+++ b/js102/riscv64.patch
@@ -10,7 +10,7 @@
  sha256sums=('e79f0ddd4914dfbff61c5eea7ff28ad2dd12ecfbf3d63a41dab57d50171d904e'
 -            'SKIP')
 +            'SKIP'
-+            '80125436a8eb5ef0ca30feb32484cfa2684566bc3eda87c451ddeb4e5da71e57')
++            '62b5ce541dd5ad58bd7582eeedaf7f2b9577c926c4aca8481e7bb01ff0cab673')
  validpgpkeys=('14F26682D0916CDD81E37B6D61B7B526D98F0353') # Mozilla Software Releases <release@mozilla.com>
  
  # Make sure the duplication between bin and lib is found

--- a/js102/riscv64.patch
+++ b/js102/riscv64.patch
@@ -1,0 +1,105 @@
+--- PKGBUILD	(revision 462791)
++++ PKGBUILD	(working copy)
+@@ -12,9 +12,11 @@
+ checkdepends=(mercurial git)
+ options=(!lto debug)
+ _relver=${pkgver}esr
+-source=(https://archive.mozilla.org/pub/firefox/releases/$_relver/source/firefox-$_relver.source.tar.xz{,.asc})
++source=(https://archive.mozilla.org/pub/firefox/releases/$_relver/source/firefox-$_relver.source.tar.xz{,.asc}
++       tests-skip-some-tests-on-rv64.patch)
+ sha256sums=('e79f0ddd4914dfbff61c5eea7ff28ad2dd12ecfbf3d63a41dab57d50171d904e'
+-            'SKIP')
++            'SKIP'
++            '80125436a8eb5ef0ca30feb32484cfa2684566bc3eda87c451ddeb4e5da71e57')
+ validpgpkeys=('14F26682D0916CDD81E37B6D61B7B526D98F0353') # Mozilla Software Releases <release@mozilla.com>
+ 
+ # Make sure the duplication between bin and lib is found
+@@ -24,6 +26,8 @@
+   mkdir mozbuild
+   cd firefox-$pkgver
+ 
++  patch -Np1 -i ../tests-skip-some-tests-on-rv64.patch
++
+   cat >../mozconfig <<END
+ ac_add_options --enable-application=js
+ mk_add_options MOZ_OBJDIR=${PWD@Q}/obj
+@@ -33,12 +37,13 @@
+ ac_add_options --enable-hardening
+ ac_add_options --enable-optimize
+ ac_add_options --enable-rust-simd
+-ac_add_options --enable-linker=lld
++ac_add_options --enable-linker=bfd
+ ac_add_options --disable-bootstrap
+ ac_add_options --disable-debug
+ ac_add_options --disable-debug-symbols
+ ac_add_options --disable-jemalloc
+ ac_add_options --disable-strip
++ac_add_options --disable-jit
+ 
+ # System libraries
+ ac_add_options --with-system-zlib
+@@ -62,40 +67,40 @@
+   # Do 3-tier PGO
+   echo "Building instrumented JS..."
+   cat >.mozconfig ../mozconfig - <<END
+-ac_add_options --enable-profile-generate=cross
++#ac_add_options --enable-profile-generate=cross
+ END
+   ./mach build
+ 
+-  echo "Profiling instrumented JS..."
+-  (
+-    local js="$PWD/obj/dist/bin/js"
+-    export LLVM_PROFILE_FILE="$PWD/js-%p-%m.profraw"
++#   echo "Profiling instrumented JS..."
++#   (
++#     local js="$PWD/obj/dist/bin/js"
++#     export LLVM_PROFILE_FILE="$PWD/js-%p-%m.profraw"
+ 
+-    cd js/src/octane
+-    "$js" run.js
++#     cd js/src/octane
++#     "$js" run.js
+ 
+-    cd ../../../third_party/webkit/PerformanceTests/ARES-6
+-    "$js" cli.js
++#     cd ../../../third_party/webkit/PerformanceTests/ARES-6
++#     "$js" cli.js
+ 
+-    cd ../SunSpider/sunspider-0.9.1
+-    "$js" sunspider-standalone-driver.js
+-  )
++#     cd ../SunSpider/sunspider-0.9.1
++#     "$js" sunspider-standalone-driver.js
++#   )
+ 
+-  llvm-profdata merge -o merged.profdata *.profraw
++#   llvm-profdata merge -o merged.profdata *.profraw
+ 
+-  stat -c "Profile data found (%s bytes)" merged.profdata
+-  test -s merged.profdata
++#   stat -c "Profile data found (%s bytes)" merged.profdata
++#   test -s merged.profdata
+ 
+-  echo "Removing instrumented JS..."
+-  ./mach clobber
++#   echo "Removing instrumented JS..."
++#   ./mach clobber
+ 
+-  echo "Building optimized JS..."
+-  cat >.mozconfig ../mozconfig - <<END
+-ac_add_options --enable-lto=cross
+-ac_add_options --enable-profile-use=cross
+-ac_add_options --with-pgo-profile-path=${PWD@Q}/merged.profdata
+-END
+-  ./mach build
++#   echo "Building optimized JS..."
++#   cat >.mozconfig ../mozconfig - <<END
++# ac_add_options --enable-lto=cross
++# ac_add_options --enable-profile-use=cross
++# ac_add_options --with-pgo-profile-path=${PWD@Q}/merged.profdata
++# END
++#   ./mach build
+ }
+ 
+ check() {

--- a/js102/tests-skip-some-tests-on-rv64.patch
+++ b/js102/tests-skip-some-tests-on-rv64.patch
@@ -1,0 +1,16 @@
+--- a/js/src/tests/non262/Array/regress-157652.js	2022-11-30 14:24:40.713125777 +0800
++++ b/js/src/tests/non262/Array/regress-157652.js	2022-11-30 16:46:55.001791795 +0800
+@@ -1,4 +1,4 @@
+-// |reftest| skip-if(xulRuntime.XPCOMABI.match(/x86_64|aarch64|ppc64|ppc64le|s390x|mips64|loongarch64/)||Android) -- No test results
++// |reftest| skip-if(xulRuntime.XPCOMABI.match(/x86_64|aarch64|ppc64|ppc64le|s390x|mips64||loongarch64|riscv64/)||Android) -- No test results
+ /* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+ /* This Source Code Form is subject to the terms of the Mozilla Public
+  * License, v. 2.0. If a copy of the MPL was not distributed with this
+--- a/js/src/tests/non262/regress/regress-422348.js	2022-11-30 14:24:40.739793319 +0800
++++ b/js/src/tests/non262/regress/regress-422348.js	2022-11-30 17:36:56.056931848 +0800
+@@ -1,4 +1,4 @@
+-// |reftest| skip-if(xulRuntime.XPCOMABI.match(/x86_64|aarch64|ppc64|ppc64le|s390x|mips64|loongarch64/)) -- On 64-bit, takes forever rather than throwing
++// |reftest| skip-if(xulRuntime.XPCOMABI.match(/x86_64|aarch64|ppc64|ppc64le|s390x|mips64|loongarch64|riscv64/)) -- On 64-bit, takes forever rather than throwing
+ /* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+ /* This Source Code Form is subject to the terms of the Mozilla Public
+  * License, v. 2.0. If a copy of the MPL was not distributed with this

--- a/js102/tests-skip-some-tests-on-rv64.patch
+++ b/js102/tests-skip-some-tests-on-rv64.patch
@@ -2,7 +2,7 @@
 +++ b/js/src/tests/non262/Array/regress-157652.js	2022-11-30 16:46:55.001791795 +0800
 @@ -1,4 +1,4 @@
 -// |reftest| skip-if(xulRuntime.XPCOMABI.match(/x86_64|aarch64|ppc64|ppc64le|s390x|mips64|loongarch64/)||Android) -- No test results
-+// |reftest| skip-if(xulRuntime.XPCOMABI.match(/x86_64|aarch64|ppc64|ppc64le|s390x|mips64||loongarch64|riscv64/)||Android) -- No test results
++// |reftest| skip-if(xulRuntime.XPCOMABI.match(/x86_64|aarch64|ppc64|ppc64le|s390x|mips64|loongarch64|riscv64/)||Android) -- No test results
  /* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
  /* This Source Code Form is subject to the terms of the Mozilla Public
   * License, v. 2.0. If a copy of the MPL was not distributed with this


### PR DESCRIPTION
Skip some tests on 64-bit architecture. Same as: https://github.com/felixonmars/archriscv-packages/commit/badeec697832d979dead2c66d3a4a172ee78d7fb