### PR TITLE
updpatch: plotutils 2.6-11

### DIFF
--- a/plotutils/riscv64.patch
+++ b/plotutils/riscv64.patch
@@ -1,13 +1,14 @@
-diff --git PKGBUILD PKGBUILD
-index d01deeb..07f4bec 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -18,6 +18,8 @@ validpgpkeys=('C7823604DFEA27BC29DD4F179DEB46C0D679F6CF') # Karl Berry
-
+@@ -20,6 +20,11 @@ sha256sums=('4f4222820f97ca08c7ea707e4c53e5a3556af4d8f1ab51e0da6ff1627ff433ab'
+             'SKIP'
+             '2d8d5a287ebaf857b76c5c3fb2da5f25c8c0c38995bb96291ba42d6d3d1d53ba')
+ 
++prepare() {
++  cd $pkgname-$pkgver
++  cp /usr/share/autoconf/build-aux/config.{guess,sub} .
++}
++
  build() {
-   cd "${srcdir}/${pkgname}-${pkgver}"
-+  CFLAGS+=" -Wno-error=format-security"
-+  CXXFLAGS+=" -Wno-error=format-security"
+   cd $pkgname-$pkgver
    patch -p0 -i ../plotutils-2.6-libpng-1.5.patch
-   ./configure --prefix=/usr \
-        --with-gnu-ld \


### PR DESCRIPTION
Update (somehow) outdated configuration files.

GNU plotutils hasn't been updated since 2009 and there's no way of upstreaming.