### PR TITLE
addpkg: zbus_xmlgen

### DIFF
--- a/zbus_xmlgen/riscv64.patch
+++ b/zbus_xmlgen/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -28,7 +28,7 @@ prepare() {
+ 
+   cd $_project_name-$pkgname-$pkgver/$pkgname
+   export RUSTUP_TOOLCHAIN=stable
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  cargo fetch --locked
+ }
+ 
+ build() {


### PR DESCRIPTION
Remove parameter: `--target "$CARCH-unknown-linux-gnu"`.

Successfully built and checked.

Output `error: target not found: zbus_xmlgen`
at the end (similar to #1417).