### PR TITLE
addpatch: libavc1394

### DIFF
--- a/libavc1394/riscv64.patch
+++ b/libavc1394/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,6 +12,11 @@ depends=('libraw1394')
+ source=("https://downloads.sourceforge.net/sourceforge/libavc1394/${pkgname}-${pkgver}.tar.gz")
+ sha256sums=('7cb1ff09506ae911ca9860bef4af08c2403f3e131f6c913a2cbd6ddca4215b53')
+ 
++prepare() {
++  cd "${srcdir}/${pkgname}-${pkgver}"
++  autoreconf -fiv
++}
++
+ build() {
+   cd "${srcdir}/${pkgname}-${pkgver}"
+   ./configure --prefix=/usr --mandir=/usr/share/man --disable-static


### PR DESCRIPTION
Fix config.guess could not guess build type issue. This project had
closed the issue ticket, so it is no longer possible to report this issue
to them.
