### PR TITLE
addpkg: m4 to qemu-user-blacklist

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -52,6 +52,7 @@ liborcus
 libseccomp
 libsecret
 libuv
+m4
 mdbook
 meilisearch
 memcached


### PR DESCRIPTION
Some tests fail in qemu-user but pass just fine on riscv hardware.

```
============================================================================
Testsuite summary for GNU M4 1.4.19
============================================================================
# TOTAL: 267
# PASS:  234
# SKIP:  33
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```