### PR TITLE
addpkg: gnu-netcat

### DIFF
--- a/gnu-netcat/riscv64.patch
+++ b/gnu-netcat/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -13,6 +13,12 @@ provides=('netcat')
+ source=("https://downloads.sourceforge.net/sourceforge/netcat/netcat-$pkgver.tar.bz2")
+ sha256sums=('b55af0bbdf5acc02d1eb6ab18da2acd77a400bafd074489003f3df09676332bb')
+ 
++prepare() {
++  cd "${srcdir}/netcat-${pkgver}"
++  autoreconf -fiv
++  autoupdate
++}
++
+ build() {
+   cd "${srcdir}/netcat-${pkgver}"
+   ./configure --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info


### PR DESCRIPTION
Fixed `config.guess` error.

upstream: https://sourceforge.net/p/netcat/bugs/68/.

Because it seems that the sourceforge repo has not been maintained for a long time, sent a mail at the same time.