### PR TITLE
addpatch: python-whatthepatch

### DIFF
--- a/python-whatthepatch/increase-test-timeout.patch
+++ b/python-whatthepatch/increase-test-timeout.patch
@@ -1,0 +1,12 @@
+--- a/tests/test_patch.py
++++ b/tests/test_patch.py
+@@ -1447,7 +1447,8 @@
+         self.assertEqual(1000007, len(result[0].changes))
+         # This is 2x the usual time for CI to allow for some slow tests
+         # Really all we care about is that this parses faster than it used to (200s+)
+-        self.assertGreater(20, time.time() - start_time)
++        # Note: riscv64 is still way too slow. Bump from 20s to 100s
++        self.assertGreater(100, time.time() - start_time)
+ 
+ 
+ if __name__ == "__main__":

--- a/python-whatthepatch/riscv64.patch
+++ b/python-whatthepatch/riscv64.patch
@@ -1,0 +1,20 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -11,12 +11,15 @@ license=(MIT)
+ depends=(python)
+ makedepends=(python-build python-installer python-setuptools python-wheel)
+ checkdepends=(python-pytest)
+-source=(https://files.pythonhosted.org/packages/source/${_pkg::1}/${_pkg}/${_pkg}-${pkgver}.tar.gz)
++source=(https://files.pythonhosted.org/packages/source/${_pkg::1}/${_pkg}/${_pkg}-${pkgver}.tar.gz
++        increase-test-timeout.patch)
+ #source=(${url}/archive/v${pkgver}rel/${pkgname}-${pkgver}.tar.gz)
+-sha256sums=('b5983a49f751158a7b5c62baf55aaf815728d3d80bf5dd0c5acb2d7d3d7391ee')
++sha256sums=('b5983a49f751158a7b5c62baf55aaf815728d3d80bf5dd0c5acb2d7d3d7391ee'
++            'e82a1dbee6c952be0aa4cdbfa0001bd3208366ab73503f3856e640fadc22ab16')
+ 
+ build() {
+   cd ${_pkg}-${pkgver}
++  patch -Np1 -i ../increase-test-timeout.patch
+   python -m build --wheel --no-isolation
+ }
+ 


### PR DESCRIPTION
`test_huge_patch` timed out on both qemu-user and real hardware. Since it is purely for ensuring performance, it is safe to increase its timeout.