### PR TITLE
addpatch: transmission

### DIFF
--- a/transmission/riscv64.patch
+++ b/transmission/riscv64.patch
@@ -1,0 +1,19 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -18,7 +18,6 @@ makedepends=(
+ 	gtk4
+ 	gtkmm-4.0
+ 	intltool
+-	libb64
+ 	libdeflate
+ 	libevent
+ 	libnatpmp
+@@ -52,7 +51,7 @@ build() {
+ 	  -DENABLE_UTILS=ON \
+ 	  -DENABLE_UTP=ON \
+ 	  -DINSTALL_LIB=ON \
+-      -DUSE_SYSTEM_B64=ON \
++      -DUSE_SYSTEM_B64=OFF \
+       -DUSE_SYSTEM_DEFLATE=ON \
+       -DUSE_SYSTEM_DHT=ON \
+ 	  -DUSE_SYSTEM_EVENT2=ON \


### PR DESCRIPTION
The original PKGBUILD link `transmission` to the system b64 library.
However, the system b64 library did not handle the data type correctly
and broke the base64 test on riscv64. This commit removes the libb64
dependency and links transmission to its forked version of the b64
library.
