### PR TITLE
addpatch: python-wxpython 4.2.0

### DIFF
--- a/python-wxpython/riscv64.patch
+++ b/python-wxpython/riscv64.patch
@@ -1,0 +1,23 @@
+Index: PKGBUILD
+===================================================================
+--- PKGBUILD	(revision 1461545)
++++ PKGBUILD	(working copy)
+@@ -18,9 +18,16 @@
+ optdepends=('python-pypubsub: Alternative to the deprecated wx.lib.pubsub API')
+ makedepends=('mesa' 'glu' 'webkit2gtk' 'python-requests' 'python-setuptools' 'python-attrdict' 'sip' 'doxygen' 'waf')
+ checkdepends=('xorg-server-xvfb' 'python-pytest-forked' 'python-numpy')
+-source=("https://files.pythonhosted.org/packages/source/w/wxPython/wxPython-$pkgver.tar.gz")
+-sha512sums=('9ec937a024efb2916403c84382a66004f0c2bb07471246b7de517778309ce459e929eeb59e261f538d3fa077c950628de62e49a3760fbd03ab9ff2114c6f354f')
++source=("https://files.pythonhosted.org/packages/source/w/wxPython/wxPython-$pkgver.tar.gz"
++        "remove-deprecated-setuptools-options.patch::https://github.com/wxWidgets/Phoenix/commit/87b606aa041eba8274d6ca50da015f92070d74c6.patch")
++sha512sums=('9ec937a024efb2916403c84382a66004f0c2bb07471246b7de517778309ce459e929eeb59e261f538d3fa077c950628de62e49a3760fbd03ab9ff2114c6f354f'
++            'db900409dfc3542ac19347f06e6e47c68933eca5a7cd9966385b7eca124764e02d31e599a44ada9a7f9d6322738ce976097563e6305ff9ae2538ff2fab9e294d')
+ 
++prepare() {
++  cd $_pkgname-$pkgver
++  patch -Np1 -i ../remove-deprecated-setuptools-options.patch
++}
++
+ build() {
+   cd $_pkgname-$pkgver
+ 


### PR DESCRIPTION
This package cannot be built because it uses some deprecated setuptools options. This problem occurs on x86_64 as well and I reported to ArchLinux at https://bugs.archlinux.org/task/78517 . This patch backports commit from upstream.