### PR TITLE
addpatch: libiec61883

### DIFF
--- a/libiec61883/riscv64.patch
+++ b/libiec61883/riscv64.patch
@@ -1,0 +1,12 @@
+diff --git PKGBUILD PKGBUILD
+index d507910c..0b37c2d7 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -16,6 +16,7 @@
+ 
+ build() {
+   cd libiec61883-${pkgver}
++  autoreconf -fiv
+   ./configure --prefix=/usr
+   make
+ }


### PR DESCRIPTION
Update autotools aux files.

Upstream report was sent, but was not listed in maillist archive for unknown reason.

And the third-party Archive shows that there are still emails in June this year, but sourceforge's own archive shows that the last email was sent in 2006.[^1][^2]

Signed-off-by: Celeste Liu <CoelacanthusHex@gmail.com>

[^1]: https://sourceforge.net/p/linux1394/mailman/linux1394-devel/
[^2]: https://marc.info/?l=linux1394-devel