### PR TITLE
addpkg: transcode

### DIFF
--- a/transcode/riscv64.patch
+++ b/transcode/riscv64.patch
@@ -1,0 +1,20 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -28,14 +28,15 @@ prepare() {
+   sed -e 's|freetype/ftglyph.h|freetype2/freetype/ftglyph.h|' -i filter/subtitler/load_font.c
+   patch -p1 -i ../transcode-gcc10.patch # Fix build with GCC 10
+   patch -p1 -i ../transcode-glibc-2.32.patch # Fix build with glibc 2.32
+-  autoreconf -vi
++  autoreconf -fvi
++  autoupdate
+ }
+ 
+ 
+ build() {
+   cd $pkgname-$pkgver
+   ./configure --prefix=/usr \
+-    --disable-sse --disable-sse2 --disable-altivec --enable-mmx \
++    --disable-sse --disable-sse2 --disable-altivec \
+     --enable-lame --enable-ogg --enable-vorbis --enable-theora \
+     --enable-libdv --enable-libxml2 --enable-v4l \
+     --enable-imagemagick --enable-libjpeg --enable-lzo --enable-mjpegtools \


### PR DESCRIPTION
- Fixed `config.guess`. (The [upstream](http://www.transcoding.org/) seems to disappear.)
- Removed the flag `--enable-mmx` of the execution of `configure` script.