### PR TITLE
upgpatch: jumpy

### DIFF
--- a/jumpy/riscv64.patch
+++ b/jumpy/riscv64.patch
@@ -1,10 +1,13 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -17,7 +17,7 @@ options=('!lto')
+@@ -17,7 +17,10 @@ options=('!lto')
  
  prepare() {
    cd "$pkgname-$pkgver"
 -  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  echo -e "ring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
++  cargo update -p ring
++  cargo update -p mimalloc --precise 0.1.36
 +  cargo fetch --locked
  }
  


### PR DESCRIPTION
- fix ring issue
- update mimalloc to 0.1.36 to fix https://github.com/purpleprotocol/mimalloc_rust/issues/92
  - upstreamed: https://github.com/fishfolk/jumpy/pull/776