### PR TITLE
updpatch: rust 1.69.0

### DIFF
--- a/rust/bump-bootstrap-cc.patch
+++ b/rust/bump-bootstrap-cc.patch
@@ -1,0 +1,15 @@
+diff -uprN rustc-1.69.0-src/src/bootstrap/Cargo.lock rustc-1.69.0-src.bump/src/bootstrap/Cargo.lock
+--- rustc-1.69.0-src/src/bootstrap/Cargo.lock	2023-04-16 23:39:51.000000000 +0200
++++ rustc-1.69.0-src.bump/src/bootstrap/Cargo.lock	2023-05-12 17:49:28.000607116 +0200
+@@ -78,9 +78,9 @@ version = "0.1.0"
+ 
+ [[package]]
+ name = "cc"
+-version = "1.0.73"
++version = "1.0.77"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
++checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+ 
+ [[package]]
+ name = "cfg-if"

--- a/rust/riscv64.patch
+++ b/rust/riscv64.patch
@@ -1,5 +1,5 @@
 diff --git PKGBUILD PKGBUILD
-index f52a8e0..b2822aa 100644
+index fb10da7c..b4f5bab3 100644
 --- PKGBUILD
 +++ PKGBUILD
 @@ -7,7 +7,6 @@
@@ -10,7 +10,7 @@ index f52a8e0..b2822aa 100644
    rust-musl
    rust-wasm
    rust-src
