### PR TITLE
addpatch: python-jupyter-client

### DIFF
--- a/python-jupyter-client/riscv64.patch
+++ b/python-jupyter-client/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -25,7 +25,7 @@ build() {
+ 
+ check() {
+   cd $_pyname-$pkgver
+-  pytest -v
++  pytest -v --deselect tests/test_client.py::TestAsyncKernelClient::test_input_request
+ }
+ 
+ package() {


### PR DESCRIPTION
Deselect a failing test that seems to be inappropriately constructed.

This test is added in https://github.com/jupyter/jupyter_client/pull/877. Its code is not platform dependent but upstream claims that it only works with cpython on ubuntu in ci.

Close #2519