### PR TITLE
addpkg: couchdb

### DIFF
--- a/couchdb/riscv64.patch
+++ b/couchdb/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -75,7 +75,7 @@ package() {
+   install -Dm644 ${pkgname}.sysusers "${pkgdir}"/usr/lib/sysusers.d/${pkgname}.conf
+ 
+   # Remove some cruft
+-  rm -r "${pkgdir}"/usr/lib/couchdb/erts-13.1.1/{doc,include,lib,man,src}
++  rm -r "${pkgdir}"/usr/lib/couchdb/erts-13.2/{doc,include,lib,man,src}
+   rm -rv "${pkgdir}"/usr/lib/couchdb/etc/
+   rm -rv "${pkgdir}"/usr/lib/couchdb/lib/couch-${pkgver}/priv/couch_{ejson_compare,js}
+ }


### PR DESCRIPTION
Fixed `package()` error.

The origin PKGBUILD file hardcoded the version number. While building, system can't find the files.

I can't find some bash variables can replace the version number, ($pkgver is not corresponding) so I just fix it to right one. However it's also hardcoding.

I don't know whether this dispose is appropriate or not, if exists better one, please teach, thanks.

Build passed.