### PR TITLE
addpatch: clang15 15.0.7-1

### DIFF
--- a/clang15/riscv64.patch
+++ b/clang15/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index 1866477..636902b 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -26,7 +26,7 @@ sha256sums=('a6b673ef15377fb46062d164e8ddc4d05c348ff8968f015f7f4af03f51000067'
+             'SKIP'
+             '8986f29b634fdaa9862eedda78513969fe9788301c9f2d938f4c10a3e7a3e7ea'
+             'SKIP'
+-            'f82449f41c8258f9ae13bd0c311e940711430d2c979eeb8255b36e0e63cda18c'
++            '75f220b68622a57b49a9480fe2ee321c7ff9b5ce643091b6cb510b9e38400e92'
+             '8c8e1a01d3a46b20a78eccec29904edca46caa2c15fb4e8998423098b482e1a2'
+             '7a9ce949579a3b02d4b91b6835c4fb45adc5f743007572fb0e28e6433e48f3a5')
+ validpgpkeys=('474E22316ABF4785A88C6E8EA2C794A986419D8A') # Tom Stellard <tstellar@redhat.com>


### PR DESCRIPTION
checksum mismatch reported to Arch: https://bugs.archlinux.org/task/79752

`nocheck` is currently needed:

```
FAIL: Clang-Unit :: Interpreter/ExceptionTests/./ClangReplInterpreterExceptionTests/0/1 (16538 of 16669)
******************** TEST 'Clang-Unit :: Interpreter/ExceptionTests/./ClangReplInterpreterExceptionTests/0/1' FAILED ********************
Script(shard):
--
GTEST_OUTPUT=json:/build/clang15/src/clang-15.0.7.src/build/unittests/Interpreter/ExceptionTests/./ClangReplInterpreterExceptionTests-Clang-Unit-13886-0-1.json GTEST_SHUFFLE=0 GTEST_TOTAL_SHARDS=1 GTEST_SHARD_INDEX=0 /build/clang15/src/clang-15.0.7.src/build/unittests/Interpreter/ExceptionTests/./ClangReplInterpreterExceptionTests
--

[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from InterpreterTest
[ RUN      ] InterpreterTest.CatchException
JIT session error: Unsupported riscv relocation:45: R_RISCV_RVC_JUMP
 #0 0x0000003f9df098a4 (/usr/lib/llvm15/lib/libLLVM-15.so+0xd098a4)
 #1 0x0000003f9df0776c llvm::sys::RunSignalHandlers() (/usr/lib/llvm15/lib/libLLVM-15.so+0xd0776c)
 #2 0x0000003f9df078c4 (/usr/lib/llvm15/lib/libLLVM-15.so+0xd078c4)
 #3 0x0000003fa3f0c800 (linux-vdso.so.1+0x800)
 #4 0x0000002ad8ecabe0

--
exit: -11
--
shard JSON output does not exist: /build/clang15/src/clang-15.0.7.src/build/unittests/Interpreter/ExceptionTests/./ClangReplInterpreterExceptionTests-Clang-Unit-13886-0-1.json
********************
Testing:  0.. 10.. 20.. 30.. 40.. 50.. 60.. 70.. 80.. 90..
********************
Failed Tests (1):
  Clang-Unit :: Interpreter/ExceptionTests/./ClangReplInterpreterExceptionTests/0/1

Testing Time: 280.65s
  Skipped          :    33
  Unsupported      :   140
  Passed           : 30874
  Expectedly Failed:    26
  Failed           :     1
```