### PR TITLE
updpatch: rust 1:1.70.0-1

### DIFF
--- a/rust/riscv64.patch
+++ b/rust/riscv64.patch
@@ -1,5 +1,5 @@
 diff --git PKGBUILD PKGBUILD
-index fb10da7c..b4f5bab3 100644
+index 0d6144b..18bf2ac 100644
 --- PKGBUILD
 +++ PKGBUILD
 @@ -7,7 +7,6 @@
@@ -18,42 +18,34 @@ index fb10da7c..b4f5bab3 100644
    libffi
    lld
    llvm
-@@ -58,13 +56,17 @@ source=(
+@@ -58,13 +56,15 @@ source=(
    0001-bootstrap-Change-libexec-dir.patch
    0002-compiler-Change-LLVM-targets.patch
    0003-compiler-Use-wasm-ld-for-wasm-targets.patch
 +  bump-bootstrap-cc.patch
-+  jemalloc-sys-pick.patch
  )
- b2sums=('1440ad3e7e52d1e31752c8a44f9e626b9c2b0388f7285ddbdf1d0f7802724e707daffe19c6ba4aec62c3dba0e60ec2426ebecf69268b1e20a0c89860964a64f3'
+ b2sums=('5b1fd44eaa10bf2ab76f64a3bb5c20ee4008031d05a49b0a32b3a9cb2e97d5684cf0c9a6b6883089afca6cab7a37a0a9cfa06d928ed3e6a3b6484b605e18a0f3'
          'SKIP'
-         'd1a029499dd221b24124b193f7d42e9cb766d4bb9c4faa61a4b60007550693c98f1d1ab6793dd16b9f5a229bc70f805d6cd5eca6e744b34c0fd2413701bc58b6'
-         '9752dc3b5fc2248c8bec4efbb3d927088d48d9416229d545a05180374549a0dda6e9d6d9a8d0a3b03437f2e3c54f9c153aab3281d46411f4c81559033b8fb04a'
-         'a92b1eb9bc4101e055f89d9810c99e6e6472b3bb27bb01f8ea8a4b35f7e25512858e1555c2807eb7e8175df22c2e7937753d6787013920f9c76587e71f8df2f4'
--        '9f3f911088a22101f8966dc16a1ecc65da5facaad5c169d9464e721aa452dd45968d359a5b35ae74ff23bd98d44c60cb04c0b8bc89e10fb99549c1670371c902')
-+        '9f3f911088a22101f8966dc16a1ecc65da5facaad5c169d9464e721aa452dd45968d359a5b35ae74ff23bd98d44c60cb04c0b8bc89e10fb99549c1670371c902'
-+        '2a92f8e5190efd4dca0a36282259caeb7cdd5dcf408c6b90276e6b22cd7a5fce4d7a405e3ca024f84742671e0f98b2ba62b4dc6722bffaa20a76ec99d5d313c1'
-+        '2ce669582737e60deb97da7c66746ed4345d4b19c41b52968afb66b37139f62fa3b12c5c17e9aaf9e5a7924237886b889efef9b6624288afa538cfd6e1798394')
+         '6de8373ee24ad9a5ae12b44a1288d474c8b8a1461ba54ccadbecefc87d034b6ef763b2909e2f1452fca30488504cabacad972c6ae78b240f74e47c0e01f25136'
+         '0b1c8f41144b2c9fc6528c67e6ac5ac0f4ccbbdddc3fd3ede0b83033f1745efc603c6dbc90eb64d0518832d8daf3f82e60bbcd042ff94effab1b5a499758dace'
+         '972b67b9ed47b9ff0d9f5156232ed63103a9d40617325ab99be000753c420a228a89a1ca098fa978fef14dc7eb11bb222b85d63a5d2aec444b8ebfdfca07fc67'
+-        '445802d26028848549781b9be7430f2f1cedcd0d1f960c61dbce870a66a867aff3b0c9905b4f81b6cefefd74d83a868742ec735dd9046943068ac98117d22987')
++        '445802d26028848549781b9be7430f2f1cedcd0d1f960c61dbce870a66a867aff3b0c9905b4f81b6cefefd74d83a868742ec735dd9046943068ac98117d22987'
++        '2a92f8e5190efd4dca0a36282259caeb7cdd5dcf408c6b90276e6b22cd7a5fce4d7a405e3ca024f84742671e0f98b2ba62b4dc6722bffaa20a76ec99d5d313c1')
  validpgpkeys=(
    108F66205EAEB0AAA8DD5E1C85AB96E6FA1BE5FE  # Rust Language (Tag and Release Signing Key) <rust-key@rust-lang.org>
    474E22316ABF4785A88C6E8EA2C794A986419D8A  # Tom Stellard <tstellar@redhat.com>
-@@ -84,6 +86,15 @@ prepare() {
+@@ -84,6 +84,9 @@ prepare() {
    # Use our wasm-ld
    patch -Np1 -i ../0003-compiler-Use-wasm-ld-for-wasm-targets.patch
  
 +  # Bump bootstrap cc to v1.0.77
 +  patch -Np1 -i ../bump-bootstrap-cc.patch
-+  
-+  cd vendor/jemalloc-sys
-+  OLDSUM=`sha256sum build.rs | head -c 64`
-+  patch -Np1 -i ../../../jemalloc-sys-pick.patch
-+  sed -i "s/$OLDSUM/`sha256sum build.rs | head -c 64`/g" .cargo-checksum.json
-+  cd ../..
 +
    cat >config.toml <<END
- changelog-seen = 2
  profile = "user"
-@@ -93,9 +104,8 @@ link-shared = true
+ changelog-seen = 2
+@@ -93,9 +96,8 @@ link-shared = true
  
  [build]
  target = [
@@ -65,7 +57,7 @@ index fb10da7c..b4f5bab3 100644
    "wasm32-unknown-unknown",
    "wasm32-wasi",
  ]
-@@ -144,22 +154,18 @@ deny-warnings = false
+@@ -144,22 +146,18 @@ deny-warnings = false
  [dist]
  compression-formats = ["gz"]
  
@@ -92,7 +84,7 @@ index fb10da7c..b4f5bab3 100644
  
  [target.wasm32-unknown-unknown]
  sanitizers = false
-@@ -200,9 +206,7 @@ build() {
+@@ -197,9 +195,7 @@ build() {
  
    # rustbuild always installs copies of the shared libraries to /usr/lib,
    # overwrite them with symlinks to the per-architecture versions
@@ -103,7 +95,7 @@ index fb10da7c..b4f5bab3 100644
  
    mkdir -p usr/share/bash-completion
    mv etc/bash_completion.d usr/share/bash-completion/completions
-@@ -210,8 +214,7 @@ build() {
+@@ -207,8 +203,7 @@ build() {
    mkdir -p usr/share/licenses/rust
    mv -t usr/share/licenses/rust usr/share/doc/rust/{COPYRIGHT,LICENSE*}
  
@@ -113,7 +105,7 @@ index fb10da7c..b4f5bab3 100644
    _pick dest-wasm usr/lib/rustlib/wasm32-*
    _pick dest-src  usr/lib/rustlib/src
  }
-@@ -240,22 +243,6 @@ package_rust() {
+@@ -237,22 +232,6 @@ package_rust() {
    cp -a dest-rust/* "$pkgdir"
  }
  


### PR DESCRIPTION
- update rotten patch
- jemalloc patch is no longer needed