### PR TITLE
updpatch: sequoia-chameleon-gnupg 0.3.2-1

### DIFF
--- a/sequoia-chameleon-gnupg/riscv64.patch
+++ b/sequoia-chameleon-gnupg/riscv64.patch
@@ -1,12 +1,10 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -15,7 +15,9 @@ b2sums=('6c371b635512c5f0dce7127c3aba4fc0a0755613f9578cd9c6ed5dc8da499c9bd614015
+@@ -15,7 +15,7 @@ b2sums=('6c371b635512c5f0dce7127c3aba4fc0a0755613f9578cd9c6ed5dc8da499c9bd614015
  
  prepare() {
    cd $pkgname-v$pkgver
 -  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
-+  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
-+  cargo update -p ring
 +  cargo fetch --locked
  }
  


### PR DESCRIPTION
`ring` is no longer needed.