### PR TITLE
addpatch: ghidra

### DIFF
--- a/ghidra/add-riscv64-build.patch
+++ b/ghidra/add-riscv64-build.patch
@@ -1,0 +1,126 @@
+diff --git a/GPL/nativeBuildProperties.gradle b/GPL/nativeBuildProperties.gradle
+index 5e9c33f4e..cfad0b1d2 100644
+--- a/GPL/nativeBuildProperties.gradle
++++ b/GPL/nativeBuildProperties.gradle
+@@ -43,6 +43,9 @@ model {
+ 				if (isCurrentArm_64()) {
+ 					target("linux_arm_64")
+ 				}
++				if (isCurrentRiscv_64()) {
++					target("linux_riscv_64")
++				}
+ 			}
+ 		}
+ 		if (isCurrentMac()) {
+diff --git a/GPL/nativePlatforms.gradle b/GPL/nativePlatforms.gradle
+index a75cf48a5..09b817dde 100644
+--- a/GPL/nativePlatforms.gradle
++++ b/GPL/nativePlatforms.gradle
+@@ -23,6 +23,7 @@ project.ext.PLATFORMS = [
+ 	[name: "win_x86_64", os: "windows", arch: "x86_64"],
+ 	[name: "linux_x86_64", os: "linux", arch: "x86_64"],
+ 	[name: "linux_arm_64", os: "linux", arch: "arm64"],
++	[name: "linux_riscv_64", os: "linux", arch: "riscv64"],
+ 	[name: "mac_x86_64", os: "osx", arch: "x86_64"],
+ 	[name: "mac_arm_64", os: "osx", arch: "arm64"]
+ ]
+@@ -71,6 +72,9 @@ ext.getCurrentPlatformName = {
+ 		case "arm64":
+ 			arch = "arm_64"
+ 			break
++		case "riscv64":
++			arch = "riscv_64"
++			break
+ 		default:
+ 			throw new GradleException("Unrecognized platform architecture: $arch" )
+ 	}
+@@ -152,6 +156,14 @@ ext.isCurrentArm_64 = {
+ 	return isArm_64(getCurrentPlatformName())
+ }
+ 
++ext.isRiscv_64 = { platform_name ->
++	return platform_name.contains("riscv")
++}
++
++ext.isCurrentRiscv_64 = {
++	return isRiscv_64(getCurrentPlatformName())
++}
++
+ /****************************************************************************
+  * Establish Visual Studio configuration environment for Windows native builds
+  * NOTE: vsconfig.gradle path is relative to each GPL project module
+diff --git a/Ghidra/Debug/Debugger-gadp/build.gradle b/Ghidra/Debug/Debugger-gadp/build.gradle
+index 1b4922f66..47eae6929 100644
+--- a/Ghidra/Debug/Debugger-gadp/build.gradle
++++ b/Ghidra/Debug/Debugger-gadp/build.gradle
+@@ -33,29 +33,31 @@ configurations {
+ def platform = getCurrentPlatformName()
+ 
+ dependencies {
+-	allProtocArtifacts 'com.google.protobuf:protoc:3.17.3:windows-x86_64@exe'
+-	allProtocArtifacts 'com.google.protobuf:protoc:3.17.3:linux-x86_64@exe'
+-	allProtocArtifacts 'com.google.protobuf:protoc:3.17.3:linux-aarch_64@exe'
+-	allProtocArtifacts 'com.google.protobuf:protoc:3.17.3:osx-x86_64@exe'
+-	allProtocArtifacts 'com.google.protobuf:protoc:3.17.3:osx-aarch_64@exe'
++	if (!isCurrentRiscv_64()) {
++		allProtocArtifacts 'com.google.protobuf:protoc:3.17.3:windows-x86_64@exe'
++		allProtocArtifacts 'com.google.protobuf:protoc:3.17.3:linux-x86_64@exe'
++		allProtocArtifacts 'com.google.protobuf:protoc:3.17.3:linux-aarch_64@exe'
++		allProtocArtifacts 'com.google.protobuf:protoc:3.17.3:osx-x86_64@exe'
++		allProtocArtifacts 'com.google.protobuf:protoc:3.17.3:osx-aarch_64@exe'
+ 
+-	if (isCurrentWindows()) {
+-		protocArtifact 'com.google.protobuf:protoc:3.17.3:windows-x86_64@exe'
+-	}
+-	if (isCurrentLinux()) {
+-		if (platform.endsWith("x86_64")) {
+-			protocArtifact 'com.google.protobuf:protoc:3.17.3:linux-x86_64@exe'
++		if (isCurrentWindows()) {
++			protocArtifact 'com.google.protobuf:protoc:3.17.3:windows-x86_64@exe'
+ 		}
+-		else {
+-			protocArtifact 'com.google.protobuf:protoc:3.17.3:linux-aarch_64@exe'
++		if (isCurrentLinux()) {
++			if (platform.endsWith("x86_64")) {
++				protocArtifact 'com.google.protobuf:protoc:3.17.3:linux-x86_64@exe'
++			}
++			else {
++				protocArtifact 'com.google.protobuf:protoc:3.17.3:linux-aarch_64@exe'
++			}
+ 		}
+-	}
+-	if (isCurrentMac()) {
+-		if (platform.endsWith("x86_64")) {
+-			protocArtifact 'com.google.protobuf:protoc:3.17.3:osx-x86_64@exe'
+-		}
+-		else {
+-			protocArtifact 'com.google.protobuf:protoc:3.17.3:osx-aarch_64@exe'
++		if (isCurrentMac()) {
++			if (platform.endsWith("x86_64")) {
++				protocArtifact 'com.google.protobuf:protoc:3.17.3:osx-x86_64@exe'
++			}
++			else {
++				protocArtifact 'com.google.protobuf:protoc:3.17.3:osx-aarch_64@exe'
++			}
+ 		}
+ 	}
+ 
+@@ -84,9 +86,15 @@ task generateProto {
+ 	inputs.files(src)
+ 	dependsOn(configurations.protocArtifact)
+ 	doLast {
+-		def exe = configurations.protocArtifact.first()
+-		if (!isCurrentWindows()) {
+-			exe.setExecutable(true)
++		def exe
++		if (isCurrentRiscv_64()) {
++			exe = System.env.PROTOBUF_DESTDIR + "/usr/local/bin/protoc"
++		}
++		else {
++			exe = configurations.protocArtifact.first()
++			if (!isCurrentWindows()) {
++				exe.setExecutable(true)
++			}
+ 		}
+ 		exec {
+ 			commandLine exe, "--java_out=$outdir", "-I$srcdir"

--- a/ghidra/riscv64.patch
+++ b/ghidra/riscv64.patch
@@ -1,0 +1,77 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -5,6 +5,7 @@ pkgname=ghidra
+ pkgver=10.2.3
+ _d2j=2.0
+ _yajsw=13.05
++_protobuf=3.17.3
+ pkgrel=1
+ pkgdesc='Software reverse engineering framework'
+ url='https://ghidra-sre.org/'
+@@ -18,16 +19,28 @@ source=(https://github.com/NationalSecurityAgency/ghidra/archive/Ghidra_${pkgver
+         "git+https://github.com/NationalSecurityAgency/ghidra-data#tag=Ghidra_${pkgver}"
+         https://github.com/pxb1988/dex2jar/releases/download/${_d2j}/dex-tools-${_d2j}.zip
+         https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/android4me/AXMLPrinter2.jar
+-        https://sourceforge.net/projects/yajsw/files/yajsw/yajsw-stable-${_yajsw}/yajsw-stable-${_yajsw}.zip)
++        https://sourceforge.net/projects/yajsw/files/yajsw/yajsw-stable-${_yajsw}/yajsw-stable-${_yajsw}.zip
++        https://github.com/protocolbuffers/protobuf/releases/download/v${_protobuf}/protobuf-cpp-${_protobuf}.tar.gz
++        fix-gradle-8-compat.patch::https://github.com/NationalSecurityAgency/ghidra/commit/69f6dae46fcf23135e97e072c316d52fa8f0c304.patch
++        add-riscv64-build.patch)
+ noextract=(AXMLPrinter2.jar
+            yajsw-beta-${_yajsw}.zip)
+ sha512sums=('f5dbc828e43acabe8e30f293726b7afa7f96aa29eb2d0ea1ccd4688012e9fdf2950fab2cfa7b8a2b94feaa8ec5ffba5d39017c8ec152e592818d6e3b67df3fc7'
+             'SKIP'
+             'c4a6c72ea09b58a44fcb8918cfada600467f10f99a02b53d2436ac68295e73c8daf9ba0a8bc7160ba1e28e87f032ee034435ebe40af35b6e2fe9fa4607581358'
+             'c1168ec913f1fbb0675915d4fd865ec9a8e8573f6c8aedcb6e68166f61f11aeaececc7548d54d78134843c0102c57d6350973f6d3027d0ffdae52a5c57a7f601'
+-            'ba6421fcc9d5fd5edf0b5f299914a54a8e3d8cbe79b83cf9b1a4a1828eb26f32f8d04299235233581a848e274665c6d2da9b8394be1d7a824e443efd2508413c')
++            'ba6421fcc9d5fd5edf0b5f299914a54a8e3d8cbe79b83cf9b1a4a1828eb26f32f8d04299235233581a848e274665c6d2da9b8394be1d7a824e443efd2508413c'
++            'efad397f5cdda6639d5e9980fe6eeadc1ef768bf1d96b1e528a1d7ba1d81ceb49e22cbd78d9b4ab3518236055140568342ff138204b4a47234fb2957a89d2db8'
++            '03e7801a3f025ea3f2503cf82144809f00682672be1da23e931f10216451d75508bf67f7976fb4ea15c1ff8fcd3a424a323a867a5c646949a9e81fc56b538e3e'
++            'a02aef395b7e6c961fbff905a396f9c6be0f6dbc9480650508de77b8d2859a51223399d74a81cf0832079b3267b9e4e941b598adcb8c443d9ce6522cf5886e0f')
+ 
+ prepare() {
++  # prepare for protobuf
++  mkdir protobuf-dst
++  cd protobuf-${_protobuf}
++  ./configure --disable-shared
++  cd ..
++
+   export PATH="/usr/lib/jvm/java-17-openjdk/bin:${PATH}"
+   cd ghidra-Ghidra_${pkgver}_build
+ 
+@@ -45,14 +58,25 @@ prepare() {
+ 
+   # Ignore lack of licensing for YAJSW zip, packed FID datasets, and the native binaries
+   sed -i '/FileTree tree/a\\t\texclude "yajsw-stable-**.zip"\n\t\texclude "src/main/fidb/**.fidb"\n\t\texclude "os/linux64/**"' gradle/support/ip.gradle
++
++  patch -Np1 -i ../fix-gradle-8-compat.patch
++  patch -Np1 -i ../add-riscv64-build.patch
+ }
+ 
+ build() {
++  # protoc
++  export PROTOBUF_DESTDIR=${srcdir}/protobuf-dst
++  cd protobuf-${_protobuf}
++  make
++  # make check
++  make DESTDIR=${PROTOBUF_DESTDIR} install
++  cd ..
++
+   export GRADLE_HOME="$(pwd)/usr/share/java/gradle/"
+   export PATH="$(pwd)/usr/share/java/gradle/bin/:${PATH}"
+   cd ghidra-Ghidra_${pkgver}_build
+   gradle yajswDevUnpack
+-  gradle buildNatives_linux_x86_64
++  gradle buildNatives_linux_riscv_64
+   gradle sleighCompile
+   gradle buildGhidra
+ }
+@@ -64,7 +88,7 @@ package() {
+   install -d "${pkgdir}"/{opt,usr/bin}
+   _appver=$(grep -oP '(?<=^application.version=).*$' Ghidra/application.properties)
+   _relname=$(grep -oP '(?<=^application.release.name=).*$' Ghidra/application.properties)
+-  unzip -u "build/dist/ghidra_${_appver}_${_relname}"_*_linux_x86_64.zip -d "${pkgdir}"/opt
++  unzip -u "build/dist/ghidra_${_appver}_${_relname}"_*_linux_riscv_64.zip -d "${pkgdir}"/opt
+ 
+   # Simplify some directory and binary names
+   mv "${pkgdir}"/opt/ghidra{_*,}


### PR DESCRIPTION
Add riscv64 build support. Compiles statically-linked protobuf build-time to match the Java library version.