### PR TITLE
fixpatch: python-sphinx_rtd_theme

### DIFF
--- a/python-sphinx_rtd_theme/fix-for-new-nodejs.patch
+++ b/python-sphinx_rtd_theme/fix-for-new-nodejs.patch
@@ -19,7 +19,7 @@ index b755632..bfd4ccc 100644
      "jquery": "^3.6.0",
      "lato-font": "^3.0.0",
      "mini-css-extract-plugin": "^0.6.0",
--    "node-sass": "^4.13.1",
+-    "node-sass": "^4.14.1",
 +    "node-sass": "^6.0.1",
      "optimize-css-assets-webpack-plugin": "^5.0.4",
      "roboto-fontface": "^0.10.0",

--- a/python-sphinx_rtd_theme/riscv64.patch
+++ b/python-sphinx_rtd_theme/riscv64.patch
@@ -1,17 +1,17 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -11,13 +11,17 @@ arch=('any')
+@@ -11,17 +11,22 @@ arch=('any')
  url=https://github.com/readthedocs/sphinx_rtd_theme
  license=('MIT')
  depends=('python-sphinx')
--makedepends=('nodejs-lts-fermium' 'npm' 'python-setuptools')
+-makedepends=('nodejs-lts-fermium' 'npm' 'python-setuptools-scm' 'python-build' 'python-installer' 'python-wheel')
 -source=("$url/archive/$pkgver/sphinx_rtd_theme-$pkgver.tar.gz")
--b2sums=('c70740d1f6b6afddd2b32b756e1f6940846459038d6ea0f03b218cfeb07e0974f4d186f9993eeddda58115d0b2a607e61b28081576b9f953d855f3cc3d51d836')
-+makedepends=('nodejs-lts-gallium' 'npm' 'python-setuptools')
+-b2sums=('1998051e814fcbee541ffe53ccaa5d1ebdeaa27bb95c2e68c840032660fc105621041f72a12c6f2ec77db400cfef21a57850e351921572a71b52dfa2e0b460fc')
++makedepends=('nodejs-lts-gallium' 'npm' 'python-setuptools-scm' 'python-build' 'python-installer' 'python-wheel')
 +source=("$url/archive/$pkgver/sphinx_rtd_theme-$pkgver.tar.gz"
 +        fix-for-new-nodejs.patch)
-+b2sums=('c70740d1f6b6afddd2b32b756e1f6940846459038d6ea0f03b218cfeb07e0974f4d186f9993eeddda58115d0b2a607e61b28081576b9f953d855f3cc3d51d836'
-+        '8a1edb03efb011756da569de7e5fe9d5450325ea8b015749208e74936f7cea6b34f30af1fe51a6815fe230e1a67fa97b0d0f1546bb6742fafca97feb29f7fb61')
++b2sums=('1998051e814fcbee541ffe53ccaa5d1ebdeaa27bb95c2e68c840032660fc105621041f72a12c6f2ec77db400cfef21a57850e351921572a71b52dfa2e0b460fc'
++        '96d06e20679149010a5714310e1e40c0892a5a6f9cc8fe337fd3564295bcf635e543b2a4b26948e8982fd575895e80a7d888f61b9c2235d2284f256a64a22b61')
  
  prepare() {
    cd sphinx_rtd_theme-$pkgver
@@ -22,3 +22,8 @@
  }
  
  build() {
+   cd sphinx_rtd_theme-$pkgver
++  export NODE_OPTIONS=--openssl-legacy-provider
+   npm run build
+   python -m build --wheel --no-isolation
+ }


### PR DESCRIPTION
Fix rotten and webpack4 issue.

The latest Node.js contains some breaking change for webpack4. This PR
add env `NODE_OPTIONS=--openssl-legacy-provider` as a workaround for the
`Error: error:0308010C:digital envelope routines::unsupported` issue.

Signed-off-by: Avimitin <avimitin@gmail.com>
