### PR TITLE
fixpatch: qt6-quick3dphysics

### DIFF
--- a/qt6-quick3dphysics/riscv64.patch
+++ b/qt6-quick3dphysics/riscv64.patch
@@ -7,10 +7,10 @@ index 659838f..673f6b9 100644
  options=(debug)
  _pkgfn=${pkgname/6-/}-everywhere-src-$_qtver
 -source=(https://download.qt.io/official_releases/qt/${pkgver%.*}/$_qtver/submodules/$_pkgfn.tar.xz)
--sha256sums=('1dd4a81e671436c8f468f84dfc52fa2fb54bde043598cdb7c6fc69d0511badbb')
+-sha256sums=('e87af86b6c39b26e5479c4c507cf670cfedef9dc8a21731c8697f4cbbe23cc91')
 +source=(https://download.qt.io/official_releases/qt/${pkgver%.*}/$_qtver/submodules/$_pkgfn.tar.xz
 +    physx-rv64.patch)
-+sha256sums=('1dd4a81e671436c8f468f84dfc52fa2fb54bde043598cdb7c6fc69d0511badbb'
++sha256sums=('e87af86b6c39b26e5479c4c507cf670cfedef9dc8a21731c8697f4cbbe23cc91'
 +            '76e430885958c5680818de9c4a0f9e4bf5ec43a3c537e3e7aa45fb7542853570')
 +
 +prepare() {


### PR DESCRIPTION
the original patch is rotten, update the sha*sums here