### PR TITLE
addpatch: qt6-base

### DIFF
--- a/qt6-base/riscv64.patch
+++ b/qt6-base/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -54,9 +54,10 @@ build() {
+     -DFEATURE_openssl_linked=ON \
+     -DFEATURE_system_sqlite=ON \
+     -DFEATURE_system_xcb_xinput=ON \
+-    -DFEATURE_no_direct_extern_access=ON \
++    -DFEATURE_reduce_relocations=OFF \
+     -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
+     -DCMAKE_MESSAGE_LOG_LEVEL=STATUS
++# -DFEATURE_reduce_relocations=OFF for https://bugreports.qt.io/browse/QTBUG-112332
+   cmake --build build
+ }
+ 


### PR DESCRIPTION
Revert [upstream upgpkg](https://github.com/archlinux/svntogit-packages/commit/395c189970fe5b20e7f84ecd60a3bf57c34ac7d9) since `-mno-direct-extern-access` is not available on riscv64.