### PR TITLE
qemu-user-blacklist: add neochat

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -67,6 +67,7 @@ memcached
 menyoki
 mkvtoolnix
 mold
+neochat
 nextcloud-client
 ninja
 nodejs-lts-gallium


### PR DESCRIPTION
g++ segfaults in qemu.

To reproduce, run `g++ -std=gnu++20 -c neochat.i`.

neochat.i is a reduced version of the original ICE file.

Attachment: [neochat.i.zip](https://github.com/felixonmars/archriscv-packages/files/12642249/neochat.i.zip)
