### PR TITLE
addpatch: dpf-plugins

### DIFF
--- a/dpf-plugins/riscv64.patch
+++ b/dpf-plugins/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -26,6 +26,7 @@ makedepends=(
+   libglvnd
+   lv2
+   projectm
++  qt5-base
+ )
+ checkdepends=(
+   lv2lint


### PR DESCRIPTION
Somehow missing Qt5 as build dependency (neither linked at runtime nor needed on x86_64)