### PR TITLE
addpatch: cargo-generate-rpm

### DIFF
--- a/cargo-generate-rpm/riscv64.patch
+++ b/cargo-generate-rpm/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,7 +17,7 @@ options=('!lto')
+ prepare() {
+   cd "$pkgname-$pkgver"
+   # https://github.com/cat-in-136/cargo-generate-rpm/issues/60
+-  cargo fetch --target "$CARCH-unknown-linux-gnu" # --locked
++  cargo fetch # --locked
+ }
+ 
+ build() {

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -6,6 +6,7 @@ beatslash-lv2
 bmake
 caps
 cargo-audit
+cargo-generate-rpm
 cargo-nextest
 cloud-init
 coreutils


### PR DESCRIPTION
Rust `std::process::Command` will never panic in QEMU user that cause
test bugs in this package. To demonstrate the issue, consider following
Rust code:

```rust
let process = Command::new("/usr/bin/non-exist-program").spawn();
assert!(process.is_err());
```

The above example will never panic in qemu user.

This commit fixes the rustc target triple issue and adds the package to
the qemu user blacklist.

Signed-off-by: Avimitin <dev@avimit.in>
