### PR TITLE
addpatch: java17-openjfx

### DIFF
--- a/java17-openjfx/add-riscv64-build.patch
+++ b/java17-openjfx/add-riscv64-build.patch
@@ -1,0 +1,39 @@
+diff --git a/build.gradle b/build.gradle
+index 071f2c89d6..ac4b5f423e 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -295,6 +295,7 @@ ext.ARCH_NAME = "x64"
+ ext.IS_64 = OS_ARCH.toLowerCase().contains("64")
+ ext.IS_AARCH64 = OS_ARCH.toLowerCase().contains("aarch64")
+ ext.IS_LOONGARCH64 = OS_ARCH.toLowerCase().contains("loongarch64")
++ext.IS_RISCV64 = OS_ARCH.toLowerCase().contains("riscv64")
+ ext.IS_MAC = OS_NAME.contains("mac") || OS_NAME.contains("darwin")
+ ext.IS_WINDOWS = OS_NAME.contains("windows")
+ ext.IS_LINUX = OS_NAME.contains("linux")
+@@ -310,7 +311,7 @@ if (IS_WINDOWS && OS_ARCH != "x86" && OS_ARCH != "amd64") {
+     fail("Unknown and unsupported build architecture: $OS_ARCH")
+ } else if (IS_MAC && OS_ARCH != "x86_64" && OS_ARCH != "aarch64") {
+     fail("Unknown and unsupported build architecture: $OS_ARCH")
+-} else if (IS_LINUX && OS_ARCH != "i386" && OS_ARCH != "amd64" && !IS_AARCH64 && !IS_LOONGARCH64) {
++} else if (IS_LINUX && OS_ARCH != "i386" && OS_ARCH != "amd64" && !IS_AARCH64 && !IS_LOONGARCH64 && !IS_RISCV64) {
+     fail("Unknown and unsupported build architecture: $OS_ARCH")
+ }
+ 
+@@ -319,6 +320,8 @@ if (IS_64) {
+         ARCH_NAME = "aarch64"
+     } else if (IS_LOONGARCH64) {
+         ARCH_NAME = "loongarch64"
++    } else if (IS_RISCV64) {
++        ARCH_NAME = "riscv64"
+     } else {
+         ARCH_NAME = "x64"
+     }
+@@ -3544,6 +3547,8 @@ project(":web") {
+                                 cmakeArgs = "$cmakeArgs -DCMAKE_SYSTEM_PROCESSOR=aarch64"
+                             } else if (IS_LOONGARCH64) {
+                                 cmakeArgs = "$cmakeArgs -DCMAKE_SYSTEM_PROCESSOR=loongarch64"
++                            } else if (IS_RISCV64) {
++                                cmakeArgs = "$cmakeArgs -DCMAKE_SYSTEM_PROCESSOR=riscv64"
+                             } else {
+                                 cmakeArgs = "$cmakeArgs -DCMAKE_SYSTEM_PROCESSOR=x86_64"
+                             }

--- a/java17-openjfx/riscv64.patch
+++ b/java17-openjfx/riscv64.patch
@@ -1,0 +1,44 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -31,7 +31,6 @@ makedepends=(
+   gdk-pixbuf2
+   glib2
+   gperf
+-  gradle
+   gtk2
+   gtk3
+   java-environment-openjdk=11
+@@ -53,12 +52,14 @@ source=(
+   java-openjfx-flags.patch
+   java-openjfx-no-xlocale.patch
+   java-openjfx-gstreamer-lite-gcc10-compat.patch
++  add-riscv64-build.patch
+ )
+ b2sums=('72dedc864eb5dba89228271b09b0713844c4457135978fd4988e09f17f1b571e4900948459b3d02839815e364147b110f88201a0edf1a104357892b62e4de15c'
+         'a77fd8814a5978827de01a652f7b945f3439df04606434ced8998c8d77a82985292490e6965299aeb52f9da3d8069b4091d75519bd4ec8a15f70bc6d28b13498'
+         'a56a5cfebb44cdbe3ada9c6da88fda6427a5bd1bf9fcc491df289c4f5c0e96ac3614c619aaf9428340f11e9dabf0a85fc7db4f49754c2700587cc66fc15372fd'
+         '13216615c01b8d48d17889ffa22668c38568870d83ab30c542eb5b5620db305f02efb1acb99d9b5e89eb0a73a134bb336cb301f4de4e8855cae50efb099e384e'
+-        '119fa1cc5da2cdefa22bbe9b6f76581faa74e05fa7b6e5576470fc0251c6e257f122fbba03754cc01f7c7251145cfa1cab4ffc2f9d59ff0c175a121e943a0f64')
++        '119fa1cc5da2cdefa22bbe9b6f76581faa74e05fa7b6e5576470fc0251c6e257f122fbba03754cc01f7c7251145cfa1cab4ffc2f9d59ff0c175a121e943a0f64'
++        '90fcb9dab7f05976cf4f3a793ebf25c112f477f8d39089fbe019c01301333ab24f760e17754fdb613686e5554dc62fb12c6b66b8622ec6284245786efa99a737')
+ 
+ prepare() {
+   # cd jfx-${pkgver//.u/-}
+@@ -68,6 +69,7 @@ prepare() {
+   patch -Np1 -i ../java-openjfx-flags.patch
+   patch -Np1 -i ../java-openjfx-no-xlocale.patch
+   patch -Np1 -i ../java-openjfx-gstreamer-lite-gcc10-compat.patch
++  patch -Np1 -i ../add-riscv64-build.patch
+   sed 's|, "-Werror"||g' -i buildSrc/linux.gradle
+ }
+ 
+@@ -78,7 +80,8 @@ build() {
+   # build against ffmpeg4.4
+   export PKG_CONFIG_PATH='/usr/lib/ffmpeg4.4/pkgconfig'
+ 
+-  gradle zips
++  chmod +x gradlew
++  ./gradlew zips
+ }
+ 
+ package_java17-openjfx() {


### PR DESCRIPTION
Backported java-openjfx's riscv64 patch.