-@@ -34,7 +33,6 @@ depends=(
+@@ -37,7 +36,6 @@ depends=(
  )
  makedepends=(
    cmake
@@ -18,27 +18,32 @@ index f52a8e0..b2822aa 100644
    libffi
    lld
    llvm
-@@ -55,13 +53,15 @@ source=(
+@@ -58,13 +56,17 @@ source=(
    0001-bootstrap-Change-libexec-dir.patch
    0002-compiler-Change-LLVM-targets.patch
    0003-compiler-Use-wasm-ld-for-wasm-targets.patch
++  bump-bootstrap-cc.patch
 +  jemalloc-sys-pick.patch
  )
- b2sums=('acc31c33a4b9ed7af2866007b995a8be074fc87d31ee20540b4caa926277e5f7982c8cecd16f25d6e4fa4986f1181a30f5c0260ec6b9cf6260c742b2a94c1581'
+ b2sums=('1440ad3e7e52d1e31752c8a44f9e626b9c2b0388f7285ddbdf1d0f7802724e707daffe19c6ba4aec62c3dba0e60ec2426ebecf69268b1e20a0c89860964a64f3'
          'SKIP'
-         'dce1c2340b172753b9d56dcc9d401e4cd9c66d64721c97e256974c18f17b0489e65e3732ef4e15538ea6e07c34f1269775a51c0c7c72e63a62f41ff258ce9ec2'
-         '01dee52ef899c0545cde37b5e1ba3ecfd5def3785145ed9f440df12945885311b63ff974294c1efed65b25b01bdb5cea37d7830e8d9775daefec8c1bcd3e159b'
-         '66c5cf262c4b865cdcc238d88aad4aa46e0861de0b4e20b5e86f7f1c312f7a40df0f9477fbc494949a99f51e9eb93537c072270e9bd20dfa79eb5cbe0d850e0f'
+         'd1a029499dd221b24124b193f7d42e9cb766d4bb9c4faa61a4b60007550693c98f1d1ab6793dd16b9f5a229bc70f805d6cd5eca6e744b34c0fd2413701bc58b6'
+         '9752dc3b5fc2248c8bec4efbb3d927088d48d9416229d545a05180374549a0dda6e9d6d9a8d0a3b03437f2e3c54f9c153aab3281d46411f4c81559033b8fb04a'
+         'a92b1eb9bc4101e055f89d9810c99e6e6472b3bb27bb01f8ea8a4b35f7e25512858e1555c2807eb7e8175df22c2e7937753d6787013920f9c76587e71f8df2f4'
 -        '9f3f911088a22101f8966dc16a1ecc65da5facaad5c169d9464e721aa452dd45968d359a5b35ae74ff23bd98d44c60cb04c0b8bc89e10fb99549c1670371c902')
 +        '9f3f911088a22101f8966dc16a1ecc65da5facaad5c169d9464e721aa452dd45968d359a5b35ae74ff23bd98d44c60cb04c0b8bc89e10fb99549c1670371c902'
++        '2a92f8e5190efd4dca0a36282259caeb7cdd5dcf408c6b90276e6b22cd7a5fce4d7a405e3ca024f84742671e0f98b2ba62b4dc6722bffaa20a76ec99d5d313c1'
 +        '2ce669582737e60deb97da7c66746ed4345d4b19c41b52968afb66b37139f62fa3b12c5c17e9aaf9e5a7924237886b889efef9b6624288afa538cfd6e1798394')
- validpgpkeys=(108F66205EAEB0AAA8DD5E1C85AB96E6FA1BE5FE  # Rust Language (Tag and Release Signing Key) <rust-key@rust-lang.org>
-               474E22316ABF4785A88C6E8EA2C794A986419D8A) # Tom Stellard <tstellar@redhat.com>
- 
-@@ -79,6 +79,12 @@ prepare() {
+ validpgpkeys=(
+   108F66205EAEB0AAA8DD5E1C85AB96E6FA1BE5FE  # Rust Language (Tag and Release Signing Key) <rust-key@rust-lang.org>
+   474E22316ABF4785A88C6E8EA2C794A986419D8A  # Tom Stellard <tstellar@redhat.com>
+@@ -84,6 +86,15 @@ prepare() {
    # Use our wasm-ld
    patch -Np1 -i ../0003-compiler-Use-wasm-ld-for-wasm-targets.patch
  
++  # Bump bootstrap cc to v1.0.77
++  patch -Np1 -i ../bump-bootstrap-cc.patch
++  
 +  cd vendor/jemalloc-sys
 +  OLDSUM=`sha256sum build.rs | head -c 64`
 +  patch -Np1 -i ../../../jemalloc-sys-pick.patch
@@ -48,7 +53,7 @@ index f52a8e0..b2822aa 100644
    cat >config.toml <<END
  changelog-seen = 2
  profile = "user"
-@@ -88,9 +94,8 @@ link-shared = true
+@@ -93,9 +104,8 @@ link-shared = true
  
  [build]
  target = [
@@ -60,7 +65,7 @@ index f52a8e0..b2822aa 100644
    "wasm32-unknown-unknown",
    "wasm32-wasi",
  ]
-@@ -138,22 +143,18 @@ deny-warnings = false
+@@ -144,22 +154,18 @@ deny-warnings = false
  [dist]
  compression-formats = ["gz"]
  
@@ -87,7 +92,7 @@ index f52a8e0..b2822aa 100644
  
  [target.wasm32-unknown-unknown]
  sanitizers = false
-@@ -191,9 +192,7 @@ build() {
+@@ -200,9 +206,7 @@ build() {
  
    # rustbuild always installs copies of the shared libraries to /usr/lib,
    # overwrite them with symlinks to the per-architecture versions
@@ -98,7 +103,7 @@ index f52a8e0..b2822aa 100644
  
    mkdir -p usr/share/bash-completion
    mv etc/bash_completion.d usr/share/bash-completion/completions
-@@ -201,8 +200,7 @@ build() {
+@@ -210,8 +214,7 @@ build() {
    mkdir -p usr/share/licenses/rust
    mv -t usr/share/licenses/rust usr/share/doc/rust/{COPYRIGHT,LICENSE*}
  
@@ -108,7 +113,7 @@ index f52a8e0..b2822aa 100644
    _pick dest-wasm usr/lib/rustlib/wasm32-*
    _pick dest-src  usr/lib/rustlib/src
  }
-@@ -231,22 +229,6 @@ package_rust() {
+@@ -240,22 +243,6 @@ package_rust() {
    cp -a dest-rust/* "$pkgdir"
  }
  


### PR DESCRIPTION
 * Bump dependency `cc-rs` of `bootstrap` for musl-gcc to work correctly.