### PR TITLE
qemu-user-blacklist: add python-xmlsec

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -89,6 +89,7 @@ pyside6
 python
 python-green
 python-prctl
+python-xmlsec
 qalculate-qt
 qbs
 qconf


### PR DESCRIPTION
Tests segfault on qemu-user:

```
tests/test_xmlsec.py::TestModule::test_reinitialize_module PASSED        [  0%]
tests/test_constants.py::test_transform_str[__Transform('aes128-cbc', 'http://www.w3.org/2001/04/xmlenc#aes128-cbc', 16)] Fatal Python error: Segmentation fault
```