### PR TITLE
addpatch: upower

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -113,6 +113,7 @@ tmuxp
 tpm2-openssl
 tpm2-tools
 tpm2-tss
+upower
 uutils-coreutils
 vim
 wanderlust

--- a/upower/riscv64.patch
+++ b/upower/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -52,7 +52,7 @@ build() {
+ }
+ 
+ check() {
+-  meson test -C build --print-errorlogs
++  meson test -C build --print-errorlogs -t 0
+ }
+ 
+ package() {


### PR DESCRIPTION
This commit disable timeout for all the tests. The test process
will get sigsegv on random test in QEMU User emulator, which make it
hard to debug. So this commit also add upower into
qemu-user-blacklist.txt.
