### PR TITLE
addpatch: avr-gcc

### DIFF
--- a/avr-gcc/riscv64.patch
+++ b/avr-gcc/riscv64.patch
@@ -1,0 +1,19 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -67,7 +67,6 @@ build() {
+                 --enable-checking=release \
+                 --enable-clocale=gnu \
+                 --enable-gnu-unique-object \
+-                --enable-gold \
+                 --enable-languages=c,c++ \
+                 --enable-ld=default \
+                 --enable-lto \
+@@ -83,7 +82,7 @@ build() {
+                 --with-gnu-as \
+                 --with-gnu-ld \
+                 --with-ld=/usr/bin/$_target-ld \
+-                --with-plugin-ld=ld.gold \
++                --with-plugin-ld=ld.bfd \
+                 --with-system-zlib \
+                 --with-isl \
+                 --enable-gnu-indirect-function


### PR DESCRIPTION
use bfd because we don't have gold in our binutils.

Fixes arduino sketch compiling error.