### PR TITLE
addpatch: python-locket

### DIFF
--- a/python-locket/riscv64.patch
+++ b/python-locket/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -23,6 +23,7 @@ build() {
+ 
+ check() {
+   cd ${_pkg}.py-${pkgver}
++  sed -i 's|time.sleep(0.1)|time.sleep(0.5)|' tests/locket_tests.py
+   PYTHONPATH="${PWD}/build/lib/" pytest
+ }
+ 


### PR DESCRIPTION
This PR increase the time.sleep duration because the tests need more
time on our machine to finish the subprocess io jobs.

Signed-off-by: Avimitin <avimitin@gmail.com>
