### PR TITLE
addpkg: xosd

### DIFF
--- a/xosd/riscv64.patch
+++ b/xosd/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -19,6 +19,8 @@ build() {
+   cd "$srcdir/$pkgname-$pkgver"
+   patch -p1 <"$srcdir"/debian/patches/25_fix_mangapges.diff
+   patch -p1 <"$srcdir"/debian/patches/328676.diff
++  cp /usr/share/autoconf/build-aux/config.guess .
++  cp /usr/share/autoconf/build-aux/config.sub .
+   ./configure --prefix=/usr --mandir=/usr/share/man
+   make
+ }


### PR DESCRIPTION
Fixed `config.guess`.

The [upstream](https://sourceforge.net/projects/libxosd/) does not have a ticket tracker to create a bug report.