### PR TITLE
updpatch: presage

### DIFF
--- a/presage/riscv64.patch
+++ b/presage/riscv64.patch
@@ -1,23 +1,11 @@
-diff --git PKGBUILD PKGBUILD
-index 376eb18..8c4bada 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -10,13 +10,16 @@ license=(GPL2)
- depends=(sqlite)
- makedepends=()
- source=(https://download.sourceforge.net/project/presage/presage/$pkgver/$pkgname-$pkgver.tar.gz
--        presage-gcc6.patch)
-+        presage-gcc6.patch
-+        presage-0.9.1-gcc11.patch)
- sha256sums=('5ed567e350402a1d72c9053c78ecec3be710b7e72153a0223c6d19a7fe58a366'
--            '81f1c7ef4d485222269e4467a79451a5515f3d633d84182d78c95683d1575015')
-+            '81f1c7ef4d485222269e4467a79451a5515f3d633d84182d78c95683d1575015'
-+            '991c76ad99e86615f887848fd9d22dad4cddf16345db6f558e1d8eda2201923c')
- 
- prepare() {
-   cd $pkgname-$pkgver
+@@ -23,6 +23,8 @@ prepare() {
    patch -p1 -i ../presage-gcc6.patch # Fix build with GCC 6
-+  patch -p1 -i ../presage-0.9.1-gcc11.patch # Fix build with GCC 11
+   patch -p1 -i ../presage-c++17.patch # Fix build with C++17 (Debian)
+   patch -p1 -i ../presage-format-security.patch # Fix build with Werror=format-security (Debian)
++  autoreconf -fiv
++  autoupdate
  }
  
  build() {


### PR DESCRIPTION
Fixed rotten.

The previous error seems not existing. However, it comes `config.guess`.

So rewrite the patch.

Upstream url: https://sourceforge.net/p/presage/bugs/17/.