### PR TITLE
updpatch: vnstat 2.11-1

### DIFF
--- a/vnstat/riscv64.patch
+++ b/vnstat/riscv64.patch
@@ -1,9 +1,9 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -20,6 +20,7 @@ validpgpkeys=(23EF1DD76E65248FB055201ADAFE84E63D140114) # Teemu Toivola
+@@ -21,6 +21,7 @@ validpgpkeys=(23EF1DD76E65248FB055201ADAFE84E63D140114) # Teemu Toivola
  
  build() {
-   cd "$srcdir"/$pkgname-$pkgver
+   cd $pkgname-$pkgver
 +  autoreconf -fiv
    ./configure --prefix=/usr --sbindir=/usr/bin --sysconfdir=/etc
    make


### PR DESCRIPTION
Fix rotten patch.

Upstream does not want to update autotools: https://github.com/vergoh/vnstat/issues/239#issuecomment-1332795086