### PR TITLE
fixpkg: luajit

### DIFF
--- a/luajit/riscv64.patch
+++ b/luajit/riscv64.patch
@@ -1,5 +1,5 @@
 diff --git PKGBUILD PKGBUILD
-index 70afb4b7..96483d20 100644
+index 70afb4b7..0f2d91da 100644
 --- PKGBUILD
 +++ PKGBUILD
 @@ -8,7 +8,7 @@
@@ -7,11 +7,11 @@ index 70afb4b7..96483d20 100644
  # LuaJIT has abandoned versioned releases and now advises using git HEAD
  # https://github.com/LuaJIT/LuaJIT/issues/665#issuecomment-784452583
 -_commit=505e2c03de35e2718eef0d2d3660712e06dadf1f
-+_commit=5ab19d91f1ea298b5cf9aa0f23f3123fa362bc60
++_commit=d60e93bacea00ac9c7e47d7b6b03e89e969c9a38
  pkgver="2.1.0.beta3.r471.g${_commit::8}"
  pkgrel=1
  pkgdesc='Just-in-time compiler and drop-in replacement for Lua 5.1'
-@@ -16,19 +16,20 @@
+@@ -16,19 +16,29 @@ arch=('x86_64')
  url='https://luajit.org/'
  license=('MIT')
  depends=('gcc-libs')
@@ -19,17 +19,27 @@ index 70afb4b7..96483d20 100644
 -md5sums=('0847dc535736846a9a1436e18d8c509d')
 -sha256sums=('b89d081aac4189a06b736c667f47cc60e0cc4591933b7ed50db38cf58496386e')
 -b2sums=('89bed923ff34d2de813dee17f130496ffeaa6bc5caf9252be1df7d35e87fa7398930f1fe35f95650694d344bc99d5b2c0c4abc4568f1dac318822a832d44c3a4')
-+makedepends=('git')
-+source=("git+https://github.com/infiWang/LuaJIT.git#commit=$_commit")
-+md5sums=('SKIP')
-+sha256sums=('SKIP')
-+b2sums=('SKIP')
++makedepends=('git' 'clang')
++source=("git+https://github.com/infiWang/LuaJIT.git#commit=$_commit"
++        "allow-clang.patch"::"https://github.com/LuaJIT/LuaJIT/commit/a4f4f5b83564a1075bea0ac7c1fd8768be1caff7.patch")
++md5sums=('SKIP'
++         '77b553386981eebe2667726501076d68')
++sha256sums=('SKIP'
++            '172ee031fa64644b91c74b8488f976b39215bd128e5217eb93791729bd20916a')
++b2sums=('SKIP'
++        '2704bcdc979eacab45d77ec2a29d0a4767a837abf8b260ccf98dc65c90cadd295b56d9ffdd0cf59399dd6e672e3ce579ffb12927ce161f7a7eca7e225f186ca4')
++options=(!lto)
++
++prepare() {
++  patch -Np1 -d "LuaJIT" < allow-clang.patch
++}
  
  build() {
 -  cd "luajit-2.0-${_commit::7}"
 +  cd "LuaJIT"
    # Avoid early stripping
-   make amalg PREFIX=/usr BUILDMODE=dynamic TARGET_STRIP=" @:"
+-  make amalg PREFIX=/usr BUILDMODE=dynamic TARGET_STRIP=" @:"
++  make CC=clang PREFIX=/usr BUILDMODE=dynamic TARGET_STRIP=" @:"
  }
  
  package() {

--- a/luajit/riscv64.patch
+++ b/luajit/riscv64.patch
@@ -7,7 +7,7 @@ index 70afb4b7..0f2d91da 100644
  # LuaJIT has abandoned versioned releases and now advises using git HEAD
  # https://github.com/LuaJIT/LuaJIT/issues/665#issuecomment-784452583
 -_commit=505e2c03de35e2718eef0d2d3660712e06dadf1f
-+_commit=d60e93bacea00ac9c7e47d7b6b03e89e969c9a38
++_commit=7c5b92527e0dacce1ff8776fa7955cc04aeee5da
  pkgver="2.1.0.beta3.r471.g${_commit::8}"
  pkgrel=1
  pkgdesc='Just-in-time compiler and drop-in replacement for Lua 5.1'


### PR DESCRIPTION
Previous patch is not able to work in most environments. According to upstream maintainer, we should use clang to avoid some issues with ffi. Also disable LTO and use default target instead of amalg. Detailed bug reported for further investigation.