### PR TITLE
qemu-user-blacklist: add mold

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -65,6 +65,7 @@ meilisearch
 memcached
 menyoki
 mkvtoolnix
+mold
 nextcloud-client
 ninja
 nodejs-lts-gallium


### PR DESCRIPTION
Some mold tests use qemu (insider qemu-user), and qemu would fail with:
ERROR:../qemu-8.0.3/accel/tcg/cpu-exec.c:1028:cpu_exec_setjmp: assertion failed: (cpu == current_cpu)