### PR TITLE
addpatch: java-openjfx

### DIFF
--- a/java-openjfx/add-riscv64-build.patch
+++ b/java-openjfx/add-riscv64-build.patch
@@ -1,0 +1,39 @@
+diff --git a/build.gradle b/build.gradle
+index 11e0293342..4cce1ad8fe 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -295,6 +295,7 @@ ext.ARCH_NAME = "x64"
+ ext.IS_64 = OS_ARCH.toLowerCase().contains("64")
+ ext.IS_AARCH64 = OS_ARCH.toLowerCase().contains("aarch64")
+ ext.IS_LOONGARCH64 = OS_ARCH.toLowerCase().contains("loongarch64")
++ext.IS_RISCV64 = OS_ARCH.toLowerCase().contains("riscv64")
+ ext.IS_MAC = OS_NAME.contains("mac") || OS_NAME.contains("darwin")
+ ext.IS_WINDOWS = OS_NAME.contains("windows")
+ ext.IS_LINUX = OS_NAME.contains("linux")
+@@ -310,7 +311,7 @@ if (IS_WINDOWS && OS_ARCH != "x86" && OS_ARCH != "amd64") {
+     fail("Unknown and unsupported build architecture: $OS_ARCH")
+ } else if (IS_MAC && OS_ARCH != "x86_64" && OS_ARCH != "aarch64") {
+     fail("Unknown and unsupported build architecture: $OS_ARCH")
+-} else if (IS_LINUX && OS_ARCH != "i386" && OS_ARCH != "amd64" && !IS_AARCH64 && !IS_LOONGARCH64) {
++} else if (IS_LINUX && OS_ARCH != "i386" && OS_ARCH != "amd64" && !IS_AARCH64 && !IS_LOONGARCH64 && !IS_RISCV64) {
+     fail("Unknown and unsupported build architecture: $OS_ARCH")
+ }
+ 
+@@ -319,6 +320,8 @@ if (IS_64) {
+         ARCH_NAME = "aarch64"
+     } else if (IS_LOONGARCH64) {
+         ARCH_NAME = "loongarch64"
++    } else if (IS_RISCV64) {
++        ARCH_NAME = "riscv64"
+     } else {
+         ARCH_NAME = "x64"
+     }
+@@ -3553,6 +3556,8 @@ project(":web") {
+                                 cmakeArgs = "$cmakeArgs -DCMAKE_SYSTEM_PROCESSOR=aarch64"
+                             } else if (IS_LOONGARCH64) {
+                                 cmakeArgs = "$cmakeArgs -DCMAKE_SYSTEM_PROCESSOR=loongarch64"
++                            } else if (IS_RISCV64) {
++                                cmakeArgs = "$cmakeArgs -DCMAKE_SYSTEM_PROCESSOR=riscv64"
+                             } else {
+                                 cmakeArgs = "$cmakeArgs -DCMAKE_SYSTEM_PROCESSOR=x86_64"
+                             }

--- a/java-openjfx/riscv64.patch
+++ b/java-openjfx/riscv64.patch
@@ -1,0 +1,48 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -31,7 +31,6 @@ makedepends=(
+   gdk-pixbuf2
+   glib2
+   gperf
+-  gradle
+   gtk2
+   gtk3
+   java-environment-openjdk=17
+@@ -52,11 +51,17 @@ source=(
+   gradle.properties
+   java-openjfx-flags.patch
+   java-openjfx-no-xlocale.patch
++  # LoongArch64 support also makes adding other platform's support (and
++  # upstreaming) easier
++  add-loongarch64-build.patch::https://github.com/openjdk/jfx/commit/cef583eef41aff3db55542d5e90423eec5601f41.patch
++  add-riscv64-build.patch
+ )
+ b2sums=('fba1046c83e709ba9558b0e9a5a164a86ca919781b822e52c7fa6a514d44aaa78a58e3639ca7be429916b95549f85ae8d916cd4b2b3f8e471c1fb87b988f4c46'
+         'a77fd8814a5978827de01a652f7b945f3439df04606434ced8998c8d77a82985292490e6965299aeb52f9da3d8069b4091d75519bd4ec8a15f70bc6d28b13498'
+         '30f5f096f29a85b7d3a40de6bd3420fc951e24eee1d19017c41f3553c1d44832bd87742af691c9f68c1149ea827faf88edfa6af1e27cb324b7bf7d093a74398e'
+-        '13216615c01b8d48d17889ffa22668c38568870d83ab30c542eb5b5620db305f02efb1acb99d9b5e89eb0a73a134bb336cb301f4de4e8855cae50efb099e384e')
++        '13216615c01b8d48d17889ffa22668c38568870d83ab30c542eb5b5620db305f02efb1acb99d9b5e89eb0a73a134bb336cb301f4de4e8855cae50efb099e384e'
++        '46f1da76ade029d6c1e047e968f75a19b6edcb57616f4d42227593779a5a6ac1029a5a217e1afa107f5775532359fef5e4f7d19f7ec5ef28f2eb3ffb5b1912aa'
++        'abb06894e5a17dc89cad4e2b71eeef97d917ad3b5c728197775426c9d548097f5dd374f121d66ea5317ebea667a4ed370db8d3f3a0cdd20fe91057ed87a218f3')
+ 
+ prepare() {
+   cd jfx-${pkgver//.u/-}
+@@ -65,6 +70,8 @@ prepare() {
+   ln -sf ../gradle.properties .
+   patch -Np1 -i ../java-openjfx-flags.patch
+   patch -Np1 -i ../java-openjfx-no-xlocale.patch
++  patch -Np1 -i ../add-loongarch64-build.patch
++  patch -Np1 -i ../add-riscv64-build.patch
+   sed 's|, "-Werror"||g' -i buildSrc/linux.gradle
+ }
+ 
+@@ -75,7 +82,8 @@ build() {
+   # build against ffmpeg4.4
+   export PKG_CONFIG_PATH='/usr/lib/ffmpeg4.4/pkgconfig'
+ 
+-  gradle zips
++  chmod +x gradlew
++  ./gradlew zips
+ }
+ 
+ package_java-openjfx() {


### PR DESCRIPTION
Enable riscv64 build.

- Also applied loongarch64 patch so that we can use the provided scaffold for porting.
- Uses Gradle wrapper since Gradle 8.x breaks the build.