### PR TITLE
addpatch: libreoffice-still

### DIFF
--- a/libreoffice-still/add-rv64-support.patch
+++ b/libreoffice-still/add-rv64-support.patch
@@ -1,0 +1,253 @@
+--- /dev/null	2023-03-05 19:58:25.675653907 +0100
++++ solenv/gbuild/platform/LINUX_RISCV64_GCC.mk	2023-03-08 08:07:07.860770758 +0100
+@@ -0,0 +1,14 @@
++# -*- Mode: makefile-gmake; tab-width: 4; indent-tabs-mode: t -*-
++#
++# This file is part of the LibreOffice project.
++#
++# This Source Code Form is subject to the terms of the Mozilla Public
++# License, v. 2.0. If a copy of the MPL was not distributed with this
++# file, You can obtain one at http://mozilla.org/MPL/2.0/.
++#
++
++#please make generic modifications to unxgcc.mk or linux.mk
++
++include $(GBUILDDIR)/platform/linux.mk
++
++# vim: set noet sw=4:
+--- configure.ac.orig	2023-03-07 09:21:52.612247951 +0100
++++ configure.ac	2023-03-07 09:22:00.552309148 +0100
+@@ -5180,6 +5180,11 @@
+         RTL_ARCH=X86_64
+         PLATFORMID=linux_x86_64
+         ;;
++    riscv64)
++        CPUNAME=RISCV64
++        RTL_ARCH=RISCV64
++        PLATFORMID=linux_riscv64
++        ;;
+     *)
+         AC_MSG_ERROR([Unsupported host_cpu $host_cpu for host_os $host_os])
+         ;;
+--- configure.ac.orig	2023-03-07 10:03:07.857481874 +0100
++++ configure.ac	2023-03-07 10:03:15.677539009 +0100
+@@ -8523,7 +8523,7 @@
+         JAVAINTERPRETER=`win_short_path_for_make "$JAVAINTERPRETER"`
+     elif test "$cross_compiling" != "yes"; then
+         case $CPUNAME in
+-            AARCH64|AXP|X86_64|HPPA|IA64|POWERPC64|S390X|SPARC64|GODSON64)
++            AARCH64|AXP|X86_64|HPPA|IA64|POWERPC64|S390X|SPARC64|GODSON64|RISCV64)
+                 if test -f "$JAVAINTERPRETER" -a "`$JAVAINTERPRETER -version 2>&1 | $GREP -i 64-bit`" = "" >/dev/null; then
+                     AC_MSG_WARN([You are building 64-bit binaries but the JDK $JAVAINTERPRETER is 32-bit])
+                     AC_MSG_ERROR([You should pass the --with-jdk-home option pointing to a 64-bit JDK])
+--- bridges/Library_cpp_uno.mk.orig	2023-03-08 08:29:15.669862243 +0100
++++ bridges/Library_cpp_uno.mk	2023-03-08 08:29:05.239759441 +0100
+@@ -186,6 +186,13 @@
+ bridge_asm_objects := call
+ endif
+ 
++else ifeq ($(OS)-$(CPUNAME),LINUX-RISCV64)
++
++bridges_SELECTED_BRIDGE := gcc3_linux_riscv64
++bridge_asm_objects := call
++bridge_noopt_objects := abi cpp2uno uno2cpp
++bridge_exception_objects := except
++
+ endif
+ 
+ $(eval $(call gb_Library_use_internal_comprehensive_api,$(CPPU_ENV)_uno,\
+--- external/firebird/UnpackedTarball_firebird.mk  2023-03-13 10:29:40.796074707 +0100
++++ external/firebird/UnpackedTarball_firebird.mk       2023-03-13 10:31:51.860432742 +0100
+@@ -51,6 +51,7 @@
+     external/firebird/0001-extern-cloop-Missing-dependencies-of-compilations-on.patch.1 \
+     external/firebird/configure-c99.patch \
+     external/firebird/configure-c99.patch \
++    external/firebird/firebird-riscv64-support.patch.1 \
+ ))
+
+ ifeq ($(OS),WNT)
+diff --git external/firebird/firebird-riscv64-support.patch.1 external/firebird/firebird-riscv64-support.patch.1
+new file mode 100644
+index 000000001..c42ebbc15
+--- /dev/null
++++ external/firebird/firebird-riscv64-support.patch.1
+@@ -0,0 +1,168 @@
++diff --git a/builds/posix/prefix.linux_riscv64 b/builds/posix/prefix.linux_riscv64
++new file mode 100644
++index 0000000..17e67e8
++--- /dev/null
+++++ b/builds/posix/prefix.linux_riscv64
++@@ -0,0 +1,28 @@
+++# The contents of this file are subject to the Interbase Public
+++# License Version 1.0 (the "License"); you may not use this file
+++# except in compliance with the License. You may obtain a copy
+++# of the License at http://www.Inprise.com/IPL.html
+++#
+++# Software distributed under the License is distributed on an
+++# "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express
+++# or implied. See the License for the specific language governing
+++# rights and limitations under the License.
+++#
+++# The Original Code was created by Inprise Corporation
+++# and its predecessors. Portions created by Inprise Corporation are
+++# Copyright (C) Inprise Corporation.
+++#
+++# All Rights Reserved.
+++# Contributor(s): ______________________________________.
+++# Start of file prefix.linux:  $(VERSION)  $(PLATFORM)
+++#      14 Apr 2008     Alan Barclay    alan AT escribe.co.uk
+++#      2018, "Manuel A. Fernandez Montecelo" <manuel.montezelo@gmail.com>
+++
+++
+++#LD=@CXX@
+++
+++#PROD_FLAGS=-ggdb -O3 -fno-omit-frame-pointer -DLINUX -pipe -MMD -fPIC
+++#DEV_FLAGS=-ggdb -DLINUX -DDEBUG_GDS_ALLOC -pipe -MMD -p -fPIC -Wall -Wno-switch
+++
+++PROD_FLAGS=-O3 -DLINUX -DRISCV64 -pipe -p -MMD -fPIC -fsigned-char -fmessage-length=0 -std=gnu++03 -fno-delete-null-pointer-checks
+++DEV_FLAGS=-ggdb -DLINUX -DRISCV64 -pipe -p -MMD -fPIC -Wall -fsigned-char -fmessage-length=0 -Wno-non-virtual-dtor
++diff --git a/configure b/configure
++index 34e0676..a287e4b 100755
++--- a/configure
+++++ b/configure
++@@ -3071,6 +3071,20 @@ $as_echo "#define LINUX 1" >>confdefs.h
++     INSTALL_PREFIX=linux
++     PLATFORM=LINUX
++ 
+++$as_echo "#define LINUX 1" >>confdefs.h
+++
+++    EDITLINE_FLG=Y
+++    SHRLIB_EXT=so
+++    STD_EDITLINE=true
+++    STD_ICU=true
+++    libdir=/usr/lib64
+++    ;;
+++
+++  riscv64*-*-linux*)
+++    MAKEFILE_PREFIX=linux_riscv64
+++    INSTALL_PREFIX=linux
+++    PLATFORM=LINUX
+++
++ $as_echo "#define LINUX 1" >>confdefs.h
++ 
++     EDITLINE_FLG=Y
++diff --git a/configure.ac b/configure.ac
++index 9412b10..ed50d32 100644
++--- a/configure.ac
+++++ b/configure.ac
++@@ -251,6 +251,18 @@ dnl CPU_TYPE=ppc64
++     libdir=/usr/lib64
++     ;;
++ 
+++  riscv64*-*-linux*)
+++    MAKEFILE_PREFIX=linux_riscv64
+++    INSTALL_PREFIX=linux
+++    PLATFORM=LINUX
+++    AC_DEFINE(LINUX, 1, [Define this if OS is Linux])
+++    EDITLINE_FLG=Y
+++    SHRLIB_EXT=so
+++    STD_EDITLINE=true
+++    STD_ICU=true
+++    libdir=/usr/lib64
+++    ;;
+++
++   powerpc64le-*-linux*)                           
++     MAKEFILE_PREFIX=linux_powerpc64el
++     INSTALL_PREFIX=linux
++diff --git a/src/common/classes/DbImplementation.cpp b/src/common/classes/DbImplementation.cpp
++index 0c2db79..112da37 100644
++--- a/src/common/classes/DbImplementation.cpp
+++++ b/src/common/classes/DbImplementation.cpp
++@@ -49,6 +49,7 @@ static const UCHAR CpuAlpha = 14;
++ static const UCHAR CpuArm64 = 15;
++ static const UCHAR CpuPowerPc64el = 16;
++ static const UCHAR CpuM68k = 17;
+++static const UCHAR CpuRiscV64 = 18;
++ 
++ static const UCHAR OsWindows = 0;
++ static const UCHAR OsLinux = 1;
++@@ -89,7 +90,8 @@ const char* hardware[] = {
++ 	"Alpha",
++ 	"ARM64",
++ 	"PowerPC64el",
++-	"M68k"
+++	"M68k",
+++	"RiscV64"
++ };
++ 
++ const char* operatingSystem[] = {
++@@ -116,22 +118,23 @@ const char* compiler[] = {
++ // This table lists pre-fb3 implementation codes
++ const UCHAR backwardTable[FB_NELEM(hardware) * FB_NELEM(operatingSystem)] =
++ {
++-//				Intel	AMD		Sparc	PPC		PPC64	MIPSEL	MIPS	ARM		IA64	s390	s390x	SH		SHEB	HPPA	Alpha	ARM64	PowerPC64el
++-/* Windows */	50,		68,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,
++-/* Linux */		60,		66,		65,		69,		86,		71,		72,		75, 	76,		79, 	78,		80,		81,		82,		83,		84,		85,
++-/* Darwin */	70,		73,		0,		63,		77,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,
++-/* Solaris */	0,		0,		30,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,
++-/* HPUX */		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		31,		0,		0,		0,
++-/* AIX */			0,		0,		0,		35,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,
++-/* MVS */			0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,
++-/* FreeBSD */	61,		67,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,
++-/* NetBSD */	62,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0
+++//				Intel	AMD		Sparc	PPC		PPC64	MIPSEL	MIPS	ARM		IA64	s390	s390x	SH		SHEB	HPPA	Alpha	ARM64	PPC64el	M68k	RiscV64
+++/* Windows */	50,		68,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,
+++/* Linux */ 	60,		66,		65,		69,		86,		71,		72,		75, 	76,		79, 	78,		80,		81,		82,		83,		84,		85,		87,		88,
+++/* Darwin */	70,		73,		0,		63,		77,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,
+++/* Solaris */	0,		0,		30,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,
+++/* HPUX */		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		31,		0,		0,		0,		0,		0,
+++/* AIX */			0,		0,		0,		35,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,
+++/* MVS */			0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,
+++/* FreeBSD */	61,		67,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,
+++/* NetBSD */	62,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0,		0
++ };
++ 
+++
++ const UCHAR backEndianess[FB_NELEM(hardware)] =
++ {
++-//	Intel	AMD		Sparc	PPC		PPC64	MIPSEL	MIPS	ARM		IA64	s390	s390x	SH		SHEB	HPPA	Alpha	ARM64	PowerPC64el	M68k
++-	0,		0,		1,		1,		1,		0,		1,		0,		0,		1,		1,		0,		1,		1,		0,		0,		0,		1
+++//	Intel	AMD		Sparc	PPC		PPC64	MIPSEL	MIPS	ARM		IA64	s390	s390x	SH		SHEB	HPPA	Alpha	ARM64	PPC64el	M68k	RiscV64
+++	0,		0,		1,		1,		1,		0,		1,		0,		0,		1,		1,		0,		1,		1,		0,		0,		0,		1,		0,
++ };
++ 
++ } // anonymous namespace
++diff --git a/src/common/common.h b/src/common/common.h
++index 58abaaf..365b97e 100644
++--- a/src/common/common.h
+++++ b/src/common/common.h
++@@ -135,6 +135,10 @@
++ #define FB_CPU CpuArm64
++ #endif /* ARM64 */
++ 
+++#ifdef RISCV64
+++#define FB_CPU CpuRiscV64
+++#endif /* RISCV64 */
+++
++ #ifdef sparc
++ #define FB_CPU CpuUltraSparc
++ #define RISC_ALIGNMENT
++diff --git a/src/jrd/inf_pub.h b/src/jrd/inf_pub.h
++index 3cc0128..76469c1 100644
++--- a/src/jrd/inf_pub.h
+++++ b/src/jrd/inf_pub.h
++@@ -245,7 +245,7 @@ enum  info_db_implementations
++ 	isc_info_db_impl_linux_ppc64el = 85,
++ 	isc_info_db_impl_linux_ppc64 = 86,
++ 	isc_info_db_impl_linux_m68k = 87,
++-
+++	isc_info_db_impl_linux_riscv64 = 88,
++ 
++ 	isc_info_db_impl_last_value   // Leave this LAST!
++ };
+--- jvmfwk/inc/vendorbase.hxx.orig	2023-03-14 06:16:32.523210267 +0100
++++ jvmfwk/inc/vendorbase.hxx	2023-03-14 06:17:19.103637327 +0100
+@@ -59,6 +59,8 @@
+ #else
+ #define JFW_PLUGIN_ARCH "mips64el"
+ #endif
++#elif defined RISCV64
++#define JFW_PLUGIN_ARCH "riscv64"
+ #elif defined S390X
+ #define JFW_PLUGIN_ARCH "s390x"
+ #elif defined S390

