### PR TITLE
addpatch: mattermost

### DIFF
--- a/mattermost/riscv64.patch
+++ b/mattermost/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -11,7 +11,7 @@ arch=(x86_64)
+ url="https://mattermost.com"
+ license=(AGPL Apache)
+ depends=(glibc)
+-makedepends=(go jq nodejs-lts-gallium npm git python)
++makedepends=(go jq nodejs-lts-gallium npm git python libpng)
+ optdepends=('mariadb: SQL server storage'
+             'mmctl: CLI admin tool'
+             'percona-server: SQL server storage'


### PR DESCRIPTION
This package can be built on qemu-user without patch because in `prepare()`, npm installs a static x86_64 pngquant binary that can be executed in qemu-user.

But on real riscv64 board, this packae FTBFS because of missing imagemin-pngquant dependency. Adding libpng to `makedepends` resolves this issue because pngquant will be built from source and dynamically linked.

libpng is only used when building the package so there is no need to put it into `depends`.

Upstream bug report: https://bugs.archlinux.org/task/78011