### PR TITLE
upgpatch: vaultwarden

### DIFF
--- a/vaultwarden/riscv64.patch
+++ b/vaultwarden/riscv64.patch
@@ -1,13 +1,11 @@
-diff --git PKGBUILD PKGBUILD
-index 11a3ae5..74bf3ae 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -37,8 +37,12 @@ prepare() {
+@@ -46,8 +46,12 @@ prepare() {
    s,/path/to/log,/var/log/$pkgname.log,
    /^# ROCKET_TLS/a ROCKET_LIMITS={json=10485760}" .env.template
  
-+  # update dependencies
-+  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
++  # Cargo.toml file already contains patch key
++  sed -i '/^\[patch\.crates-io]/ a ring = { git = "https://github.com/felixonmars/ring", branch = "0.16.20" }' Cargo.toml
 +  cargo update -p ring
 +
    # download dependencies


### PR DESCRIPTION
The Cargo.toml file already has key `patch.crates-io`. This patch attach
the ring patch to the existing `patch.crates-io` key.

Signed-off-by: Avimitin <avimitin@gmail.com>
