### PR TITLE
addpkg: startup-notification

### DIFF
--- a/startup-notification/riscv64.patch
+++ b/startup-notification/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -13,6 +13,12 @@ depends=('glibc' 'libx11' 'libxcb' 'xcb-util')
+ source=("https://www.freedesktop.org/software/startup-notification/releases/$pkgname-$pkgver.tar.gz")
+ sha256sums=('3c391f7e930c583095045cd2d10eb73a64f085c7fde9d260f2652c7cb3cfbe4a')
+ 
++prepare() {
++  cd $pkgname-$pkgver
++  autoreconf -fiv
++  autoupdate
++}
++
+ build() {
+   cd $pkgname-$pkgver
+   ./configure --prefix=/usr


### PR DESCRIPTION
Fixed `config.guess`.

upstream url: https://gitlab.freedesktop.org/xdg/startup-notification/-/issues/5.