### PR TITLE
devtools-riscv64: use https://riscv.mirror.pkgbuild.com as default mirror

### DIFF
--- a/devtools-riscv64/pacman-extra-riscv64.patch
+++ b/devtools-riscv64/pacman-extra-riscv64.patch
@@ -14,23 +14,23 @@
  
  #[testing]
 -#Include = /etc/pacman.d/mirrorlist
-+#Server = https://archriscv.felixc.at/repo/$repo
++#Server = https://riscv.mirror.pkgbuild.com/repo/$repo
  
  [core]
 -Include = /etc/pacman.d/mirrorlist
-+Server = https://archriscv.felixc.at/repo/$repo
++Server = https://riscv.mirror.pkgbuild.com/repo/$repo
  
  [extra]
 -Include = /etc/pacman.d/mirrorlist
-+Server = https://archriscv.felixc.at/repo/$repo
++Server = https://riscv.mirror.pkgbuild.com/repo/$repo
  
  #[community-testing]
 -#Include = /etc/pacman.d/mirrorlist
-+#Server = https://archriscv.felixc.at/repo/$repo
++#Server = https://riscv.mirror.pkgbuild.com/repo/$repo
  
  [community]
 -Include = /etc/pacman.d/mirrorlist
-+Server = https://archriscv.felixc.at/repo/$repo
++Server = https://riscv.mirror.pkgbuild.com/repo/$repo
  
  # An example of a custom package repository.  See the pacman manpage for
  # tips on creating your own repositories.


### PR DESCRIPTION

Get better performance everywhere. And the mirror synchronization frequency is high enough.

As we do in rootfs.