### PR TITLE
addpkg: aarch64-linux-gnu-gcc-bootstrap

### DIFF
--- a/aarch64-linux-gnu-gcc-bootstrap/PKGBUILD
+++ b/aarch64-linux-gnu-gcc-bootstrap/PKGBUILD
@@ -1,0 +1,64 @@
+#BASED ON: https://aur.archlinux.org/packages/aarch64-gcc-bootstrap
+
+_target=aarch64-linux-gnu
+pkgname=$_target-gcc-bootstrap
+pkgver=12.2.0
+pkgrel=1
+pkgdesc='The GNU Compiler Collection - cross compiler for ARM64 target - bootstrap compiler'
+arch=(riscv64)
+url='https://gcc.gnu.org/'
+license=(GPL LGPL FDL)
+depends=(libmpc zstd libisl $_target-binutils)
+makedepends=(git)
+provides=($_target-gcc)
+conflicts=($_target-gcc)
+options=(!emptydirs !strip staticlibs !lto)
+source=(https://ftp.gnu.org/gnu/gcc/gcc-$pkgver/gcc-$pkgver.tar.xz{,.sig})
+
+sha256sums=('e549cf9cf3594a00e27b6589d4322d70e0720cdd213f39beb4181e06926230ff'
+            'SKIP')
+
+validpgpkeys=(D3A93CAD751C2AF4F8C7AD516C35B99309B5FA62  # Jakub Jelinek <jakub@redhat.com>
+              33C235A34C46AA3FFB293709A328C3A2C3C45C06  # Jakub Jelinek <jakub@redhat.com>
+              13975A70E63C361C73AE69EF6EEB81F8981C74C7) # Richard Guenther <richard.guenther@gmail.com>
+
+prepare() {
+  [[ ! -d gcc ]] && ln -s gcc-${pkgver/+/-} gcc
+  cd gcc
+
+  rm -rf "$srcdir"/gcc-build
+  mkdir "$srcdir"/gcc-build
+}
+
+build() {
+  cd gcc-build
+
+  # Credits @allanmcrae
+  # https://github.com/allanmcrae/toolchain/blob/f18604d70c5933c31b51a320978711e4e6791cf1/gcc/PKGBUILD
+  # TODO: properly deal with the build issues resulting from this
+  CFLAGS=${CFLAGS/-Werror=format-security/}
+  CXXFLAGS=${CXXFLAGS/-Werror=format-security/}
+
+  "$srcdir"/gcc/configure \
+      --prefix=/usr \
+      --with-sysroot=/usr/$_target/sys-root \
+      --libexecdir=/usr/lib \
+      --target=$_target \
+      --disable-nls \
+      --enable-languages=c \
+      --with-system-zlib \
+      --disable-multilib \
+      --disable-threads --without-headers \
+      --disable-shared --with-newlib --with-arch=armv8-a
+
+  make all-gcc all-target-libgcc
+}
+
+package() {
+  cd gcc-build
+
+  make install-strip-gcc install-strip-target-libgcc DESTDIR="$pkgdir"
+  # Remove files that conflict with host gcc package
+  rm -r "$pkgdir"/usr/{include,share}
+
+}


### PR DESCRIPTION
This package provides a bootstrap compiler for 'aarch64-linux-gnu-gcc'.

This bootstrap compiler is also needed for compiling 'aarch64-linux-gnu-glibc', which depends on 'aarch64-linux-gnu-gcc'