### PR TITLE
addpkg: memtest86+ to blacklist

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -34,6 +34,7 @@ intel-ucode
 intel-undervolt
 libmfx
 libva-intel-driver
+memtest86+
 throttled
 tp_smapi
 tp_smapi-lts


### PR DESCRIPTION
As described on their homepage, this program is a memory tester for
x86 and x86-64 architecture computers.

Signed-off-by: Avimitin <avimitin@gmail.com>
