### PR TITLE
addpatch: sbcl 2.3.7-1

### DIFF
--- a/sbcl/riscv64.patch
+++ b/sbcl/riscv64.patch
@@ -1,0 +1,22 @@
+diff --git PKGBUILD PKGBUILD
+index ce5d4ca..3dec932 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,7 +12,7 @@
+ license=('custom')
+ depends=('zlib')
+ provides=('common-lisp' 'cl-asdf')
+-makedepends=('sbcl')
++makedepends=('clisp')
+ source=("https://downloads.sourceforge.net/project/sbcl/sbcl/$pkgver/$pkgname-$pkgver-source.tar.bz2"
+   "arch-fixes.lisp")
+ sha256sums=('698144fb805a31919a610de999ab98391d52eb698adaa8ca19b28fc6ed0d99f7'
+@@ -28,7 +28,7 @@
+   export LINKFLAGS="$LDFLAGS"
+   unset LDFLAGS
+   unset MAKEFLAGS
+-  sh make.sh sbcl --prefix=/usr --fancy
++  sh make.sh sbcl --prefix=/usr --fancy --xc-host='env LC_ALL=C.utf8 clisp -q -norc'
+   make -C doc/manual info
+ }
+ 


### PR DESCRIPTION
sbcl can't bootstrap itself now, use clisp instead. 
[Related bug report](https://bugs.launchpad.net/sbcl/+bug/2031965)

Some tests are failing, see https://pb.mgt.moe/1kop