### PR TITLE
upgpatch: cargo-edit 0.11.11-1

### DIFF
--- a/cargo-edit/riscv64.patch
+++ b/cargo-edit/riscv64.patch
@@ -1,12 +1,10 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -17,7 +17,9 @@ b2sums=('4714269414ecc7509d8ee9dd28d705e56dc3b74486256ed95a8c93c86c6594ea1d708d5
+@@ -17,7 +17,7 @@ b2sums=('b576b93a28e55ce3c6c6a77efd4c4db157a94a60400b42b4cdc4a3ed598b089faec8c5c
  prepare() {
    cd "${pkgname}-${pkgver}"
    sed -i '/\"vendored-libgit2\"/d' Cargo.toml
 -  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
-+  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
-+  cargo update -p ring
 +  cargo fetch --locked
  }
  


### PR DESCRIPTION
`ring` dependency is excluded from unsupported platforms.

Test case depends on Cargo's output, which differs from 1.68 to 1.69. This PR should be merged after successfully building Rust 1.69.