### PR TITLE
qemu-user-blacklist: add lmdb

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -54,6 +54,7 @@ liborcus
 libseccomp
 libsecret
 libuv
+lmdb
 m4
 mdbook
 meilisearch


### PR DESCRIPTION
check() failed on qemu-user (operation not supported).