### PR TITLE
upgpatch: sequoia-wot

### DIFF
--- a/sequoia-wot/riscv64.patch
+++ b/sequoia-wot/riscv64.patch
@@ -1,14 +1,10 @@
-diff --git PKGBUILD PKGBUILD
-index 0d84f194..b55ec2f4 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -15,7 +15,9 @@
+@@ -25,7 +25,7 @@ b2sums=('e4cdfb68eaf542ae8783735ca1ae40b30c2fde4e97c08583e5dcd1afcdd21494176e60a
  
  prepare() {
    cd $pkgname-v$pkgver
 -  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
-+  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
-+  cargo update -p ring
 +  cargo fetch --locked
  }
  


### PR DESCRIPTION
`ring👿` is no longer a denepdency. 😇😇😇