### PR TITLE
qemu-user-blacklist: add guile{,2.2}

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -29,13 +29,15 @@ fulcio
 gauche
 gawk
 gdk-pixbuf2
-glib-perl
 glibc
+glib-perl
 go
 gpxsee
 grep
 gssdp
 gtest
+guile
+guile2.2
 gupnp
 gupnp-igd
 gxplugins.lv2


### PR DESCRIPTION
rlimit does not seem to work properly in qemu-user, causing test-stack-overflow to eat a lot of memory and test-out-of-memory to fail.

There is a changed line of "glib-perl" because a previous modification didn't keep this file sorted.

![image](https://user-images.githubusercontent.com/18085551/236405940-d186c572-5a21-4330-a77c-2f58641550c0.png)

![image](https://user-images.githubusercontent.com/18085551/236405975-ac42b811-07dc-4349-b398-ed64d175f3d7.png)
