### PR TITLE
addpatch: staticcheck 2023.1.2-1

### DIFF
--- a/staticcheck/riscv64.patch
+++ b/staticcheck/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -41,7 +41,7 @@ build(){
+ 
+ check(){
+ 	cd "go-tools-$pkgver"
+-	GOROOT="/usr/lib/go" go test -v ./...
++	GOROOT="/usr/lib/go" go test -v ./... -timeout 20m
+ }
+ 
+ package(){


### PR DESCRIPTION
This patch resolves test timeout.