### PR TITLE
addpatch: onednn

### DIFF
--- a/onednn/riscv64.patch
+++ b/onednn/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -21,7 +21,8 @@ build() {
+   cmake \
+       -Bbuild \
+       -GNinja \
+-      -DCMAKE_INSTALL_PREFIX="/usr"
++      -DCMAKE_INSTALL_PREFIX="/usr" \
++      -DDNNL_CPU_RUNTIME=SEQ
+   ninja -C build
+ }
+ 


### PR DESCRIPTION
Use sequential CPU runtime since it is the only supported one on riscv64.