### PR TITLE
addpatch: neko

### DIFF
--- a/neko/riscv64.patch
+++ b/neko/riscv64.patch
@@ -1,0 +1,22 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -19,14 +19,17 @@ makedepends=(apache apr cmake git mbedtls ninja)
+ optdepends=('apache: for extending Apache with mod_neko')
+ options=(!strip)
+ source=(2023-04-10.patch
+-        "git+https://github.com/HaxeFoundation/neko#commit=ff67a696a718cba0a6bc0ec583e355272b4a5923") # tag: v2-3-0
++        "git+https://github.com/HaxeFoundation/neko#commit=ff67a696a718cba0a6bc0ec583e355272b4a5923" # tag: v2-3-0
++        "add-riscv64-support.patch::https://patch-diff.githubusercontent.com/raw/HaxeFoundation/neko/pull/285.diff")
+ b2sums=('83a08288938a294dbcd2e6c91e7912989332807375173a5f6c11ec818e3e8bad59e0f4826a6743a6a3802b4faa0c85837424a20a314c7cb9a596367283aaf564'
+-        'SKIP')
++        'SKIP'
++        '519796a02ffa2a0bf101339e0b1e643d6d78fe3a4dd555f8838fc44d575505752a6e711b99c1d2470a9d0546af9b0e039fce13c5a1de8b32e2a74d670febd512')
+ 
+ prepare() {
+   cd $pkgname
+   sed -i '/xlocale.h/d' libs/std/sys.c
+   patch -p1 -i ../2023-04-10.patch
++  patch -p1 -i ../add-riscv64-support.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
This package is deprecated upstream, but still required by Haxe.

Upstream: https://github.com/HaxeFoundation/neko/pull/285