### PR TITLE
qemu-user-blacklist: add tpm2-pkcs11

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -114,6 +114,7 @@ tiled
 tinyssh
 tmuxp
 tpm2-openssl
+tpm2-pkcs11
 tpm2-tools
 tpm2-tss
 upower


### PR DESCRIPTION
The tests failed in qemu-user but passed on Unmatched.