### PR TITLE
addpatch: element.io

### DIFF
--- a/element.io/app-builder-lib+24.5.2.patch
+++ b/element.io/app-builder-lib+24.5.2.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/app-builder-lib/out/linuxPackager.js b/node_modules/app-builder-lib/out/linuxPackager.js
+index 4f179fc..13f0e6c 100644
+--- a/node_modules/app-builder-lib/out/linuxPackager.js
++++ b/node_modules/app-builder-lib/out/linuxPackager.js
+@@ -68,6 +68,8 @@ function toAppImageOrSnapArch(arch) {
+             return "arm";
+         case builder_util_1.Arch.arm64:
+             return "arm_aarch64";
++        case builder_util_1.Arch.riscv64:
++            return "riscv64";
+         default:
+             throw new Error(`Unsupported arch ${arch}`);
+     }

--- a/element.io/builder-util+24.4.0.patch
+++ b/element.io/builder-util+24.4.0.patch
@@ -1,0 +1,38 @@
+diff --git a/node_modules/builder-util/out/arch.js b/node_modules/builder-util/out/arch.js
+index c4e4cb4..71649f9 100644
+--- a/node_modules/builder-util/out/arch.js
++++ b/node_modules/builder-util/out/arch.js
+@@ -8,6 +8,7 @@ var Arch;
+     Arch[Arch["armv7l"] = 2] = "armv7l";
+     Arch[Arch["arm64"] = 3] = "arm64";
+     Arch[Arch["universal"] = 4] = "universal";
++    Arch[Arch["riscv64"] = 5] = "riscv64";
+ })(Arch = exports.Arch || (exports.Arch = {}));
+ function toLinuxArchString(arch, targetName) {
+     switch (arch) {
+@@ -19,13 +20,15 @@ function toLinuxArchString(arch, targetName) {
+             return targetName === "snap" || targetName === "deb" ? "armhf" : targetName === "flatpak" ? "arm" : "armv7l";
+         case Arch.arm64:
+             return targetName === "pacman" || targetName === "rpm" || targetName === "flatpak" ? "aarch64" : "arm64";
++        case Arch.riscv64:
++            return "riscv64";
+         default:
+             throw new Error(`Unsupported arch ${arch}`);
+     }
+ }
+ exports.toLinuxArchString = toLinuxArchString;
+ function getArchCliNames() {
+-    return [Arch[Arch.ia32], Arch[Arch.x64], Arch[Arch.armv7l], Arch[Arch.arm64]];
++    return [Arch[Arch.ia32], Arch[Arch.x64], Arch[Arch.armv7l], Arch[Arch.arm64], Arch[Arch.riscv64]];
+ }
+ exports.getArchCliNames = getArchCliNames;
+ function getArchSuffix(arch, defaultArch) {
+@@ -45,6 +48,8 @@ function archFromString(name) {
+             return Arch.armv7l;
+         case "universal":
+             return Arch.universal;
++        case "riscv64":
++            return Arch.riscv64;
+         default:
+             throw new Error(`Unsupported arch ${name}`);
+     }

--- a/element.io/element-desktop-riscv64-support.patch
+++ b/element.io/element-desktop-riscv64-support.patch
@@ -1,0 +1,40 @@
+--- scripts/hak/target.ts.orig	2023-08-13 08:44:26.292841975 -0400
++++ scripts/hak/target.ts	2023-08-13 08:50:33.362395808 -0400
+@@ -33,13 +33,14 @@
+     | "aarch64-unknown-linux-musl"
+     | "aarch64-unknown-linux-gnu"
+     | "powerpc64le-unknown-linux-musl"
+-    | "powerpc64le-unknown-linux-gnu";
++    | "powerpc64le-unknown-linux-gnu"
++    | "riscv64gc-unknown-linux-gnu";
+ 
+ // Values are expected to match those used in `process.platform`.
+ export type Platform = "darwin" | "linux" | "win32";
+ 
+ // Values are expected to match those used in `process.arch`.
+-export type Arch = "arm64" | "ia32" | "x64" | "ppc64" | "universal";
++export type Arch = "arm64" | "ia32" | "x64" | "ppc64" | "universal" | "riscv";
+ 
+ // Values are expected to match those used by Visual Studio's `vcvarsall.bat`.
+ // See https://docs.microsoft.com/cpp/build/building-on-the-command-line?view=msvc-160#vcvarsall-syntax
+@@ -162,6 +163,12 @@
+     libC: MUSL,
+ };
+ 
++const riscv64gcUnknownLinuxGnu: LinuxTarget = {
++    id: "riscv64gc-unknown-linux-gnu",
++    platform: "linux",
++    arch: "riscv64",
++    libC: GLIBC,
++};
+ export const TARGETS: Record<TargetId, Target> = {
+     // macOS
+     "aarch64-apple-darwin": aarch64AppleDarwin,
+@@ -180,6 +187,7 @@
+     "aarch64-unknown-linux-gnu": aarch64UnknownLinuxGnu,
+     "powerpc64le-unknown-linux-musl": powerpc64leUnknownLinuxMusl,
+     "powerpc64le-unknown-linux-gnu": powerpc64leUnknownLinuxGnu,
++    "riscv64gc-unknown-linux-gnu": riscv64gcUnknownLinuxGnu
+ };
+ 
+ export function getHost(): Target | undefined {

--- a/element.io/riscv64.patch
+++ b/element.io/riscv64.patch
@@ -1,0 +1,97 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,7 +12,7 @@ pkgdesc="Glossy Matrix collaboration client — "
+ arch=(x86_64)
+ url="https://element.io"
+ license=(Apache)
+-makedepends=(npm git yarn python rust tcl ${_electron} nodejs libxcrypt-compat)
++makedepends=(npm git yarn python rust tcl ${_electron} nodejs libxcrypt-compat sentry-cli go jq zip p7zip)
+ _url="https://github.com/vector-im/element"
+ source=(element-web-${pkgver}.tar.gz::${_url}-web/archive/v${pkgver}.tar.gz
+         element-web-${pkgver}.tar.gz.asc::${_url}-web/releases/download/v${pkgver}/v${pkgver}-src.tar.gz.asc
+@@ -20,28 +20,64 @@ source=(element-web-${pkgver}.tar.gz::${_url}-web/archive/v${pkgver}.tar.gz
+         element-desktop-${pkgver}.tar.gz.asc::${_url}-desktop/releases/download/v${pkgver}/v${pkgver}-src.tar.gz.asc
+         autolaunch.patch
+         io.element.Element.desktop
+-        element-desktop.sh)
++        element-desktop.sh
++        element-desktop-riscv64-support.patch
++        git+https://github.com/kxxt/app-builder
++        builder-util+24.4.0.patch
++        app-builder-lib+24.5.2.patch)
+ sha256sums=('3e92beb12f19b73a111d3481b275ce8600ed84f714f536a730d1ba37c520d85f'
+             'SKIP'
+             'bde90a6ff893a46872845d4e04825087c05a05b42a859694548821c43d968a47'
+             'SKIP'
+             '268485f35103d00a89be7f5c84703e3d393350c71f4f90932f7bcb5ea2fd094f'
+             '0103f28a32fe31f698836516783c1c70a76a0117b5df7fd0af5c422c224220f9'
+-            'c1bd9ace215e3ec9af14d7f28b163fc8c8b42e23a2cf04ce6f4ce2fcc465feba')
++            'c1bd9ace215e3ec9af14d7f28b163fc8c8b42e23a2cf04ce6f4ce2fcc465feba'
++            'b2d5381ad4b6f406ea2edce11cbd013840bab6af09d6a2a067b214d85eb84ebf'
++            'SKIP'
++            '887a6c6e0f1ad5ceceef1e35582bd7498145406945d08ed036d98311cec35a89'
++            '96f0242d8071075b2f8d916b2f0eabeba660d7314a504792965ee2ff89965175')
+ validpgpkeys=(712BFBEE92DCA45252DB17D7C7BE97EFA179B100) # Element Releases <releases@riot.im>
+ 
+ prepare() {
+   # Specify electron version in launcher
+   sed -i "s|@ELECTRON@|${_electron}|" element-desktop.sh
+ 
++  export ELECTRON_SKIP_BINARY_DOWNLOAD=1 
++  export SENTRYCLI_USE_LOCAL=1 SENTRYCLI_SKIP_DOWNLOAD=1
++  export PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
++
+   cd element-web-${pkgver}
+   yarn install --no-fund
+ 
+   cd ../element-desktop-${pkgver}
+   patch -p1 < ../autolaunch.patch
+-  sed -i 's|"target": "deb"|"target": "dir"|' package.json
++  patch -Np0 -i ../element-desktop-riscv64-support.patch
++  jq '.build.linux.target=["dir"]' package.json > package.json.new
++  mv package.json.new package.json
+   sed -i 's|"https://packages.element.io/desktop/update/"|null|' element.io/release/config.json
+   yarn install --no-fund
++
++  mkdir patches
++  cp ../builder-util+24.4.0.patch ../app-builder-lib+24.5.2.patch patches
++  npx patch-package </dev/null
++
++  yarn run hak fetch matrix-seshat
++  pushd .hak/matrix-seshat/riscv64gc-unknown-linux-gnu/build/
++  echo -e "[patch.crates-io]\nnix = { git = 'https://github.com/kxxt/nix.git', branch = 'archrv-element-fix' }" >> Cargo.toml
++  cargo update -p nix
++  popd
++
++  mkdir -p  node_modules/7zip-bin/linux/riscv64
++  ln -s /usr/bin/7za node_modules/7zip-bin/linux/riscv64/7za
++
++  local _builder_bin=node_modules/app-builder-bin/linux/riscv64
++  mkdir "$_builder_bin"
++  go build -C ../app-builder
++  cp ../app-builder/app-builder "$_builder_bin"
++
++  local _electron_ver=$(jq -r .version node_modules/electron/package.json)
++  local _electron_zip="electron-v$_electron_ver-linux-riscv64.zip"
++  cd "/usr/lib/$_electron" && zip -r "/tmp/$_electron_zip" ./
+ }
+ 
+ build() {
+@@ -53,7 +89,7 @@ build() {
+   export SQLCIPHER_BUNDLED=1
+   export CFLAGS+=" -ffat-lto-objects"
+   yarn run build:native
+-  yarn run build
++  ELECTRON_CACHE=/tmp yarn run build
+ }
+ 
+ package_element-web() {
+@@ -81,7 +117,7 @@ package_element-desktop() {
+   install -d "${pkgdir}"{/usr/lib/element/,/etc/webapps/element}
+ 
+   # Install the app content, replace the webapp with a symlink to the system package
+-  cp -r dist/linux-unpacked/resources/* "${pkgdir}"/usr/lib/element/
++  cp -r dist/linux-riscv64-unpacked/resources/* "${pkgdir}"/usr/lib/element/
+   ln -s /usr/share/webapps/element "${pkgdir}"/usr/lib/element/webapp
+ 
+   # Config file


### PR DESCRIPTION
- Skip electron, playwright browsers and sentry-cli downloads
- Use system p7zip, sentry-cli, electron25
- Build app-builder using my fork, patch previously upstreamed as https://github.com/develar/app-builder/pull/90
- Patching build recipes to add riscv64 support
- Patching electron-builder packages, patch previously upstreamed as https://github.com/electron-userland/electron-builder/pull/7646
- Make matrix-seshat use my fork of a higher version of rust-nix, which contains a hack that pretend its version as 0.14.1 so that cargo won't complain. `#[deny(unused)]` is removed from that crate to fix compliation errors that seems arising due to higher rust version.
- Tested on talonframe machine, it works fine. But it won't work on rvv0.7 machines.