### PR TITLE
addpatch: pari

### DIFF
--- a/pari/riscv64.patch
+++ b/pari/riscv64.patch
@@ -1,0 +1,20 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -35,7 +35,7 @@ build() {
+     --mt=pthread \
+     --with-gmp
+   make all
+-  make -C Olinux-x86_64 gp-sta
++  make -C Olinux-riscv64 gp-sta
+ }
+ 
+ check() {
+@@ -46,7 +46,7 @@ check() {
+ package() {
+   cd $pkgname-$pkgver
+   make DESTDIR="$pkgdir" install
+-  make DESTDIR="$pkgdir" -C Olinux-x86_64 install-bin-sta
++  make DESTDIR="$pkgdir" -C Olinux-riscv64 install-bin-sta
+   ln -sf gp.1.gz "$pkgdir"/usr/share/man/man1/pari.1
+   chrpath -d "$pkgdir"/usr/bin/gp-*
+ }


### PR DESCRIPTION
The first build needs `nocheck`.
See #2571 for more context.