### PR TITLE
addpatch: wpewebkit

### DIFF
--- a/wpewebkit/fix-riscv64-build.patch
+++ b/wpewebkit/fix-riscv64-build.patch
@@ -1,0 +1,28 @@
+diff --git a/Source/JavaScriptCore/offlineasm/riscv64.rb b/Source/JavaScriptCore/offlineasm/riscv64.rb
+index 81f356d04ae1..4abb1761509d 100644
+--- a/Source/JavaScriptCore/offlineasm/riscv64.rb
++++ b/Source/JavaScriptCore/offlineasm/riscv64.rb
+@@ -1523,7 +1523,8 @@ def riscv64GenerateWASMPlaceholders(list)
+         if node.is_a? Instruction
+             case node.opcode
+             when "loadlinkacqb", "loadlinkacqh", "loadlinkacqi", "loadlinkacqq",
+-                 "storecondrelb", "storecondrelh", "storecondreli", "storecondrelq"
++                 "storecondrelb", "storecondrelh", "storecondreli", "storecondrelq",
++                 "loadv", "storev"
+                 newList << Instruction.new(node.codeOrigin, "rv_ebreak", [], "WebAssembly placeholder for opcode #{node.opcode}")
+             else
+                 newList << node
+diff --git a/Source/WTF/wtf/PlatformEnable.h b/Source/WTF/wtf/PlatformEnable.h
+index e30a3d8ce077..937fdd447f92 100644
+--- a/Source/WTF/wtf/PlatformEnable.h
++++ b/Source/WTF/wtf/PlatformEnable.h
+@@ -616,7 +616,7 @@
+ #undef ENABLE_WEBASSEMBLY
+ #define ENABLE_WEBASSEMBLY 1
+ #undef ENABLE_WEBASSEMBLY_B3JIT
+-#define ENABLE_WEBASSEMBLY_B3JIT 0
++#define ENABLE_WEBASSEMBLY_B3JIT 1
+ #undef ENABLE_WEBASSEMBLY_BBQJIT
+ #define ENABLE_WEBASSEMBLY_BBQJIT 0
+ #endif
+

--- a/wpewebkit/riscv64.patch
+++ b/wpewebkit/riscv64.patch
@@ -1,0 +1,23 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -64,9 +64,11 @@ makedepends=(
+ )
+ source=(
+   $url/releases/wpewebkit-$pkgver.tar.xz{,.asc}
++  fix-riscv64-build.patch # bpo: https://github.com/WebKit/WebKit/commit/c07cdb6ae80b0847da58a6acb1022b8b3e170073
+ )
+ sha256sums=('a8ec2bcfa1613768ab3ce7f65cac4f214835266c2ff59440d72180baec3086b6'
+-            'SKIP')
++            'SKIP'
++            '565e21e1e474ae1769ce2e3e8939193aa58bfe12a3c30f85c8bf2eb140007362')
+ validpgpkeys=(
+   'D7FCF61CF9A2DEAB31D81BD3F3D322D0EC4582C3'  # Carlos Garcia Campos <cgarcia@igalia.com>
+   '5AA3BC334FD7E3369E7C77B291C559DBE4C9123B'  # Adrián Pérez de Castro <aperez@igalia.com>
+@@ -74,6 +76,7 @@ validpgpkeys=(
+ 
+ prepare() {
+   cd wpewebkit-$pkgver
++  patch -Np1 -i ../fix-riscv64-build.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
Backported riscv64 build fix from master, with modification

Source: https://commits.webkit.org/261498@main

(FYI this package is independent of webkit2gtk, but currently shares the same package and WebKit version with it.)