### PR TITLE
addpatch: dive

### DIFF
--- a/dive/riscv64.patch
+++ b/dive/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -30,6 +30,7 @@ build() {
+ 
+ check() {
+   cd "$pkgname-$pkgver"
++  sed -i 's|go test -race|go test|' Makefile
+   make test
+ }
+ 


### PR DESCRIPTION
Go's -race is not supported on riscv64.