### PR TITLE
addpatch: libcerf

### DIFF
--- a/libcerf/riscv64.patch
+++ b/libcerf/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,7 +15,7 @@ sha256sums=('cceefee46e84ce88d075103390b4f9d04c34e4bc3b96d733292c36836d4f7065')
+
+ build() {
+   cmake -B build -S $pkgname-v$pkgver \
+-    -DCMAKE_INSTALL_PREFIX=/usr
++    -DCMAKE_INSTALL_PREFIX=/usr -DPORTABLE=ON
+   cmake --build build
+ }


### PR DESCRIPTION
Disable `-march=native` flag by using `-DPORTABLE=ON` flag according to the author's suggestion.

Upstream report: https://bugs.archlinux.org/task/77321