### PR TITLE
addpkg: golang-github-kr-text

### DIFF
--- a/golang-github-kr-text/fix-missing-entry.patch
+++ b/golang-github-kr-text/fix-missing-entry.patch
@@ -1,0 +1,17 @@
+diff --color -aruN text-0.2.0-orig/go.mod text-0.2.0-new/go.mod
+--- text-0.2.0-orig/go.mod	2020-02-15 04:31:06.000000000 +0800
++++ text-0.2.0-new/go.mod	2023-03-20 20:35:19.626678269 +0800
+@@ -1,3 +1,5 @@
+-module "github.com/kr/text"
++module github.com/kr/text
+ 
+-require "github.com/creack/pty" v1.1.9
++go 1.20
++
++require github.com/creack/pty v1.1.9
+diff --color -aruN text-0.2.0-orig/go.sum text-0.2.0-new/go.sum
+--- text-0.2.0-orig/go.sum	1970-01-01 08:00:00.000000000 +0800
++++ text-0.2.0-new/go.sum	2023-03-20 20:35:19.626678269 +0800
+@@ -0,0 +1,2 @@
++github.com/creack/pty v1.1.9 h1:uDmaGzcdjhF4i/plgjmEsriH11Y0o7RKapEf/LDaM3w=
++github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/golang-github-kr-text/riscv64.patch
+++ b/golang-github-kr-text/riscv64.patch
@@ -1,0 +1,21 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -8,8 +8,16 @@ arch=('any')
+ url="https://github.com/kr/text"
+ license=('MIT')
+ depends=('go' 'golang-github-kr-pty')
+-source=("$pkgname-$pkgver.tar.gz::https://github.com/kr/text/archive/v$pkgver.tar.gz")
+-sha512sums=('69c73f437834b6c07a5c47c51bfd726ec1709939622d5bfa419deac449858e519f01fce0e5abe734ab502249914e526ae6437b8d3462f05cd5b414da9bb145c1')
++source=("$pkgname-$pkgver.tar.gz::https://github.com/kr/text/archive/v$pkgver.tar.gz"
++		"fix-missing-entry.patch")
++sha512sums=('69c73f437834b6c07a5c47c51bfd726ec1709939622d5bfa419deac449858e519f01fce0e5abe734ab502249914e526ae6437b8d3462f05cd5b414da9bb145c1'
++			'52a4a6b15ff39a9025d2f579b13643c23095dbd52079812fc06e3f808584bf60337cbf4ec3bbd7f97bbe0abc4a429e68a7820bb3c7373b8a4b97c04a400a8d13')
++
++prepare() {
++	export GOPROXY=https://goproxy.io,direct
++	cd text-$pkgver
++	patch -Np1 -i ../fix-missing-entry.patch
++}
+ 
+ check() {
+   export GOPATH="$srcdir/build:/usr/share/gocode"


### PR DESCRIPTION
Previously, a compilation failed due to a missing go.sum entry. This commit adds the required go.sum using the `go mod tidy` command.