### PR TITLE
addpatch: highway

### DIFF
--- a/highway/compile-only-emu128.patch
+++ b/highway/compile-only-emu128.patch
@@ -1,0 +1,14 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 8212477..d8cc55f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -185,6 +185,9 @@ else()
+     -Wsign-conversion
+     -Wvla
+     -Wnon-virtual-dtor
++
++    # Workaround for RV64GC without V
++    -DHWY_COMPILE_ONLY_EMU128
+   )
+ 
+   if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")

--- a/highway/riscv64.patch
+++ b/highway/riscv64.patch
@@ -1,0 +1,21 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -9,8 +9,16 @@ url='https://github.com/google/highway/'
+ license=('Apache')
+ depends=('gcc-libs')
+ makedepends=('cmake' 'gtest')
+-source=("https://github.com/google/highway/archive/${pkgver}/${pkgname}-${pkgver}.tar.gz")
+-sha256sums=('5434488108186c170a5e2fca5e3c9b6ef59a1caa4d520b008a9b8be6b8abe6c5')
++source=("https://github.com/google/highway/archive/${pkgver}/${pkgname}-${pkgver}.tar.gz"
++        "compile-only-emu128.patch")
++sha256sums=('5434488108186c170a5e2fca5e3c9b6ef59a1caa4d520b008a9b8be6b8abe6c5'
++            '068ca74f3c33bed3ebd2ea5ef59c42e50b81101809893292335b9a38b47743cf')
++options=(!lto)
++
++prepare() {
++    cd ${pkgname}-${pkgver}
++    patch -Np1 -i ../compile-only-emu128.patch
++}
+ 
+ build() {
+     cmake -B build -S "${pkgname}-${pkgver}" \


### PR DESCRIPTION
- Disable LTO.

```
[  5%] Linking CXX shared library libhwy.so
lto1: fatal error: target specific builtin not available
compilation terminated.
lto-wrapper: fatal error: /usr/bin/c++ returned 1 exit status
compilation terminated.
/usr/bin/ld: error: lto-wrapper failed
```

- Define `HWY_COMPILE_ONLY_EMU128` to force using scalar implementation only to work around RVV detection. Needs better solution for upstream.