### PR TITLE
addpatch: gjs

### DIFF
--- a/gjs/riscv64.patch
+++ b/gjs/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -43,7 +43,7 @@ build() {
+ 
+ check() {
+   xvfb-run -s '-nolisten local' \
+-    meson test -C build --print-errorlogs
++    meson test -C build --print-errorlogs -t 2
+ }
+ 
+ package() {


### PR DESCRIPTION
gjs needs ~26secs to finish its test in VisionFive, ~33secs in QEMU
System. So double the default timeout should be enough.

Signed-off-by: Avimitin <avimitin@gmail.com>
