### PR TITLE
qemu-user-blacklist: add zettlr

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -124,5 +124,6 @@ wanderlust
 wayland
 xmonk.lv2
 zeromq
+zettlr
 zram-generator
 zsh


### PR DESCRIPTION
`electron24 --version` fails in qemu-user:

clone: Invalid argument
Illegal instruction