### PR TITLE
qemu-user-blacklist: add glib2

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -31,6 +31,7 @@ gauche
 gawk
 gdk-pixbuf2
 glib-perl
+glib2
 glibc
 go
 gpxsee


### PR DESCRIPTION
expects process name to start with the real program:
```
 65/353 glib:glib+core / spawn-test                                            ERROR            1.51s   killed by signal 6 SIGABRT                                                                                                                                                 
>>> MALLOC_CHECK_=2 LD_LIBRARY_PATH=/build/glib2/src/build/glib MALLOC_PERTURB_=205 G_ENABLE_DIAGNOSTIC=1 G_DEBUG=gc-friendly G_TEST_SRCDIR=/build/glib2/src/glib/glib/tests G_TEST_BUILDDIR=/build/glib2/src/build/glib/tests /build/glib2/src/build/glib/tests/spawn-test        
――――――――――――――――――――――――――――――――――――― ✀  ―――――――――――――――――――――――――――――――――――――                                                                                                                                                                                                     
stderr:                                                                                                                                                                                                                                                                            
**                                                                                                                                                                                                                                                                                 
GLib:ERROR:../glib/glib/tests/spawn-test.c:295:test_spawn_basics: 'g_str_has_prefix (erroutput, "sort: ")' should be TRUE       
```

ptrace not implemented by qemu-user:
```
 347/353 /gsubprocess/exit-status/trapped - GLib-GIO:ERROR:../glib/gio/tests/gsubprocess.c:2007:trace_children: assertion failed (ptrace (PTRACE_SETOPTIONS, main_child, NULL, (PTRACE_O_TRACEFORK | PTRACE_O_EXITKILL | PTRACE_O_TRACEVFORK | PTRACE_O_TRACECLONE | PTRACE_O_TRAC
EEXEC)) >= 0): errno 38: Function not implemented FAIL   
```