### PR TITLE
addpatch: libtg_owt 0.git23.a45d8b8-1

### DIFF
--- a/libtg_owt/riscv64.patch
+++ b/libtg_owt/riscv64.patch
@@ -1,0 +1,28 @@
+diff --git PKGBUILD PKGBUILD
+index 5766440..7b62001 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -19,11 +19,13 @@
+ source=("tg_owt::git+${url}.git#commit=${_commit}"
+         "libvpx::git+https://chromium.googlesource.com/webm/libvpx.git"
+         "libyuv::git+https://chromium.googlesource.com/libyuv/libyuv.git"
+-        "pipewire::git+https://github.com/PipeWire/pipewire.git")
++        "pipewire::git+https://github.com/PipeWire/pipewire.git"
++        "riscv.patch::https://github.com/desktop-app/tg_owt/pull/124.patch")
+ b2sums=('SKIP'
+         'SKIP'
+         'SKIP'
+-        'SKIP')
++        'SKIP'
++        'feadbeac2e0c2bc8a92ae73cc7842ba890a2f136fd435c41117ee1e7547701709d5e6ec136650c35ab068213c1adfa5352a582a9faa9deea6a56a7054b87299f')
+ 
+ prepare() {
+   cd tg_owt
+@@ -32,6 +34,7 @@
+   git config submodule.src/third_party/libyuv.url "$srcdir"/libyuv
+   git config submodule.src/third_party/pipewire.url "$srcdir"/pipewire
+   git -c protocol.file.allow=always submodule update
++  patch -Np1 -i ../riscv.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
Add support for riscv and disable RVV.
Build `telegram-desktop` after rebuilding `libtg_owt`.