### PR TITLE
qemu-user-blacklist: remove pyside{2,6}

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -85,8 +85,6 @@ pyqt6-charts
 pyqt6-datavisualization
 pyqt6-networkauth
 pyqt6-webengine
-pyside2
-pyside6
 python
 python-green
 python-prctl


### PR DESCRIPTION
The stddef.h issue no longer occurs.