### PR TITLE
addpkg: aarch64-linux-gnu-binutils

### DIFF
--- a/aarch64-linux-gnu-binutils/riscv64.patch
+++ b/aarch64-linux-gnu-binutils/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -61,9 +61,6 @@ package() {
+   # Remove file conflicting with host binutils and manpages for MS Windows tools
+   rm "$pkgdir"/usr/share/man/man1/$_target-{dlltool,windres,windmc}*
+   rm "$pkgdir"/usr/lib/bfd-plugins/libdep.so
+-  rm "$pkgdir"/usr/etc/gprofng.rc
+-  rm -r "$pkgdir"/usr/include
+-  rm -r "$pkgdir"/usr/lib/gprofng/
+ 
+   # Remove info documents that conflict with host version
+   rm -r "$pkgdir"/usr/share/info


### PR DESCRIPTION
$pkgdir/usr/etc/gprofng.rc does not exist on riscv64 platform.