### PR TITLE
fixpatch: gnu-efi

### DIFF
--- a/gnu-efi/riscv64-fix-build.patch
+++ b/gnu-efi/riscv64-fix-build.patch
@@ -1,0 +1,17 @@
+diff --git a/inc/riscv64/efibind.h b/inc/riscv64/efibind.h
+index 4fdf81d..d8b4f39 100644
+--- a/inc/riscv64/efibind.h
++++ b/inc/riscv64/efibind.h
+@@ -32,11 +32,9 @@ typedef uint16_t                UINT16;
+ typedef int16_t                 INT16;
+ typedef uint8_t                 UINT8;
+ typedef int8_t                  INT8;
++typedef char                    CHAR8;
+ typedef wchar_t                 CHAR16;
+ #define WCHAR                   CHAR16
+-#ifndef BOOLEAN
+-typedef uint8_t                 BOOLEAN;
+-#endif
+ #undef VOID
+ typedef void                    VOID;
+ typedef int64_t                 INTN;

--- a/gnu-efi/riscv64.patch
+++ b/gnu-efi/riscv64.patch
@@ -1,13 +1,27 @@
-Index: PKGBUILD
-===================================================================
---- PKGBUILD	(revision 452639)
-+++ PKGBUILD	(working copy)
-@@ -33,7 +33,7 @@
-   make -C inc
-   # unset LDFLAGS for custom linker used in apps, as we have patched our
-   # LDFLAGS in manually in prepare()
--  LDFLAGS=""
-+  LDFLAGS="--no-warn-rwx-segments"
-   make -C apps
+diff --git PKGBUILD PKGBUILD
+index f13ba2f3..7a23136b 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -10,14 +10,19 @@ license=(BSD)
+ conflicts=(gnu-efi-libs)
+ provides=(gnu-efi-libs)
+ replaces=(gnu-efi-libs)
+-source=(https://download.sourceforge.net/$pkgname/$pkgname-$pkgver.tar.bz2)
++source=(https://download.sourceforge.net/$pkgname/$pkgname-$pkgver.tar.bz2
++    riscv64-fix-build.patch)
+ options=(!lto !strip)
+-sha512sums=('0893ca234272584f889b1ae1c75341a9ceee60acfd32765daa5d704191ba00450536a287b949304c6d055d1bf125cc29e24fc41df8e5230e0da4f9d944876512')
+-b2sums=('27f8171b411a6a8a138d44d91c7e4e4291aa399562825d51a398913572119482ffeb303d7508ae13eacd2cd10b8f5098405ab16eb56243587efe93235f661285')
++sha512sums=('0893ca234272584f889b1ae1c75341a9ceee60acfd32765daa5d704191ba00450536a287b949304c6d055d1bf125cc29e24fc41df8e5230e0da4f9d944876512'
++            '260b77e0b4be0bfd4736e680910707bdebba8bc3184b26bbdeb305dc919699aa0de9320b2ffc606adf533271cde3b369f0a890fa301fab4ddf2ca586f2b9a4d4')
++b2sums=('27f8171b411a6a8a138d44d91c7e4e4291aa399562825d51a398913572119482ffeb303d7508ae13eacd2cd10b8f5098405ab16eb56243587efe93235f661285'
++        'f98702b451886098774f2ee98b1f178f2d3bbe314a9702fadcb57268e819ae8813d20f2b1b27af7b46a44010d51872c716860db021fd64c068af63e3821ccb07')
+ 
+ prepare() {
+   # -Werror, not even once
+   sed -e 's/-Werror//g' -i $pkgname-$pkgver/Make.defaults
++  cd $pkgname-$pkgver
++  patch -Np1 < $srcdir/riscv64-fix-build.patch
  }
  
+ build() {


### PR DESCRIPTION
BOOLEAN isn't a macro anymore and CHAR8 should be typedef-ed