### PR TITLE
fixci: use devtools in makedeps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     container: archlinux/archlinux:latest
     steps:
       - name: Install dependencies
-        run: pacman -Syu --noconfirm git patch subversion binutils sudo
+        run: pacman -Syu --noconfirm devtools patch binutils sudo
       - name: Fix git unsafe repository
         run: git config --global --add safe.directory /__w/archriscv-packages/archriscv-packages
       - uses: actions/checkout@v3


### PR DESCRIPTION
See https://github.com/felixonmars/archriscv-packages/issues/2501
I want to add breezy to CI dependencies.
I added devtools to CI dependencies instead and removed git and subversion which are covered by devtools.