### PR TITLE
qemu-user-blacklist: add pandoc

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -67,6 +67,7 @@ ob-xd
 odin2-synthesizer
 openh264
 openldap
+pandoc
 pangomm-2.48
 percona-server
 perl


### PR DESCRIPTION
New pandoc PKGBUILD invokes the non-suid version of bwrap, which qemu-user doesn't seem to support:

```
bwrap: Creating new namespace failed, likely because the kernel does not
support user namespaces.  bwrap must be installed setuid on such
systems.
```