### PR TITLE
qemu-user-blacklist: add lmdb

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -54,6 +54,7 @@ liborcus
 libseccomp
 libsecret
 libuv
+lmdb
 m4
 mdbook
 meilisearch


### PR DESCRIPTION
lmdb can be built in qemu-system but it fails to build in qemu-user because of an "Operation not supported" error raised in `check()`


Related: #2226