### PR TITLE
qemu-user-blacklist: add digikam

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -14,6 +14,7 @@ ctags
 datovka
 dbus
 diffutils
+digikam
 dovecot
 dqlite
 element


### PR DESCRIPTION
The package checks SSE availability by reading /proc/info, which is inherited from host machine in nspawn.