### PR TITLE
addpatch: openrct2

### DIFF
--- a/openrct2/riscv64.patch
+++ b/openrct2/riscv64.patch
@@ -1,0 +1,23 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -19,14 +19,18 @@ optdepends=('zenity: System dialog box support (GNOME/GTK)'
+             'alsa-lib: ALSA audio driver'
+             'libpulse: PulseAudio audio driver')
+ source=($pkgname-$pkgver.tar.gz::https://github.com/OpenRCT2/OpenRCT2/archive/v$pkgver.tar.gz
+-        googletest-fix-maybe-uninitialized.patch)
++        googletest-fix-maybe-uninitialized.patch
++        fix-64-bit-check.patch::https://patch-diff.githubusercontent.com/raw/OpenRCT2/OpenRCT2/pull/20498.diff)
+ sha256sums=('eb9e20dc0dcbf10b02b5f334a029983a0a2b43d931f95a2088a64e8b2657bab1'
+-            '6c4becab25ec1824883a4c1946d4aa4b45534b9a6199b782db7879b78178ff84')
++            '6c4becab25ec1824883a4c1946d4aa4b45534b9a6199b782db7879b78178ff84'
++            'f58f41110ccb8bc08af145410de9a61f1173a9d9878ef7a259ce2548f5224191')
+ 
+ prepare() {
+   cd "$srcdir/OpenRCT2-$pkgver"
+   mkdir build
+ 
++  patch -p1 -i ../fix-64-bit-check.patch
++
+   # add cmake command to patch googletest with https://github.com/google/googletest/pull/3024
+   sed '/URL https:\/\/github.com\/google\/googletest/ a PATCH_COMMAND patch -p1 -i ../../../../../googletest-fix-maybe-uninitialized.patch' -i test/tests/CMakeLists.txt
+ }


### PR DESCRIPTION
Fix 64-bit platform check. Upstreamed to https://patch-diff.githubusercontent.com/raw/OpenRCT2/OpenRCT2/pull/20498.diff.