### PR TITLE
updpatch: ocaml 5.0.0-1

### DIFF
--- a/ocaml/riscv64.patch
+++ b/ocaml/riscv64.patch
@@ -1,13 +1,13 @@
-Index: PKGBUILD
-===================================================================
---- PKGBUILD	(revision 452604)
-+++ PKGBUILD	(working copy)
-@@ -20,7 +20,7 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -20,8 +20,8 @@ build() {
    cd "${srcdir}/${pkgname}-${pkgver}"
    CFLAGS+=' -ffat-lto-objects'
    CXXFLAGS+=' -ffat-lto-objects'
--  ./configure --prefix /usr --mandir /usr/share/man --disable-force-safe-string --enable-frame-pointers
-+  ./configure --prefix /usr --mandir /usr/share/man --disable-force-safe-string
-   make --debug=v world.opt
+-  ./configure --prefix /usr --mandir /usr/share/man -enable-frame-pointers
+-  make --debug=v world.opt
++  ./configure --prefix /usr --mandir /usr/share/man
++  make --debug=v world
  }
  
+ package_ocaml() {


### PR DESCRIPTION
OCaml 5.0.0 temporarily disabled native compiler support for riscv64. It is added back in an alpha version of 5.1.0.