### PR TITLE
addpkg: flex

### DIFF
--- a/flex/riscv64.patch
+++ b/flex/riscv64.patch
@@ -1,0 +1,14 @@
+diff --git repos/core-x86_64/PKGBUILD repos/core-x86_64/PKGBUILD
+index 5b65e7c..4a54e2f 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -23,6 +23,9 @@ prepare() {
+   cd "$pkgname-$pkgver"
+   patch -p1 -i "$srcdir"/flex-pie.patch
+   autoreconf
++
++  # get current config.guess and config.sub to recognize riscv64
++  cp /usr/share/autoconf/build-aux/config.{guess,sub} build-aux/
+ }
+ 
+ build() {


### PR DESCRIPTION
Replace config.guess and config.sub with current versions to recognize riscv64.

This problem is already [fixed upstream](https://github.com/westes/flex/commit/0954f389d3eb50f0d39eba06eb0f2730d2ad3d50) and the git master builds on riscv64, but the current release tarball is from 2017.