### PR TITLE
addpatch: arduino

### DIFF
--- a/arduino/arduino-add-riscv64-support.patch
+++ b/arduino/arduino-add-riscv64-support.patch
@@ -1,0 +1,139 @@
+diff --git a/build/build.xml b/build/build.xml
+index c4de6aecf..418be1f1e 100644
+--- a/build/build.xml
++++ b/build/build.xml
+@@ -24,6 +24,7 @@
+   <condition property="platform" value="linux64"><os family="unix" arch="amd64" /></condition>
+   <condition property="platform" value="linuxarm"><os family="unix" arch="arm" /></condition>
+   <condition property="platform" value="linuxaarch64"><os family="unix" arch="aarch64" /></condition>
++  <condition property="platform" value="linuxriscv64"><os family="unix" arch="riscv64" /></condition>
+ 
+   <condition property="windows_host" value="true"><os family="windows" /></condition>
+ 
+@@ -35,6 +36,7 @@
+   <condition property="linux"><equals arg1="${platform}" arg2="linux64" /></condition>
+   <condition property="linux"><equals arg1="${platform}" arg2="linuxarm" /></condition>
+   <condition property="linux"><equals arg1="${platform}" arg2="linuxaarch64" /></condition>
++  <condition property="linux"><equals arg1="${platform}" arg2="linuxriscv64" /></condition>
+ 
+   <condition property="staging_folder" value="macosx"><equals arg1="${platform}" arg2="macosx" /></condition>
+   <condition property="staging_folder" value="windows"><equals arg1="${platform}" arg2="windows" /></condition>
+@@ -42,6 +44,7 @@
+   <condition property="staging_folder" value="linux"><equals arg1="${platform}" arg2="linux64" /></condition>
+   <condition property="staging_folder" value="linux"><equals arg1="${platform}" arg2="linuxarm" /></condition>
+   <condition property="staging_folder" value="linux"><equals arg1="${platform}" arg2="linuxaarch64" /></condition>
++  <condition property="staging_folder" value="linux"><equals arg1="${platform}" arg2="linuxriscv64" /></condition>
+ 
+   <condition property="staging_hardware_folder" value="Arduino.app/Contents/Java/hardware"><equals arg1="${platform}" arg2="macosx" /></condition>
+   <condition property="staging_hardware_folder" value="hardware"><equals arg1="${platform}" arg2="windows" /></condition>
+@@ -49,6 +52,7 @@
+   <condition property="staging_hardware_folder" value="hardware"><equals arg1="${platform}" arg2="linux64" /></condition>
+   <condition property="staging_hardware_folder" value="hardware"><equals arg1="${platform}" arg2="linuxarm" /></condition>
+   <condition property="staging_hardware_folder" value="hardware"><equals arg1="${platform}" arg2="linuxaarch64" /></condition>
++  <condition property="staging_hardware_folder" value="hardware"><equals arg1="${platform}" arg2="linuxriscv64" /></condition>
+ 
+   <condition property="arch-bits" value="32">
+     <equals arg1="${platform}" arg2="linux32"/>
+@@ -62,6 +66,9 @@
+   <condition property="arch-bits" value="64">
+     <equals arg1="${platform}" arg2="linuxaarch64"/>
+   </condition>
++  <condition property="arch-bits" value="64">
++    <equals arg1="${platform}" arg2="linuxriscv64"/>
++  </condition>
+ 
+   <condition property="launch4j-download-unpack-target-name" value="launch4j-windows"><os family="windows" /></condition>
+   <property name="launch4j-download-unpack-target-name" value="launch4j-linux"/>
+@@ -72,12 +79,14 @@
+   <property name="LINUX64_BUNDLED_JVM" value="none"/>
+   <property name="LINUXARM_BUNDLED_JVM" value="none"/>
+   <property name="LINUXAARCH64_BUNDLED_JVM" value="none"/>
++  <property name="LINUXRISCV64_BUNDLED_JVM" value="none"/>
+   <condition property="linux-bundle-jvm-task" value="noop">
+     <and>
+       <equals arg1="${LINUX32_BUNDLED_JVM}" arg2="none"/>
+       <equals arg1="${LINUX64_BUNDLED_JVM}" arg2="none"/>
+       <equals arg1="${LINUXARM_BUNDLED_JVM}" arg2="none"/>
+       <equals arg1="${LINUXAARCH64_BUNDLED_JVM}" arg2="none"/>
++      <equals arg1="${LINUXRISCV64_BUNDLED_JVM}" arg2="none"/>
+     </and>
+   </condition>
+   <condition property="linux-bundle-jvm-task" value="bundle">
+@@ -94,6 +103,9 @@
+       <not>
+         <equals arg1="${LINUXAARCH64_BUNDLED_JVM}" arg2="none"/>
+       </not>
++      <not>
++        <equals arg1="${LINUXRISCV64_BUNDLED_JVM}" arg2="none"/>
++      </not>
+     </or>
+   </condition>
+ 
+@@ -776,6 +788,23 @@
+     </antcall>
+   </target>
+ 
++  <target name="linux-libastyle-riscv64" depends="linux-build" description="Copy libastyle.so for Riscv64">
++    <antcall target="portable-${portable}">
++      <param name="parentdir" value="linux/work" />
++    </antcall>
++    <copy file="../../astyle/libastylej.so" tofile="linux/work/lib/libastylej.so" />
++    <chmod perm="755" file="linux/work/lib/libastylej.so" />
++    <copy file="../../listSerialPortsC/liblistSerialsj.so"  todir="linux/work/lib/" />
++    <chmod perm="755" file="linux/work/lib/liblistSerialsj.so" />
++  </target>
++
++  <target name="linuxriscv64-build" depends="linux-libastyle-riscv64" description="Build linux (Riscv64) version">
++    <antcall target="linux-jvm-${linux-bundle-jvm-task}">
++      <param name="JVM" value="${LINUXRISCV64_BUNDLED_JVM}"/>
++    </antcall>
++    <antcall target="build-arduino-builder" />
++  </target>
++
+   <target name="linux32-build" depends="linux-libastyle-x86" description="Build linux (32-bit) version">
+     <antcall target="linux-jvm-${linux-bundle-jvm-task}">
+       <param name="JVM" value="${LINUX32_BUNDLED_JVM}"/>
+@@ -832,6 +861,8 @@
+ 
+   <target name="linuxaarch64-run" depends="build,start"/>
+ 
++  <target name="linuxriscv64-run" depends="build,start"/>
++
+   <target name="linux32-start">
+     <exec executable="./linux/work/arduino" spawn="false" failonerror="true"/>
+   </target>
+@@ -848,6 +879,10 @@
+     <exec executable="./linux/work/arduino" spawn="false" failonerror="true"/>
+   </target>
+ 
++  <target name="linuxriscv64-start">
++    <exec executable="./linux/work/arduino" spawn="false" failonerror="true"/>
++  </target>
++
+   <target name="build-arduino-builder" unless="no_arduino_builder">
+     <property name="ARDUINO-BUILDER-EXTRA-VERSION" value="" /> <!-- default if not set already -->
+     <delete dir="${staging_folder}/arduino-builder-${platform}" includeemptydirs="true"/>
+@@ -979,6 +1014,9 @@
+   <target name="linuxaarch64-dist" depends="linux-dist"
+ 	  description="Build .tar.xz of linux aarch64 version" />
+ 
++  <target name="linuxriscv64-dist" depends="linux-dist"
++	  description="Build .tar.xz of linux riscv64 version" />
++
+   <!-- - - - - - - - -->
+   <!-- Windows       -->
+   <!-- - - - - - - - -->
+diff --git a/build/build_all_dist.bash b/build/build_all_dist.bash
+index 65e67a743..68f98c575 100755
+--- a/build/build_all_dist.bash
++++ b/build/build_all_dist.bash
+@@ -18,6 +18,9 @@ mv linux/arduino-*-linuxarm.tar.xz ../
+ ant -Djava.net.preferIPv4Stack=true -Dplatform=linuxaarch64 $@ clean dist
+ mv linux/arduino-*-linuxaarch64.tar.xz ../
+ 
++ant -Djava.net.preferIPv4Stack=true -Dplatform=linuxriscv64 $@ clean dist
++mv linux/arduino-*-linuxriscv64.tar.xz ../
++
+ ant -Djava.net.preferIPv4Stack=true -Dplatform=windows $@ clean dist
+ mv windows/arduino-*-windows.zip ../
+ 

