### PR TITLE
addpkg: influx-cli

### DIFF
--- a/influx-cli/riscv64.patch
+++ b/influx-cli/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -37,7 +37,7 @@ check(){
+ 
+ package(){
+   cd "$pkgname"
+-  install -Dm755 bin/linux/amd64/influx -t "$pkgdir/usr/bin"
++  install -Dm755 bin/linux/riscv64/influx -t "$pkgdir/usr/bin"
+   install -Dm644 LICENSE -t "$pkgdir/usr/share/licenses/${pkgname}"
+   bin/linux/influx completion bash | install -Dm644 /dev/stdin "$pkgdir/usr/share/bash-completion/completions/influx-cli"
+   bin/linux/influx completion zsh | install -Dm644 /dev/stdin "$pkgdir/usr/share/zsh/site-functions/_influx-cli"


### PR DESCRIPTION
Fixed hard-code `amd64` architecture to `riscv64`  in `package()` function of PKGBUILD to let system find the files.

Build passed.