### PR TITLE
addpatch: web-ext

### DIFF
--- a/web-ext/riscv64.patch
+++ b/web-ext/riscv64.patch
@@ -1,0 +1,34 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -18,13 +18,20 @@ conflicts=('nodejs-web-ext')
+ options=('!strip')
+ # tarball on npmjs lacks scripts for building from sources
+ source=("https://github.com/mozilla/web-ext/archive/$pkgver/web-ext-$pkgver.tar.gz"
+-        "nodejs19.diff")
++        "nodejs19.diff"
++	"web-ext-no-jit.patch")
+ sha256sums=('5a1f57be9be07c231a62a88e328eecde4bd6cabcb240e1147ae38431d9935493'
+-            '9475a50851a8442dd8edad55f5b678923808396eedfae45dd29a960cc0646529')
++            '9475a50851a8442dd8edad55f5b678923808396eedfae45dd29a960cc0646529'
++            '4e6742f7a0001fb0c032daaa7a63fe98d092ee521da65749c78af478b088d931')
+ 
+ prepare() {
+   cd "$srcdir"
+ 
++  # Disable V8's buggy JIT
++  pushd $pkgname-$pkgver
++  patch -Np1 -i ../web-ext-no-jit.patch
++  popd
++
+   # Make tests pass with Node.js 19 https://github.com/mozilla/web-ext/issues/2564
+   pushd $pkgname-$pkgver
+   patch -Np1 -i ../nodejs19.diff
+@@ -50,7 +57,7 @@ check() {
+ 
+   # web-ext uses flow-bin, which does not support some architectures (e.g., RISC-V)
+   # Some tests match error messages and fail if messages are translated
+-  LANG=C.UTF-8 CI_SKIP_FLOWCHECK=y npm test
++  LANG=C.UTF-8 CI_SKIP_FLOWCHECK=y MOCHA_TIMEOUT=100000 npm test
+ }
+ 
+ package() {

--- a/web-ext/riscv64.patch
+++ b/web-ext/riscv64.patch
@@ -6,7 +6,7 @@
  source=("https://github.com/mozilla/web-ext/archive/$pkgver/web-ext-$pkgver.tar.gz"
 -        "nodejs19.diff")
 +        "nodejs19.diff"
-+	"web-ext-no-jit.patch")
++        "web-ext-no-jit.patch")
  sha256sums=('5a1f57be9be07c231a62a88e328eecde4bd6cabcb240e1147ae38431d9935493'
 -            '9475a50851a8442dd8edad55f5b678923808396eedfae45dd29a960cc0646529')
 +            '9475a50851a8442dd8edad55f5b678923808396eedfae45dd29a960cc0646529'

--- a/web-ext/web-ext-no-jit.patch
+++ b/web-ext/web-ext-no-jit.patch
@@ -1,0 +1,41 @@
+diff --git a/scripts/lib/babel.js b/scripts/lib/babel.js
+index 8fedf51..30ea003 100644
+--- a/scripts/lib/babel.js
++++ b/scripts/lib/babel.js
+@@ -34,8 +34,8 @@ export function isBuilt() {
+ 
+ export default () => {
+   const res = spawnSync(
+-    'babel',
+-    ['--source-maps', 'true', 'src/', '-d', 'lib/'],
++    'node',
++    ['--max-opt=0', 'node_modules/.bin/babel', '--source-maps', 'true', 'src/', '-d', 'lib/'],
+     {
+       stdio: 'inherit',
+       shell: true,
+diff --git a/scripts/lib/eslint.js b/scripts/lib/eslint.js
+index 94df352..82e9a8d 100644
+--- a/scripts/lib/eslint.js
++++ b/scripts/lib/eslint.js
+@@ -3,7 +3,7 @@ import { spawnSync } from 'child_process';
+ import config from './config.js';
+ 
+ export default () => {
+-  const res = spawnSync('eslint', config.eslint.files, {
++  const res = spawnSync('node', ['--max-opt=0', 'node_modules/.bin/eslint', ...config.eslint.files], {
+     stdio: 'inherit',
+     shell: true,
+   });
+diff --git a/scripts/lib/mocha.js b/scripts/lib/mocha.js
+index da1e67c..cc70e34 100644
+--- a/scripts/lib/mocha.js
++++ b/scripts/lib/mocha.js
+@@ -14,6 +14,8 @@ const runMocha = (args, execMochaOptions = {}, coverageEnabled) => {
+   const binArgs = coverageEnabled ? [mochaPath, ...args] : args;
+   const binPath = coverageEnabled ? which('nyc') : mochaPath;
+ 
++  binArgs.push('-n', 'max-opt=0');
++
+   if (process.env.MOCHA_TIMEOUT) {
+     const { MOCHA_TIMEOUT } = process.env;
+     binArgs.push('--timeout', MOCHA_TIMEOUT);


### PR DESCRIPTION
- Disable V8's buggy JIT that makes eslint and babel fail <https://github.com/babel/babel/issues/15501>
  - Upstream bug report: https://bugs.chromium.org/p/v8/issues/detail?id=13836
- Increase test timeout