### PR TITLE
upgpatch: gnupg 2.2.41-1

### DIFF
--- a/gnupg/riscv64.patch
+++ b/gnupg/riscv64.patch
@@ -1,11 +1,25 @@
+diff --git PKGBUILD PKGBUILD
+index 99fe39d5..cef66063 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -59,6 +59,8 @@ prepare() {
-   # improve reproducibility
-   rm doc/gnupg.info*
- 
-+  autoreconf -fiv
-+
-   ./autogen.sh
- }
- 
+@@ -39,15 +39,18 @@
+   "https://gnupg.org/ftp/gcrypt/${pkgname}/${pkgname}-${pkgver}.tar.bz2"{,.sig}
+   'drop-import-clean.patch'
+   'avoid-beta-warning.patch'
++  'update-config.guess.patch::https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=patch;h=7e44f883664e23503b5507852a342939c9aced8a'
+ )
+ sha256sums=('13f3291007a5e8546fcb7bc0c6610ce44aaa9b3995059d4f8145ba09fd5be3e1'
+             'SKIP'
+             '02d375f0045f56f7dd82bacdb5ce559afd52ded8b75f6b2673c39ec666e81abc'
+-            '22fdf9490fad477f225e731c417867d9e7571ac654944e8be63a1fbaccd5c62d')
++            '22fdf9490fad477f225e731c417867d9e7571ac654944e8be63a1fbaccd5c62d'
++            '544cc41e5fbc31da44ade84ca6b20364ed11929c4795ec6cbeffaea198d02627')
+ b2sums=('0be2965a646a8636a127f89329030860908b0bbc447381782527459aed85f5276c29e7a2c89f87cb715407d9f1aabbf3ae1765073764d05e422035e8d5962569'
+         'SKIP'
+         'd598015e7f27b27840667d1656c083b4ad85d6acdd312e9929854067313a5f28415ee7eecf4d84a4b8da0385b667aaa01a9743461f5c785402a56c238274e376'
+-        '7ea069e81e2d91a3154bcb62516b4b599f34596de277f95ad1ccaba73869c4f84f94f063b65026ba0bc8a72c0fd8e8e182b82346964f67ea78166b6399c923c5')
++        '7ea069e81e2d91a3154bcb62516b4b599f34596de277f95ad1ccaba73869c4f84f94f063b65026ba0bc8a72c0fd8e8e182b82346964f67ea78166b6399c923c5'
++        'a5755f11fd53b200550587eab8fce18f9d37e55f3f4c8c4b6fc53dd94150bb6c6b88e7547134a3a91a2ab55ad415ff1a4d0adb452b931f56a3d40001ac0c995e')
+ validpgpkeys=(
+   '5B80C5754298F0CB55D8ED6ABCEF7E294B092E28' # Andre Heinecke (Release Signing Key)
+   '6DAA6E64A76D2840571B4902528897B826403ADA' # Werner Koch (dist signing 2020)


### PR DESCRIPTION
Fix old config.guess.

Note for reviewers: Arch's `prepare()` will apply all patches with .patch extension, so we don't need to patch manually.