--- a/libreoffice-still/riscv64.patch
+++ b/libreoffice-still/riscv64.patch
@@ -1,0 +1,66 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -39,6 +39,7 @@ _mirror="https://download.documentfoundation.org/libreoffice/src/${pkgver}"
+ #_mirror="https://dev-builds.libreoffice.org/pre-releases/src"
+ _additional_source_url="https://dev-www.libreoffice.org/src"
+ _additional_source_url2="https://dev-www.libreoffice.org/extern"
++_additional_source_url3="https://cgit.freedesktop.org/libreoffice/core/plain/bridges/source/cpp_uno/gcc3_linux_riscv64"
+ source=(${_mirror}/libreoffice{,-help,-translations}-${_LOver}.tar.xz{,.asc}
+ 	${_additional_source_url}/35c94d2df8893241173de1d16b6034c0-swingExSrc.zip
+ 	${_additional_source_url}/798b2ffdc8bcfe7bca2cf92b62caf685-rhino1_5R5.zip # keep old bundled version, new system version ftbs
+@@ -64,7 +65,16 @@ source=(${_mirror}/libreoffice{,-help,-translations}-${_LOver}.tar.xz{,.asc}
+         0001_Remove_dependency_on_BitArray.h_from_zxing-1.2.0.patch
+         623ea5c.diff
+ 	soffice-template.desktop.in 
+-	libreoffice-still.sh libreoffice-still.csh)
++	libreoffice-still.sh libreoffice-still.csh
++	${_additional_source_url3}/abi.cxx
++	${_additional_source_url3}/abi.hxx
++	${_additional_source_url3}/call.hxx
++	${_additional_source_url3}/call.s
++	${_additional_source_url3}/cpp2uno.cxx
++	${_additional_source_url3}/except.cxx
++	${_additional_source_url3}/share.hxx
++	${_additional_source_url3}/uno2cpp.cxx
++	add-rv64-support.patch)
+ noextract=(35c94d2df8893241173de1d16b6034c0-swingExSrc.zip
+            798b2ffdc8bcfe7bca2cf92b62caf685-rhino1_5R5.zip
+            a7983f859eafb2677d7ff386a023bc40-xsltml_2.1.2.zip
+@@ -117,7 +127,16 @@ sha256sums=('380ecf12cb37b94a2f5f210d277fc2d1e14b9f14d1d39e09d49135194e6ce18d'
+             '440c9af5f3d1213d8ed7177282380f25cbc981cabc8b590dcb777aaae84178e5'
+             'd0be8099cbee3c9dfda694a828149b881c345b204ab68826f317580aafb50879'
+             'b43ed267643fc5ced803dca010427b12b1f10db485173ccb19efb3395e60c82e'
+-            '66f2cb5d2ff9909ee9633aea73d5306fc8c4ff358fa526f45d9994210d3e23ff')
++            '66f2cb5d2ff9909ee9633aea73d5306fc8c4ff358fa526f45d9994210d3e23ff'
++            'a4605132dd891856ff78e7223dbb78ddfeb328d9d151605e9624c4444c8fee99'
++            'b1845200c0df1109fa825bcb3e874bfae79d9a7a04cde3e61e6c2b92c3aa1c65'
++            '077007f53d27f496a90b8593022f21a62a36c37bfbfcdc47d015dbb43496eb88'
++            'f8abe5fee4ad8fd6a9379492258420bbe1aa4284cf1ab506e2116a70747fcb13'
++            '8da25b703728cb4e53b08fe5cf671a0b2762a592e080a96adef78114ee149b0e'
++            'e0ff0079de44c6b7f96a4f548279d6d958ffc0b7fbdc161ffd4e13e7578746e3'
++            '651d2a23c50332616ec5aad55383dbbb305641e74273aaa1fe4d57bb2c78da9d'
++            'b9fcae5897082553f9da47a96cc147efcc08235e7049a49307a1667c5910d541'
++            '1bfd011625f96937c526368268482695c8c3ad07ced9a1a6e32f60e4ad987f2d')
+ 
+ prepare() {
+ 
+@@ -154,6 +173,10 @@ prepare() {
+ 		esac
+ 		ARCH_FLAGS="$ARCH_FLAGS $i"
+ 	done
++
++	patch -Np0 -i "${srcdir}"/add-rv64-support.patch
++	mkdir bridges/source/cpp_uno/gcc3_linux_riscv64
++	cp ${srcdir}/{abi.cxx,abi.hxx,call.hxx,call.s,cpp2uno.cxx,except.cxx,share.hxx,uno2cpp.cxx} bridges/source/cpp_uno/gcc3_linux_riscv64
+ }
+ 
+ build() {
+@@ -194,7 +217,7 @@ build() {
+ 		--enable-gtk3 \
+ 		--enable-gtk4 \
+ 		--enable-introspection \
+-		--enable-lto \
++		--disable-lto \
+ 		--enable-openssl \
+ 		--enable-odk\
+ 		--enable-python=system \


### PR DESCRIPTION
This commit backport upstream RISC-V support.

Modified libraries:

* solenv: add riscv64 build config
* bridges: backport riscv64 cpp_uno implementation
* jvmfwk: add riscv64 build target
* firebird: add riscv64 implementation
