### PR TITLE
addpatch: stfl

### DIFF
--- a/stfl/riscv64.patch
+++ b/stfl/riscv64.patch
@@ -1,0 +1,17 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -6,12 +6,12 @@
+ pkgrel=5
+ pkgdesc="Library implementing a curses-based widget set for text terminals"
+ arch=('x86_64')
+-url="http://clifford.at/stfl/"
++url="http://bygone.clairexen.net/stfl/"
+ license=('GPL3')
+ depends=('ncurses')
+ makedepends=('patch' 'swig')
+ changelog=$pkgname.changelog
+-source=(http://clifford.at/stfl/$pkgname-$pkgver.tar.gz
++source=(http://bygone.clairexen.net/stfl/$pkgname-$pkgver.tar.gz
+         $pkgname-archlinux.patch)
+ sha256sums=('d4a7aa181a475aaf8a8914a8ccb2a7ff28919d4c8c0f8a061e17a0c36869c090'
+             'c7d7c787bcd287a776aad3b26e6a90a3b121c281125c34c7c35a87f36dcdc453')


### PR DESCRIPTION
According to the author's tweet(https://twitter.com/oe1cxw/status/906550696971046914),

she lost control of the original domain.

The upstream domain has been changed to clairexen.net.

The sha256 of the file has not changed.

Upstream bug report: https://bugs.archlinux.org/task/76958