### PR TITLE
addpatch: lurk

### DIFF
--- a/lurk/riscv64.patch
+++ b/lurk/riscv64.patch
@@ -1,0 +1,38 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -9,16 +9,31 @@ arch=('x86_64')
+ url="https://github.com/JakWai01/lurk"
+ license=('MIT' 'Apache')
+ depends=('gcc-libs')
+-makedepends=('cargo')
++makedepends=('cargo' 'git')
+ source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz"
+-        "$pkgname-$pkgver-fix-tests.patch::$url/commit/87eb4aa8bf9a551b24cec2146699cb2c22d62019.patch")
++        "$pkgname-$pkgver-fix-tests.patch::$url/commit/87eb4aa8bf9a551b24cec2146699cb2c22d62019.patch"
++        "$pkgname-add-riscv64-support.patch::https://github.com/hack3ric/lurk/commit/44cfa7df0caaae60d5a93ec52041f2da35612b7d.diff"
++        "git+https://github.com/nix-rust/nix#tag=v0.26.2"
++        "nix-add-ptrace-getregs.patch::https://patch-diff.githubusercontent.com/raw/nix-rust/nix/pull/2044.diff")
+ sha512sums=('0f19b2a529e65e5f25c84cc30380dc3c83e56faf58e469a669ae8e904b6b0abd9507132ebbce4d3841870a8bdb3225dd402681848b46a3411a2b0065663d6d60'
+-            '48861e66cfa466def8543b4edc8bb6e1b6e5ace5ae430129ca0602c231f2772fd4a8a6f041f31c5f60ea9ceac6ff731b22d3f6179c932f6a1f9c7e6ac34f8db7')
++            '48861e66cfa466def8543b4edc8bb6e1b6e5ace5ae430129ca0602c231f2772fd4a8a6f041f31c5f60ea9ceac6ff731b22d3f6179c932f6a1f9c7e6ac34f8db7'
++            '3e74ee03665fac053eae6ace51fb646f01127d6af9df5f6bfd20993db087510e3270219d773332a37169d59a11b52aff3acbc69463f4a1de8c7b6c389c728c15'
++            'SKIP'
++            'e0fa7da81ae9a337fe9f48f24ab38c6076130060cc2c836784244bc9e9274923f601dde7e703cd0c88b9a246dcb6208ef36cd3a7fdda872d56194f1905a9ea49')
+ 
+ prepare() {
++  pushd nix
++  git apply ../nix-add-ptrace-getregs.patch
++  popd
++
+   cd "$pkgname-$pkgver"
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  echo -e '\n[patch.crates-io]\nnix = { path = "../nix" }\n' >> Cargo.toml
++  cargo update -p nix
++  cargo update -p libc
++  cargo update -p syscalls
++  cargo fetch --locked
+   patch -Np1 -i "../$pkgname-$pkgver-fix-tests.patch"
++  patch -Np1 -i "../$pkgname-add-riscv64-support.patch"
+ }
+ 
+ build() {


### PR DESCRIPTION
- nix: Add `nix::sys::ptrace::{get,set}regs` for newer platforms that does not support `PTRACE_{GET,SET}REGS`
(https://github.com/nix-rust/nix/pull/2044)
- syscalls: Add riscv32 and riscv64 syscall support (https://github.com/jasonwhite/syscalls/pull/37)
- lurk: Add syscalls groups (taken from strace) and parameter lists for riscv64 (will upstream when nix's PR is merged)