### PR TITLE
addpatch: libosmosdr 0.1.r10.gba4fd96-2

### DIFF
--- a/libosmosdr/riscv64.patch
+++ b/libosmosdr/riscv64.patch
@@ -1,0 +1,12 @@
+diff --git PKGBUILD PKGBUILD
+index 75067ac..defd01f 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -9,6 +9,7 @@
+ arch=('x86_64')
+ url='https://sdr.osmocom.org/trac/'
+ license=('GPL3')
++depends=('libusb')
+ makedepends=('git' 'cmake')
+ source=("git+https://git.osmocom.org/osmo-sdr#commit=$_commit")
+ sha512sums=('SKIP')


### PR DESCRIPTION
Upstream patch: https://bugs.archlinux.org/task/77787