### PR TITLE
upgpatch: go 2:1.19.5-1

### DIFF
--- a/go/riscv64.patch
+++ b/go/riscv64.patch
@@ -1,24 +1,9 @@
 diff --git PKGBUILD PKGBUILD
-index 0ad3ab1..9c6b68d 100644
+index 1a4d48d4..d10bb477 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -24,14 +24,20 @@
- replaces=(go-pie)
- provides=(go-pie)
- options=(!strip staticlibs)
--source=(https://go.dev/dl/go${pkgver}.src.tar.gz{,.asc})
-+source=(https://go.dev/dl/go${pkgver}.src.tar.gz{,.asc}
-+        go-riscv64-sv57.patch::https://github.com/golang/go/commit/1e3c19f3fee12e5e2b7802a54908a4d4d03960da.patch)
- validpgpkeys=('EB4C1BFD4F042F6DDDCCEC917721F63BD38B4796')
- sha256sums=('18ac263e39210bcf68d85f4370e97fb1734166995a1f63fb38b4f6e07d90d212'
--            'SKIP')
-+            'SKIP'
-+            'a571c0fbf71afc121cd663f9a21924dc99acc9d8d1e6e0004751d9604ab298f9')
-+
-+prepare() {
-+  cd go/src
-+  patch -p2 -i "${srcdir}/go-riscv64-sv57.patch"
-+}
+@@ -30,8 +30,7 @@
+             'SKIP')
  
  build() {
 -  export GOARCH=amd64
@@ -27,7 +12,7 @@ index 0ad3ab1..9c6b68d 100644
    export GOROOT_FINAL=/usr/lib/go
    export GOROOT_BOOTSTRAP=/usr/lib/go
  
-@@ -50,7 +56,7 @@
+@@ -50,7 +49,7 @@
    cd "$pkgname"
  
    install -d "$pkgdir/usr/bin" "$pkgdir/usr/lib/go" "$pkgdir/usr/share/doc/go" \


### PR DESCRIPTION
Remove the sv57 patch since we have done this in kernel.

This might fail randomly on Unmatched board. Just retry it. I would need to make a further diagnosis later.