### PR TITLE
updpatch: python-pyarrow 10.0.1-2

### DIFF
--- a/python-pyarrow/riscv64.patch
+++ b/python-pyarrow/riscv64.patch
@@ -1,32 +1,13 @@
 diff --git PKGBUILD PKGBUILD
-index 8ad3017..ab8a9d8 100644
+index a1ddd1d..52e537c 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -15,11 +15,13 @@
- checkdepends=(python-brotli python-cffi python-hypothesis python-pandas python-pytest python-pytest-lazy-fixture python-pytz)
- source=(https://archive.apache.org/dist/${_pkg}/${_pkg}-${pkgver}/apache-${_pkg}-${pkgver}.tar.gz{,.asc}
-         git+https://github.com/apache/arrow-testing.git
--        tensorflow-abi.patch)
--sha256sums=(ad9a05705117c989c116bae9ac70492fe015050e1b80fb0e38fde4b5d863aaa3
--            SKIP
--            SKIP
--            d20e9cef6b18d3801a1ac1db50808631bec8097be58c194d6b036a5773e14958)
-+        tensorflow-abi.patch
-+        add-riscv-support.patch::https://github.com/apache/arrow/commit/050876c5b502e73339de4d45e9bb2b54a3b3e095.patch)
-+sha256sums=('ad9a05705117c989c116bae9ac70492fe015050e1b80fb0e38fde4b5d863aaa3'
-+            'SKIP'
-+            'SKIP'
-+            'd20e9cef6b18d3801a1ac1db50808631bec8097be58c194d6b036a5773e14958'
-+            '6c3b04143ef65ae3ade20e7684f3651092b139dc2ef5786d2ca796f4c8024a98')
+@@ -25,7 +25,7 @@ source=(
+ sha512sums=('c6198e5c9b8fe5ccd89e445c9252da44d8d7c9e0c8eb5a802fa0cabf89482fddf775ed383bac1acc9331bc3195d21df7ea02c4a73aa6ee163c2959f34175d650'
+             'SKIP'
+             'SKIP'
+-            'e94510c97884b9334a6f1fb70ad5fb92920a3b0610b9d3c64770c41148059aaa3c8100ad385e4ebc610b256af5fb8d13f6a0efdf233cbb734f753f48ee7ba07a')
++            '936a6e9e73f6fcd1128d9caa23c0d9cde1b5ff8b54a97ac5ebcba3764c2d49688f9d24a17ed3391854f1cf7f68c8d4bf4b6bfb7a0dddc888422c2455dccb5254')
  validpgpkeys=(265F80AB84FE03127E14F01125BCCA5220D84079  # Krisztian Szucs (apache) <szucs.krisztian@gmail.com>
                08D3564B7C6A9CAFBFF6A66791D18FCF079F8007) # Kouhei Sutou <kou@cozmixng.org>
  
-@@ -27,6 +29,8 @@
- prepare(){
-   cd apache-${_pkg}-${pkgver}
-   patch -p1 < ../tensorflow-abi.patch
-+  sed -i 's/cpp/python/g' ../add-riscv-support.patch
-+  patch -p1 < ../add-riscv-support.patch
- }
- 
- build(){


### PR DESCRIPTION
- riscv support patch has been merged upstream
- checksum mismatch reported as https://bugs.archlinux.org/task/79069