### PR TITLE
devtools-riscv64: restore force architecture

### DIFF
--- a/devtools-riscv64/PKGBUILD
+++ b/devtools-riscv64/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Xeonacid <h.dwwwwww at gmail dot com>
 
 pkgname=devtools-riscv64
-pkgver=1.5.0
+pkgver=1.5.1
 pkgrel=1
 pkgdesc='Tools for Arch Linux RISC-V package maintainers'
 arch=('x86_64' 'riscv64')
@@ -14,7 +14,7 @@ source=(makepkg-riscv64.patch
         sogrep-riscv64)
 source_x86_64=('z-archriscv-qemu-riscv64.conf')
 sha256sums=('2abae300509c2fbae0246f195fb7ffa17c4ad240052f1e60b0bc504de6149685'
-            '1c79f2817f81e18060a37b237bd1ec619af5447d0884d525aa87aa2165df16b2'
+            'c7ecb5434e1594fdd0a95cac9132d3bf37e865d22e2efd9056874cdb3501a414'
             '3721d7ca08eae58ef2a9de6d8f9ccf2fae1f330949bbf5f566db4c2efbd06105')
 sha256sums_x86_64=('c59273c423e815e4c27e8486632d80a768adddd172119035d48f7c2fac98a87a')
 

--- a/devtools-riscv64/pacman-extra-riscv64.patch
+++ b/devtools-riscv64/pacman-extra-riscv64.patch
@@ -1,5 +1,14 @@
---- /usr/share/devtools/pacman-extra.conf	2023-01-06 03:00:58.000000000 +0800
-+++ pacman-extra-riscv64.conf	2023-01-24 22:31:14.871571646 +0800
+--- /usr/share/devtools/pacman-extra.conf	2023-03-08 01:56:48.000000000 +0200
++++ pacman-extra-riscv64.conf	2023-03-15 07:59:42.601735222 +0200
+@@ -19,7 +19,7 @@
+ #XferCommand = /usr/bin/curl -L -C - -f -o %o %u
+ #XferCommand = /usr/bin/wget --passive-ftp -c -O %o %u
+ #CleanMethod = KeepInstalled
+-Architecture = auto
++Architecture = riscv64
+ 
+ # Pacman won't upgrade packages listed in IgnorePkg and members of IgnoreGroup
+ #IgnorePkg   =
 @@ -71,19 +71,19 @@
  # after the header, and they will be used before the default mirrors.
  


### PR DESCRIPTION
`pacman` actually checks for valid architecture, and uses the output of `uname()` for `auto`. This didn't break our regular packaging because pacman only checks for the specified targets to install, and `base` / `base-devel` are `any` packages and passes the check. It unfortunately breaks when, for example, trying to run `pacstrap` with it as an alternative pacman conf and specified anything that isn't an `any` package.

While it may sound an out-of-scope usage, I think we should not rely on the undocument fact that architecture checks are only done for the specified targets. `handle->architectures` being `x86_64` only is a problem on its own and _might_ break elsewhere too. So let's just be specific here.