### PR TITLE
updpatch: jumpy

### DIFF
--- a/jumpy/riscv64.patch
+++ b/jumpy/riscv64.patch
@@ -1,10 +1,12 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -20,7 +20,7 @@ sha512sums=('b697ece72321ca88fc0ca6732a5eee217903f6c74cd0c007b4cf045292d537a3c50
+@@ -17,7 +17,9 @@ options=('!lto')
  
  prepare() {
    cd "$pkgname-$pkgver"
 -  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  echo -e "ring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
++  cargo update -p ring
 +  cargo fetch --locked
  }
  


### PR DESCRIPTION
Fixed rotten.

`echo -e "ring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml`

This line is a little different from previous, because the src has `[patch.crates-io]`.

So simply added it to the file's last line, which is also `[patch.crates-io]` located.