### PR TITLE
updpatch: libjxl 0.8.1-2

### DIFF
--- a/libjxl/riscv64.patch
+++ b/libjxl/riscv64.patch
@@ -1,26 +1,26 @@
---- PKGBUILD	(revision 1403198)
-+++ PKGBUILD	(working copy)
-@@ -21,7 +21,8 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -21,7 +21,8 @@ source=("git+https://github.com/libjxl/libjxl.git#tag=v${pkgver}"
          'git+https://github.com/google/highway.git'
          'git+https://github.com/glennrp/libpng.git'
          'git+https://github.com/madler/zlib.git'
 -        'libjxl-testdata'::'git+https://github.com/libjxl/testdata.git')
 +        'libjxl-testdata'::'git+https://github.com/libjxl/testdata.git'
-+        'fix-atomic.patch'::'https://github.com/libjxl/libjxl/pull/2211.patch')
++        'fix-atomic.patch'::'https://github.com/libjxl/libjxl/pull/2211.diff')
  sha256sums=('SKIP'
              'SKIP'
              'SKIP'
-@@ -31,7 +32,8 @@
+@@ -31,7 +32,8 @@ sha256sums=('SKIP'
              'SKIP'
              'SKIP'
              'SKIP'
 -            'SKIP')
 +            'SKIP'
-+            '7af32fdd7c671ede03a31ccbd5eaf48d369e9b5234b7e28d25269cf939e3a29d')
++            '18cdcb0752694d3ce2ce456dc6e714bc0d4db790491a7d325abb96781452959f')
  
  prepare() {
      git -C libjxl submodule init
-@@ -43,6 +45,8 @@
+@@ -43,6 +45,8 @@ prepare() {
      git -C libjxl config --local submodule.third_party/lcms.url "${srcdir}/Little-CMS"
      git -C libjxl config --local submodule.third_party/testdata.url "${srcdir}/libjxl-testdata"
      git -C libjxl -c protocol.file.allow='always' submodule update


### PR DESCRIPTION
Use .diff instead of .patch to ensure content is unchanged.