### PR TITLE
updpatch: rust 1:1.72.0-1

### DIFF
--- a/rust/bump-bootstrap-cc.patch
+++ b/rust/bump-bootstrap-cc.patch
@@ -1,15 +1,14 @@
-diff -uprN rustc-1.69.0-src/src/bootstrap/Cargo.lock rustc-1.69.0-src.bump/src/bootstrap/Cargo.lock
---- rustc-1.69.0-src/src/bootstrap/Cargo.lock	2023-04-16 23:39:51.000000000 +0200
-+++ rustc-1.69.0-src.bump/src/bootstrap/Cargo.lock	2023-05-12 17:49:28.000607116 +0200
+--- a/src/bootstrap/Cargo.lock
++++ b/src/bootstrap/Cargo.lock
 @@ -78,9 +78,9 @@ version = "0.1.0"
  
  [[package]]
  name = "cc"
 -version = "1.0.73"
-+version = "1.0.77"
++version = "1.0.79"
  source = "registry+https://github.com/rust-lang/crates.io-index"
 -checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
-+checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
++checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
  
  [[package]]
  name = "cfg-if"

--- a/rust/riscv64.patch
+++ b/rust/riscv64.patch
@@ -16,35 +16,35 @@
    libffi
    lld
    llvm
-@@ -60,6 +58,7 @@ source=(
+@@ -59,6 +57,7 @@ source=(
+   0002-bootstrap-Change-bash-completion-dir.patch
    0003-compiler-Change-LLVM-targets.patch
    0004-compiler-Use-wasm-ld-for-wasm-targets.patch
-   0005-bootstrap-Unbreak-building-Rust-1.71.1-with-1.71.0.patch
 +  bump-bootstrap-cc.patch
  )
- b2sums=('66c155e7a96d4c21e50feebe412fec0b4f4e3f6566f249a018b439c1e1ad1d807f00bcd854fecc267120db0a6d24939e21c86f46b1b13570b6f589d10f5b83c7'
+ b2sums=('cb0b20523154da26ce2e8cd2e214c3e3c62a66dcf15f1615c92c2efcf3cfc2a437e8b7d582f05cc123e0450ae924aef9c28884b2579c589f9e4336f6bc1b6e70'
          'SKIP'
-@@ -68,7 +67,8 @@ b2sums=('66c155e7a96d4c21e50feebe412fec0b4f4e3f6566f249a018b439c1e1ad1d807f00bcd
-         'fdf2159315b96337da84b45fc49b55ea73d6d14710f3967710da4fcee6d049ef9e5bb18e438e604750f4a3af9c909e58eea143f4a3c497acb7d806f834fd3b44'
-         '2ecae93bc6323ef8285b590d576f8b7de385dc121317bd108e1e0863e0ef57d6bd7529564342443b182f1979d2e432a105998da61db16be8e6ea24f79c9acfcd'
-         'e0acea294146ae14ec18ac1f99cb9113dfe0dbe87cfd557fb093b56fc15cf036ac076af905fbe358a11a913d2fc845619c5fd8e18ac97127c232127a28666117'
--        '13a0d671e86a385237b69d7fda728f04c910eef20fc5c46ba5c4bc6b3defea0d5b34c6744f137c6b4e86d01ad098ac2c4dd0d9a114eb20749f18ffc5d34477ed')
-+        '13a0d671e86a385237b69d7fda728f04c910eef20fc5c46ba5c4bc6b3defea0d5b34c6744f137c6b4e86d01ad098ac2c4dd0d9a114eb20749f18ffc5d34477ed'
-+        '2a92f8e5190efd4dca0a36282259caeb7cdd5dcf408c6b90276e6b22cd7a5fce4d7a405e3ca024f84742671e0f98b2ba62b4dc6722bffaa20a76ec99d5d313c1')
+@@ -66,7 +65,8 @@ b2sums=('cb0b20523154da26ce2e8cd2e214c3e3c62a66dcf15f1615c92c2efcf3cfc2a437e8b7d
+         '0b079767043116d1e2c30ce66e82972266bc46a70b54884c0d41786c7f4271fdacb04611d34d4106a394db9df4b384b0138fa4f52c3076bfb3932d410f668b15'
+         'f165abb36f03bb1ddcdca8e674244e51c7ce3a6b83e59b44d520e16e3735952cdd1c6da9edca51a755b343323f6f37c7ea7093708212300974e41560d15ee6ef'
+         '5faa0c65de5186dd225afcb58d0d0b2fddf2f2a7008f7a7d84bf14e78a23dbf08ae04c016d3c8241359ec9eb286f5186a7ae84ce03446f37e56fc2667fa1c114'
+-        'e0acea294146ae14ec18ac1f99cb9113dfe0dbe87cfd557fb093b56fc15cf036ac076af905fbe358a11a913d2fc845619c5fd8e18ac97127c232127a28666117')
++        'e0acea294146ae14ec18ac1f99cb9113dfe0dbe87cfd557fb093b56fc15cf036ac076af905fbe358a11a913d2fc845619c5fd8e18ac97127c232127a28666117'
++        '413136e94c9ecef6faf1bc2a98db62bd9df7a1e132fece834f2a9f65e8387e4357a4330d015587506dbd2e2d4e51f55102cfb780bea3647fa9857134b798e122')
  validpgpkeys=(
    108F66205EAEB0AAA8DD5E1C85AB96E6FA1BE5FE  # Rust Language (Tag and Release Signing Key) <rust-key@rust-lang.org>
  )
-@@ -93,6 +93,9 @@ prepare() {
-   # https://github.com/rust-lang/rust/issues/114444
-   patch -Np1 -i ../0005-bootstrap-Unbreak-building-Rust-1.71.1-with-1.71.0.patch
+@@ -88,6 +88,9 @@ prepare() {
+   # Use our wasm-ld
+   patch -Np1 -i ../0004-compiler-Use-wasm-ld-for-wasm-targets.patch
  
-+  # Bump bootstrap cc to v1.0.77
++  # Bump bootstrap cc to v1.0.79
 +  patch -Np1 -i ../bump-bootstrap-cc.patch
 +
    cat >config.toml <<END
  profile = "user"
  changelog-seen = 2
-@@ -102,9 +105,8 @@ link-shared = true
+@@ -97,9 +100,8 @@ link-shared = true
  
  [build]
  target = [
@@ -56,7 +56,7 @@
    "wasm32-unknown-unknown",
    "wasm32-wasi",
  ]
-@@ -153,22 +155,18 @@ deny-warnings = false
+@@ -148,22 +150,18 @@ deny-warnings = false
  [dist]
  compression-formats = ["gz"]
  
@@ -83,7 +83,7 @@
  
  [target.wasm32-unknown-unknown]
  sanitizers = false
-@@ -207,15 +205,12 @@ build() {
+@@ -202,15 +200,12 @@ build() {
  
    # rustbuild always installs copies of the shared libraries to /usr/lib,
    # overwrite them with symlinks to the per-architecture versions
@@ -101,7 +101,7 @@
    _pick dest-wasm usr/lib/rustlib/wasm32-*
    _pick dest-src  usr/lib/rustlib/src
  }
-@@ -244,22 +239,6 @@ package_rust() {
+@@ -239,22 +234,6 @@ package_rust() {
    cp -a dest-rust/* "$pkgdir"
  }
  


### PR DESCRIPTION
Fix rotten patch.
- Bump bootstrap cc to 1.79, provided by vendor/