### PR TITLE
addpatch: cjdns

### DIFF
--- a/cjdns/cjdns-add-riscv64-support.patch
+++ b/cjdns/cjdns-add-riscv64-support.patch
@@ -1,0 +1,22 @@
+diff --git a/util/ArchInfo.c b/util/ArchInfo.c
+index 1303934b..e10e658c 100644
+--- a/util/ArchInfo.c
++++ b/util/ArchInfo.c
+@@ -53,6 +53,7 @@ gcc arch.c
+ #define ArchInfo_AUDIT_ARCH_IA64 0xc0000032
+ #define ArchInfo_AUDIT_ARCH_PARISC 0x0000000f
+ #define ArchInfo_AUDIT_ARCH_MIPS64 0x80000008
++#define ArchInfo_AUDIT_ARCH_RISCV64 0xc00000f3
+ #define ArchInfo_AUDIT_ARCH_PPC64LE 0xc0000015
+ #define ArchInfo_AUDIT_ARCH_ALPHA 0xc0009026
+ #define ArchInfo_AUDIT_ARCH_MIPSEL 0x40000008
+@@ -155,6 +156,9 @@ gcc arch.c
+ #elif defined(__s390x__)
+     #define ARCH ArchInfo_AUDIT_ARCH_S390X
+     #define ARCHSTR "s390x"
++#elif defined(__riscv) && __riscv_xlen == 64
++    #define ARCH ArchInfo_AUDIT_ARCH_RISCV64
++    #define ARCHSTR "riscv64"
+ #else
+     #error architecture unknown
+ #endif

