### PR TITLE
addpatch: bnfc

### DIFF
--- a/bnfc/riscv64.patch
+++ b/bnfc/riscv64.patch
@@ -1,0 +1,12 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1356680)
++++ PKGBUILD	(working copy)
+@@ -20,6 +20,7 @@
+ 
+ prepare() {
+   cd $_hkgname-$pkgver
++  sed -i '/test-suite doctests/a \  buildable: False' $_hkgname.cabal
+   # Use -dynamic by default
+   sed -i 's/ghc --make/ghc -dynamic --make/g' src/BNFC/Backend/Haskell.hs
+ }


### PR DESCRIPTION
Disable doctests until we fix our GHCi crashes.