### PR TITLE
upgpatch: electron22

### DIFF
--- a/electron22/riscv64.patch
+++ b/electron22/riscv64.patch
@@ -20,7 +20,7 @@
  # shellcheck disable=SC2034
  optdepends=('kde-cli-tools: file deletion support (kioclient5)'
              'libappindicator-gtk3: StatusNotifierItem support'
-@@ -87,6 +90,19 @@ source=("git+https://github.com/electron/electron.git#tag=v$pkgver"
+@@ -87,6 +90,18 @@ source=("git+https://github.com/electron/electron.git#tag=v$pkgver"
          'REVERT-roll-src-third_party-ffmpeg-m102.patch'
          'REVERT-roll-src-third_party-ffmpeg-m106.patch'
          'angle-wayland-include-protocol.patch'
@@ -36,11 +36,10 @@
 +        "$_electron-swiftshader-LLVMJIT-AddressSanitizerPass-dead-code-remove.patch"
 +        "$_electron-gclient-ignore-prebuilt-platform-specific-deps.patch"
 +        "$_electron-deps-parser.py"
-+        "git+https://chromium.googlesource.com/infra/infra"
         )
  # shellcheck disable=SC2034
  sha256sums=('SKIP'
-@@ -124,7 +140,20 @@ sha256sums=('SKIP'
+@@ -124,7 +139,19 @@ sha256sums=('SKIP'
              'bfafedebd915e1824562329a3afc8589401342eff87dba53c78502b869023b7e'
              '30df59a9e2d95dcb720357ec4a83d9be51e59cc5551365da4c0073e68ccdec44'
              '4c12d31d020799d31355faa7d1fe2a5a807f7458e7f0c374adf55edb37032152'
@@ -57,23 +56,22 @@
 +            'd901e905a9b4303e6334bf39475bcbcdf22959796954de66507857108d53570f'
 +            'cf80c0d70f8933a4495c71d7be681c1457a69d26e95d2ad41da4bb02b7cbee4c'
 +            'b28b64181c46549e94e8c26d5401b0036991c18c60040c444a262484addd0d0d'
-+            'cb8c2d8d620f95053e5de17b2234099b56c8ae6fa5868a38dbb0dbaf322e19a5'
-+            'SKIP')
++            'cb8c2d8d620f95053e5de17b2234099b56c8ae6fa5868a38dbb0dbaf322e19a5')
  
  # Possible replacements are listed in build/linux/unbundle/replace_gn_files.py
  # Keys are the names in the above script; values are the dependencies in Arch
-@@ -188,11 +217,36 @@ EOF
+@@ -188,11 +215,36 @@ EOF
    echo "Linking chromium from sources..."
    ln -s chromium-mirror src
  
 +  echo "Building build tools that doesn't have prebuilt binaries for riscv64..."
 +  export GOBIN="$HOME/bin"
-+  export PATH="$PATH:$HOME/bin" 
++  export PATH="$PATH:$HOME/bin"
 +
 +  # Install the build tools
 +  local infra_rev=$(python "$_electron-deps-parser.py" infra src/DEPS)
-+  git -C infra checkout "$infra_rev"
-+  local luci_go_rev=$(python "$_electron-deps-parser.py" luci_go infra/DEPS)
++  curl "https://chromium.googlesource.com/infra/infra/+/$infra_rev/DEPS?format=text" | base64 -d > DEPS_infra
++  local luci_go_rev=$(python "$_electron-deps-parser.py" luci_go DEPS_infra)
 +  go install "go.chromium.org/luci/swarming/cmd/...@$luci_go_rev"       # not sure if it really get used
 +  go install "go.chromium.org/luci/client/cmd/...@$luci_go_rev"         # not sure if it really get used
 +  go install "go.chromium.org/luci/cipd/client/cmd/...@$luci_go_rev"    # usage confirmed
@@ -99,7 +97,7 @@
    (
      cd src/electron || exit
      patch -Np1 -i ../../std-vector-non-const.patch
-@@ -248,11 +302,24 @@ EOF
+@@ -248,11 +300,24 @@ EOF
    filterdiff -p1 -x include/GLSLANG/ShaderLang.h < ../5d1ac2e0d5f61913aad62dadb65a7fea6f1b93ae.patch | patch -Np1 -d third_party/angle
    patch -Np1  <../dawn-tint-add-cstdint.patch -d third_party/dawn
    patch -Np1 -i ../comp-viz-add-cstdint.patch
@@ -124,26 +122,18 @@
  
    # Revert ffmpeg roll requiring new channel layout API support
    # https://crbug.com/1325301
-@@ -302,14 +369,15 @@ build() {
-   export CXX=clang++
-   export AR=ar
-   export NM=nm
-+  unset LDFLAGS
+@@ -311,6 +376,10 @@ build() {
+   CXXFLAGS+=' -Wno-builtin-macro-redefined'
+   CPPFLAGS+=' -D__DATE__=  -D__TIME__=  -D__TIMESTAMP__='
  
-   # https://github.com/webpack/webpack/issues/14532
-   export NODE_OPTIONS=--openssl-legacy-provider
- 
-   # Facilitate deterministic builds (taken from build/config/compiler/BUILD.gn)
--  CFLAGS+='   -Wno-builtin-macro-redefined'
--  CXXFLAGS+=' -Wno-builtin-macro-redefined'
--  CPPFLAGS+=' -D__DATE__=  -D__TIME__=  -D__TIMESTAMP__='
-+  export CFLAGS='   -Wno-builtin-macro-redefined'
-+  export CXXFLAGS=' -Wno-builtin-macro-redefined'
-+  export CPPFLAGS=' -D__DATE__=  -D__TIME__=  -D__TIMESTAMP__='
- 
++  # Remove flags that are causing weird bugs on riscv64
++  CFLAGS=${CFLAGS/-Wp,-D_FORTIFY_SOURCE=2}
++  CXXFLAGS=${CXXFLAGS/-Wp,-D_FORTIFY_SOURCE=2}
++
    # Let Chromium set its own symbol level
    CFLAGS=${CFLAGS/-g }
-@@ -340,7 +408,6 @@ build() {
+   CXXFLAGS=${CXXFLAGS/-g }
+@@ -340,7 +409,6 @@ build() {
      host_toolchain = "//build/toolchain/linux/unbundle:default"
      clang_base_path = "/usr"
      clang_use_chrome_plugins = false
@@ -151,7 +141,7 @@
      chrome_pgo_phase = 0
      treat_warnings_as_errors = false
      disable_fieldtrial_testing_config = true
-@@ -355,17 +422,18 @@ build() {
+@@ -355,17 +423,18 @@ build() {
      use_system_wayland_scanner = true
      icu_use_data_file = false
      is_component_ffmpeg = false


### PR DESCRIPTION
- Remove the offending compiler flag instead of unsetting all flags.
- Avoid clone the 1GB infra repo.