### PR TITLE
upgpatch: code

### DIFF
--- a/code/riscv64.patch
+++ b/code/riscv64.patch
@@ -4,8 +4,8 @@
  optdepends=('bash-completion: Bash completions'
              'zsh-completions: ZSH completitons'
              'x11-ssh-askpass: SSH authentication')
--makedepends=('git' 'gulp' 'npm' 'python' 'yarn' 'nodejs-lts-gallium' 'desktop-file-utils')
-+makedepends=('git' 'gulp' 'npm' 'python' 'yarn' 'nodejs-lts-gallium' 'desktop-file-utils' 'zip')
+-makedepends=('git' 'gulp' 'npm' 'python' 'yarn' 'nodejs-lts-hydrogen' 'desktop-file-utils')
++makedepends=('git' 'gulp' 'npm' 'python' 'yarn' 'nodejs-lts-hydrogen' 'desktop-file-utils' 'zip')
  provides=('vscode')
  source=("$pkgname::git+$url.git#tag=$pkgver"
          'code.js'
@@ -29,7 +29,7 @@
    # Change electron binary name to the target electron
    sed -e "s|name=electron|name=$_electron |" \
        -e '/PKGBUILD/d' \
-@@ -99,7 +105,30 @@ prepare() {
+@@ -102,7 +108,30 @@ prepare() {
  
  build() {
    cd $pkgname


### PR DESCRIPTION
- Fix rotten.
- We still need to build native node extensions in debug mode. They still segfaults in release mode even with electron25.