### PR TITLE
addpkg: rust-bindgen

### DIFF
--- a/rust-bindgen/riscv64.patch
+++ b/rust-bindgen/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,7 +15,7 @@ sha512sums=('b43c415c4ac55c0cf8ccba6a21b945e890321ff3c11a3afacfd8c724d83ee6e2106
+ 
+ prepare() {
+   cd $pkgname-$pkgver
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  cargo fetch --locked
+ }
+ 
+ build() {


### PR DESCRIPTION
Fixed `--target "$CARCH-unknown-linux-gnu"` issue.