### PR TITLE
addpkg: coin-or-coinutils

### DIFF
--- a/coin-or-coinutils/riscv64.patch
+++ b/coin-or-coinutils/riscv64.patch
@@ -1,0 +1,27 @@
+diff --git a/trunk/PKGBUILD b/trunk/PKGBUILD
+index fe2a5bc..f2522bc 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,12 +12,19 @@ license=(EPL)
+ depends=(zlib bzip2 glpk lapack coin-or-data-sample)
+ makedepends=(gcc-fortran doxygen)
+ groups=(coin-or)
+-source=($pkgname-$pkgver.tar.gz::https://github.com/coin-or/CoinUtils/archive/refs/tags/releases/$pkgver.tar.gz)
+-sha256sums=('202e347d1c1d2ccf5355e3c2874a4dc16500226c180b00d6677f464d80be337e')
++source=($pkgname-$pkgver.tar.gz::https://github.com/coin-or/CoinUtils/archive/refs/tags/releases/$pkgver.tar.gz
++        https://github.com/coin-or/CoinUtils/raw/aae9b0b807a920c41d7782d7bf2775afb17a12c6/config.guess
++        https://github.com/coin-or/CoinUtils/raw/aae9b0b807a920c41d7782d7bf2775afb17a12c6/config.sub)
++sha256sums=('202e347d1c1d2ccf5355e3c2874a4dc16500226c180b00d6677f464d80be337e'
++            'af8a1922c9b3c240bf2119d4ec0965a0b5ec36b1016017ba66db44b3b53e9cea'
++            'd611751fba98e807c9684d253bb02aa73d6825fe0e0b9ae3cbf258a59171c9b0')
+ 
+ build() {
+   cd CoinUtils-releases-$pkgver
+-
++  cp -f ${srcdir}/config.guess ./CoinUtils/config.guess
++  cp -f ${srcdir}/config.guess ./config.guess
++  cp -f ${srcdir}/config.sub ./CoinUtils/config.sub
++  cp -f ${srcdir}/config.sub ./config.sub 
+   ./configure --prefix=/usr --with-blas-lib='-lblas' --with-lapack-lib='-llapack' --with-glpk-lib='-lglpk' --enable-dependency-linking
+   make
+ }


### PR DESCRIPTION
Update config.guess&config.sub
Upstream updated it in master branch but did not in 2.11.8 release.