### PR TITLE
addpatch: stratisd

### DIFF
--- a/stratisd/riscv64.patch
+++ b/stratisd/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -18,6 +18,8 @@ b2sums=('98eaf29eed7613d8279952dfd3138e5d632a2ebc711c8da30b800a299a775001253ba29
+ 
+ prepare() {
+   cd "${pkgname}-${pkgver}"
++  echo -e '\n[patch.crates-io]\nlibmount = { git = "https://github.com/liushuyu/libmount", rev = "163b2a70d10a4b38c1653c7283c8de28aad6bd54" }\n' >> Cargo.toml
++  cargo update -p libmount
+ }
+ 
+ build() {


### PR DESCRIPTION
Replace libmount with https://github.com/liushuyu/libmount, which includes several fixes.