### PR TITLE
Switch OpenSSL target to 'linux64-riscv64' for RISC-V assembly

### DIFF
--- a/openssl/riscv64.patch
+++ b/openssl/riscv64.patch
@@ -5,7 +5,7 @@
  	# mark stack as non-executable: http://bugs.archlinux.org/task/12434
  	./Configure --prefix=/usr --openssldir=/etc/ssl --libdir=lib \
 -		shared enable-ktls enable-ec_nistp_64_gcc_128 linux-x86_64 \
-+		shared enable-ktls enable-ec_nistp_64_gcc_128 linux-generic64 \
++		shared enable-ktls enable-ec_nistp_64_gcc_128 linux64-riscv64 \
  		"-Wa,--noexecstack ${CPPFLAGS} ${CFLAGS} ${LDFLAGS}"
  
  	make depend


### PR DESCRIPTION
Reconfigure target platform from 'linux-generic64' to 'linux64-riscv64' within the OpenSSL 3 project. This adjustment is motivated by the significant presence of [RISC-V optimization codes](https://github.com/search?q=repo%3Aopenssl%2Fopenssl%20riscv64&type=code) embedded throughout the OpenSSL 3 codebase.