### PR TITLE
qemu-user-blacklist: add zeromq

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -122,5 +122,6 @@ vim
 wanderlust
 wayland
 xmonk.lv2
+zeromq
 zram-generator
 zsh


### PR DESCRIPTION
`test_radio_dish` always times out on qemu-user, while passes on Unmatched.