### PR TITLE
addpatch: db5.3

### DIFF
--- a/db5.3/riscv64.patch
+++ b/db5.3/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -43,6 +43,9 @@ prepare() {
+   patch -Np1 -i ../db-5.3.28-mmap-high-cpu-usage.patch
+   # gcc fix
+   patch -Np1 -i ../db-5.3.28-atomic_compare_exchange.patch
++
++  cd dist
++  cp /usr/share/autoconf/build-aux/config.{guess,sub} .
+ }
+ 
+ 


### PR DESCRIPTION
Fix the config.guess issue. Upstream report:
https://community.oracle.com/tech/developers/discussion/4509264/fail-to-build-berkeley-db-on-risc-v/p1?new=1

Signed-off-by: Avimitin <avimitin@gmail.com>