--- a/cjdns/libsodium-fix-rust-c-target.patch
+++ b/cjdns/libsodium-fix-rust-c-target.patch
@@ -1,0 +1,37 @@
+diff --git a/libsodium-sys/build.rs b/libsodium-sys/build.rs
+index 46f0cc2..7443abd 100644
+--- a/libsodium-sys/build.rs
++++ b/libsodium-sys/build.rs
+@@ -150,7 +150,7 @@ fn make_libsodium(target: &str, source_dir: &Path, install_dir: &Path) -> PathBu
+     let mut compiler = build_compiler.path().to_str().unwrap().to_string();
+     let mut cflags = build_compiler.cflags_env().into_string().unwrap();
+     let mut host_arg = format!("--host={}", target);
+-    let mut cross_compiling = target != env::var("HOST").unwrap();
++    let mut cross_compiling = target != rust_triple_to_c(env::var("HOST").unwrap());
+     if target.contains("-ios") {
+         // Determine Xcode directory path
+         let xcode_select_output = Command::new("xcode-select").arg("-p").output().unwrap();
+@@ -331,12 +331,22 @@ fn get_lib_dir() -> PathBuf {
+     get_crate_dir().join("mingw/win64/")
+ }
+ 
++// Rust and C compiler don't agree on some triples, for example riscv64 (riscv64gc
++// in Rust vs riscv64 in C).
++fn rust_triple_to_c(triple: String) -> String {
++    if triple.starts_with("riscv64gc-") {
++        triple.replacen("riscv64gc", "riscv64", 1)
++    } else {
++        triple
++    }
++}
++
+ fn build_libsodium() {
+     use std::{ffi::OsStr, fs};
+ 
+     // Determine build target triple
+     let mut out_dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+-    let target = env::var("TARGET").unwrap();
++    let target = rust_triple_to_c(env::var("TARGET").unwrap());
+     let profile = env::var("PROFILE").unwrap();
+ 
+     // Avoid issues with paths containing spaces by falling back to using a tempfile.

--- a/cjdns/riscv64.patch
+++ b/cjdns/riscv64.patch
@@ -1,0 +1,42 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,11 +14,35 @@ arch=('x86_64')
+ license=('GPL3')
+ depends=('glibc' 'sh')
+ optdepends=('nodejs: optional utilities support')
+-makedepends=('nodejs' 'python' 'libseccomp' 'util-linux' 'which' 'audit' 'rust' 'linux-headers')
++makedepends=('nodejs' 'python' 'libseccomp' 'util-linux' 'which' 'audit' 'rust' 'linux-headers' 'git')
+ install=cjdns.install
+-source=(${pkgname}-${pkgver}.tar.gz::https://github.com/cjdelisle/${pkgname}/archive/cjdns-v${pkgver}.tar.gz)
+-sha512sums=('fd22ae084edf174052b2683fc5591aeb036791b1a710f49d57cab475b1fdc7e7a2d4fcc3482d5fd401e15b8fef49a8985bea93a4b5a192c62b31647c4667b610')
+-b2sums=('06bd852cd22e93eea9f215409253270f0ba1e781a50d2c333f14c1ddac3eec4f93c02c93cb55adca26b76aab1586d85a3e559aa250ce0ddbf8ee2d6ca134b4c8')
++source=(${pkgname}-${pkgver}.tar.gz::https://github.com/cjdelisle/${pkgname}/archive/cjdns-v${pkgver}.tar.gz
++        sodiumoxide::git+https://github.com/cjdelisle/sodiumoxide.git#commit=9f6a18d40a4db253edfebac9f2ce5c22d09b1f47
++        libsodium-fix-rust-c-target.patch
++        cjdns-add-riscv64-support.patch)
++sha512sums=('fd22ae084edf174052b2683fc5591aeb036791b1a710f49d57cab475b1fdc7e7a2d4fcc3482d5fd401e15b8fef49a8985bea93a4b5a192c62b31647c4667b610'
++            'SKIP'
++            'df8f2bd742c8e0406e2e70147775a2d69ce63bc054662598c305d4ecb7058eea12f253619d89aa51c8ef794e8db3b77515e0e556725be3f5fd8fd6036f17e193'
++            '5e588c9fb6e786cb90053cb2112827ec6258c7b14e6c234f82bc583b1213ac31e7a382cc55a336e9efd0f95ba60370f0b9ebc1ed871289ae22350f441d5b6275')
++b2sums=('06bd852cd22e93eea9f215409253270f0ba1e781a50d2c333f14c1ddac3eec4f93c02c93cb55adca26b76aab1586d85a3e559aa250ce0ddbf8ee2d6ca134b4c8'
++        'SKIP'
++        'b95c448cff7ec72bd5177b62ee247d18b6f1122e715ce8c11a1c65dfc47c496cb89737c212f5c382736e74edec9e8d7ea738111711904f65678cb87de77c0c4d'
++        '9e9acda7ead57424a2d9294288350bf890deec5f033252e0130d9fde0955e5842865ac71c5213603891fd0865f5320ef8a0ec12fc429eee9265a3b9edd9d11c8')
++
++prepare() {
++  cd sodiumoxide
++  git submodule update --init --recursive
++  patch -Np1 -i ../libsodium-fix-rust-c-target.patch
++
++  cd ../${pkgname}-${pkgname}-v${pkgver}
++  patch -Np1 -i ../cjdns-add-riscv64-support.patch
++  echo -e '\n[patch."https://github.com/cjdelisle/sodiumoxide"]\nlibsodium-sys = { path = "../sodiumoxide/libsodium-sys" }' \
++    >> Cargo.toml
++  echo -e '\n[patch.crates-io]\nring = { git = "https://github.com/felixonmars/ring", branch = "0.16.20" }' \
++    >> Cargo.toml
++  cargo update -p libsodium-sys
++  cargo update -p ring
++}
+ 
+ build() {
+   cd ${pkgname}-${pkgname}-v${pkgver}


### PR DESCRIPTION
- Replace riscv64gc with riscv64 in TARGET and HOST (that passes into C compilation) in `libsodium-sys`
- Enable riscv64 build in `cjdns_sys`