### PR TITLE
upgpatch: python-nodeenv

### DIFF
--- a/python-nodeenv/riscv64.patch
+++ b/python-nodeenv/riscv64.patch
@@ -1,19 +1,22 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -10,8 +10,15 @@ arch=('any')
+@@ -10,8 +10,18 @@ arch=('any')
  depends=('python-setuptools' 'make')
  optdepends=('nodejs: for --node=system')
  checkdepends=('nodejs' 'python-pytest-runner' 'python-coverage' 'python-mock')
 -source=("$pkgname-$pkgver.tar.gz::https://github.com/ekalinin/nodeenv/archive/$pkgver.tar.gz")
 -sha512sums=('1e3e4068591d51d8915de73ab0f82f04620ca628152ec5a454e7ad18001ff20b698f9818353c44b80200ab529d95fa3196a3dbc85f0c497ea49f60eaa5dc9ea7')
 +source=("$pkgname-$pkgver.tar.gz::https://github.com/ekalinin/nodeenv/archive/$pkgver.tar.gz"
-+        $pkgname-riscv64-support.patch::https://github.com/ekalinin/nodeenv/pull/313.patch)
++        "$pkgname-riscv64-support.patch::https://github.com/ekalinin/nodeenv/pull/313.diff"
++        "use-system-node-in-tests.patch")
 +sha512sums=('1e3e4068591d51d8915de73ab0f82f04620ca628152ec5a454e7ad18001ff20b698f9818353c44b80200ab529d95fa3196a3dbc85f0c497ea49f60eaa5dc9ea7'
-+            'fd5cbfb4cc6870ab9e5678ee213e15ee9442fb555bcdb2ea555c1aa338371a482f1a4be69e6546427ca2ce6a28308b9c7f9e5e39c701046ac4b0fcc6fade03a0')
++            'f6e8c582e63c13f4413840097ba695f69e1ab4994b87346a7b2f7b4f9c6b2584ea5548cb3e07528e882f3b8aee8986a02418a178a0f961f862d8af56104357b0'
++            '3a706d78a7946204995a5f6a53f265fe4a4f77dbd18340fe7479bf597010f440c4328d410cd7dd2cf832ee166122476bbcf99826a6f2733a871e2e7657dbb951')
 +
 +prepare() {
 +  cd nodeenv-$pkgver
 +  patch -p1 -Ni "$srcdir/$pkgname-riscv64-support.patch"
++  patch -p1 -Ni "$srcdir/use-system-node-in-tests.patch"
 +}
  
  build() {

--- a/python-nodeenv/use-system-node-in-tests.patch
+++ b/python-nodeenv/use-system-node-in-tests.patch
@@ -1,0 +1,13 @@
+diff --git a/tests/nodeenv_test.py b/tests/nodeenv_test.py
+index 0422cfa..eb6ca5d 100644
+--- a/tests/nodeenv_test.py
++++ b/tests/nodeenv_test.py
+@@ -23,7 +23,7 @@ def test_smoke(tmpdir):
+     subprocess.check_call([
+         # Enable coverage
+         'coverage', 'run', '-p',
+-        '-m', 'nodeenv', '--prebuilt', nenv_path,
++        '-m', 'nodeenv', '--node=system', nenv_path,
+     ])
+     assert os.path.exists(nenv_path)
+     activate = pipes.quote(os.path.join(nenv_path, 'bin', 'activate'))


### PR DESCRIPTION
- Use .diff rather than .patch in GitHub PR patch for consistent content
- Use system nodejs since riscv64 prebuilt of latest version may not be present