### PR TITLE
updpatch: java11-openjdk 11.0.20.u8-2

### DIFF
--- a/java11-openjdk/riscv64.patch
+++ b/java11-openjdk/riscv64.patch
@@ -6,10 +6,10 @@
          freedesktop-jconsole.desktop
 -        freedesktop-jshell.desktop)
 +        freedesktop-jshell.desktop
-+        
++
 +        # see https://build.opensuse.org/package/show/home:Andreas_Schwab:riscv:java/java-11-openjdk
 +        java11-riscv64.patch)
- sha256sums=('25fd9ab3042a284aa4e6348969403016404bc2706a4a02c149a0054fbe477337'
+ sha256sums=('b2a37ef209ae7eaf8f34182b7c9aa3252af20a214d02970f96ce62242c805479'
              '575587ad58dfa9908f046d307b9afc7b0b2eb20a1eb454f8fdbbd539ea7b3d01'
              '2f57b7c7dd671eabe9fa10c4f1283573e99d7f7c36eccd82c95b705979a2e8cb'
 -            'f271618a8c2a892b554caf26857af41efdf0d8bcb95d57ce7ba535d6979e96da')


### PR DESCRIPTION
Fix rotten patch.