### PR TITLE
addpatch: haskell-tasty

### DIFF
--- a/haskell-tasty/riscv64.patch
+++ b/haskell-tasty/riscv64.patch
@@ -1,0 +1,16 @@
+diff --git PKGBUILD PKGBUILD
+index bce6b08..ad1a486 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,6 +14,11 @@ makedepends=('ghc')
+ source=("https://hackage.haskell.org/packages/archive/${_hkgname}/${pkgver}/${_hkgname}-${pkgver}.tar.gz")
+ sha512sums=('88d4e13bdc6e70a865d9779c9c990b2ce98bb495dd8aa7893254d99ae87e37a696ad6930323d3c213f804bc5b18063f261cdc2f8332054fc4112068a458fa466')
+ 
++prepare() {
++    cd $_hkgname-$pkgver
++    sed -i 's/!arch(aarch64))/!arch(aarch64) \&\& !arch(riscv64))/' tasty.cabal
++}
++
+ build() {
+     cd $_hkgname-$pkgver
+ 


### PR DESCRIPTION
Don't depend on unbounded-delays for riscv64.

Upstreamed as https://github.com/UnkindPartition/tasty/pull/371