### PR TITLE
addpatch: abletonlink

### DIFF
--- a/abletonlink/riscv64.patch
+++ b/abletonlink/riscv64.patch
@@ -1,0 +1,31 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,13 +14,16 @@ source=(
+   $pkgname-$pkgver.tar.gz::https://github.com/Ableton/$_name/archive/Link-$pkgver.tar.gz
+   $pkgname-3.0.5-devendor_asio_and_catch2.patch
+   $pkgname-3.0.5-cmake_system_paths.patch
++  fix-fma-tests.patch::https://github.com/Ableton/link/pull/134.diff
+ )
+ sha512sums=('7dd811d3b7792722a8754cd0875777b8cf4902a0babff2822a6fd997137eb5feac576263169c71fca24358189e56b5106a32ae1313b33fb6148eb845691a6438'
+             'e6f5dd22dd3c6cc770aa7b4408b3bbf3e80a5fc2fb813494e5e63aa28480d8190bec66de09a3fe5d9ef14019f5de60de8f211c58b4275394c46150747079fd27'
+-            '826a6e83b6ad859197475551b82f8391844d8d3717a1f2df4a7b16d77d47a1a557ce4c7231a68fa11b7d1112a10746e23875d387efa50af8735df150bb26a6cd')
++            '826a6e83b6ad859197475551b82f8391844d8d3717a1f2df4a7b16d77d47a1a557ce4c7231a68fa11b7d1112a10746e23875d387efa50af8735df150bb26a6cd'
++            '8ea14a8efd11095e60cab26bd46b10892f3dd59db69954c6a3192f33fa5abadba667215d2f77755677c024b89c075f41112d50ce7fbeb9b518d86fe8d9636d00')
+ b2sums=('7267712fd935a5faff65dd9e9a4137b381991007d1392fca4caa79760c74dcfad692832e0f1150678a5ffb4c3bb5b5a42445d78891bac528b704b848f5c7a9c6'
+         '47fa7fbded04df629e83859e2f8732ac1ae368ea563171c59e4a356899d1f6bd0899780ccc508dfcd059ff33bd48fa160b0b7f000fb21f89dd666bf895977fea'
+-        '63c23dddf60ebe055f9087f7fe5c7519773a3af055059025d283bb02581a25d3fd0ffec8be2aecde43fb1427400bdaadaee9d8387364d81725484ea5f38bd13a')
++        '63c23dddf60ebe055f9087f7fe5c7519773a3af055059025d283bb02581a25d3fd0ffec8be2aecde43fb1427400bdaadaee9d8387364d81725484ea5f38bd13a'
++        'c95f51d5fec7ad765dd3eab6c9b33a905048628621ae2bd7693ffb02949472e22bf6fd37953d3a5bb35fb65496ac34c94241d556ca36385c9dd428b7e720b185')
+ 
+ prepare() {
+   # use system-wide provided versions of asio and catch2
+@@ -32,6 +35,9 @@ prepare() {
+ 
+   # provide cmake integration with system-wide paths (for other projects)
+   patch -Np1 -d $_name-Link-$pkgver-system -i ../$pkgname-3.0.5-cmake_system_paths.patch
++
++  # fix FMA tests
++  patch -Np1 -d $_name-Link-$pkgver -i ../fix-fma-tests.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
Fix floating point test failure. Upstreamed to https://github.com/Ableton/link/pull/134.

Supersedes #1717.