### PR TITLE
addpatch: opencolorio

### DIFF
--- a/opencolorio/0001-CheckSupportSSE2-Fix-sse-flags-unexpected-propagatio.patch
+++ b/opencolorio/0001-CheckSupportSSE2-Fix-sse-flags-unexpected-propagatio.patch
@@ -1,0 +1,40 @@
+From d994e432989318d384e7234581e8134aa811cc0f Mon Sep 17 00:00:00 2001
+From: Letu Ren <fantasquex@gmail.com>
+Date: Tue, 8 Nov 2022 17:04:16 +0100
+Subject: [PATCH] CheckSupportSSE2: Fix sse flags unexpected propagation
+
+Set function will affects all variables in current directory. If sse
+flags are added in CheckSupportSSE2.cmake, they will remain in
+Findminizip-ng.cmake which will cause liblzma cannot be detected. This
+patch keep CMAKE_REQUIRED_FLAGS being changed only in current file
+scope. This patch has been tested on riscv64.
+
+Signed-off-by: Letu Ren <fantasquex@gmail.com>
+---
+ share/cmake/utils/CheckSupportSSE2.cmake | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/share/cmake/utils/CheckSupportSSE2.cmake b/share/cmake/utils/CheckSupportSSE2.cmake
+index 3d97bf8a..f30bbb76 100644
+--- a/share/cmake/utils/CheckSupportSSE2.cmake
++++ b/share/cmake/utils/CheckSupportSSE2.cmake
+@@ -3,6 +3,8 @@
+ 
+ include(CheckCXXSourceCompiles)
+ 
++set(_cmake_required_flags_old "${CMAKE_REQUIRED_FLAGS}")
++
+ if(NOT CMAKE_SIZE_OF_VOID_P EQUAL 8)
+     # As CheckCXXCompilerFlag implicitly uses CMAKE_CXX_FLAGS some custom flags could trigger
+     # unrelated warnings causing a detection failure. So, the code disables all warnings to focus
+@@ -27,4 +29,7 @@ check_cxx_source_compiles ("
+     }"
+     HAVE_SSE2)
+ 
++set(CMAKE_REQUIRED_FLAGS "${_cmake_required_flags_old}")
++unset(_cmake_required_flags_old)
++
+ mark_as_advanced(HAVE_SSE2)
+-- 
+2.38.1
+

--- a/opencolorio/riscv64.patch
+++ b/opencolorio/riscv64.patch
@@ -1,0 +1,28 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 460916)
++++ PKGBUILD	(working copy)
+@@ -13,9 +13,11 @@
+ makedepends=('cmake' 'python' 'pybind11' 'ninja')
+ optdepends=('python: python bindings')
+ source=($pkgname-$pkgver.tar.gz::https://github.com/AcademySoftwareFoundation/OpenColorIO/archive/v$pkgver.tar.gz
+-        use-system-minizip.patch)
++        use-system-minizip.patch
++        0001-CheckSupportSSE2-Fix-sse-flags-unexpected-propagatio.patch)
+ sha512sums=('f9fc6991f99f28bb2117ecf6af6ea907310c9ae118d17e54c1bf642ec99e35bf899463d80bccdbaca6cd66bae62e17fdd0417e2fb42c8b8f80c6892e7cbe8770'
+-            'de760fa88f9680e9bd02c3810957f68f82ef461591763de47e4ffa31739aebd1ebf0793dd7e93582aaef11afd9d4ba088f8911259c749dc6a74b9cf4b163470e')
++            'de760fa88f9680e9bd02c3810957f68f82ef461591763de47e4ffa31739aebd1ebf0793dd7e93582aaef11afd9d4ba088f8911259c749dc6a74b9cf4b163470e'
++            '614dc60b42a1f6ed9bfc72a4dc5f93d409040d9521462adad4ffbde346b4bafc438081e36a99f61c4b4d63260d01fe5ae722f51d4a022affefcb4e72cbf3765a')
+ 
+ prepare() {
+   cd OpenColorIO-$pkgver
+@@ -22,6 +24,9 @@
+ 
+   # We don't care about the failures of this patch in this current release
+   patch -Np1 -i "$srcdir"/use-system-minizip.patch
++
++  # Fix sse flags unexpected propagation
++  patch -Np1 -i "$srcdir"/0001-CheckSupportSSE2-Fix-sse-flags-unexpected-propagatio.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
Set function will affects all variables in current directory. If sse flags are added in CheckSupportSSE2.cmake, they will remain in Findminizip-ng.cmake which will cause liblzma cannot be detected. This patch keep CMAKE_REQUIRED_FLAGS being changed only in current file scope.

Upstream link: https://github.com/AcademySoftwareFoundation/OpenColorIO/pull/1721