### PR TITLE
updpatch: sccache 0.5.3-1

### DIFF
--- a/sccache/riscv64.patch
+++ b/sccache/riscv64.patch
@@ -1,8 +1,6 @@
-Index: PKGBUILD
-===================================================================
---- PKGBUILD	(revision 1013105)
-+++ PKGBUILD	(working copy)
-@@ -34,6 +34,8 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -34,6 +34,8 @@ pkgver() {
  }
  
  prepare() {
@@ -11,3 +9,21 @@ Index: PKGBUILD
    cargo fetch \
      --locked \
      --manifest-path sccache/Cargo.toml
+@@ -46,7 +48,7 @@ build() {
+     --release \
+     --frozen \
+     --manifest-path sccache/Cargo.toml \
+-    --features all,dist-server,native-zlib
++    --features all,native-zlib
+ }
+ 
+ #check() {
+@@ -66,7 +68,7 @@ package() {
+     --no-track \
+     --path sccache \
+     --root "${pkgdir}"/usr \
+-    --features all,dist-server,native-zlib
++    --features all,native-zlib
+ }
+ 
+ # vim: ts=2 sw=2 et:


### PR DESCRIPTION
Disable `dist-server` feature as it is currently only supported on x86_64.