### PR TITLE
addpatch: opus

### DIFF
--- a/opus/riscv64.patch
+++ b/opus/riscv64.patch
@@ -1,0 +1,20 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -39,6 +39,8 @@ build() {
+   local meson_options=(
+     -D asm=disabled
+     -D custom-modes=true
++    -D intrinsics=disabled
++    -D rtcd=disabled
+   )
+ 
+   arch-meson opus build "${meson_options[@]}"
+@@ -46,7 +48,7 @@ build() {
+ }
+ 
+ check() {
+-  meson test -C build --print-errorlogs
++  meson test -C build --print-errorlogs -t 10
+ }
+ 
+ package_opus() {


### PR DESCRIPTION
- Disable intrisics
- Increase test timeout due to poor software codec performance