### PR TITLE
upgpatch: chromium

### DIFF
--- a/chromium/riscv-sandbox.patch
+++ b/chromium/riscv-sandbox.patch
@@ -1,7 +1,35 @@
-Index: chromium-114.0.5735.133/sandbox/features.gni
-===================================================================
---- chromium-114.0.5735.133.orig/sandbox/features.gni
-+++ chromium-114.0.5735.133/sandbox/features.gni
+From 50538ec46b4ef930fedf96aa8d5519f678240dfa Mon Sep 17 00:00:00 2001
+From: kxxt <rsworktech@outlook.com>
+Date: Sat, 12 Aug 2023 08:34:05 +0800
+Subject: [PATCH] upgpatch: fix sandbox for chromium
+
+---
+ sandbox/features.gni                          |    3 +-
+ sandbox/linux/bpf_dsl/linux_syscall_ranges.h  |    7 +
+ sandbox/linux/bpf_dsl/seccomp_macros.h        |   40 +
+ .../seccomp-bpf-helpers/baseline_policy.cc    |   11 +-
+ .../syscall_parameters_restrictions.cc        |    3 +-
+ .../linux/seccomp-bpf-helpers/syscall_sets.cc |   69 +-
+ .../linux/seccomp-bpf-helpers/syscall_sets.h  |   14 +-
+ sandbox/linux/seccomp-bpf/syscall.cc          |   36 +-
+ sandbox/linux/services/credentials.cc         |    2 +-
+ sandbox/linux/services/syscall_wrappers.cc    |    2 +-
+ .../linux/syscall_broker/broker_process.cc    |   20 +-
+ sandbox/linux/system_headers/linux_seccomp.h  |    8 +
+ sandbox/linux/system_headers/linux_signal.h   |    2 +-
+ sandbox/linux/system_headers/linux_stat.h     |    2 +-
+ sandbox/linux/system_headers/linux_syscalls.h |    4 +
+ .../system_headers/riscv64_linux_syscalls.h   | 1222 +++++++++++++++++
+ .../linux/bpf_cros_amd_gpu_policy_linux.cc    |    2 +-
+ sandbox/policy/linux/bpf_gpu_policy_linux.cc  |    2 +-
+ .../policy/linux/bpf_network_policy_linux.cc  |    2 +-
+ 19 files changed, 1397 insertions(+), 54 deletions(-)
+ create mode 100644 sandbox/linux/system_headers/riscv64_linux_syscalls.h
+
+diff --git a/sandbox/features.gni b/sandbox/features.gni
+index 8434144118b49..8aa52983f78f8 100644
+--- a/sandbox/features.gni
++++ b/sandbox/features.gni
 @@ -9,7 +9,8 @@
  use_seccomp_bpf = (is_linux || is_chromeos || is_android) &&
                    (current_cpu == "x86" || current_cpu == "x64" ||
@@ -12,10 +40,10 @@ Index: chromium-114.0.5735.133/sandbox/features.gni
  
  # SSBD (Speculative Store Bypass Disable) is a mitigation of Spectre Variant 4.
  # As Spectre Variant 4 can be mitigated by site isolation, opt-out SSBD on site
-Index: chromium-114.0.5735.133/sandbox/linux/bpf_dsl/linux_syscall_ranges.h
-===================================================================
---- chromium-114.0.5735.133.orig/sandbox/linux/bpf_dsl/linux_syscall_ranges.h
-+++ chromium-114.0.5735.133/sandbox/linux/bpf_dsl/linux_syscall_ranges.h
+diff --git a/sandbox/linux/bpf_dsl/linux_syscall_ranges.h b/sandbox/linux/bpf_dsl/linux_syscall_ranges.h
+index 1d0590b7dd6ce..b722fbc95ee3e 100644
+--- a/sandbox/linux/bpf_dsl/linux_syscall_ranges.h
++++ b/sandbox/linux/bpf_dsl/linux_syscall_ranges.h
 @@ -56,6 +56,13 @@
  #define MAX_PUBLIC_SYSCALL __NR_syscalls
  #define MAX_SYSCALL MAX_PUBLIC_SYSCALL
@@ -30,10 +58,10 @@ Index: chromium-114.0.5735.133/sandbox/linux/bpf_dsl/linux_syscall_ranges.h
  #else
  #error "Unsupported architecture"
  #endif
-Index: chromium-114.0.5735.133/sandbox/linux/bpf_dsl/seccomp_macros.h
-===================================================================
---- chromium-114.0.5735.133.orig/sandbox/linux/bpf_dsl/seccomp_macros.h
-+++ chromium-114.0.5735.133/sandbox/linux/bpf_dsl/seccomp_macros.h
+diff --git a/sandbox/linux/bpf_dsl/seccomp_macros.h b/sandbox/linux/bpf_dsl/seccomp_macros.h
+index 87d5825aa3ddb..cc9b89ba3714a 100644
+--- a/sandbox/linux/bpf_dsl/seccomp_macros.h
++++ b/sandbox/linux/bpf_dsl/seccomp_macros.h
 @@ -343,6 +343,46 @@ struct regs_struct {
  #define SECCOMP_PT_PARM4(_regs) (_regs).regs[3]
  #define SECCOMP_PT_PARM5(_regs) (_regs).regs[4]
@@ -81,21 +109,21 @@ Index: chromium-114.0.5735.133/sandbox/linux/bpf_dsl/seccomp_macros.h
  #else
  #error Unsupported target platform
  
-Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
-===================================================================
---- chromium-114.0.5735.133.orig/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
-+++ chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
-@@ -60,6 +60,9 @@ bool IsBaselinePolicyAllowed(int sysno)
+diff --git a/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc b/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
+index 7bde501115bdf..b92ab3901acd8 100644
+--- a/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
++++ b/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
+@@ -59,6 +59,9 @@ bool IsBaselinePolicyAllowed(int sysno) {
+ #endif
  #if defined(__mips__)
           SyscallSets::IsMipsPrivate(sysno) ||
- #endif
++#endif
 +#if defined(__riscv)
 +         SyscallSets::IsRiscvPrivate(sysno) ||
-+#endif
+ #endif
           SyscallSets::IsAllowedOperationOnFd(sysno);
    // clang-format on
- }
-@@ -193,7 +196,7 @@ ResultExpr EvaluateSyscallImpl(int fs_de
+@@ -193,7 +196,7 @@ ResultExpr EvaluateSyscallImpl(int fs_denied_errno,
      return RestrictFcntlCommands();
  #endif
  
@@ -104,7 +132,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/baseline_policy
    // fork() is never used as a system call (clone() is used instead), but we
    // have seen it in fallback code on Android.
    if (sysno == __NR_fork) {
-@@ -255,7 +258,7 @@ ResultExpr EvaluateSyscallImpl(int fs_de
+@@ -255,7 +258,7 @@ ResultExpr EvaluateSyscallImpl(int fs_denied_errno,
    }
  
  #if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
@@ -113,7 +141,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/baseline_policy
    if (sysno == __NR_mmap)
      return RestrictMmapFlags();
  #endif
-@@ -276,7 +279,7 @@ ResultExpr EvaluateSyscallImpl(int fs_de
+@@ -276,7 +279,7 @@ ResultExpr EvaluateSyscallImpl(int fs_denied_errno,
      return RestrictPrctl();
  
  #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
@@ -122,7 +150,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/baseline_policy
    if (sysno == __NR_socketpair) {
      // Only allow AF_UNIX, PF_UNIX. Crash if anything else is seen.
      static_assert(AF_UNIX == PF_UNIX,
-@@ -366,7 +369,7 @@ ResultExpr EvaluateSyscallImpl(int fs_de
+@@ -366,7 +369,7 @@ ResultExpr EvaluateSyscallImpl(int fs_denied_errno,
    // Allow creating pipes, but don't allow weird flags to pipe2().
    // O_NOTIFICATION_PIPE (== O_EXCL) can be used to create
    // "notification pipes", which are rarely used.
@@ -131,10 +159,10 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/baseline_policy
    if (sysno == __NR_pipe) {
      return Allow();
    }
-Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
-===================================================================
---- chromium-114.0.5735.133.orig/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
-+++ chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
+diff --git a/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc b/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
+index 026e86bd85bec..ebb72ddcd5f67 100644
+--- a/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
++++ b/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
 @@ -37,6 +37,7 @@
  
  #if (BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS_LACROS)) && \
@@ -143,7 +171,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_paramet
      !defined(PTRACE_GET_THREAD_AREA)
  // Also include asm/ptrace-abi.h since ptrace.h in older libc (for instance
  // the one in Ubuntu 16.04 LTS) is missing PTRACE_GET_THREAD_AREA.
-@@ -446,7 +447,7 @@ ResultExpr RestrictPtrace() {
+@@ -449,7 +450,7 @@ ResultExpr RestrictPtrace() {
  #endif
    return Switch(request)
        .Cases({
@@ -152,10 +180,10 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_paramet
                   PTRACE_GETREGS, PTRACE_GETFPREGS, PTRACE_GET_THREAD_AREA,
                   PTRACE_GETREGSET,
  #endif
-Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
-===================================================================
---- chromium-114.0.5735.133.orig/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
-+++ chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
+diff --git a/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc b/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
+index 27ea264070dcd..8fc2d3c354adb 100644
+--- a/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
++++ b/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
 @@ -103,7 +103,7 @@ bool SyscallSets::IsUmask(int sysno) {
  // Both EPERM and ENOENT are valid errno unless otherwise noted in comment.
  bool SyscallSets::IsFileSystem(int sysno) {
@@ -165,7 +193,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
      case __NR_access:  // EPERM not a valid errno.
      case __NR_chmod:
      case __NR_chown:
-@@ -136,7 +136,7 @@ bool SyscallSets::IsFileSystem(int sysno
+@@ -136,7 +136,7 @@ bool SyscallSets::IsFileSystem(int sysno) {
      case __NR_faccessat2:
      case __NR_fchmodat:
      case __NR_fchownat:  // Should be called chownat ?
@@ -174,7 +202,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
      case __NR_newfstatat:  // fstatat(). EPERM not a valid errno.
  #elif defined(__i386__) || defined(__arm__) || \
      (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS))
-@@ -241,7 +241,7 @@ bool SyscallSets::IsAllowedFileSystemAcc
+@@ -241,7 +241,7 @@ bool SyscallSets::IsAllowedFileSystemAccessViaFd(int sysno) {
      case __NR_oldfstat:
  #endif
  #if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
@@ -183,7 +211,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
      case __NR_sync_file_range:  // EPERM not a valid errno.
  #elif defined(__arm__)
      case __NR_arm_sync_file_range:  // EPERM not a valid errno.
-@@ -260,7 +260,7 @@ bool SyscallSets::IsDeniedFileSystemAcce
+@@ -260,7 +260,7 @@ bool SyscallSets::IsDeniedFileSystemAccessViaFd(int sysno) {
  #if defined(__i386__) || defined(__arm__)
      case __NR_fchown32:
  #endif
@@ -192,7 +220,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
      case __NR_getdents:    // EPERM not a valid errno.
  #endif
      case __NR_getdents64:  // EPERM not a valid errno.
-@@ -339,7 +339,7 @@ bool SyscallSets::IsProcessPrivilegeChan
+@@ -339,7 +339,7 @@ bool SyscallSets::IsProcessPrivilegeChange(int sysno) {
  bool SyscallSets::IsProcessGroupOrSession(int sysno) {
    switch (sysno) {
      case __NR_setpgid:
@@ -201,7 +229,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
      case __NR_getpgrp:
  #endif
      case __NR_setsid:
-@@ -373,7 +373,7 @@ bool SyscallSets::IsAllowedSignalHandlin
+@@ -373,7 +373,7 @@ bool SyscallSets::IsAllowedSignalHandling(int sysno) {
      case __NR_rt_sigqueueinfo:
      case __NR_rt_sigsuspend:
      case __NR_rt_tgsigqueueinfo:
@@ -210,7 +238,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
      case __NR_signalfd:
  #endif
      case __NR_signalfd4:
-@@ -397,12 +397,12 @@ bool SyscallSets::IsAllowedOperationOnFd
+@@ -397,12 +397,12 @@ bool SyscallSets::IsAllowedOperationOnFd(int sysno) {
    switch (sysno) {
      case __NR_close:
      case __NR_dup:
@@ -225,7 +253,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
      case __NR_shutdown:
  #endif
        return true;
-@@ -441,7 +441,7 @@ bool SyscallSets::IsAllowedProcessStartO
+@@ -441,7 +441,7 @@ bool SyscallSets::IsAllowedProcessStartOrDeath(int sysno) {
        return true;
      case __NR_clone:  // Should be parameter-restricted.
      case __NR_setns:  // Privileged.
@@ -234,7 +262,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
      case __NR_fork:
  #endif
  #if defined(__i386__) || defined(__x86_64__)
-@@ -452,7 +452,7 @@ bool SyscallSets::IsAllowedProcessStartO
+@@ -452,7 +452,7 @@ bool SyscallSets::IsAllowedProcessStartOrDeath(int sysno) {
  #endif
      case __NR_set_tid_address:
      case __NR_unshare:
@@ -243,7 +271,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
      case __NR_vfork:
  #endif
      default:
-@@ -477,7 +477,7 @@ bool SyscallSets::IsAllowedFutex(int sys
+@@ -477,7 +477,7 @@ bool SyscallSets::IsAllowedFutex(int sysno) {
  
  bool SyscallSets::IsAllowedEpoll(int sysno) {
    switch (sysno) {
@@ -252,7 +280,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
      case __NR_epoll_create:
      case __NR_epoll_wait:
  #endif
-@@ -499,7 +499,7 @@ bool SyscallSets::IsAllowedEpoll(int sys
+@@ -499,7 +499,7 @@ bool SyscallSets::IsAllowedEpoll(int sysno) {
  bool SyscallSets::IsDeniedGetOrModifySocket(int sysno) {
    switch (sysno) {
  #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
@@ -261,7 +289,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
      case __NR_accept:
      case __NR_accept4:
      case __NR_bind:
-@@ -553,7 +553,7 @@ bool SyscallSets::IsAllowedAddressSpaceA
+@@ -553,7 +553,7 @@ bool SyscallSets::IsAllowedAddressSpaceAccess(int sysno) {
      case __NR_mincore:
      case __NR_mlockall:
  #if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
@@ -270,7 +298,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
      case __NR_mmap:
  #endif
  #if defined(__i386__) || defined(__arm__) || \
-@@ -586,7 +586,7 @@ bool SyscallSets::IsAllowedGeneralIo(int
+@@ -586,7 +586,7 @@ bool SyscallSets::IsAllowedGeneralIo(int sysno) {
      (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS))
      case __NR__llseek:
  #endif
@@ -279,7 +307,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
      case __NR_poll:
  #endif
      case __NR_ppoll:
-@@ -607,7 +607,7 @@ bool SyscallSets::IsAllowedGeneralIo(int
+@@ -607,7 +607,7 @@ bool SyscallSets::IsAllowedGeneralIo(int sysno) {
      case __NR_recv:
  #endif
  #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
@@ -288,7 +316,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
      case __NR_recvfrom:  // Could specify source.
      case __NR_recvmsg:   // Could specify source.
  #endif
-@@ -622,7 +622,7 @@ bool SyscallSets::IsAllowedGeneralIo(int
+@@ -622,7 +622,7 @@ bool SyscallSets::IsAllowedGeneralIo(int sysno) {
      case __NR_send:
  #endif
  #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
@@ -315,7 +343,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
      case __NR_migrate_pages:
  #endif
      case __NR_move_pages:
-@@ -790,7 +790,7 @@ bool SyscallSets::IsGlobalProcessEnviron
+@@ -790,7 +790,7 @@ bool SyscallSets::IsGlobalProcessEnvironment(int sysno) {
    switch (sysno) {
      case __NR_acct:  // Privileged.
  #if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
@@ -333,7 +361,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
      case __NR__sysctl:
      case __NR_sysfs:
  #endif
-@@ -843,7 +843,7 @@ bool SyscallSets::IsGlobalSystemStatus(i
+@@ -843,7 +843,7 @@ bool SyscallSets::IsGlobalSystemStatus(int sysno) {
  
  bool SyscallSets::IsEventFd(int sysno) {
    switch (sysno) {
@@ -342,7 +370,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
      case __NR_eventfd:
  #endif
      case __NR_eventfd2:
-@@ -895,7 +895,8 @@ bool SyscallSets::IsKeyManagement(int sy
+@@ -895,7 +895,8 @@ bool SyscallSets::IsKeyManagement(int sysno) {
  }
  
  #if defined(__x86_64__) || defined(__arm__) || defined(__aarch64__) || \
@@ -352,7 +380,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
  bool SyscallSets::IsSystemVSemaphores(int sysno) {
    switch (sysno) {
      case __NR_semctl:
-@@ -915,7 +916,8 @@ bool SyscallSets::IsSystemVSemaphores(in
+@@ -915,7 +916,8 @@ bool SyscallSets::IsSystemVSemaphores(int sysno) {
  
  #if defined(__i386__) || defined(__x86_64__) || defined(__arm__) || \
      defined(__aarch64__) ||                                         \
@@ -362,7 +390,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
  // These give a lot of ambient authority and bypass the setuid sandbox.
  bool SyscallSets::IsSystemVSharedMemory(int sysno) {
    switch (sysno) {
-@@ -931,7 +933,8 @@ bool SyscallSets::IsSystemVSharedMemory(
+@@ -931,7 +933,8 @@ bool SyscallSets::IsSystemVSharedMemory(int sysno) {
  #endif
  
  #if defined(__x86_64__) || defined(__arm__) || defined(__aarch64__) || \
@@ -372,7 +400,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
  bool SyscallSets::IsSystemVMessageQueue(int sysno) {
    switch (sysno) {
      case __NR_msgctl:
-@@ -962,7 +965,8 @@ bool SyscallSets::IsSystemVIpc(int sysno
+@@ -962,7 +965,8 @@ bool SyscallSets::IsSystemVIpc(int sysno) {
  
  bool SyscallSets::IsAnySystemV(int sysno) {
  #if defined(__x86_64__) || defined(__arm__) || defined(__aarch64__) || \
@@ -382,7 +410,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
    return IsSystemVMessageQueue(sysno) || IsSystemVSemaphores(sysno) ||
           IsSystemVSharedMemory(sysno);
  #elif defined(__i386__) || \
-@@ -999,7 +1003,7 @@ bool SyscallSets::IsAdvancedScheduler(in
+@@ -999,7 +1003,7 @@ bool SyscallSets::IsAdvancedScheduler(int sysno) {
  bool SyscallSets::IsInotify(int sysno) {
    switch (sysno) {
      case __NR_inotify_add_watch:
@@ -400,7 +428,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
      case __NR_vserver:
  #endif
        return true;
-@@ -1196,6 +1200,17 @@ bool SyscallSets::IsMipsMisc(int sysno)
+@@ -1196,6 +1200,17 @@ bool SyscallSets::IsMipsMisc(int sysno) {
  }
  #endif  // defined(__mips__)
  
@@ -418,10 +446,10 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
  bool SyscallSets::IsGoogle3Threading(int sysno) {
    switch (sysno) {
      case __NR_getitimer:
-Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h
-===================================================================
---- chromium-114.0.5735.133.orig/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h
-+++ chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h
+diff --git a/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h b/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h
+index 9be7b03ec4377..41b3605dce15d 100644
+--- a/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h
++++ b/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h
 @@ -52,7 +52,7 @@ class SANDBOX_EXPORT SyscallSets {
  #endif
  
@@ -466,10 +494,10 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h
    static bool IsGoogle3Threading(int sysno);
  };
  
-Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf/syscall.cc
-===================================================================
---- chromium-114.0.5735.133.orig/sandbox/linux/seccomp-bpf/syscall.cc
-+++ chromium-114.0.5735.133/sandbox/linux/seccomp-bpf/syscall.cc
+diff --git a/sandbox/linux/seccomp-bpf/syscall.cc b/sandbox/linux/seccomp-bpf/syscall.cc
+index 02cbb047c1558..57da8c1754f46 100644
+--- a/sandbox/linux/seccomp-bpf/syscall.cc
++++ b/sandbox/linux/seccomp-bpf/syscall.cc
 @@ -18,7 +18,7 @@ namespace sandbox {
  namespace {
  
@@ -479,7 +507,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf/syscall.cc
  // Number that's not currently used by any Linux kernel ABIs.
  const int kInvalidSyscallNumber = 0x351d3;
  #else
-@@ -308,6 +308,28 @@ asm(// We need to be able to tell the ke
+@@ -308,6 +308,28 @@ asm(// We need to be able to tell the kernel exactly where we made a
      "2:ret\n"
      ".cfi_endproc\n"
      ".size SyscallAsm, .-SyscallAsm\n"
@@ -518,19 +546,19 @@ Index: chromium-114.0.5735.133/sandbox/linux/seccomp-bpf/syscall.cc
 +    register intptr_t inout __asm__("a0") = nr;
 +    register const intptr_t* data __asm__("t0") = args;
 +    asm volatile("jal SyscallAsm\n"
-+                 : "+r"(inout)
-+                 : "r"(data)
-+                 : "memory", "a1", "a2", "a3", "a4", "a5", "a6");
++                 : "=r"(inout)
++                 : "0"(inout), "r"(data)
++                 : "memory", "a1", "a2", "a3", "a4", "a5", "a6", "a7");
 +    ret = inout;
 +  }
 +
  #else
  #error "Unimplemented architecture"
  #endif
-Index: chromium-114.0.5735.133/sandbox/linux/services/credentials.cc
-===================================================================
---- chromium-114.0.5735.133.orig/sandbox/linux/services/credentials.cc
-+++ chromium-114.0.5735.133/sandbox/linux/services/credentials.cc
+diff --git a/sandbox/linux/services/credentials.cc b/sandbox/linux/services/credentials.cc
+index e284c59d239ae..5b5346a2778bc 100644
+--- a/sandbox/linux/services/credentials.cc
++++ b/sandbox/linux/services/credentials.cc
 @@ -80,7 +80,7 @@ bool ChrootToSafeEmptyDir() {
    pid_t pid = -1;
    alignas(16) char stack_buf[PTHREAD_STACK_MIN];
@@ -540,10 +568,10 @@ Index: chromium-114.0.5735.133/sandbox/linux/services/credentials.cc
    // The stack grows downward.
    void* stack = stack_buf + sizeof(stack_buf);
  #else
-Index: chromium-114.0.5735.133/sandbox/linux/services/syscall_wrappers.cc
-===================================================================
---- chromium-114.0.5735.133.orig/sandbox/linux/services/syscall_wrappers.cc
-+++ chromium-114.0.5735.133/sandbox/linux/services/syscall_wrappers.cc
+diff --git a/sandbox/linux/services/syscall_wrappers.cc b/sandbox/linux/services/syscall_wrappers.cc
+index 7650e983b3802..bb4bd33236381 100644
+--- a/sandbox/linux/services/syscall_wrappers.cc
++++ b/sandbox/linux/services/syscall_wrappers.cc
 @@ -61,7 +61,7 @@ long sys_clone(unsigned long flags,
  #if defined(ARCH_CPU_X86_64)
    return syscall(__NR_clone, flags, child_stack, ptid, ctid, tls);
@@ -553,11 +581,11 @@ Index: chromium-114.0.5735.133/sandbox/linux/services/syscall_wrappers.cc
    // CONFIG_CLONE_BACKWARDS defined.
    return syscall(__NR_clone, flags, child_stack, ptid, tls, ctid);
  #endif
-Index: chromium-114.0.5735.133/sandbox/linux/syscall_broker/broker_process.cc
-===================================================================
---- chromium-114.0.5735.133.orig/sandbox/linux/syscall_broker/broker_process.cc
-+++ chromium-114.0.5735.133/sandbox/linux/syscall_broker/broker_process.cc
-@@ -122,44 +122,46 @@ bool BrokerProcess::IsSyscallBrokerable(
+diff --git a/sandbox/linux/syscall_broker/broker_process.cc b/sandbox/linux/syscall_broker/broker_process.cc
+index a55b548a8ec75..39279b947828e 100644
+--- a/sandbox/linux/syscall_broker/broker_process.cc
++++ b/sandbox/linux/syscall_broker/broker_process.cc
+@@ -122,44 +122,46 @@ bool BrokerProcess::IsSyscallBrokerable(int sysno, bool fast_check) const {
    // and are default disabled in Android. So, we should refuse to broker them
    // to be consistent with the platform's restrictions.
    switch (sysno) {
@@ -611,7 +639,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/syscall_broker/broker_process.cc
      case __NR_stat:
      case __NR_lstat:
  #endif
-@@ -169,7 +171,7 @@ bool BrokerProcess::IsSyscallBrokerable(
+@@ -169,7 +171,7 @@ bool BrokerProcess::IsSyscallBrokerable(int sysno, bool fast_check) const {
  #if defined(__NR_fstatat64)
      case __NR_fstatat64:
  #endif
@@ -620,7 +648,7 @@ Index: chromium-114.0.5735.133/sandbox/linux/syscall_broker/broker_process.cc
      case __NR_newfstatat:
  #endif
        return !fast_check || policy_->allowed_command_set.test(COMMAND_STAT);
-@@ -184,7 +186,7 @@ bool BrokerProcess::IsSyscallBrokerable(
+@@ -184,7 +186,7 @@ bool BrokerProcess::IsSyscallBrokerable(int sysno, bool fast_check) const {
        return !fast_check || policy_->allowed_command_set.test(COMMAND_STAT);
  #endif
  
@@ -629,10 +657,10 @@ Index: chromium-114.0.5735.133/sandbox/linux/syscall_broker/broker_process.cc
      case __NR_unlink:
        return !fast_check || policy_->allowed_command_set.test(COMMAND_UNLINK);
  #endif
-Index: chromium-114.0.5735.133/sandbox/linux/system_headers/linux_seccomp.h
-===================================================================
---- chromium-114.0.5735.133.orig/sandbox/linux/system_headers/linux_seccomp.h
-+++ chromium-114.0.5735.133/sandbox/linux/system_headers/linux_seccomp.h
+diff --git a/sandbox/linux/system_headers/linux_seccomp.h b/sandbox/linux/system_headers/linux_seccomp.h
+index 8690a96eb01b1..dec2afc744985 100644
+--- a/sandbox/linux/system_headers/linux_seccomp.h
++++ b/sandbox/linux/system_headers/linux_seccomp.h
 @@ -39,6 +39,10 @@
  #define EM_AARCH64 183
  #endif
@@ -655,10 +683,10 @@ Index: chromium-114.0.5735.133/sandbox/linux/system_headers/linux_seccomp.h
  // For prctl.h
  #ifndef PR_SET_SECCOMP
  #define PR_SET_SECCOMP               22
-Index: chromium-114.0.5735.133/sandbox/linux/system_headers/linux_signal.h
-===================================================================
---- chromium-114.0.5735.133.orig/sandbox/linux/system_headers/linux_signal.h
-+++ chromium-114.0.5735.133/sandbox/linux/system_headers/linux_signal.h
+diff --git a/sandbox/linux/system_headers/linux_signal.h b/sandbox/linux/system_headers/linux_signal.h
+index 69ccaf1081578..2ffe30973cd32 100644
+--- a/sandbox/linux/system_headers/linux_signal.h
++++ b/sandbox/linux/system_headers/linux_signal.h
 @@ -13,7 +13,7 @@
  // (not undefined, but defined different values and in different memory
  // layouts). So, fill the gap here.
@@ -668,10 +696,10 @@ Index: chromium-114.0.5735.133/sandbox/linux/system_headers/linux_signal.h
  
  #define LINUX_SIGHUP 1
  #define LINUX_SIGINT 2
-Index: chromium-114.0.5735.133/sandbox/linux/system_headers/linux_stat.h
-===================================================================
---- chromium-114.0.5735.133.orig/sandbox/linux/system_headers/linux_stat.h
-+++ chromium-114.0.5735.133/sandbox/linux/system_headers/linux_stat.h
+diff --git a/sandbox/linux/system_headers/linux_stat.h b/sandbox/linux/system_headers/linux_stat.h
+index 3aae8cbced775..74977adb53caf 100644
+--- a/sandbox/linux/system_headers/linux_stat.h
++++ b/sandbox/linux/system_headers/linux_stat.h
 @@ -150,7 +150,7 @@ struct kernel_stat {
    int st_blocks;
    int st_pad4[14];
@@ -681,10 +709,10 @@ Index: chromium-114.0.5735.133/sandbox/linux/system_headers/linux_stat.h
  struct kernel_stat {
    unsigned long st_dev;
    unsigned long st_ino;
-Index: chromium-114.0.5735.133/sandbox/linux/system_headers/linux_syscalls.h
-===================================================================
---- chromium-114.0.5735.133.orig/sandbox/linux/system_headers/linux_syscalls.h
-+++ chromium-114.0.5735.133/sandbox/linux/system_headers/linux_syscalls.h
+diff --git a/sandbox/linux/system_headers/linux_syscalls.h b/sandbox/linux/system_headers/linux_syscalls.h
+index 438147b4018b6..d6de8c1cb2340 100644
+--- a/sandbox/linux/system_headers/linux_syscalls.h
++++ b/sandbox/linux/system_headers/linux_syscalls.h
 @@ -35,5 +35,9 @@
  #include "sandbox/linux/system_headers/arm64_linux_syscalls.h"
  #endif
@@ -695,10 +723,11 @@ Index: chromium-114.0.5735.133/sandbox/linux/system_headers/linux_syscalls.h
 +
  #endif  // SANDBOX_LINUX_SYSTEM_HEADERS_LINUX_SYSCALLS_H_
  
-Index: chromium-114.0.5735.133/sandbox/linux/system_headers/riscv64_linux_syscalls.h
-===================================================================
+diff --git a/sandbox/linux/system_headers/riscv64_linux_syscalls.h b/sandbox/linux/system_headers/riscv64_linux_syscalls.h
+new file mode 100644
+index 0000000000000..822f660dc5086
 --- /dev/null
-+++ chromium-114.0.5735.133/sandbox/linux/system_headers/riscv64_linux_syscalls.h
++++ b/sandbox/linux/system_headers/riscv64_linux_syscalls.h
 @@ -0,0 +1,1222 @@
 +// Copyright 2014 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
@@ -1922,11 +1951,11 @@ Index: chromium-114.0.5735.133/sandbox/linux/system_headers/riscv64_linux_syscal
 +#endif
 +
 +#endif  // SANDBOX_LINUX_SYSTEM_HEADERS_RISCV64_LINUX_SYSCALLS_H_
-Index: chromium-114.0.5735.133/sandbox/policy/linux/bpf_cros_amd_gpu_policy_linux.cc
-===================================================================
---- chromium-114.0.5735.133.orig/sandbox/policy/linux/bpf_cros_amd_gpu_policy_linux.cc
-+++ chromium-114.0.5735.133/sandbox/policy/linux/bpf_cros_amd_gpu_policy_linux.cc
-@@ -38,7 +38,7 @@ ResultExpr CrosAmdGpuProcessPolicy::Eval
+diff --git a/sandbox/policy/linux/bpf_cros_amd_gpu_policy_linux.cc b/sandbox/policy/linux/bpf_cros_amd_gpu_policy_linux.cc
+index df2567f74981f..41e158a292369 100644
+--- a/sandbox/policy/linux/bpf_cros_amd_gpu_policy_linux.cc
++++ b/sandbox/policy/linux/bpf_cros_amd_gpu_policy_linux.cc
+@@ -38,7 +38,7 @@ ResultExpr CrosAmdGpuProcessPolicy::EvaluateSyscall(int sysno) const {
      case __NR_sched_setscheduler:
      case __NR_sysinfo:
      case __NR_uname:
@@ -1935,11 +1964,11 @@ Index: chromium-114.0.5735.133/sandbox/policy/linux/bpf_cros_amd_gpu_policy_linu
      case __NR_readlink:
      case __NR_stat:
  #endif
-Index: chromium-114.0.5735.133/sandbox/policy/linux/bpf_gpu_policy_linux.cc
-===================================================================
---- chromium-114.0.5735.133.orig/sandbox/policy/linux/bpf_gpu_policy_linux.cc
-+++ chromium-114.0.5735.133/sandbox/policy/linux/bpf_gpu_policy_linux.cc
-@@ -73,7 +73,7 @@ ResultExpr GpuProcessPolicy::EvaluateSys
+diff --git a/sandbox/policy/linux/bpf_gpu_policy_linux.cc b/sandbox/policy/linux/bpf_gpu_policy_linux.cc
+index 35ccbb7a7f82b..65a0587e25af5 100644
+--- a/sandbox/policy/linux/bpf_gpu_policy_linux.cc
++++ b/sandbox/policy/linux/bpf_gpu_policy_linux.cc
+@@ -73,7 +73,7 @@ ResultExpr GpuProcessPolicy::EvaluateSyscall(int sysno) const {
      (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS))
      case __NR_ftruncate64:
  #endif
@@ -1948,11 +1977,11 @@ Index: chromium-114.0.5735.133/sandbox/policy/linux/bpf_gpu_policy_linux.cc
      case __NR_getdents:
  #endif
      case __NR_getdents64:
-Index: chromium-114.0.5735.133/sandbox/policy/linux/bpf_network_policy_linux.cc
-===================================================================
---- chromium-114.0.5735.133.orig/sandbox/policy/linux/bpf_network_policy_linux.cc
-+++ chromium-114.0.5735.133/sandbox/policy/linux/bpf_network_policy_linux.cc
-@@ -235,7 +235,7 @@ ResultExpr NetworkProcessPolicy::Evaluat
+diff --git a/sandbox/policy/linux/bpf_network_policy_linux.cc b/sandbox/policy/linux/bpf_network_policy_linux.cc
+index 98e738a7e38be..b72914eafc775 100644
+--- a/sandbox/policy/linux/bpf_network_policy_linux.cc
++++ b/sandbox/policy/linux/bpf_network_policy_linux.cc
+@@ -255,7 +255,7 @@ ResultExpr NetworkProcessPolicy::EvaluateSyscall(int sysno) const {
      case __NR_fdatasync:
      case __NR_fsync:
      case __NR_mremap:
@@ -1961,3 +1990,6 @@ Index: chromium-114.0.5735.133/sandbox/policy/linux/bpf_network_policy_linux.cc
      case __NR_getdents:
  #endif
      case __NR_getdents64:
+-- 
+2.41.0
+

--- a/chromium/riscv64.patch
+++ b/chromium/riscv64.patch
@@ -1,32 +1,48 @@
-diff --git PKGBUILD PKGBUILD
-index 9a8e0e9..e09bf6c 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -29,13 +29,19 @@ source=(https://commondatastorage.googleapis.com/chromium-browser-official/chrom
-         https://github.com/stha09/chromium-patches/releases/download/chromium-${pkgver%%.*}-patchset-$_gcc_patchset/chromium-${pkgver%%.*}-patchset-$_gcc_patchset.tar.xz
+@@ -29,13 +29,21 @@ source=(https://commondatastorage.googleapis.com/chromium-browser-official/chrom
+         https://github.com/stha09/chromium-patches/releases/download/chromium-$_gcc_patchset/chromium-$_gcc_patchset.tar.xz
          REVERT-disable-autoupgrading-debug-info.patch
          random-build-fixes.patch
 -        use-oauth2-client-switches-as-default.patch)
 +        use-oauth2-client-switches-as-default.patch
++        swiftshader-use-llvm16.patch
 +        riscv-{angle,crashpad,dav1d,libgav1,sandbox}.patch)
- sha256sums=('e9d4bcae7bc812afc430188b48cdc86ab31c4a6d161c34a770b8d56d3121f771'
+ sha256sums=('6da04e232fcb3ebffdd4354c4ae382df24db0ddd6cf29eaaa4ed905ae84b47d3'
              '213e50f48b67feb4441078d50b0fd431df34323be15be97c55302d3fdac4483a'
              '4f91bd10a8ae2aa7b040a8b27e01f38910ad33cbe179e39a1ae550c9c1523384'
              '1b782b0f6d4f645e4e0daa8a4852d63f0c972aa0473319216ff04613a0592a69'
-             'fd472e8c2a68b2d13ce6cab1db99818d7043e49cecf807bf0c5fc931f0c036a3'
+             'cf8e3db56da0fd45dfd4d4194169067db75b49fd11890f35cf618e6942f3ae43'
 -            'e393174d7695d0bafed69e868c5fbfecf07aa6969f3b64596d0bae8b067e1711')
 +            'e393174d7695d0bafed69e868c5fbfecf07aa6969f3b64596d0bae8b067e1711'
++            '2ea949ed1d20a1745ce72f760a7d9297dc0002a747c4bd53e243c4d58ba2c7ca'
 +            'd092ee05e50b4140e9b94038c3da76eceac2de498cec092ac35eb7f89273a04f'
 +            '85644fd6b1a64e7cf76f690f1427010cdf773938987f7e1a93b2977873707a4f'
 +            '5689e9422624c8725509b6fdc277e20c3e8862cf515656faef7507978489bc4e'
 +            '4b2dcfdeb8ab32130d220d9827f49a930cf748bf4d6c7aef97a7b36a98316430'
-+            'c11730bfbc8788540582c9f5922b8d6ba16c264b97f0f7bd05db3fba008cac7f')
++            '8d52d4da703c8a86059418d1a4ed63d2d6bc1134e9dfe569695a830479a9afae')
  
  if (( _manual_clone )); then
    source[0]=fetch-chromium-release
-@@ -120,6 +126,13 @@ prepare() {
+@@ -64,7 +72,7 @@ declare -gA _system_libs=(
+   [libxml]=libxml2
+   [libxslt]=libxslt
+   [opus]=opus
+-  [re2]=re2
++  #[re2]=re2
+   [snappy]=snappy
+   [woff2]=woff2
+   [zlib]=minizip
+@@ -111,12 +119,20 @@ prepare() {
+ 
+   # Build fixes
+   patch -Np1 -i ../random-build-fixes.patch
++  patch -Np0 -i ../swiftshader-use-llvm16.patch
+ 
+   # Fixes for building with libstdc++ instead of libc++
+   patch -Np1 -i ../patches/chromium-114-ruy-include.patch
+   patch -Np1 -i ../patches/chromium-114-vk_mem_alloc-include.patch
    patch -Np1 -i ../patches/chromium-114-maldoca-include.patch
-   patch -Np1 -i ../patches/chromium-115-verify_name_match-include.patch
  
 +  # riscv64
 +  for rvpatch in riscv-{angle,dav1d,libgav1,sandbox}.patch; do
@@ -38,7 +54,7 @@ index 9a8e0e9..e09bf6c 100644
    # Link to system tools required by the build
    mkdir -p third_party/node/linux/node-linux-x64/bin
    ln -s /usr/bin/node third_party/node/linux/node-linux-x64/bin/
-@@ -176,6 +189,10 @@ build() {
+@@ -172,6 +188,10 @@ build() {
      'enable_nacl=false'
      'enable_rust=false'
      "google_api_key=\"$_google_api_key\""

--- a/chromium/swiftshader-use-llvm16.patch
+++ b/chromium/swiftshader-use-llvm16.patch
@@ -1,0 +1,11 @@
+--- third_party/swiftshader/src/Reactor/BUILD.gn.orig	2023-08-12 03:48:39.116173586 +0200
++++ third_party/swiftshader/src/Reactor/BUILD.gn	2023-08-12 03:49:30.233446545 +0200
+@@ -307,7 +307,7 @@
+ 
+ if (supports_llvm) {
+   swiftshader_source_set("swiftshader_llvm_reactor") {
+-    llvm_dir = "../../third_party/llvm-10.0"
++    llvm_dir = "../../third_party/llvm-16.0"
+ 
+     deps = [
+       ":swiftshader_reactor_base",


### PR DESCRIPTION
- Fix sandbox patch. After this, our chromium no longer crashes when opening https://vscode.dev
- Fix compliation errors by using bundled re2, as Arch already did with electrons.
- Use llvm16 because an upstream risc-v update breaks build with llvm10. (https://github.com/google/swiftshader/commit/b8f1a3ad5f9e077cd4c67e2f612e42bc8ef2fd30)