### PR TITLE
updpatch: python-gdstk 0.9.30-2

### DIFF
--- a/python-gdstk/riscv64.patch
+++ b/python-gdstk/riscv64.patch
@@ -1,13 +1,20 @@
-diff --git PKGBUILD PKGBUILD
-index f384906e..30d93b5d 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -15,6 +15,8 @@ sha512sums=('c89e53a8e1dbb56050f20ef1c8ebe0892747a7e75f3ba9f8aa8fde0d025a9af6690
+@@ -11,8 +11,15 @@ arch=('x86_64')
+ depends=('python-numpy')
+ makedepends=('git' 'python-setuptools' 'cmake')
+ checkdepends=('python-pytest-runner')
+-source=("git+https://github.com/heitzmann/gdstk.git#commit=$_commit")
+-sha512sums=('SKIP')
++source=("git+https://github.com/heitzmann/gdstk.git#commit=$_commit"
++        "fix-fma-test-failure.patch::https://github.com/heitzmann/gdstk/pull/177.diff")
++sha512sums=('SKIP'
++            '2e45858d939ab725184ee17093cb9c447fcad86f22864ea618fa002390983c17feb66d73b6f43a814e72389af58a7a8a647e3c68f100b1f568aa6afab3223a01')
++
++prepare() {
++  cd gdstk
++  patch -Np1 -i ../fix-fma-test-failure.patch
++}
  
  build() {
-   cd gdstk-$pkgver
-+  CFLAGS="$CFLAGS -ffp-contract=off" \
-+  CXXFLAGS="$CXXFLAGS -ffp-contract=off" \
-   python setup.py build
- }
- 
+   cd gdstk


### PR DESCRIPTION
Fix FMA test failure directly instead of using `-ffp-contract=off`.

Upstream: https://github.com/heitzmann/gdstk/pull/177