### PR TITLE
updgpatch: python-eventlet 0.33.3-1

### DIFF
--- a/python-eventlet/riscv64.patch
+++ b/python-eventlet/riscv64.patch
@@ -1,23 +1,20 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -20,17 +20,25 @@ optdepends=(
+@@ -20,17 +20,21 @@ optdepends=(
  )
  options=('!makeflags')
  source=(https://github.com/eventlet/eventlet/archive/v${pkgver}/${_pyname}-${pkgver}.tar.gz
 -        python310.patch)
 +        python310.patch
-+        "increase-test-thread-sleep-time.patch"
-+        greendns.patch::'https://patch-diff.githubusercontent.com/raw/eventlet/eventlet/pull/782.diff')
- sha512sums=('11083c4c6d38221591f89b3300b55e2715cb3e000dfc38e1ec72cb69cb1a3ee3cf4613e70ed3888a01373f80a8e2d6a7e2d0f9899305e36784dcd9db681a9bba'
++        "increase-test-thread-sleep-time.patch")
+ sha512sums=('b2e1818c7b6134be4020d2b4315bbb3db795960df76da08a490e0d952549eafb477800c884e7a99493146c1ac082aed5fb87c7e2882ee468ea42b5cc26b8517f'
 -            '07739075628ff9d140064e04189332b479f184e4647753f987b0818fa55aaca907d4880afb5cf31f980426f315e1014027dcd848551149000a12145f982cd883')
 +            '07739075628ff9d140064e04189332b479f184e4647753f987b0818fa55aaca907d4880afb5cf31f980426f315e1014027dcd848551149000a12145f982cd883'
-+            '86dffff4fee9dcd4d17cd7c7ad04908874a68e6328641f72903f2e92438b537344712957f45476b872a489ef530915fc4c67916830e557b17c6b9cdbfd5a36cd'
-+            '42fdbce589e70867321c39bbf67c19656b333729eb38d976ba7fe19a515c8072a6162c0865a646b1541b059c5436b7946e37e6a819a33d7cd052a5903bf233b1')
- b2sums=('06effe51098fd8f9de147f2b078031f11bba451713b9125efa716c38b8b5125d482473138bd2d41d9f2a60ff3cb841eb7d871405051776f8536e674f2c4e4706'
++            '86dffff4fee9dcd4d17cd7c7ad04908874a68e6328641f72903f2e92438b537344712957f45476b872a489ef530915fc4c67916830e557b17c6b9cdbfd5a36cd')
+ b2sums=('19bcd7a5adc2ef24f2637bfd9b19e68a9a268ebb7791cc9c419d9da88e5860c4cbbf6ecbaa0f3c300246584082622e6dab7ab75374f7d54f3c4a65661e22dbfd'
 -        '783445f708c12586e026f7feac982a7b6c21f86468609c375568b51ad6055977df3d0bc740f3127b9f8bc95c1c50e81aae02ca0e0be674ed4627910d39b1ef47')
 +        '783445f708c12586e026f7feac982a7b6c21f86468609c375568b51ad6055977df3d0bc740f3127b9f8bc95c1c50e81aae02ca0e0be674ed4627910d39b1ef47'
-+        'b2415a0e47894115fd785e458cd4f8972c1c2128dd815e7e12479db4b6573a01d1ad2e73d7f36463c25c0b80eb789528ee94d4a86bfd24b50d094456178700ad'
-+        'e995c3add75375607ea79d23ad5b1aa5d2138e9056a656ebdd6078d221f387374771d53ccc7c373c158f2169305968aa5b398560bfe667c5a62ecb8bf03b7450')
++        'b2415a0e47894115fd785e458cd4f8972c1c2128dd815e7e12479db4b6573a01d1ad2e73d7f36463c25c0b80eb789528ee94d4a86bfd24b50d094456178700ad')
  
  prepare() {
    cd ${_pyname}-${pkgver}
@@ -25,7 +22,6 @@
    # https://github.com/eventlet/eventlet/issues/739
    patch -Np1 -i ../python310.patch
 +  patch -Np1 -i "../increase-test-thread-sleep-time.patch"
-+  patch -Np1 -i "../greendns.patch"
    sed -r 's|(check_idle_cpu_usage\(.*,) .*\)|\1 0.8\)|g' -i tests/*_test.py
  }
  


### PR DESCRIPTION
Fix rotten.

The updated version now includes the greendns patch.