### PR TITLE
qemu-user-blacklist: add python-setproctitle

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -88,6 +88,7 @@ pyqt6-webengine
 python
 python-green
 python-prctl
+python-setproctitle
 python-xmlsec
 qalculate-qt
 qbs


### PR DESCRIPTION
It's obvious from the log: https://archriscv.felixc.at/.status/log.htm?url=logs/python-setproctitle/python-setproctitle-1.3.2-2.log