### PR TITLE
addpatch: glusterfs

### DIFF
--- a/glusterfs/riscv64.patch
+++ b/glusterfs/riscv64.patch
@@ -1,0 +1,19 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -20,7 +20,7 @@ backup=('etc/glusterfs/glusterd.vol'
+         'etc/glusterfs/glusterd.vol'
+         'etc/glusterfs/glusterfs-georep-logrotate'
+         'etc/glusterfs/glusterfs-logrotate')
+-depends=(fuse python libxml2 libaio liburcu attr rpcbind liburing gperftools)
++depends=(fuse python libxml2 libaio liburcu attr rpcbind liburing)
+ makedepends=(rpcsvc-proto)
+ optdepends=('glib2: qemu-block'
+ 	    'python-prettytable: gluster-georep-sshkey')
+@@ -46,6 +46,7 @@ build() {
+     --libexecdir=/usr/lib/$pkgname \
+     --with-systemddir=/usr/lib/systemd/system \
+     --with-tmpfilesdir=/usr/lib/tmpfiles.d \
++    --without-tcmalloc \
+     --enable-gnfs \
+     LEXLIB=
+   make


### PR DESCRIPTION
tcmalloc on platforms other than x86_64 has caused [problems][1], which causes libvirt's tests to fail:

```
TEST: virdrivermoduletest
 3) Test driver "storage"                                             ... libvirt:  error : internal error: Failed to load module '/home/hacker/libvirt/src/libvirt-9.3.0/build/src/libvirt_storage_backend_gluster.so': /usr/lib/libtcmalloc_minimal.so.4: cannot allocate memory in static TLS block
```

Fedora [has it disabled][2] for those platforms, so we disable it too.

[1]: https://github.com/gluster/glusterfs/issues/2913
[2]: https://src.fedoraproject.org/rpms/glusterfs/blob/rawhide/f/glusterfs.spec#_78