### PR TITLE
updpatch: gstreamer 1.22.4-2

### DIFF
--- a/gstreamer/riscv64.patch
+++ b/gstreamer/riscv64.patch
@@ -1,25 +1,29 @@
-Index: PKGBUILD
-===================================================================
---- PKGBUILD	(revision 437782)
-+++ PKGBUILD	(working copy)
-@@ -10,7 +10,6 @@
+diff --git PKGBUILD PKGBUILD
+index db927c2..5ff1936 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -10,11 +10,9 @@ pkgname=(
    gst-plugins-good
    gst-plugins-bad
    gst-plugin-gtk
 -  gst-plugin-msdk
    gst-plugin-opencv
+   gst-plugin-qml6
    gst-plugin-qmlgl
+-  gst-plugin-qsv
    gst-plugin-va
-@@ -50,7 +49,7 @@
+   gst-plugin-wpe
+   gst-plugins-ugly
+@@ -53,7 +51,7 @@ makedepends=(
    libltc bluez-libs libavtp libbs2b bzip2 chromaprint libdca faac faad2
-   libfdk-aac fluidsynth libgme libkate liblrdf ladspa libde265 lilv lv2
-   libmicrodns mjpegtools libmpcdec neon openal libdvdnav rtmpdump sbc soundtouch
--  spandsp libsrtp svt-hevc zvbi libnice webrtc-audio-processing wildmidi
-+  spandsp libsrtp zvbi libnice webrtc-audio-processing wildmidi
-   zxing-cpp zbar nettle libxml2 gsm libopenmpt wpewebkit libldac libfreeaptx
+   libfdk-aac fluidsynth libgme libkate liblrdf ladspa libde265 lilv libmodplug
+   lv2 libmicrodns mjpegtools libmpcdec neon openal libdvdnav rtmpdump sbc
+-  soundtouch spandsp libsrtp svt-hevc zvbi libnice webrtc-audio-processing
++  soundtouch spandsp libsrtp zvbi libnice webrtc-audio-processing
+   wildmidi zxing-cpp zbar libxml2 gsm libopenmpt wpewebkit libldac libfreeaptx
    qrencode json-glib libva libxkbcommon-x11
  
-@@ -134,6 +133,7 @@
+@@ -131,10 +129,13 @@ build() {
      -D gst-plugins-bad:iqa=disabled
      -D gst-plugins-bad:isac=disabled
      -D gst-plugins-bad:magicleap=disabled
@@ -27,24 +31,22 @@ Index: PKGBUILD
      -D gst-plugins-bad:onnx=disabled
      -D gst-plugins-bad:openh264=disabled
      -D gst-plugins-bad:openni2=disabled
-@@ -140,6 +140,7 @@
      -D gst-plugins-bad:opensles=disabled
-     -D gst-plugins-bad:package-name="Arch Linux gst-plugins-bad $pkgver-$pkgrel"
-     -D gst-plugins-bad:package-origin="https://www.archlinux.org/"
++    -D gst-plugins-bad:qsv=disabled
 +    -D gst-plugins-bad:svthevcenc=disabled
      -D gst-plugins-bad:tinyalsa=disabled
      -D gst-plugins-bad:voaacenc=disabled
      -D gst-plugins-bad:voamrwbenc=disabled
-@@ -487,7 +488,7 @@
+@@ -481,7 +482,7 @@ package_gst-plugins-bad() {
      openjpeg2 opus libdvdnav libdvdread librsvg rtmpdump sbc libsndfile libltc
-     soundtouch spandsp srt libsrtp zvbi vulkan-icd-loader libxcb wayland libwebp
-     libnice webrtc-audio-processing wildmidi x265 zbar gsm libopenmpt libldac
--    libfreeaptx qrencode json-glib libavtp libmicrodns svt-hevc zxing-cpp
-+    libfreeaptx qrencode json-glib libavtp libmicrodns zxing-cpp
+     soundtouch spandsp srt libsrtp zvbi libwebp webrtc-audio-processing wildmidi
+     x265 zbar gsm libopenmpt libldac libfreeaptx qrencode json-glib libavtp
+-    libmicrodns svt-hevc zxing-cpp
++    libmicrodns zxing-cpp
    )
  
    cd root; local files=(
-@@ -541,7 +542,6 @@
+@@ -535,7 +536,6 @@ package_gst-plugins-bad() {
      usr/lib/gstreamer-1.0/libgstspandsp.so
      usr/lib/gstreamer-1.0/libgstsrt.so
      usr/lib/gstreamer-1.0/libgstsrtp.so
@@ -52,19 +54,3 @@ Index: PKGBUILD
      usr/lib/gstreamer-1.0/libgstteletext.so
      usr/lib/gstreamer-1.0/libgsttimecode.so
      usr/lib/gstreamer-1.0/libgstttmlsubs.so
-@@ -566,15 +566,6 @@
-   ); _install
- }
- 
--package_gst-plugin-msdk() {
--  pkgdesc+=" - msdk plugin"
--  depends=("gst-plugins-bad-libs=$pkgver" libmfx libva)
--
--  cd root; local files=(
--    usr/lib/gstreamer-1.0/libgstmsdk.so
--  ); _install
--}
--
- package_gst-plugin-opencv() {
-   pkgdesc+=" - opencv plugin"
-   depends=("gst-plugins-base-libs=$pkgver" opencv)


### PR DESCRIPTION
- Disable qsv plugin as it has only x86_64 support
- Test timeouts are still present so this requires nocheck at the moment.