--- a/arduino/riscv64.patch
+++ b/arduino/riscv64.patch
@@ -1,0 +1,99 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,7 +17,7 @@ arch=('x86_64')
+ url="https://github.com/arduino/Arduino"
+ license=('GPL' 'LGPL')
+ depends=('gtk3' 'desktop-file-utils' 'shared-mime-info' 'java-runtime=8' 'arduino-builder')
+-makedepends=('gtk2-compat' 'java-environment=8' 'ant' 'unzip' 'asciidoc')
++makedepends=('gtk2-compat' 'java-environment=8' 'ant' 'unzip' 'asciidoc' 'git' 'subversion')
+ optdepends=('arduino-docs: Offline documentation for arduino'
+             'arduino-avr-core: AVR core with upstream avr-gcc and avrdude')
+ options=(!strip)
+@@ -32,7 +32,13 @@ source=("${pkgname}-${pkgver}.tar.xz::https://github.com/arduino/Arduino/release
+         "https://downloads.arduino.cc/libastylej-2.05.1-5.zip.asc"
+         "https://downloads.arduino.cc/liblistSerials/liblistSerials-1.4.2-2.zip"
+         "https://downloads.arduino.cc/liblistSerials/liblistSerials-1.4.2-2.zip.asc"
+-        "arduino.sh")
++        "arduino.sh"
++        "$pkgname-add-riscv64-support.patch"
++        "git+https://github.com/arduino/listSerialPortsC#commit=e4427fa91eb09dcb27541221e134e3333311d32d"
++        "git+https://github.com/arduino/libserialport"
++        "git+https://github.com/java-native/jssc#tag=v2.8.0"
++        "arduino-astyle::git+https://github.com/arduino/astyle#commit=ad8512f5043ae752c1e07b35ef5c5fc0e7bcedb2"
++        "astyle::svn://svn.code.sf.net/p/astyle/code/tags/2.05.1")
+ sha512sums=('a7ebc544c3fdc528763dee6f31b923c889aec65139c7ff8bd5309e034cad681d089a5f5fa7fecf3b00e553f812cbfb5ae330344edabdf2cbdaa34425e3ea06ba'
+             'SKIP'
+             '17e2d07fbdca491a8d80abb6f2ceb000c68af59b755da7db70dce2d5f781204340f43365c40e641acf0b084b2073b3b056f63d68990f405adefb76887f4c5b72'
+@@ -41,11 +47,61 @@ sha512sums=('a7ebc544c3fdc528763dee6f31b923c889aec65139c7ff8bd5309e034cad681d089
+             'SKIP'
+             '5ee4ca9c3137957b4130434cd0ee740fc1747ed1e015a94e5909e2392563c87ad7b60b156aed305510ec5f6cec495b2b478d8e355a9cdef6ca6bfb3ce97badf5'
+             'SKIP'
+-            '78e2959daeb84828fe3a17b931831cf2581182ef14cc4afacdfba7c305967ebf461bf4098dbae3c07acab5a54d8ee64ba5245c8a75cd2064172bcfbf5dcc243d')
++            '78e2959daeb84828fe3a17b931831cf2581182ef14cc4afacdfba7c305967ebf461bf4098dbae3c07acab5a54d8ee64ba5245c8a75cd2064172bcfbf5dcc243d'
++            'd555d409c9f2338c10cc33ae19cf229a7acdebc91984c7d3fd164b8f7e9e0354a921af2b1d281e14d3936f4e15329123a6e099d16e5b6b3995e3c987301e0d19'
++            'SKIP'
++            'SKIP'
++            'SKIP'
++            'SKIP'
++            'SKIP')
+ validpgpkeys=('326567C1C6B288DF32CB061A95FA6F43E21188C4') # Arduino Packages <support@arduino.cc>
+ 
++prepare() {
++    # liblistSerials
++    cd listSerialPortsC
++    git submodule init
++    git config submodule.libserialport.url "$srcdir/libserialport"
++    git -c protocol.file.allow=always submodule update
++
++    # astyle
++    cd ../astyle
++    for f in `ls ../arduino-astyle/patches/*.patch` ; do
++	patch -p0 < $f
++    done
++
++    # arduino
++    cd "../arduino-${pkgver}"
++    patch -Np1 -i ../$pkgname-add-riscv64-support.patch
++}
++
+ build() {
+-    cd "arduino-${pkgver}/build"
++    # liblistSerials
++    cd listSerialPortsC/libserialport
++    JAVA_INCLUDE_PATH=/usr/lib/jvm/java-8-openjdk/include
++    ./autogen.sh
++    ./configure
++
++    make
++    cd ..
++    gcc main.c libserialport/linux_termios.c libserialport/linux.c libserialport/serialport.c -Ilibserialport/  -o listSerialC
++    gcc jnilib.c libserialport/linux_termios.c libserialport/linux.c libserialport/serialport.c -Ilibserialport/ -I$JAVA_INCLUDE_PATH -I$JAVA_INCLUDE_PATH/linux/ -shared -fPIC -o liblistSerialsj.so
++
++    # jssc
++    cd ../jssc
++    mkdir build
++    cp -r src/java/libs build
++    g++ src/cpp/_nix_based/jssc.cpp -I$JAVA_INCLUDE_PATH -I$JAVA_INCLUDE_PATH/linux/ \
++        -shared -fPIC -o build/libs/linux/libjSSC-2.8_riscv64.so -static-libstdc++ -static-libgcc
++    find src/java/jssc -type f -name '*.java' | xargs javac -d build
++    jar cf jssc-2.8.0-arduino4.jar -C build .
++
++    # astyle
++    cd ../astyle/AStyle/build/gcc
++    JAVA_HOME=/usr/lib/jvm/java-8-openjdk CFLAGS="-Os" LDFLAGS="-s" make java
++    cp bin/libastyle*.so ../../../libastylej.so
++
++    # arduino
++    cd "../../../../arduino-${pkgver}/build"
+ 
+     # Compile with java8
+     export PATH=/usr/lib/jvm/default/bin/:"$PATH"
+@@ -69,6 +125,8 @@ package() {
+     # Copy the whole SDK
+     cp -a . "${pkgdir}/usr/share/arduino"
+ 
++    cp "${srcdir}/jssc/jssc-2.8.0-arduino4.jar" "${pkgdir}/usr/share/arduino/lib"
++
+     # Create wrapper for java8 + buider and documentation symlink
+     install -Dm755 "${srcdir}/arduino.sh" "${pkgdir}/usr/bin/arduino"
+ 


### PR DESCRIPTION
- Patch build.xml to add riscv64 support
- No prebuilt astyle and listSerialPortsC available so we build them ourselves.
  - Pin the source to a commit because upstream didn't create new tags for them.
- I prefer not to upstream the patch as upstream previously didn't accept the powerpc port.