### PR TITLE
addpkg: cargo-modules

### DIFF
--- a/cargo-modules/riscv64.patch
+++ b/cargo-modules/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,7 +14,7 @@ sha256sums=('92be935f02b154e297d7be5d42bb0ea09fa4d3a738eb3a9fbc3a14378457096d')
+ 
+ prepare() {
+   cd "$pkgname-$pkgver"
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  cargo fetch --locked
+ }
+ 
+ build() {


### PR DESCRIPTION
Remove parameter: `--target "$CARCH-unknown-linux-gnu"`.

Successfully built and checked.

Output `error: target not found: cargo-modules`
at the end (similar to #1417).