### PR TITLE
addpatch: menu-cache

### DIFF
--- a/menu-cache/riscv64.patch
+++ b/menu-cache/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -21,6 +21,7 @@ prepare() {
+   cd $pkgname-$pkgver
+   # Fix build (taken from Fedora)
+   patch -Np1 -i ../menu-cache-1.1.0-0001-Support-gcc10-compilation.patch
++  autoreconf -fi
+ }
+ 
+ build() {


### PR DESCRIPTION
Upstream hasn't been updated for 6 years so I guess there is not need to report to upstream.