### PR TITLE
updpatch: toastify 0.5.2-1

### DIFF
--- a/toastify/riscv64.patch
+++ b/toastify/riscv64.patch
@@ -1,21 +1,13 @@
 diff --git PKGBUILD PKGBUILD
-index 4dbaf439..3c004689 100644
+index e310ed0..f7d3c7c 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -12,9 +12,15 @@ makedepends=('rust')
- source=("$url/archive/v$pkgver/$pkgname-v$pkgver.tar.gz")
- sha512sums=('ea1bd87e059c945ec69734685f3c91aa573e47665627647279dbf373f1f9db163d1803afab988fffe7ff7df6b32a6d1cf9873080516b8d87895844bd97800cc0')
+@@ -14,7 +14,7 @@ b2sums=('73dc40a9baa2cc6ea839f2aa1c005b850d642b2327ee52d4b5b481d3a9bf293801402ec
  
-+prepare() {
-+  cd $pkgname-$pkgver
-+  cargo update --package libc --precise 0.2.107
-+  cargo fetch --locked
-+}
-+
- build() {
+ prepare() {
    cd $pkgname-$pkgver
--  cargo build --release --locked
-+  cargo build --release --frozen
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  cargo fetch --locked
  }
  
- package() {
+ build() {


### PR DESCRIPTION
`libc` hack is no longer needed.