### PR TITLE
addpatch: libdc1394

### DIFF
--- a/libdc1394/riscv64.patch
+++ b/libdc1394/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -13,6 +13,11 @@ makedepends=('doxygen')
+ source=("https://downloads.sourceforge.net/$pkgname/$pkgname-$pkgver.tar.gz")
+ sha256sums=('2b905fc9aa4eec6bdcf6a2ae5f5ba021232739f5be047dec8fe8dd6049c10fed')
+ 
++prepare() {
++  cd $pkgname-$pkgver
++  cp /usr/share/autoconf/build-aux/config.{sub,guess} ./
++}
++
+ build() {
+   cd $pkgname-$pkgver
+   ./configure --prefix=/usr --enable-doxygen-html


### PR DESCRIPTION
Fix config.{guess,sub}. Upstreamed to libdc1394-devel mailing list.

Unblocks opencv.