### PR TITLE
addpkg: neovide

### DIFF
--- a/neovide/riscv64.patch
+++ b/neovide/riscv64.patch
@@ -1,0 +1,41 @@
+diff --git PKGBUILD PKGBUILD
+index 65cfd16b..e48be588 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -18,16 +18,32 @@ makedepends=(cargo
+              gtk3
+              make
+              python
+-             sdl2)
++             sdl2
++             git
++             gn
++             ninja
++             clang)
+ optdepends=('vulkan-intel: vulkan support for intel')
+ _archive=("$pkgname-$pkgver")
+-source=("$url/archive/$pkgver/$_archive.tar.gz")
+-sha256sums=('db3e34cfeda562e292c236570b43f6815e668cae81bdaeaa422739ae92e842c3')
++source=("$url/archive/$pkgver/$_archive.tar.gz"
++        "skia_native_build.patch")
++sha256sums=('db3e34cfeda562e292c236570b43f6815e668cae81bdaeaa422739ae92e842c3'
++            '556990d259c5017082d5346b1184c256436abc05e052f2995e60f29c60e4d1ad')
++options=(!lto)
+ 
+ prepare() {
+ 	cd "$_archive"
+ 	sed -i -e '/^incremental/a opt-level = 3' Cargo.toml
+-	cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++	echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
++	cargo update -p ring
++	mkdir .cargo
++	cargo vendor >> .cargo/config.toml
++	pushd vendor/skia-bindings
++	curl 'https://codeload.github.com/rust-skia/skia/tar.gz/m103-0.51.1' | tar -xz && mv 'skia-m103-0.51.1' 'skia'
++	mkdir depot_tools
++	cp /usr/bin/ninja depot_tools/
++	popd
++	patch -Np1 -i "../skia_native_build.patch"
+ }
+ 
+ build() {

--- a/neovide/skia_native_build.patch
+++ b/neovide/skia_native_build.patch
@@ -1,0 +1,75 @@
+diff --git a/vendor/skia-bindings/.cargo-checksum.json b/vendor/skia-bindings/.cargo-checksum.json
+index 13fcccac..9f91f448 100644
+--- a/vendor/skia-bindings/.cargo-checksum.json
++++ b/vendor/skia-bindings/.cargo-checksum.json
+@@ -1 +1 @@
+-{"files":{"Cargo.toml":"a16e886e50034fa6293794597651ac21595f75e2f349596f585fa1c8658d85d6","build.rs":"407d3fd45ab8d3df40ed3c19f7c9c6e9fe0a92241961c5db71c871c1f8e0b81b","build_support.rs":"e2a36d5d7ac543a08bcc1be22018bb71a3b8d4877f6cbd217d40bc9568ef7af3","build_support/android.rs":"14b7a5e0cc89edcd6ed162753016fabcf59edbe3a84a0a4c4af8a38675d39c3b","build_support/binaries_config.rs":"d1b9730471cfc2f5a99523e7feb221aee7745192019f4590e86241a44b250985","build_support/binary_cache.rs":"c7fd014af686034b9f44a9a7d2ce9477195be06a7c5f3d75ecfac50e6791f52c","build_support/binary_cache/binaries.rs":"f342181618a19bbd4cd4696ee67f533734771e879af631127efa9d92ee269c03","build_support/binary_cache/download.rs":"fb699daaf1f83cce71ffdc3ba9e5f9ad170d34a560207841b09adbf00814ce1a","build_support/binary_cache/env.rs":"fded2f5d19c1ae4c1c9ce6d6b0e858e2fc50efbb81aef1e5fd3caa80e2b36a32","build_support/binary_cache/export.rs":"8da019199aea089f142f6d3b7ed05b816a6c75ef76dd5876e760660853fb07bf","build_support/binary_cache/git.rs":"332120bd06d2a12588d10e8508e39d9e838e5debfa08c5c7cb551657e0c3c5fe","build_support/binary_cache/github_actions.rs":"2720c0fe2829b49120a12e6e6e52c963dc83e819b4b24ae4fb7bed644d63ad4f","build_support/binary_cache/utils.rs":"9ae8a692c246d506551bd367477ac5194b334837e07228e8549c8390c4deaa1d","build_support/cargo.rs":"86583e539e090daed18d3b990034ad8a6b7d2bd0252005aa3e81df6f276a105f","build_support/clang.rs":"8e1f91083fd0b678904d4125a1d12dd40962a44d5c9f0c4f6090c7e22ddab214","build_support/features.rs":"6a92c3168dfc640bad771b62abeed7ae2ad59aeae425d6ed283ea8d391005576","build_support/ios.rs":"c734dcda6bcf81e0fce0ff68de7a700a215f95c6ca32780cb73faa34e64a05d2","build_support/skia.rs":"f380f6822a730bd9ffc21388aaf23bb5e2a477b6dbbfd03f326053dd85d99327","build_support/skia/config.rs":"373bc8e101a2030c1e4c2dfd44035585854b862a9134212d0cd3edf1872072a3","build_support/skia/env.rs":"782bce92555e181e3c88df3e9c83fe8fb3a5966b92d110f1e491a8e63c0528be","build_support/skia/llvm.rs":"4d37e31d15a2eba3c87e4bfa1da3f164bb59d888ad341b87bbb0411b7f396696","build_support/skia/vs.rs":"5c2ae487a55f6e7565cd5eb085c314b13cf9e7202bd5b1aa9c29486cb80956e6","build_support/skia_bindgen.rs":"77d85ccb2706217e93f356a402fac4395c2c528655d3fa461c5225ee9fece0bb","build_support/xcode.rs":"2b6d6a97ec63d60d1b88f777118b2ae96eb82c640a42bd15118adc01cfc743b0","src/bindings.cpp":"59c0ca6212099e28d229197b1e1f48c9e4271f3359fc7965abdda4d35c570e52","src/bindings.h":"c074a795f42b39370276662c031dd9d8d960cdde55ab1b3e102428b3826a1d2e","src/d3d.cpp":"cb3e525d19d804e10f1a06e07b4445ad61e526e9259c205be9b6060d5fa65a24","src/defaults.rs":"2f4a3f226d8624d443f89350047bd0067d6358d7934fa167b01b96f4c8f93b9e","src/gl.cpp":"8a88b7cca7adb6224ea3bcb239edaa3c98ab9b1a0308ccecbf1324ca47a7ed97","src/gpu.cpp":"bb16273c4bcb33fa99442ddaa0064bad1e205abe8f8393b76ca054924ecf35a8","src/icu.rs":"157d6f8f9fddf38355bd9253e695233b8013f269add92a675a187f2e4eaa88be","src/impls.rs":"d25007a858f1b099631d46f803e7069bf3fd1b3b24facc0bf2e77ffe05230918","src/lib.rs":"72117f8525756e5bd36e7d9773dbe479a6ff8f50ddf5357f639fd09a8a85fdb0","src/metal.cpp":"78a2f5581d97531d9fc5dace213b948165ff5c07dcb0d44dc0b722ae6bf5901e","src/paragraph.cpp":"0864432211c2b28f1134d5d6deca683a8d21d65570cd90ab1a45a18305fddc8a","src/shaper.cpp":"8d685af360c6207201b4b370f96d6bbbf94be81f30ea88af2047926c75561340","src/svg.cpp":"43fcedf95922d049b60f6afaac0a1c4beed6d702be1ef3e3ec2c1f82f53e756d","src/vulkan.cpp":"9baeee2403ccc02254b0f893a02c6498abd6965499f200853a2a736bdf9887d1"},"package":"5f249be649ae13f65934370168f742a7be27096f432f15572fb70f5367916b8f"}
+\ No newline at end of file
++{"files":{"Cargo.toml":"a16e886e50034fa6293794597651ac21595f75e2f349596f585fa1c8658d85d6","build.rs":"407d3fd45ab8d3df40ed3c19f7c9c6e9fe0a92241961c5db71c871c1f8e0b81b","build_support.rs":"e2a36d5d7ac543a08bcc1be22018bb71a3b8d4877f6cbd217d40bc9568ef7af3","build_support/android.rs":"14b7a5e0cc89edcd6ed162753016fabcf59edbe3a84a0a4c4af8a38675d39c3b","build_support/binaries_config.rs":"d1b9730471cfc2f5a99523e7feb221aee7745192019f4590e86241a44b250985","build_support/binary_cache.rs":"c7fd014af686034b9f44a9a7d2ce9477195be06a7c5f3d75ecfac50e6791f52c","build_support/binary_cache/binaries.rs":"f342181618a19bbd4cd4696ee67f533734771e879af631127efa9d92ee269c03","build_support/binary_cache/download.rs":"9364a9d592b5d5f2455f72ace255da41192d88522c842cc9ac237fe34a1f1c5d","build_support/binary_cache/env.rs":"fded2f5d19c1ae4c1c9ce6d6b0e858e2fc50efbb81aef1e5fd3caa80e2b36a32","build_support/binary_cache/export.rs":"8da019199aea089f142f6d3b7ed05b816a6c75ef76dd5876e760660853fb07bf","build_support/binary_cache/git.rs":"332120bd06d2a12588d10e8508e39d9e838e5debfa08c5c7cb551657e0c3c5fe","build_support/binary_cache/github_actions.rs":"2720c0fe2829b49120a12e6e6e52c963dc83e819b4b24ae4fb7bed644d63ad4f","build_support/binary_cache/utils.rs":"9ae8a692c246d506551bd367477ac5194b334837e07228e8549c8390c4deaa1d","build_support/cargo.rs":"86583e539e090daed18d3b990034ad8a6b7d2bd0252005aa3e81df6f276a105f","build_support/clang.rs":"8e1f91083fd0b678904d4125a1d12dd40962a44d5c9f0c4f6090c7e22ddab214","build_support/features.rs":"6a92c3168dfc640bad771b62abeed7ae2ad59aeae425d6ed283ea8d391005576","build_support/ios.rs":"c734dcda6bcf81e0fce0ff68de7a700a215f95c6ca32780cb73faa34e64a05d2","build_support/skia.rs":"f380f6822a730bd9ffc21388aaf23bb5e2a477b6dbbfd03f326053dd85d99327","build_support/skia/config.rs":"cfb6646d0244eec58c6d19334209e92203b08a0901ea6737109bd0616c32e2b4","build_support/skia/env.rs":"782bce92555e181e3c88df3e9c83fe8fb3a5966b92d110f1e491a8e63c0528be","build_support/skia/llvm.rs":"4d37e31d15a2eba3c87e4bfa1da3f164bb59d888ad341b87bbb0411b7f396696","build_support/skia/vs.rs":"5c2ae487a55f6e7565cd5eb085c314b13cf9e7202bd5b1aa9c29486cb80956e6","build_support/skia_bindgen.rs":"77d85ccb2706217e93f356a402fac4395c2c528655d3fa461c5225ee9fece0bb","build_support/xcode.rs":"2b6d6a97ec63d60d1b88f777118b2ae96eb82c640a42bd15118adc01cfc743b0","src/bindings.cpp":"59c0ca6212099e28d229197b1e1f48c9e4271f3359fc7965abdda4d35c570e52","src/bindings.h":"c074a795f42b39370276662c031dd9d8d960cdde55ab1b3e102428b3826a1d2e","src/d3d.cpp":"cb3e525d19d804e10f1a06e07b4445ad61e526e9259c205be9b6060d5fa65a24","src/defaults.rs":"2f4a3f226d8624d443f89350047bd0067d6358d7934fa167b01b96f4c8f93b9e","src/gl.cpp":"8a88b7cca7adb6224ea3bcb239edaa3c98ab9b1a0308ccecbf1324ca47a7ed97","src/gpu.cpp":"bb16273c4bcb33fa99442ddaa0064bad1e205abe8f8393b76ca054924ecf35a8","src/icu.rs":"157d6f8f9fddf38355bd9253e695233b8013f269add92a675a187f2e4eaa88be","src/impls.rs":"d25007a858f1b099631d46f803e7069bf3fd1b3b24facc0bf2e77ffe05230918","src/lib.rs":"72117f8525756e5bd36e7d9773dbe479a6ff8f50ddf5357f639fd09a8a85fdb0","src/metal.cpp":"78a2f5581d97531d9fc5dace213b948165ff5c07dcb0d44dc0b722ae6bf5901e","src/paragraph.cpp":"0864432211c2b28f1134d5d6deca683a8d21d65570cd90ab1a45a18305fddc8a","src/shaper.cpp":"8d685af360c6207201b4b370f96d6bbbf94be81f30ea88af2047926c75561340","src/svg.cpp":"43fcedf95922d049b60f6afaac0a1c4beed6d702be1ef3e3ec2c1f82f53e756d","src/vulkan.cpp":"9baeee2403ccc02254b0f893a02c6498abd6965499f200853a2a736bdf9887d1"},"package":"5f249be649ae13f65934370168f742a7be27096f432f15572fb70f5367916b8f"}
+diff --git a/vendor/skia-bindings/build_support/binary_cache/download.rs b/vendor/skia-bindings/build_support/binary_cache/download.rs
+index 1b376a2a..2071bbb2 100644
+--- a/vendor/skia-bindings/build_support/binary_cache/download.rs
++++ b/vendor/skia-bindings/build_support/binary_cache/download.rs
+@@ -13,6 +13,7 @@ use std::{
+ /// submodules, or when `build.rs` was invoked outside of the git repository by downloading and
+ /// unpacking them from GitHub.
+ pub fn resolve_dependencies() {
++    return; // manually do this in PKGBUILD
+     if cargo::is_crate() {
+         // In a crate.
+         download_dependencies();
+diff --git a/vendor/skia-bindings/build_support/skia/config.rs b/vendor/skia-bindings/build_support/skia/config.rs
+index f658c50b..20bd35f6 100644
+--- a/vendor/skia-bindings/build_support/skia/config.rs
++++ b/vendor/skia-bindings/build_support/skia/config.rs
+@@ -140,7 +140,7 @@ impl FinalBuildConfiguration {
+ 
+             // target specific gn args.
+             let target = cargo::target();
+-            let mut target_str = format!("--target={}", target);
++            let mut target_str = format!("--target={}", if target.to_string() == "riscv64gc-unknown-linux-gnu" { "riscv64-unknown-linux-gnu".to_string() } else { target.to_string() });
+             let mut set_target = true;
+             let mut cflags: Vec<String> = Vec::new();
+             let mut asmflags: Vec<String> = Vec::new();
+@@ -278,7 +278,11 @@ impl FinalBuildConfiguration {
+                         (_, _) => os,
+                     };
+                     args.push(("target_os", quote(skia_target_os)));
+-                    args.push(("target_cpu", quote(clang::target_arch(arch))));
++                    if arch == "riscv64gc" {
++                        args.push(("target_cpu", quote("riscv64")));
++                    } else {
++                        args.push(("target_cpu", quote(clang::target_arch(arch))));
++                    }
+                 }
+             }
+ 
+diff --git a/vendor/skia-bindings/skia/bin/fetch-gn b/vendor/skia-bindings/skia/bin/fetch-gn
+index 47777410..0f63fa4b 100755
+--- a/vendor/skia-bindings/skia/bin/fetch-gn
++++ b/vendor/skia-bindings/skia/bin/fetch-gn
+@@ -20,22 +20,12 @@ else:
+ 
+ os.chdir(os.path.join(os.path.dirname(__file__), os.pardir))
+ 
+-gnzip = os.path.join(tempfile.mkdtemp(), 'gn.zip')
+-with open(gnzip, 'wb') as f:
+-  OS  = {'darwin': 'mac', 'linux': 'linux', 'linux2': 'linux', 'win32': 'windows', 'msys': 'windows'}[sys.platform]
+-  cpu = {'aarch64': 'arm64', 'amd64': 'amd64', 'arm64': 'arm64', 'x86_64': 'amd64'}[platform.machine().lower()]
+-
+-  rev = 'd62642c920e6a0d1756316d225a90fd6faa9e21e'
+-  url = 'https://chrome-infra-packages.appspot.com/dl/gn/gn/{}-{}/+/git_revision:{}'.format(
+-          OS,cpu,rev)
+-  f.write(urlopen(url).read())
+-
+ gn = 'gn.exe' if 'win32' in sys.platform or 'msys' in sys.platform else 'gn'
+-with zipfile.ZipFile(gnzip, 'r') as f:
+-  f.extract(gn, 'bin')
+ 
+ gn = os.path.join('bin', gn)
+ 
++shutil.copy('/usr/bin/gn', gn) # use system gn
++
+ os.chmod(gn, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR |
+              stat.S_IRGRP                | stat.S_IXGRP |
+              stat.S_IROTH                | stat.S_IXOTH )


### PR DESCRIPTION
This patch allows skia-bindings to compile natively on a previously unsupported architecture.