### PR TITLE
updpkg: meson 1.1.0

### DIFF
--- a/meson/riscv64.patch
+++ b/meson/riscv64.patch
@@ -1,22 +1,39 @@
-Index: PKGBUILD
-===================================================================
---- PKGBUILD	(revision 459439)
-+++ PKGBUILD	(working copy)
-@@ -10,12 +10,12 @@
- arch=('any')
- license=('Apache')
- depends=('python-setuptools' 'ninja')
--checkdepends=('gcc-objc' 'vala' 'rust' 'gcc-fortran' 'mono' 'boost' 'qt5-base' 'git' 'cython'
-+checkdepends=('gcc-objc' 'vala' 'rust' 'gcc-fortran' 'boost' 'qt5-base' 'git' 'cython'
-               'gtkmm3' 'gtest' 'gmock' 'protobuf' 'wxgtk3' 'python-gobject' 'gobject-introspection'
--              'itstool' 'gtk3' 'java-environment=8' 'gtk-doc' 'llvm' 'clang' 'sdl2' 'graphviz'
--              'doxygen' 'vulkan-validation-layers' 'openssh' 'mercurial' 'gtk-sharp-2' 'qt5-tools'
--              'libwmf' 'valgrind' 'cmake' 'netcdf-fortran' 'openmpi' 'nasm' 'gnustep-base' 'libelf'
--              'python-pytest-xdist' 'ldc' 'rust-bindgen' 'cuda' 'hotdoc')
-+              'itstool' 'gtk3' 'gtk-doc' 'llvm' 'clang' 'sdl2' 'graphviz'
-+              'doxygen' 'vulkan-validation-layers' 'openssh' 'mercurial' 'qt5-tools'
-+              'libwmf' 'cmake' 'netcdf-fortran' 'openmpi' 'nasm' 'gnustep-base' 'libelf'
-+              'python-pytest-xdist' 'ldc' 'rust-bindgen' 'hotdoc')
- source=(https://github.com/mesonbuild/meson/releases/download/${pkgver}/meson-${pkgver}.tar.gz{,.asc}
-         0001-Skip-broken-tests.patch
-         arch-meson)
+diff --git PKGBUILD PKGBUILD
+index 8acfbfd9..371f5b04 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -24,7 +24,6 @@ checkdepends=(
+   boost
+   clang
+   cmake
+-  cuda
+   cython
+   doxygen
+   gcc-fortran
+@@ -36,18 +35,15 @@ checkdepends=(
+   graphviz
+   gtest
+   gtk-doc
+-  gtk-sharp-2
+   gtk3
+   gtkmm3
+   hotdoc
+   itstool
+-  java-environment=8
+   ldc
+   libelf
+   libwmf
+   llvm
+   mercurial
+-  mono
+   nasm
+   netcdf-fortran
+   openmpi
+@@ -61,7 +57,6 @@ checkdepends=(
+   rust-bindgen
+   sdl2
+   vala
+-  valgrind
+   vulkan-validation-layers
+   wxgtk3
+ )


### PR DESCRIPTION
 * REQUIRES SKIPPING CHECKS because `ldc` is not ready yet
 * Some other tests also fails because of outdated `gobject-introspection`, but this package depends on `meson`, forming a circular dependency. So just skip the test for now.