### PR TITLE
qemu-user-blacklist: add haskell-pandoc

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -38,6 +38,7 @@ gtest
 gupnp
 gupnp-igd
 gxplugins.lv2
+haskell-pandoc
 haxe
 hyperfine
 iaito
@@ -69,7 +70,6 @@ ob-xd
 odin2-synthesizer
 openh264
 openldap
-pandoc
 pangomm-2.48
 percona-server
 perl


### PR DESCRIPTION
```
Test suite test-pandoc: RUNNING...
test-pandoc: /proc/self/exe: readSymbolicLink: does not exist (No such file or directory)
```