### PR TITLE
updpatch: arrow 13.0.0-4

### DIFF
--- a/arrow/riscv64.patch
+++ b/arrow/riscv64.patch
@@ -1,22 +1,12 @@
-diff --git a/PKGBUILD b/PKGBUILD
-index d381f84..f378721 100644
+diff --git PKGBUILD PKGBUILD
+index 408de2c..77a6916 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -14,6 +14,7 @@ depends=(apache-orc boost-libs brotli bzip2 double-conversion c-ares gflags
+@@ -13,6 +13,7 @@ depends=(apache-orc brotli bzip2 gflags grpc google-glog libutf8proc
  provides=(parquet-cpp)
  conflicts=(parquet-cpp)
- makedepends=(boost cmake flatbuffers gmock python-numpy git clang)
+ makedepends=(boost clang cmake flatbuffers git gmock rapidjson xsimd)
 +options=(!lto)
  source=(https://archive.apache.org/dist/${pkgname}/${pkgname}-${pkgver}/apache-${pkgname}-${pkgver}.tar.gz{,.asc}
          git+https://github.com/apache/parquet-testing.git
          git+https://github.com/apache/arrow-testing.git)
-@@ -58,7 +59,8 @@ build(){
-     -DARROW_WITH_SNAPPY=ON \
-     -DARROW_WITH_ZLIB=ON \
-     -DARROW_WITH_ZSTD=ON \
--    -DPARQUET_REQUIRE_ENCRYPTION=ON
-+    -DPARQUET_REQUIRE_ENCRYPTION=ON \
-+    -DARROW_CPU_FLAG=riscv64
-   make -C build
- }
- 


### PR DESCRIPTION
LTO is still broken:
```
/usr/bin/ld: error: LLVM gold plugin: linking module flags
'SmallDataLimit': IDs have conflicting values in
'CMakeFiles/arrow_acero_testing.dir/test_util_internal.cc.o' and
'ld-temp.o'
```