### PR TITLE
addpatch: libotf

### DIFF
--- a/libotf/riscv64.patch
+++ b/libotf/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,6 +17,7 @@ sha256sums=('68db0ca3cda2d46a663a92ec26e6eb5adc392ea5191bcda74268f0aefa78066b'
+ prepare() {
+ 	cd "${srcdir}/${pkgname}-${pkgver}"
+ 	patch -p1 -i ${srcdir}/replace-freetype-config.patch
++	autoreconf -fiv
+ }
+ 
+ build() {


### PR DESCRIPTION
Fix config.guess could not guess build type issue. This issue has been
reported to upstream via Email.
