### PR TITLE
updpatch: keycloak 22.0.3-1

### DIFF
--- a/keycloak/riscv64.patch
+++ b/keycloak/riscv64.patch
@@ -5,7 +5,7 @@
  license=('Apache')
  depends=("java-runtime-headless=${_java}" 'grep' 'bash' 'coreutils' 'util-linux')
 -makedepends=('maven' "java-environment=${_java}")
-+makedepends=('maven' "java-environment=${_java}" 'nodejs-lts-gallium' 'npm' 'pnpm')
++makedepends=('maven' "java-environment=${_java}" 'nodejs' 'npm' 'pnpm')
  backup=(
    'etc/keycloak/keycloak.conf'
  )
@@ -15,7 +15,7 @@
          pin-java-version.patch
 -        )
 +        use-system-node.patch)
- sha512sums=('2412e613ad0d0800075acca472115729c77bc5b042b12b12ae5231d5324169961223bbd165c460062d0ec6c2224e5609e5180af6d82d54e1397a980019ffe351'
+ sha512sums=('65e3e01d008f8935aaca9d32323d78491125fc794c25ec089e044f8a280255f1c28db9634c81892693fd73e82417af5a6644ff358a31820944330bd042fc57ab'
              '925ca021a9989a6d5181a90f42ec9e67a4957e98bb716acba75e13e1b01a03e4bd3a5939f5f0abe4cf57157be54dda5e373286041b22d84f5079eba94df4e6c9'
              '2e2ba147007ad74e38579a8838d79de47beac509b4bd1a14d7f80905953d79a7396d781f141b461ec688f5ceef9a1081a825a4ca8afc1ea12c178d8ae7f5a7dd'
              '155db40105c08d0aaa810ca5533dc16fc9f82060280541ede6fafd754d30b4844f6d10ace1417a5ad68d89fc54e1b9e6d906ce7ccf973f4ac964422211ed9a72'


### PR DESCRIPTION
- Fix rotten patch
- Replace EOL Node.js 16 with current version