### PR TITLE
addpatch: deno

### DIFF
--- a/deno/riscv64.patch
+++ b/deno/riscv64.patch
@@ -1,0 +1,49 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -11,17 +11,42 @@ url="https://deno.land"
+ license=('MIT')
+ options=('!lto')
+ depends=('gcc-libs')
+-makedepends=('git' 'python' 'cargo' 'nodejs')
+-source=("git+https://github.com/denoland/deno.git#commit=$_commit")
+-sha512sums=('SKIP')
++makedepends=('git' 'python' 'cargo' 'nodejs' 'gn' 'ninja' 'clang' 'lld')
++source=("git+https://github.com/denoland/deno.git#commit=$_commit"
++        "git+https://github.com/denoland/rusty_v8.git#commit=1f5aa8a0c8d75d2fbe79385090db188410002332" # v0.68.0
++        "rusty-v8-support-unconventional-builds.patch::https://patch-diff.githubusercontent.com/raw/denoland/rusty_v8/pull/1209.patch")
++sha512sums=('SKIP'
++            'SKIP'
++            '5e5fa1ab4a38510d3347d98bb87394ebab246ba2b0c2bb0415f691413f76a2b4dc8f026a1330d84d175ebf45a43aa2ddeb672608a92ac75dbb49795a222c3313')
+ 
+ prepare() {
+-  cd $pkgname
++  cd rusty_v8
++  git submodule update --init --recursive
++  patch -Np1 -i ../rusty-v8-support-unconventional-builds.patch
++
++  cd ../$pkgname
+   git submodule update --init --recursive
++  echo -e "\n[patch.crates-io]\nv8 = { path = '../rusty_v8' }\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
++  cargo update -p v8
++  cargo update -p ring
+ }
+ 
+ build() {
+   cd $pkgname
++
++  local _extra_gn_args=(
++    'custom_toolchain="//build/toolchain/linux/unbundle:default"'
++    'host_toolchain="//build/toolchain/linux/unbundle:default"'
++    'v8_enable_shared_ro_heap=true'
++  )
++
++  export CC=clang CXX=clang++ AR=ar NM=nm
++  export CFLAGS="${CFLAGS//-fstack-clash-protection/}" CXXFLAGS="${CXXFLAGS//-fstack-clash-protection/}"
++  export V8_FROM_SOURCE=1
++  export CLANG_BASE_PATH=/usr
++  export GN=/usr/bin/gn NINJA=/usr/bin/ninja
++  export EXTRA_GN_ARGS="${_extra_gn_args[@]}"
++  export NO_PRINT_GN_ARGS=1
+   cargo build --release
+ }
+ 


### PR DESCRIPTION
- Patch rusty_v8 to allow passing custom GN arguments, as well as disabling printing GN arguments (it segfaults, but it is trivial for now since it only affects printing arguments, not generating) [1]

- Use system clang, lld, gn and ninja to build V8 from scratch, since there's no riscv64 prebuilt libraries available.

- Enable `v8_enable_shared_ro_heap`. This is intentially disabled by upstream [2], but we need to wait for pointer compression to meet rusty_v8's requirement [3] and disable it

[1]: https://github.com/denoland/rusty_v8/pull/1209
[2]: https://github.com/denoland/rusty_v8/blob/5dce1eaeef6457b7571b12c9c6170a362a62bb38/.gn#L52
[3]: https://github.com/denoland/rusty_v8/blob/5dce1eaeef6457b7571b12c9c6170a362a62bb38/src/binding.cc#L2907