### PR TITLE
updpatch: deno 1.36.3-1

### DIFF
--- a/deno/riscv-v8.patch
+++ b/deno/riscv-v8.patch
@@ -1,0 +1,69 @@
+From 86e54fe85fba80a75805d52031c16e83cba03671 Mon Sep 17 00:00:00 2001
+From: Lu Yahan <yahan@iscas.ac.cn>
+Date: Mon, 04 Dec 2023 10:19:55 +0800
+Subject: [PATCH] [riscv][builtins][masm] Use CallBuiltin/TailCallBuiltin where possible
+
+Port commit 063210c08c0dcbff02e3fc59f4afd430b8108432
+Port commit 12203e0c46b507dc138047c0fe22ce254bfced91
+
+Bug: v8:14496
+
+Change-Id: I7cabcbc444b21ff8352cf0aea3dbb55177c398d5
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/5081171
+Auto-Submit: Yahan Lu <yahan@iscas.ac.cn>
+Reviewed-by: Ji Qiu <qiuji@iscas.ac.cn>
+Commit-Queue: Yahan Lu <yahan@iscas.ac.cn>
+Cr-Commit-Position: refs/heads/main@{#91322}
+---
+
+diff --git a/src/codegen/riscv/macro-assembler-riscv.cc b/src/codegen/riscv/macro-assembler-riscv.cc
+index 6799a12..59666bf9 100644
+--- a/v8/src/codegen/riscv/macro-assembler-riscv.cc
++++ b/v8/src/codegen/riscv/macro-assembler-riscv.cc
+@@ -401,7 +401,7 @@
+   Pop(slot_address_parameter);
+   Pop(object_parameter);
+ 
+-  CallBuiltin(Builtins::GetEphemeronKeyBarrierStub(fp_mode));
++  CallBuiltin(Builtins::EphemeronKeyBarrier(fp_mode));
+   MaybeRestoreRegisters(registers);
+ }
+ 
+@@ -6696,7 +6696,7 @@
+   __ StoreReturnAddressAndCall(function_address);
+   __ bind(&done_api_call);
+ 
+-  Label promote_scheduled_exception;
++  Label propagate_exception;
+   Label delete_allocated_handles;
+   Label leave_exit_frame;
+ 
+@@ -6739,11 +6739,10 @@
+   {
+     ASM_CODE_COMMENT_STRING(masm,
+                             "Check if the function scheduled an exception.");
+-    __ LoadRoot(scratch2, RootIndex::kTheHoleValue);
+-    __ LoadWord(scratch, __ ExternalReferenceAsOperand(
+-                             ER::scheduled_exception_address(isolate), no_reg));
+-    __ Branch(&promote_scheduled_exception, ne, scratch2, Operand(scratch),
+-              Label::Distance::kNear);
++    __ LoadRoot(scratch, RootIndex::kTheHoleValue);
++    __ LoadWord(scratch2, __ ExternalReferenceAsOperand(
++                              ER::exception_address(isolate), no_reg));
++    __ Branch(&propagate_exception, ne, scratch, Operand(scratch2));
+   }
+   {
+     ASM_CODE_COMMENT_STRING(masm, "Convert return value");
+@@ -6770,9 +6769,9 @@
+     __ Branch(&done_api_call);
+   }
+ 
+-  __ RecordComment("Re-throw by promoting a scheduled exception.");
+-  __ bind(&promote_scheduled_exception);
+-  __ TailCallRuntime(Runtime::kPromoteScheduledException);
++  __ RecordComment("An exception was thrown. Propagate it.");
++  __ bind(&propagate_exception);
++  __ TailCallRuntime(Runtime::kPropagateException);
+ 
+   {
+     ASM_CODE_COMMENT_STRING(

--- a/deno/riscv64.patch
+++ b/deno/riscv64.patch
@@ -1,13 +1,38 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -11,13 +11,26 @@ url="https://deno.land"
+@@ -11,13 +11,49 @@ url="https://deno.land"
  license=('MIT')
  options=('!lto')
  depends=('gcc-libs')
 -makedepends=('git' 'python' 'rust' 'nodejs' 'cmake' 'protobuf')
+-source=("git+https://github.com/denoland/deno.git#commit=$_commit")
+-sha512sums=('SKIP')
 +makedepends=('git' 'python' 'rust' 'nodejs' 'gn' 'ninja' 'clang' 'lld' 'cmake' 'protobuf')
- source=("git+https://github.com/denoland/deno.git#commit=$_commit")
- sha512sums=('SKIP')
++source=("git+https://github.com/denoland/deno.git#commit=$_commit"
++        "git+https://github.com/denoland/rusty_v8.git#commit=ff2a50ccdf7d5f7091e2bfbdedf0927101e2844c"  # 0.83.1
++        "riscv-v8.patch")
++sha512sums=('SKIP'
++            'SKIP'
++            '6dbd86917c815e04f84f30a49afc75f7fad01c97b2d5e40731f11f87eb2d7a5c73bdada824f19f7150bc2921a10cd452306f3ef7e8205ba894f0738f33acec71')
++
++prepare() {
++  cd rusty_v8
++  git config -f .gitmodules submodule.v8.shallow true
++  git submodule update --init --recursive
++  patch -Np1 -i ../riscv-v8.patch
++
++  cd ../deno
++
++  # 0.8.0 -> (at least) 0.8.1
++  # which contains https://github.com/simd-lite/value-trait/commit/136603dcc6c6313b437cc42410aa4c85c709ea58
++  cargo update -p value-trait
++
++  # 0.13.4 -> (at least) 0.13.8
++  # https://github.com/simd-lite/simd-json/commit/f46dc2ab7ca5eab0d531cb7ad7ae11bcac8c2d06
++  cargo update -p simd-json
++
++  echo -e "\n[patch.crates-io]\nv8 = { path = '../rusty_v8' }" >> Cargo.toml
++}
  
  build() {
    cd $pkgname


### PR DESCRIPTION
Revert use of zlib-ng upstream [1] due to RVV detection problems.

[1]: https://github.com/denoland/deno/commit/85a2b281f566d3404d23852ae29d4a75d020dd5e