### PR TITLE
addpatch: webkit2gtk{,-4.1}, webkitgtk-6.0

### DIFF
--- a/webkit2gtk-4.1/riscv64.patch
+++ b/webkit2gtk-4.1/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -87,6 +87,7 @@ validpgpkeys=(
+   'D7FCF61CF9A2DEAB31D81BD3F3D322D0EC4582C3'  # Carlos Garcia Campos <cgarcia@igalia.com>
+   '5AA3BC334FD7E3369E7C77B291C559DBE4C9123B'  # Adrián Pérez de Castro <aperez@igalia.com>
+ )
++options=(!lto)
+ 
+ prepare() {
+   cd webkitgtk-$pkgver

--- a/webkit2gtk/riscv64.patch
+++ b/webkit2gtk/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -87,6 +87,7 @@ validpgpkeys=(
+   'D7FCF61CF9A2DEAB31D81BD3F3D322D0EC4582C3'  # Carlos Garcia Campos <cgarcia@igalia.com>
+   '5AA3BC334FD7E3369E7C77B291C559DBE4C9123B'  # Adrián Pérez de Castro <aperez@igalia.com>
+ )
++options=(!lto)
+ 
+ prepare() {
+   cd webkitgtk-$pkgver

--- a/webkitgtk-6.0/riscv64.patch
+++ b/webkitgtk-6.0/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -87,6 +87,7 @@ validpgpkeys=(
+   'D7FCF61CF9A2DEAB31D81BD3F3D322D0EC4582C3'  # Carlos Garcia Campos <cgarcia@igalia.com>
+   '5AA3BC334FD7E3369E7C77B291C559DBE4C9123B'  # Adrián Pérez de Castro <aperez@igalia.com>
+ )
++options=(!lto)
+ 
+ prepare() {
+   cd webkitgtk-$pkgver


### PR DESCRIPTION
Disable LTO:

```
[1364/6887] Linking CXX executable bin/LLIntSettingsExtractor
FAILED: bin/LLIntSettingsExtractor
: && /usr/bin/clang++ -fdiagnostics-color=always -fcolor-diagnostics -Wextra -Wall -pipe -Wno-noexcept-type -Wno-psabi -Wno-misleading-indentation -Wno-parentheses-equality -Qunused-arguments -Wundef -Wpointer-arith ...
ld.lld: error: linking module flags 'SmallDataLimit': IDs have conflicting values in 'Source/WTF/wtf/CMakeFiles/WTF.dir/./ASCIICType.cpp.o' and 'ld-temp.o'
clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
```