### PR TITLE
qemu-user-blacklist: add nodejs-lts-hydrogen

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -70,6 +70,7 @@ mold
 nextcloud-client
 ninja
 nodejs-lts-gallium
+nodejs-lts-hydrogen
 notepadqq
 nuitka
 nushell


### PR DESCRIPTION
g++ segmentation faults in qemu-user riscv64. But it doesn't fail on real riscv64 boards.

Bug report: https://gitlab.com/qemu-project/qemu/-/issues/1895

Minimal reproduction: https://gitlab.com/qemu-project/qemu/uploads/d63b1867a458a240ef0d90c760d76bc7/testcase.i