### PR TITLE
blacklist: add iucode-tool

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -32,6 +32,7 @@ intel-mkl-static
 intel-opencl-clang
 intel-ucode
 intel-undervolt
+iucode-tool
 libmfx
 libva-intel-driver
 throttled


### PR DESCRIPTION
This package is used for manipulating Intel x86 ucode.