### PR TITLE
qemu-user-blacklist: add lmdb

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -58,6 +58,7 @@ liborcus
 libseccomp
 libsecret
 libuv
+lmdb
 m4
 mdbook
 meilisearch


### PR DESCRIPTION
Check failed on qemu-user while passed on real hardware:

```
mtest.c:50: mdb_env_open(env, "./testdb", MDB_FIXEDMAP , 0664): Operation not supported
```