### PR TITLE
updpatch: gcc

### DIFF
--- a/gcc/riscv64.patch
+++ b/gcc/riscv64.patch
@@ -1,15 +1,17 @@
---- PKGBUILD
-+++ PKGBUILD
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 467214)
++++ PKGBUILD	(working copy)
 @@ -7,7 +7,7 @@
  # toolchain build order: linux-api-headers->glibc->binutils->gcc->glibc->binutils->gcc
  # NOTE: libtool requires rebuilt with each new gcc version
  
 -pkgname=(gcc gcc-libs lib32-gcc-libs gcc-fortran gcc-objc gcc-ada gcc-go gcc-d lto-dump libgccjit)
 +pkgname=(gcc gcc-libs gcc-fortran gcc-objc gcc-go gcc-d lto-dump libgccjit)
- pkgver=12.2.0
+ pkgver=12.2.1
  _majorver=${pkgver%%.*}
- _commit=2ee5e4300186a92ad73f1a1a64cb918dc76c8d67
-@@ -19,14 +19,10 @@ url='https://gcc.gnu.org'
+ _commit=eec3a65ed638a1c58fa08ddf508d2d60b64d311d
+@@ -19,11 +19,8 @@
  makedepends=(
    binutils
    doxygen
@@ -20,11 +22,8 @@
 -  lib32-gcc-libs
    libisl
    libmpc
--  libxcrypt
-   python
-   zstd
- )
-@@ -44,6 +40,7 @@ _libdir=usr/lib/gcc/$CHOST/${pkgver%%+*}
+   libxcrypt
+@@ -42,6 +39,7 @@
  source=(git+https://sourceware.org/git/gcc.git#commit=${_commit}
          c89 c99
          gcc-ada-repro.patch
@@ -32,7 +31,7 @@
  )
  validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
                86CFFCA918CF3AF47147588051E8B148A9999C34  # evangelos@foutrelis.com
