### PR TITLE
upgpkg: devtools-riscv64 1:1.0.0+patch1-1

### DIFF
--- a/devtools-riscv64/PKGBUILD
+++ b/devtools-riscv64/PKGBUILD
@@ -1,20 +1,21 @@
 # Maintainer: Xeonacid <h.dwwwwww at gmail dot com>
 
 pkgname=devtools-riscv64
-pkgver=1.5.1
+epoch=1
+pkgver=1.0.0+patch1
 pkgrel=1
 pkgdesc='Tools for Arch Linux RISC-V package maintainers'
 arch=('x86_64' 'riscv64')
 license=('GPL')
 url='https://github.com/felixonmars/archriscv-packages'
-depends=('devtools')
-depends_x86_64=('qemu-user-static')
+depends=(devtools)
+depends_x86_64=(qemu-user-static)
 source=(makepkg-riscv64.patch
         pacman-extra-riscv64.patch
         sogrep-riscv64)
-source_x86_64=('z-archriscv-qemu-riscv64.conf')
+source_x86_64=(z-archriscv-qemu-riscv64.conf)
 sha256sums=('2abae300509c2fbae0246f195fb7ffa17c4ad240052f1e60b0bc504de6149685'
-            'c7ecb5434e1594fdd0a95cac9132d3bf37e865d22e2efd9056874cdb3501a414'
+            '5c80d7f727c4cca6c3ae515dbcb9b9a69d2cae952aa520a82df97cf37432c9cc'
             '3721d7ca08eae58ef2a9de6d8f9ccf2fae1f330949bbf5f566db4c2efbd06105')
 sha256sums_x86_64=('c59273c423e815e4c27e8486632d80a768adddd172119035d48f7c2fac98a87a')
 
@@ -22,9 +23,10 @@ package() {
   install -Dm755 sogrep-riscv64 -t "$pkgdir"/usr/bin/
   ln -s /usr/bin/archbuild "$pkgdir"/usr/bin/extra-riscv64-build
 
-  patch /usr/share/devtools/makepkg-x86_64.conf -i makepkg-riscv64.patch -o makepkg-riscv64.conf
-  patch /usr/share/devtools/pacman-extra.conf -i pacman-extra-riscv64.patch -o pacman-extra-riscv64.conf
-  install -Dm644 makepkg-riscv64.conf pacman-extra-riscv64.conf -t "$pkgdir"/usr/share/devtools/
+  patch /usr/share/devtools/makepkg.conf.d/x86_64.conf -i makepkg-riscv64.patch -o riscv64.conf
+  install -Dm644 riscv64.conf -t "$pkgdir"/usr/share/devtools/makepkg.conf.d
+  patch /usr/share/devtools/pacman.conf.d/extra.conf -i pacman-extra-riscv64.patch -o extra-riscv64.conf
+  install -Dm644 extra-riscv64.conf -t "$pkgdir"/usr/share/devtools/pacman.conf.d
 
   if [[ ! "$CARCH" =~ riscv ]]; then
     install -dm755 "$pkgdir"/usr/share/devtools/setarch-aliases.d

--- a/devtools-riscv64/pacman-extra-riscv64.patch
+++ b/devtools-riscv64/pacman-extra-riscv64.patch
@@ -1,5 +1,5 @@
---- /usr/share/devtools/pacman-extra.conf	2023-03-08 01:56:48.000000000 +0200
-+++ pacman-extra-riscv64.conf	2023-03-15 07:59:42.601735222 +0200
+--- /usr/share/devtools/pacman.conf.d/extra.conf	2023-05-21 18:50:42.000000000 +0800
++++ extra-riscv64.conf	2023-05-22 10:32:48.462290337 +0800
 @@ -19,7 +19,7 @@
  #XferCommand = /usr/bin/curl -L -C - -f -o %o %u
  #XferCommand = /usr/bin/wget --passive-ftp -c -O %o %u
@@ -9,10 +9,10 @@
  
  # Pacman won't upgrade packages listed in IgnorePkg and members of IgnoreGroup
  #IgnorePkg   =
-@@ -71,19 +71,19 @@
+@@ -71,16 +71,16 @@
  # after the header, and they will be used before the default mirrors.
  
- #[testing]
+ #[core-testing]
 -#Include = /etc/pacman.d/mirrorlist
 +#Server = https://archriscv.felixc.at/repo/$repo
  
@@ -20,15 +20,11 @@
 -Include = /etc/pacman.d/mirrorlist
 +Server = https://archriscv.felixc.at/repo/$repo
  
- [extra]
--Include = /etc/pacman.d/mirrorlist
-+Server = https://archriscv.felixc.at/repo/$repo
- 
- #[community-testing]
+ #[extra-testing]
 -#Include = /etc/pacman.d/mirrorlist
 +#Server = https://archriscv.felixc.at/repo/$repo
  
- [community]
+ [extra]
 -Include = /etc/pacman.d/mirrorlist
 +Server = https://archriscv.felixc.at/repo/$repo
  


### PR DESCRIPTION
sogrep-riscv64 is not upgraded. Let's have a working devtools first and upgrade it later.