### PR TITLE
updpatch: busybox 1.36.1-1

### DIFF
--- a/busybox/riscv64.patch
+++ b/busybox/riscv64.patch
@@ -1,8 +1,6 @@
-Index: PKGBUILD
-===================================================================
---- PKGBUILD	(revision 1209968)
-+++ PKGBUILD	(working copy)
-@@ -9,16 +9,17 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -9,16 +9,17 @@ pkgdesc="Utilities for rescue and embedded systems"
  arch=("x86_64")
  url="https://www.busybox.net"
  license=('GPL')
@@ -12,18 +10,18 @@ Index: PKGBUILD
  validpgpkeys=('C9E9416F76E610DBD09D040F47B70C55ACC9965B')
  source=("$url/downloads/$pkgname-$pkgver.tar.bz2"{,.sig}
          "config")
- sha256sums=('415fbd89e5344c96acf449d94a6f956dbed62e18e835fc83e064db33a34bd549'
+ sha256sums=('b8cc24c9574d809e7279c3be349795c5d5ceb6fdf19ca709f80cde50e47de314'
              'SKIP'
--            '82e934fbdf143028ffb19b195e34c2171dd3b2c17d1c5e37499068ade4d5b28f')
-+            'dfd14b68b4cb71af3090060302cae979694ff469742d87a320c577f4798c7eff')
- b2sums=('1f45f58db26ae0bae2eb728db3a7d49680d611f489c4633d1fdf2827d3c33285721e232f722ac1f80f2ad7616352df9fd6b8880bcb5fa0dc6787b70c897dd033'
+-            '239001693b58e471c594952b9805c24b0d8174ba2cab245cd624e4423d993cd3')
++            '67a5d71bfc0cb33f9cc428fecf5cef6ff19f694a4da0ed2e3e803e811953d2bf')
+ b2sums=('e515825cb3ab1c520e16b9c2512e9fc72947366a72a0466bff59b507fdffbc78fc9d16b44a26116175fc7a429d849ad944b1bc379d36c6d3a0eb20969997336e'
          'SKIP'
--        'ec7ab659d02bda59be7e0eaae532e5a3e1a53f630559fe66ddadadbdebe5baf31f9f9897e73a6a6f11aa9523158331eac74803035bf84ffab27d8941c181cc61')
-+        '51db786bcc96bf81c913f7e23c4aac607e44c351b073e5288959bf6fec8dd7dc19442e3d4c2622546a17336042e5b0cf2d5b550921656752dbf0541e2c105be1')
+-        '7d4759036db05d7e0c06571e8fd24db488edf87a9b82a5382eee3fb43fc5318bbd75398e43c9b30c88b78630e910ee9a5316aaa824b5ab26f93fc1b3f834f07d')
++        'bf88f8bb38bb8ceb6393722255af9434652464958817123b6b8f1802f7c22e1e37a6cbe950a74bd483c627f7df7d4e5ddaaaedf5f0d7ca23d449a35f2111d4bd')
  
  build() {
    cd "$srcdir/$pkgname-$pkgver"
-@@ -26,7 +27,7 @@
+@@ -26,7 +27,7 @@ build() {
    cp "$srcdir"/config .config
    # reproducible build
    export KCONFIG_NOTIMESTAMP=1
@@ -32,19 +30,9 @@ Index: PKGBUILD
  }
  
  package() {
-Index: config
-===================================================================
---- config	(revision 1209968)
-+++ config	(working copy)
-@@ -1,6 +1,6 @@
- #
- # Automatically generated make config: don't edit
--# Busybox version: 1.33.1
-+# Busybox version: 1.34.1
- #
- CONFIG_HAVE_DOT_CONFIG=y
- 
-@@ -39,8 +39,8 @@
+--- config
++++ config
+@@ -39,8 +39,8 @@ CONFIG_FEATURE_SYSLOG=y
  #
  # Build Options
  #
@@ -55,7 +43,7 @@ Index: config
  # CONFIG_NOMMU is not set
  # CONFIG_BUILD_LIBBUSYBOX is not set
  # CONFIG_FEATURE_LIBBUSYBOX_STATIC is not set
-@@ -53,7 +53,7 @@
+@@ -53,7 +53,7 @@ CONFIG_EXTRA_LDFLAGS=""
  CONFIG_EXTRA_LDLIBS=""
  # CONFIG_USE_PORTABLE_CODE is not set
  CONFIG_STACK_OPTIMIZATION_386=y
@@ -64,21 +52,3 @@ Index: config
  
  #
  # Installation Options ("make install" behavior)
-@@ -317,7 +317,6 @@
- CONFIG_FEATURE_TEST_64=y
- CONFIG_TIMEOUT=y
- CONFIG_TOUCH=y
--CONFIG_FEATURE_TOUCH_NODEREF=y
- CONFIG_FEATURE_TOUCH_SUSV3=y
- CONFIG_TR=y
- CONFIG_FEATURE_TR_CLASSES=y
-@@ -1139,8 +1138,8 @@
- # CONFIG_SHELL_HUSH is not set
- # CONFIG_HUSH_BASH_COMPAT is not set
- # CONFIG_HUSH_BRACE_EXPANSION is not set
-+# CONFIG_HUSH_BASH_SOURCE_CURDIR is not set
- # CONFIG_HUSH_LINENO_VAR is not set
--# CONFIG_HUSH_BASH_SOURCE_CURDIR is not set
- # CONFIG_HUSH_INTERACTIVE is not set
- # CONFIG_HUSH_SAVEHISTORY is not set
- # CONFIG_HUSH_JOB is not set


### PR DESCRIPTION
Fix rotten patch.

Also planning to port kernel-header-musl and allow it to be built statically.