### PR TITLE
upgpatch: java-commons-lang

### DIFF
--- a/java-commons-lang/riscv64.patch
+++ b/java-commons-lang/riscv64.patch
@@ -1,25 +1,28 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -9,10 +9,12 @@ license=('APACHE')
+@@ -9,10 +9,14 @@ license=('APACHE')
  depends=('java-runtime-headless')
  makedepends=('maven')
  source=("https://www.apache.org/dist/commons/lang/source/commons-lang3-$pkgver-src.tar.gz"{,.asc}
 -        'java-commons-lang-3.10_improve-reproducibility-of-generated-JARs.patch')
 +        'java-commons-lang-3.10_improve-reproducibility-of-generated-JARs.patch'
-+        'java-commons-lang-3.12-fix-check.patch::https://github.com/apache/commons-lang/commit/ab96fb0245702e74397f15ad49955d581af5a3d9.patch')
++        "$pkgname-3.12-fix-check-for-java-16-and-later.patch::https://github.com/apache/commons-lang/commit/ab96fb0245702e74397f15ad49955d581af5a3d9.patch"
++        "$pkgname-fix-ThreadUtilsTest-testThreadGroups.patch::https://github.com/apache/commons-lang/pull/1051.patch")
  sha512sums=('80d1b960ae0b02859be329ea60d68cef33f3c7be7ec19752b3c9cfef442adef480878317ce2cfa309a27e662e2c72cab22023eaa3702e27970a1e5d55ca43f57'
              'SKIP'
 -            'e07e11717ac80e2232a1e4161bd9bc76e7e0d5d6e8a616077fd03f06c3501010e7b5f8e67d24a69acca06df020e4a59bb2cf005163ae3ee0ab9f149cc8f1c796')
 +            'e07e11717ac80e2232a1e4161bd9bc76e7e0d5d6e8a616077fd03f06c3501010e7b5f8e67d24a69acca06df020e4a59bb2cf005163ae3ee0ab9f149cc8f1c796'
-+            'cd21eed999c50e0499bfbd2cb5cda29522612666fae8bf93199823fdb059509172277f3ed4c0a2712d28c511fc351bdc66adef4a0f3f568bf46cb365a5e3ecae')
++            'cd21eed999c50e0499bfbd2cb5cda29522612666fae8bf93199823fdb059509172277f3ed4c0a2712d28c511fc351bdc66adef4a0f3f568bf46cb365a5e3ecae'
++            '8baec46e6a6ca95107be45ec123043f2d8f47839ba107403d91756365712884017f248682c5185717e12a8ed5f52897ac41d5f2cff910f924fa8d128df0f050f')
  validpgpkeys=('B6E73D84EA4FCC47166087253FAAD2CD5ECBB314'  # Rob Tompkins <chtompki@apache.org>
                '2DB4F1EF0FA761ECC4EA935C86FDC7E2A11262CB') # Gary David Gregory (Code signing key) <ggregory@apache.org>
  
-@@ -20,6 +22,7 @@ prepare() {
+@@ -20,6 +24,8 @@ prepare() {
  	cd "commons-lang3-$pkgver-src"
  	# Remove build-dependent manifest headers from JAR (https://github.com/apache/commons-lang/pull/578)
  	patch --strip=1 --input="$srcdir/java-commons-lang-3.10_improve-reproducibility-of-generated-JARs.patch"
-+	patch -Np1 -i ../java-commons-lang-3.12-fix-check.patch
++	patch -Np1 -i ../$pkgname-3.12-fix-check-for-java-16-and-later.patch
++	patch -Np1 -i ../$pkgname-fix-ThreadUtilsTest-testThreadGroups.patch
  }
  
  build() {


### PR DESCRIPTION
Upstreamed to arch bug tracker(new comment with updated patch): https://bugs.archlinux.org/task/78492#comment218243