### PR TITLE
qemu-user-blacklist: add cockatrice

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -9,6 +9,7 @@ cargo-audit
 cargo-generate-rpm
 cargo-nextest
 cloud-init
+cockatrice
 coreutils
 ctags
 datovka


### PR DESCRIPTION
Test segmentation fault only happens in qemu-user.

```
7/7 Test #7: loading_from_clipboard_test ......***Exception: SegFault  0.34 sec
```