### PR TITLE
addpatch: helm

### DIFF
--- a/helm/add-riscv64-build.patch
+++ b/helm/add-riscv64-build.patch
@@ -1,0 +1,80 @@
+diff --git a/go.mod b/go.mod
+index 29401f307..8f57e889a 100644
+--- a/go.mod
++++ b/go.mod
+@@ -57,7 +57,6 @@ require (
+ 	github.com/beorn7/perks v1.0.1 // indirect
+ 	github.com/bshuster-repo/logrus-logstash-hook v1.0.0 // indirect
+ 	github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd // indirect
+-	github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b // indirect
+ 	github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 // indirect
+ 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+ 	github.com/chai2010/gettext-go v1.0.2 // indirect
+@@ -103,6 +102,7 @@ require (
+ 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
+ 	github.com/josharian/intern v1.0.0 // indirect
+ 	github.com/json-iterator/go v1.1.12 // indirect
++	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 // indirect
+ 	github.com/klauspost/compress v1.16.0 // indirect
+ 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
+ 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect
+@@ -162,3 +162,5 @@ require (
+ 	sigs.k8s.io/kustomize/kyaml v0.14.1 // indirect
+ 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
+ )
++
++replace github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 => github.com/hack3ric/panicwrap v0.0.0-20230905013234-d1739d73e061
+diff --git a/go.sum b/go.sum
+index c905a60c9..f08d46ce3 100644
+--- a/go.sum
++++ b/go.sum
+@@ -92,10 +92,6 @@ github.com/bshuster-repo/logrus-logstash-hook v1.0.0 h1:e+C0SB5R1pu//O4MQ3f9cFuP
+ github.com/bshuster-repo/logrus-logstash-hook v1.0.0/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
+ github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd h1:rFt+Y/IK1aEZkEHchZRSq9OQbsSzIT/OrI8YFFmRIng=
+ github.com/bugsnag/bugsnag-go v0.0.0-20141110184014-b1d153021fcd/go.mod h1:2oa8nejYd4cQ/b0hMIopN0lCRxU0bueqREvZLWFrtK8=
+-github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b h1:otBG+dV+YK+Soembjv71DPz3uX/V/6MMlSyD9JBQ6kQ=
+-github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
+-github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXer/kZD8Ri1aaunCxIEsOst1BVJswV0o=
+-github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
+ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
+ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+@@ -330,6 +326,8 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmg
+ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
+ github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
+ github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
++github.com/hack3ric/panicwrap v0.0.0-20230905013234-d1739d73e061 h1:CZYJsYF9a5ds8h3VCbn69d8PwVztjTeCkSKszbBudYs=
++github.com/hack3ric/panicwrap v0.0.0-20230905013234-d1739d73e061/go.mod h1:JSxncccr8cxyVcfuq8Kzp1ysqoNqP/7DjSWNUIcCQGM=
+ github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
+ github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
+ github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+@@ -386,6 +384,8 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
+ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+ github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
++github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0 h1:iQTw/8FWTuc7uiaSepXwyf3o52HaUYcV+Tu66S3F5GA=
++github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
+ github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
+ github.com/karrick/godirwalk v1.16.1/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
+ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
+diff --git a/pkg/plugin/plugin_test.go b/pkg/plugin/plugin_test.go
+index e8aead6ae..7e41753cd 100644
+--- a/pkg/plugin/plugin_test.go
++++ b/pkg/plugin/plugin_test.go
+@@ -91,6 +91,7 @@ func TestPlatformPrepareCommand(t *testing.T) {
+ 				{OperatingSystem: "linux", Architecture: "arm64", Command: "echo -n linux-arm64"},
+ 				{OperatingSystem: "linux", Architecture: "ppc64le", Command: "echo -n linux-ppc64le"},
+ 				{OperatingSystem: "linux", Architecture: "s390x", Command: "echo -n linux-s390x"},
++				{OperatingSystem: "linux", Architecture: "riscv64", Command: "echo -n linux-riscv64"},
+ 				{OperatingSystem: "windows", Architecture: "amd64", Command: "echo -n win-64"},
+ 			},
+ 		},
+@@ -108,6 +109,8 @@ func TestPlatformPrepareCommand(t *testing.T) {
+ 		osStrCmp = "linux-ppc64le"
+ 	} else if os == "linux" && arch == "s390x" {
+ 		osStrCmp = "linux-s390x"
++	} else if os == "linux" && arch == "riscv64" {
++		osStrCmp = "linux-riscv64"
+ 	} else if os == "windows" && arch == "amd64" {
+ 		osStrCmp = "win-64"
+ 	} else {

--- a/helm/riscv64.patch
+++ b/helm/riscv64.patch
@@ -1,0 +1,28 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,13 +15,15 @@ depends=('glibc')
+ makedepends=("go" "git")
+ options=("!lto")
+ _commit=c9f554d75773799f72ceef38c51210f1842a1dea	#refs/tags/v3.12.0^{}
+-source=("git+https://github.com/helm/helm.git#commit=${_commit}?signed")
++source=("git+https://github.com/helm/helm.git#commit=${_commit}?signed"
++        "add-riscv64-build.patch")
+ # source=("git+https://github.com/helm/helm.git#tag=v${pkgver}?signed")
+ validpgpkeys=('672C657BE06B4B30969C4A57461449C25E36B98E'
+               'CABAA8D44DFACA14791FBE9892C44A3D421FF7F9'
+               '967F8AC5E2216F9F4FD270AD92AA783CBAAE8E3B'
+               'F1261BDE929012C8FF2E501D6EA5D7598529A53E')
+-sha256sums=('SKIP')
++sha256sums=('SKIP'
++            '3dbecb25078aacaff8abd1aa8657ceabb6d04a8727ef600573902be072c03488')
+ 
+ pkgver() {
+   cd "${pkgname}"
+@@ -30,6 +32,7 @@ pkgver() {
+ 
+ prepare() {
+   cd "${pkgname}"
++  patch -Np1 -i ../add-riscv64-build.patch
+   go mod tidy -compat=1.17
+ }
+ 


### PR DESCRIPTION
Fix check:
- Add riscv64 entry in plugin_test.go.
- Fork github.com/bugsnag/osext and fix dup2 issue.