### PR TITLE
qemu-user-blacklist: add lmdbxx

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -53,6 +53,7 @@ liborcus
 libseccomp
 libsecret
 libuv
+lmdbxx
 m4
 mdbook
 meilisearch


### PR DESCRIPTION
Operation mdb_env_open not supported.