### PR TITLE
addpatch: afpfs-ng

### DIFF
--- a/afpfs-ng/riscv64.patch
+++ b/afpfs-ng/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -16,6 +16,11 @@ source=(
+ )
+ sha256sums=('SKIP')
+ 
++prepare() {
++    cd "$pkgname"
++    cp -vf /usr/share/autoconf/build-aux/config.{guess,sub} .
++}
++
+ build() {
+     cd "$pkgname"
+     CFLAGS+=' -fcommon' # https://wiki.gentoo.org/wiki/Gcc_10_porting_notes/fno_common


### PR DESCRIPTION
Fix config.guess could not guess build type issue.
Upstream had archived the project, so it is currently impossible to
submit this issue to upstream.
