### PR TITLE
addpkg: evemu

### DIFF
--- a/evemu/riscv64.patch
+++ b/evemu/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -16,6 +16,12 @@ source=(https://www.freedesktop.org/software/$pkgname/$pkgname-$pkgver.tar.xz{,.
+ validpgpkeys=(0A75E35E0FAEE97EC769103E2F2670AC164DB36F) # Benjamin Tissoires <benjamin.tissoires@gmail.com>
+ sha256sums=('78c9400d55eeeb5ab75161360543f9376438c4da4934cb34cdda5b46021ae379'
+             'SKIP')
++
++prepare() {
++  cd $pkgname-$pkgver
++  autoreconf -fiv
++  autoupdate
++}
+  
+ build() {
+   cd $pkgname-$pkgver


### PR DESCRIPTION
Fixed `config.guess`.
Upstream url: https://gitlab.freedesktop.org/libevdev/evemu/-/issues/5.