### PR TITLE
fixpatch: qt6-webengine

### DIFF
--- a/qt6-webengine/qt6-webengine-chromium-riscv64.patch
+++ b/qt6-webengine/qt6-webengine-chromium-riscv64.patch
@@ -3464,19 +3464,6 @@ Index: chromium/third_party/highway/src/hwy/base.h
  #define HWY_NATIVE_FLOAT16 1
  #else
  #define HWY_NATIVE_FLOAT16 0
-Index: chromium/third_party/libaom/BUILD.gn
-===================================================================
---- chromium/third_party/libaom/BUILD.gn
-+++ chromium/third_party/libaom/BUILD.gn
-@@ -36,6 +36,8 @@ if (current_cpu == "x86") {
-   } else {
-     cpu_arch_full = "arm"
-   }
-+} else if (current_cpu == "riscv64") {
-+  cpu_arch_full = "generic"
- } else {
-   cpu_arch_full = current_cpu
- }
 Index: chromium/third_party/libvpx/BUILD.gn
 ===================================================================
 --- chromium/third_party/libvpx/BUILD.gn

--- a/qt6-webengine/riscv64.patch
+++ b/qt6-webengine/riscv64.patch
@@ -5,12 +5,12 @@
  options=(debug)
  _pkgfn=${pkgname/6-/}-everywhere-src-$_qtver
 -source=(https://download.qt.io/official_releases/qt/${pkgver%.*}/$_qtver/submodules/$_pkgfn.tar.xz)
--sha256sums=('ffa945518d1cc8d9ee73523e8d9c2090844f5a2d9c7eac05c4ad079472a119c9')
+-sha256sums=('55f85af736a1dc79a41b8d95014ba27d8fce0be44293a69e64fece7fa12b2925')
 +source=(https://download.qt.io/official_releases/qt/${pkgver%.*}/$_qtver/submodules/$_pkgfn.tar.xz
 +        qt6-webengine-chromium-riscv64.patch
 +        qt6-webengine-cmake-riscv64.patch)
-+sha256sums=('ffa945518d1cc8d9ee73523e8d9c2090844f5a2d9c7eac05c4ad079472a119c9'
-+            'd703b2f270cf225e84a4f2d71dd6da3eba58ab22f32cac309c2f925fe7fb4644'
++sha256sums=('55f85af736a1dc79a41b8d95014ba27d8fce0be44293a69e64fece7fa12b2925'
++            '9d745072a01417a39f1ec532fcee26cf8a214332e7cea29e94d61684d10de377'
 +            'fdf8bb4f09adefa432ed7ab3b0e2f375f5b99fcb80d39415f3c574cbe6b71fb2')
 +
 +prepare() {


### PR DESCRIPTION
It seems like one part of the patch has been upstream-ed, plus the source hash change.