-@@ -52,7 +49,8 @@ validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.
+@@ -50,7 +48,8 @@
  sha256sums=('SKIP'
              'de48736f6e4153f03d0a5d38ceb6c6fdb7f054e8f47ddd6af0a3dbf14f27b931'
              '2513c6d9984dd0a2058557bf00f06d8d5181734e41dcfe07be7ed86f2959622a'
@@ -42,7 +41,7 @@
  
  prepare() {
    [[ ! -d gcc ]] && ln -s gcc-${pkgver/+/-} gcc
-@@ -67,6 +65,9 @@ prepare() {
+@@ -65,6 +64,9 @@
    # Reproducible gcc-ada
    patch -Np0 < "$srcdir/gcc-ada-repro.patch"
  
@@ -52,15 +51,7 @@
    mkdir -p "$srcdir/gcc-build"
    mkdir -p "$srcdir/libgccjit-build"
  }
-@@ -79,7 +80,6 @@ build() {
-       --mandir=/usr/share/man
-       --infodir=/usr/share/info
-       --with-bugurl=https://bugs.archlinux.org/
--      --with-build-config=bootstrap-lto
-       --with-linker-hash-style=gnu
-       --with-system-zlib
-       --enable-__cxa_atexit
-@@ -94,13 +94,13 @@ build() {
+@@ -92,12 +94,12 @@
        --enable-link-serialization=1
        --enable-linker-build-id
        --enable-lto
@@ -70,12 +61,11 @@
        --enable-threads=posix
        --disable-libssp
        --disable-libstdcxx-pch
-       --disable-werror
 +      --disable-multilib
+       --disable-werror
    )
  
-   cd gcc-build
-@@ -112,7 +112,7 @@ build() {
+@@ -110,7 +112,7 @@
    CXXFLAGS=${CXXFLAGS/-Werror=format-security/}
  
    "$srcdir/gcc/configure" \
@@ -84,18 +74,18 @@
      --enable-bootstrap \
      "${_confflags[@]:?_confflags unset}"
  
-@@ -126,6 +126,10 @@ build() {
+@@ -123,6 +125,10 @@
+ 
    # make documentation
    make -O -C $CHOST/libstdc++-v3/doc doc-man-doxygen
- 
++  
 +  # Patch spec strings embedded in binaries
 +  sed -i 's/%{pthread:--push-state --as-needed -latomic --pop-state}/  --push-state --as-needed -latomic --pop-state         /' gcc/xgcc
 +  sed -i 's/%{pthread:--push-state --as-needed -latomic --pop-state}/  --push-state --as-needed -latomic --pop-state         /' gcc/xg++
-+
+ 
    # Build libgccjit separately, to avoid building all compilers with --enable-host-shared
    # which brings a performance penalty
-   cd "${srcdir}"/libgccjit-build
-@@ -160,9 +164,9 @@ check() {
+@@ -158,9 +164,9 @@
  package_gcc-libs() {
    pkgdesc='Runtime libraries shipped by GCC'
    depends=('glibc>=2.27')
@@ -107,7 +97,7 @@
    replaces=($pkgname-multilib libgphobos)
  
    cd gcc-build
-@@ -175,9 +179,8 @@ package_gcc-libs() {
+@@ -173,9 +179,8 @@
               libgomp \
               libitm \
               libquadmath \
@@ -119,7 +109,7 @@
      make -C $CHOST/$lib DESTDIR="$pkgdir" install-toolexeclibLTLIBRARIES
    done
  
-@@ -194,19 +197,18 @@ package_gcc-libs() {
+@@ -192,12 +197,12 @@
      make -C $CHOST/$lib DESTDIR="$pkgdir" install-info
    done
  
@@ -135,14 +125,15 @@
  }
  
  package_gcc() {
+@@ -204,7 +209,6 @@
    pkgdesc="The GNU Compiler Collection - C and C++ frontends"
    depends=("gcc-libs=$pkgver-$pkgrel" 'binutils>=2.28' libmpc zstd libisl.so)
    groups=('base-devel')
 -  optdepends=('lib32-gcc-libs: for generating code for 32-bit ABI')
    provides=($pkgname-multilib)
    replaces=($pkgname-multilib)
-   options=(!emptydirs staticlibs debug)
-@@ -220,22 +222,18 @@ package_gcc() {
+   options=(!emptydirs staticlibs)
+@@ -218,22 +222,18 @@
    install -m755 -t "$pkgdir/${_libdir}/" gcc/{cc1,cc1plus,collect2,lto1}
  
    make -C $CHOST/libgcc DESTDIR="$pkgdir" install
@@ -167,7 +158,7 @@
  
    make DESTDIR="$pkgdir" install-fixincludes
    make -C gcc DESTDIR="$pkgdir" install-mkheaders
-@@ -250,16 +248,11 @@ package_gcc() {
+@@ -248,16 +248,11 @@
    make -C $CHOST/libquadmath DESTDIR="$pkgdir" install-nodist_libsubincludeHEADERS
    make -C $CHOST/libsanitizer DESTDIR="$pkgdir" install-nodist_{saninclude,toolexeclib}HEADERS
    make -C $CHOST/libsanitizer/asan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
@@ -185,7 +176,19 @@
  
    make -C libcpp DESTDIR="$pkgdir" install
    make -C gcc DESTDIR="$pkgdir" install-po
-@@ -274,9 +267,6 @@ package_gcc() {
+@@ -266,9 +261,9 @@
+   ln -s gcc "$pkgdir"/usr/bin/cc
+ 
+   # create cc-rs compatible symlinks
+-  # https://github.com/rust-lang/cc-rs/blob/1.0.73/src/lib.rs#L2578-L2581
++  # https://github.com/rust-lang/cc-rs/blob/1.0.73/src/lib.rs#L2624
+   for binary in {c++,g++,gcc,gcc-ar,gcc-nm,gcc-ranlib}; do
+-    ln -s /usr/bin/${binary} "${pkgdir}"/usr/bin/x86_64-linux-gnu-${binary}
++    ln -s /usr/bin/${binary} "${pkgdir}"/usr/bin/riscv64-linux-gnu-${binary}
+   done
+ 
+   # POSIX conformance launcher scripts for c89 and c99
+@@ -278,9 +273,6 @@
    # install the libstdc++ man pages
    make -C $CHOST/libstdc++-v3/doc DESTDIR="$pkgdir" doc-install-man
  
@@ -195,7 +198,7 @@
    # byte-compile python libraries
    python -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
    python -O -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
-@@ -296,8 +286,6 @@ package_gcc-fortran() {
+@@ -300,8 +292,6 @@
    cd gcc-build
    make -C $CHOST/libgfortran DESTDIR="$pkgdir" install-cafexeclibLTLIBRARIES \
      install-{toolexeclibDATA,nodist_fincludeHEADERS,gfor_cHEADERS}
@@ -204,7 +207,7 @@
    make -C $CHOST/libgomp DESTDIR="$pkgdir" install-nodist_fincludeHEADERS
    make -C gcc DESTDIR="$pkgdir" fortran.install-{common,man,info}
    install -Dm755 gcc/f951 "$pkgdir/${_libdir}/f951"
-@@ -327,45 +315,6 @@ package_gcc-objc() {
+@@ -331,45 +321,6 @@
      "$pkgdir/usr/share/licenses/$pkgname/"
  }
  
@@ -213,7 +216,7 @@
 -  depends=("gcc=$pkgver-$pkgrel" libisl.so)
 -  provides=($pkgname-multilib)
 -  replaces=($pkgname-multilib)
--  options=(!emptydirs staticlibs debug)
+-  options=(!emptydirs staticlibs)
 -
 -  cd gcc-build/gcc
 -  make DESTDIR="$pkgdir" ada.install-{common,info}
@@ -250,7 +253,7 @@
  package_gcc-go() {
    pkgdesc='Go front-end for GCC'
    depends=("gcc=$pkgver-$pkgrel" libisl.so)
-@@ -375,11 +324,10 @@ package_gcc-go() {
+@@ -379,11 +330,10 @@
  
    cd gcc-build
    make -C $CHOST/libgo DESTDIR="$pkgdir" install-exec-am
@@ -263,7 +266,7 @@
    install -Dm755 gcc/go1 "$pkgdir/${_libdir}/go1"
  
    # Install Runtime Library Exception
-@@ -388,43 +336,6 @@ package_gcc-go() {
+@@ -392,43 +342,6 @@
      "$pkgdir/usr/share/licenses/$pkgname/"
  }
  
@@ -307,7 +310,7 @@
  package_gcc-d() {
    pkgdesc="D frontend for GCC"
    depends=("gcc=$pkgver-$pkgrel" libisl.so)
-@@ -440,7 +351,6 @@ package_gcc-d() {
+@@ -444,7 +357,6 @@
  
    make -C $CHOST/libphobos DESTDIR="$pkgdir" install
    rm -f "$pkgdir/usr/lib/"lib{gphobos,gdruntime}.so*


### PR DESCRIPTION
This patch update to gcc 12.2.1.

- Readd libxcrypt as makedepends. ArchLinux has removed it in trunk https://github.com/archlinux/svntogit-packages/commit/2a8c63a30bd3c47b0888d25c346d744b58f974e2.
- Reenable bootstrap lto.
- Create cc-rs compatible symlinks

Note: gcc may needs `nocheck`. Building freezes two out of three times.