### PR TITLE
upgpatch: nodejs-lts-gallium

### DIFF
--- a/nodejs-lts-gallium/riscv64.patch
+++ b/nodejs-lts-gallium/riscv64.patch
@@ -1,6 +1,6 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -43,12 +43,12 @@ build() {
+@@ -54,7 +54,7 @@ build() {
      # --shared-v8
      # --shared-http-parser
  
@@ -9,9 +9,12 @@
  }
  
  check() {
-   cd node-v${pkgver}
--  make test-only
-+  make CFLAGS="-fno-strict-aliasing $CFLAGS" CXXFLAGS="-fno-strict-aliasing $CXXFLAGS" test-only
+@@ -63,7 +63,7 @@ check() {
+   rm test/parallel/{test-https-agent-session-eviction.js,test-tls-alert.js,test-tls-cli-max-version-1.2.js,test-tls-cli-min-version-1.2.js,test-tls-cli-min-version-1.3.js,test-tls-cli-max-version-1.3.js,test-tls-cli-min-version-1.1.js,test-tls-cli-min-version-1.0.js,test-tls-getprotocol.js,test-tls-session-cache.js,test-tls-min-max-version.js}
+   rm test/wpt/test-url.js
+ 
+-  make -j1 test-only # || /bin/true
++  make -j1 CFLAGS="-fno-strict-aliasing $CFLAGS" CXXFLAGS="-fno-strict-aliasing $CXXFLAGS"  test-only # || /bin/true
  }
  
  package() {


### PR DESCRIPTION
Fix rotten. Needs nocheck as usual.