### PR TITLE
noqemu: qscintilla

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -87,6 +87,7 @@ python-prctl
 qalculate-qt
 qbs
 qconf
+qscintilla
 qxmledit
 razor
 rbutil


### PR DESCRIPTION
QMake `system()` does not work under qemu-user which will cause
`Variable QMAKE_CXX.CPMILER_MACROS` is not defined issue.

Signed-off-by: Avimitin <avimitin@gmail.com>
