### PR TITLE
addpatch: glade

### DIFF
--- a/glade/riscv64.patch
+++ b/glade/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -44,7 +44,7 @@ build() {
+ 
+ check() {
+   dbus-run-session xvfb-run -s '-nolisten local' \
+-    meson test -C build --print-errorlogs
++    meson test -C build --print-errorlogs -t 5
+ }
+ 
+ package() {


### PR DESCRIPTION
Package glade require ~43secs to finish `add-child` test in VisionFive.
So add 5 mutiplier should be enough.

Signed-off-by: Avimitin <avimitin@gmail.com>
