### PR TITLE
updpatch: gcc 13.1.1-1.1

### DIFF
--- a/gcc/riscv64.patch
+++ b/gcc/riscv64.patch
@@ -1,5 +1,3 @@
-diff --git PKGBUILD PKGBUILD
-index 6bc839a..3288375 100644
 --- PKGBUILD
 +++ PKGBUILD
 @@ -7,7 +7,7 @@
@@ -41,17 +39,20 @@ index 6bc839a..3288375 100644
  
  prepare() {
    [[ ! -d gcc ]] && ln -s gcc-${pkgver/+/-} gcc
-@@ -64,6 +63,9 @@ prepare() {
+@@ -64,6 +63,12 @@ prepare() {
    # Reproducible gcc-ada
    patch -Np0 < "$srcdir/gcc-ada-repro.patch"
  
 +  # Remove codes filtering default library paths to make mold work correctly
 +  patch -Np1 < ../unfilter-default-library-path.patch
 +
++  # https://github.com/golang/go/issues/57691
++  git cherry-pick -n 21a07620f4bfe38f12e6d5be8b1eeecc29fa6852
++
    mkdir -p "$srcdir/gcc-build"
    mkdir -p "$srcdir/libgccjit-build"
  }
-@@ -91,12 +93,12 @@ build() {
+@@ -91,12 +96,12 @@ build() {
        --enable-link-serialization=1
        --enable-linker-build-id
        --enable-lto
@@ -65,7 +66,7 @@ index 6bc839a..3288375 100644
        --disable-werror
    )
  
-@@ -109,7 +111,7 @@ build() {
+@@ -109,7 +114,7 @@ build() {
    CXXFLAGS=${CXXFLAGS/-Werror=format-security/}
  
    "$srcdir/gcc/configure" \
@@ -74,7 +75,7 @@ index 6bc839a..3288375 100644
      --enable-bootstrap \
      "${_confflags[@]:?_confflags unset}"
  
-@@ -122,6 +124,10 @@ build() {
+@@ -122,6 +127,10 @@ build() {
  
    # make documentation
    make -O -C $CHOST/libstdc++-v3/doc doc-man-doxygen
@@ -85,7 +86,7 @@ index 6bc839a..3288375 100644
  
    # Build libgccjit separately, to avoid building all compilers with --enable-host-shared
    # which brings a performance penalty
-@@ -157,9 +163,9 @@ check() {
+@@ -157,9 +166,9 @@ check() {
  package_gcc-libs() {
    pkgdesc='Runtime libraries shipped by GCC'
    depends=('glibc>=2.27')
@@ -97,7 +98,7 @@ index 6bc839a..3288375 100644
    replaces=($pkgname-multilib libgphobos)
  
    cd gcc-build
-@@ -172,9 +178,8 @@ package_gcc-libs() {
+@@ -172,9 +181,8 @@ package_gcc-libs() {
               libgomp \
               libitm \
               libquadmath \
@@ -109,7 +110,7 @@ index 6bc839a..3288375 100644
      make -C $CHOST/$lib DESTDIR="$pkgdir" install-toolexeclibLTLIBRARIES
    done
  
-@@ -191,18 +196,17 @@ package_gcc-libs() {
+@@ -191,18 +199,17 @@ package_gcc-libs() {
      make -C $CHOST/$lib DESTDIR="$pkgdir" install-info
    done
  
@@ -131,7 +132,7 @@ index 6bc839a..3288375 100644
    provides=($pkgname-multilib)
    replaces=($pkgname-multilib)
    options=(!emptydirs staticlibs)
-@@ -216,22 +220,18 @@ package_gcc() {
+@@ -216,22 +223,18 @@ package_gcc() {
    install -m755 -t "$pkgdir/${_libdir}/" gcc/{cc1,cc1plus,collect2,lto1}
  
    make -C $CHOST/libgcc DESTDIR="$pkgdir" install
@@ -156,7 +157,7 @@ index 6bc839a..3288375 100644
  
    make DESTDIR="$pkgdir" install-fixincludes
    make -C gcc DESTDIR="$pkgdir" install-mkheaders
-@@ -246,16 +246,11 @@ package_gcc() {
+@@ -246,16 +249,11 @@ package_gcc() {
    make -C $CHOST/libquadmath DESTDIR="$pkgdir" install-nodist_libsubincludeHEADERS
    make -C $CHOST/libsanitizer DESTDIR="$pkgdir" install-nodist_{saninclude,toolexeclib}HEADERS
    make -C $CHOST/libsanitizer/asan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
@@ -174,7 +175,7 @@ index 6bc839a..3288375 100644
  
    make -C libcpp DESTDIR="$pkgdir" install
    make -C gcc DESTDIR="$pkgdir" install-po
-@@ -264,9 +259,9 @@ package_gcc() {
+@@ -264,9 +262,9 @@ package_gcc() {
    ln -s gcc "$pkgdir"/usr/bin/cc
  
    # create cc-rs compatible symlinks
@@ -186,7 +187,7 @@ index 6bc839a..3288375 100644
    done
  
    # POSIX conformance launcher scripts for c89 and c99
-@@ -276,9 +271,6 @@ package_gcc() {
+@@ -276,9 +274,6 @@ package_gcc() {
    # install the libstdc++ man pages
    make -C $CHOST/libstdc++-v3/doc DESTDIR="$pkgdir" doc-install-man
  
@@ -196,7 +197,7 @@ index 6bc839a..3288375 100644
    # byte-compile python libraries
    python -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
    python -O -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
-@@ -298,8 +290,6 @@ package_gcc-fortran() {
+@@ -298,8 +293,6 @@ package_gcc-fortran() {
    cd gcc-build
    make -C $CHOST/libgfortran DESTDIR="$pkgdir" install-cafexeclibLTLIBRARIES \
      install-{toolexeclibDATA,nodist_fincludeHEADERS,gfor_cHEADERS}
@@ -205,7 +206,7 @@ index 6bc839a..3288375 100644
    make -C $CHOST/libgomp DESTDIR="$pkgdir" install-nodist_fincludeHEADERS
    make -C gcc DESTDIR="$pkgdir" fortran.install-{common,man,info}
    install -Dm755 gcc/f951 "$pkgdir/${_libdir}/f951"
-@@ -329,45 +319,6 @@ package_gcc-objc() {
+@@ -329,45 +322,6 @@ package_gcc-objc() {
      "$pkgdir/usr/share/licenses/$pkgname/"
  }
  
@@ -251,7 +252,7 @@ index 6bc839a..3288375 100644
  package_gcc-go() {
    pkgdesc='Go front-end for GCC'
    depends=("gcc=$pkgver-$pkgrel" libisl.so)
-@@ -377,11 +328,10 @@ package_gcc-go() {
+@@ -377,11 +331,10 @@ package_gcc-go() {
  
    cd gcc-build
    make -C $CHOST/libgo DESTDIR="$pkgdir" install-exec-am
@@ -264,7 +265,7 @@ index 6bc839a..3288375 100644
    install -Dm755 gcc/go1 "$pkgdir/${_libdir}/go1"
  
    # Install Runtime Library Exception
-@@ -390,42 +340,6 @@ package_gcc-go() {
+@@ -390,42 +343,6 @@ package_gcc-go() {
      "$pkgdir/usr/share/licenses/$pkgname/"
  }
  
@@ -307,7 +308,7 @@ index 6bc839a..3288375 100644
  package_gcc-d() {
    pkgdesc="D frontend for GCC"
    depends=("gcc=$pkgver-$pkgrel" libisl.so)
-@@ -441,7 +355,6 @@ package_gcc-d() {
+@@ -441,7 +358,6 @@ package_gcc-d() {
  
    make -C $CHOST/libphobos DESTDIR="$pkgdir" install
    rm -f "$pkgdir/usr/lib/"lib{gphobos,gdruntime}.so*


### PR DESCRIPTION
Fix libasan error for downstream projects such as Go.

Discussion: https://github.com/golang/go/issues/57691