### PR TITLE
chore: add new linux config maintain tool

### DIFF
--- a/patch-linux-config.sh
+++ b/patch-linux-config.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/bash
+
+if [[ ! -x ./scripts/config ]]; then
+  echo "This script must be executed in Linux source tree!"
+  exit 1
+fi
+
+configs=(
+    '-e' 'SOC_STARFIVE' # StarFive board support
+    '-e' 'SOC_SIFIVE' '-e' 'GPIO_SIFIVE' '-e' 'SIFIVE_CCACHE' '-e' 'EDAC_SIFIVE' '-e' 'PCIE_FU740' '-m' 'PWM_SIFIVE' # SiFive board support
+    '-e' 'ERRATA_THEAD' '-e' 'ERRATA_THEAD_PBMT' # # THead board support
+    '-e' 'SOC_MICROCHIP_POLARFIRE' '-e' 'PCIE_MICROCHIP_HOST' '-e' 'PCIE_XILINX' '-e' 'SERIAL_OF_PLATFORM' '-m' 'USB_MUSB_POLARFIRE_SOC' '-m' 'RTC_DRV_POLARFIRE_SOC' '-m' 'POLARFIRE_SOC_MAILBOX' '-m' 'I2C_MICROCHIP_CORE' '-m' 'POLARFIRE_SOC_SYS_CTRL' '-m' 'HW_RANDOM_POLARFIRE_SOC' # PolarFire board support
+    '-e' 'SOC_VIRT' '-e' 'PCI_HOST_GENERIC' # QEMU support
+    '-m' 'MMC_DW_PLTFM' '-m' 'MMC_DW'
+)
+
+if [[ -n "$1" ]]; then
+  ./scripts/config "${configs[@]}"
+elif
+  ./scripts/config --file "$1" "${configs[@]}"
+fi
+


### PR DESCRIPTION
Copy config from Arch upstream to Linux source tree, then run `make olddefconfig` in **RISC-V environment**, then run this script to apply our modifications, check new option in config and add them to configs array, then run `make olddefconfig` in **RISC-V environment**.

To avoid polluting the patch, you must run `make olddefconfig` in the RISC-V environment to get the same compiler support options.