### PR TITLE
updpatch: gcc 13.2.1-3.1

### DIFF
--- a/gcc/riscv64.patch
+++ b/gcc/riscv64.patch
@@ -1,5 +1,5 @@
 diff --git PKGBUILD PKGBUILD
-index f716aff..cc84b4b 100644
+index f716aff..4b1fba7 100644
 --- PKGBUILD
 +++ PKGBUILD
 @@ -7,7 +7,7 @@
@@ -41,12 +41,15 @@ index f716aff..cc84b4b 100644
  
  prepare() {
    [[ ! -d gcc ]] && ln -s gcc-${pkgver/+/-} gcc
-@@ -64,6 +63,12 @@ prepare() {
+@@ -64,6 +63,15 @@ prepare() {
    # Reproducible gcc-ada
    patch -Np0 < "$srcdir/gcc-ada-repro.patch"
  
 +  # Remove codes filtering default library paths to make mold work correctly
 +  patch -Np1 < ../unfilter-default-library-path.patch
++
++  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110066
++  git cherry-pick -n bbc1a102735c72e3c5a4dede8ab382813d12b058
 +
 +  # https://github.com/golang/go/issues/57691
 +  git cherry-pick -n 21a07620f4bfe38f12e6d5be8b1eeecc29fa6852
@@ -54,7 +57,7 @@ index f716aff..cc84b4b 100644
    mkdir -p "$srcdir/gcc-build"
    mkdir -p "$srcdir/libgccjit-build"
  }
-@@ -91,12 +96,12 @@ build() {
+@@ -91,12 +99,12 @@ build() {
        --enable-link-serialization=1
        --enable-linker-build-id
        --enable-lto
@@ -68,7 +71,7 @@ index f716aff..cc84b4b 100644
        --disable-werror
    )
  
-@@ -109,7 +114,7 @@ build() {
+@@ -109,7 +117,7 @@ build() {
    CXXFLAGS=${CXXFLAGS/-Werror=format-security/}
  
    "$srcdir/gcc/configure" \
@@ -77,7 +80,7 @@ index f716aff..cc84b4b 100644
      --enable-bootstrap \
      "${_confflags[@]:?_confflags unset}"
  
-@@ -157,9 +162,9 @@ check() {
+@@ -157,9 +165,9 @@ check() {
  package_gcc-libs() {
    pkgdesc='Runtime libraries shipped by GCC'
    depends=('glibc>=2.27')
@@ -89,7 +92,7 @@ index f716aff..cc84b4b 100644
    replaces=($pkgname-multilib libgphobos)
  
    cd gcc-build
-@@ -172,9 +177,8 @@ package_gcc-libs() {
+@@ -172,9 +180,8 @@ package_gcc-libs() {
               libgomp \
               libitm \
               libquadmath \
@@ -101,7 +104,7 @@ index f716aff..cc84b4b 100644
      make -C $CHOST/$lib DESTDIR="$pkgdir" install-toolexeclibLTLIBRARIES
    done
  
-@@ -191,18 +195,17 @@ package_gcc-libs() {
+@@ -191,18 +198,17 @@ package_gcc-libs() {
      make -C $CHOST/$lib DESTDIR="$pkgdir" install-info
    done
  
@@ -123,7 +126,7 @@ index f716aff..cc84b4b 100644
    provides=($pkgname-multilib)
    replaces=($pkgname-multilib)
    options=(!emptydirs staticlibs)
-@@ -216,22 +219,18 @@ package_gcc() {
+@@ -216,22 +222,18 @@ package_gcc() {
    install -m755 -t "$pkgdir/${_libdir}/" gcc/{cc1,cc1plus,collect2,lto1}
  
    make -C $CHOST/libgcc DESTDIR="$pkgdir" install
@@ -148,7 +151,7 @@ index f716aff..cc84b4b 100644
  
    make DESTDIR="$pkgdir" install-fixincludes
    make -C gcc DESTDIR="$pkgdir" install-mkheaders
-@@ -246,16 +245,11 @@ package_gcc() {
+@@ -246,16 +248,11 @@ package_gcc() {
    make -C $CHOST/libquadmath DESTDIR="$pkgdir" install-nodist_libsubincludeHEADERS
    make -C $CHOST/libsanitizer DESTDIR="$pkgdir" install-nodist_{saninclude,toolexeclib}HEADERS
    make -C $CHOST/libsanitizer/asan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
@@ -166,7 +169,7 @@ index f716aff..cc84b4b 100644
  
    make -C libcpp DESTDIR="$pkgdir" install
    make -C gcc DESTDIR="$pkgdir" install-po
-@@ -264,9 +258,9 @@ package_gcc() {
+@@ -264,9 +261,9 @@ package_gcc() {
    ln -s gcc "$pkgdir"/usr/bin/cc
  
    # create cc-rs compatible symlinks
@@ -178,7 +181,7 @@ index f716aff..cc84b4b 100644
    done
  
    # POSIX conformance launcher scripts for c89 and c99
-@@ -276,9 +270,6 @@ package_gcc() {
+@@ -276,9 +273,6 @@ package_gcc() {
    # install the libstdc++ man pages
    make -C $CHOST/libstdc++-v3/doc DESTDIR="$pkgdir" doc-install-man
  
@@ -188,7 +191,7 @@ index f716aff..cc84b4b 100644
    # byte-compile python libraries
    python -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
    python -O -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
-@@ -298,8 +289,6 @@ package_gcc-fortran() {
+@@ -298,8 +292,6 @@ package_gcc-fortran() {
    cd gcc-build
    make -C $CHOST/libgfortran DESTDIR="$pkgdir" install-cafexeclibLTLIBRARIES \
      install-{toolexeclibDATA,nodist_fincludeHEADERS,gfor_cHEADERS}
@@ -197,7 +200,7 @@ index f716aff..cc84b4b 100644
    make -C $CHOST/libgomp DESTDIR="$pkgdir" install-nodist_fincludeHEADERS
    make -C gcc DESTDIR="$pkgdir" fortran.install-{common,man,info}
    install -Dm755 gcc/f951 "$pkgdir/${_libdir}/f951"
-@@ -329,45 +318,6 @@ package_gcc-objc() {
+@@ -329,45 +321,6 @@ package_gcc-objc() {
      "$pkgdir/usr/share/licenses/$pkgname/"
  }
  
@@ -243,7 +246,7 @@ index f716aff..cc84b4b 100644
  package_gcc-go() {
    pkgdesc='Go front-end for GCC'
    depends=("gcc=$pkgver-$pkgrel" libisl.so)
-@@ -377,11 +327,10 @@ package_gcc-go() {
+@@ -377,11 +330,10 @@ package_gcc-go() {
  
    cd gcc-build
    make -C $CHOST/libgo DESTDIR="$pkgdir" install-exec-am
@@ -256,7 +259,7 @@ index f716aff..cc84b4b 100644
    install -Dm755 gcc/go1 "$pkgdir/${_libdir}/go1"
  
    # Install Runtime Library Exception
-@@ -390,42 +339,6 @@ package_gcc-go() {
+@@ -390,42 +342,6 @@ package_gcc-go() {
      "$pkgdir/usr/share/licenses/$pkgname/"
  }
  
@@ -299,7 +302,7 @@ index f716aff..cc84b4b 100644
  package_gcc-d() {
    pkgdesc="D frontend for GCC"
    depends=("gcc=$pkgver-$pkgrel" libisl.so)
-@@ -441,7 +354,6 @@ package_gcc-d() {
+@@ -441,7 +357,6 @@ package_gcc-d() {
  
    make -C $CHOST/libphobos DESTDIR="$pkgdir" install
    rm -f "$pkgdir/usr/lib/"lib{gphobos,gdruntime}.so*


### PR DESCRIPTION
Cherry-pick fix for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110066 which breaks glibc's test suite.