### PR TITLE
addpatch: libdv

### DIFF
--- a/libdv/riscv64.patch
+++ b/libdv/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,6 +12,11 @@ depends=('popt')
+ source=(https://downloads.sourceforge.net/$pkgname/$pkgname-$pkgver.tar.gz)
+ sha256sums=('a305734033a9c25541a59e8dd1c254409953269ea7c710c39e540bd8853389ba')
+ 
++prepare() {
++  cd "$srcdir/$pkgname-$pkgver"
++  cp -vf /usr/share/autoconf/build-aux/config.{guess,sub} .
++}
++
+ build() {
+   cd "$srcdir/$pkgname-$pkgver"
+   ./configure --prefix=/usr --disable-gtk


### PR DESCRIPTION
Fix the config.guess could not guess build type issue.
The bug report tickets had been closed, so it is currently impossible to
report the issue to them.

Signed-off-by: Avimitin <avimitin@gmail.com>
