### PR TITLE
addpatch: python-jupyter-sphinx 0.4.0-2

### DIFF
--- a/python-jupyter-sphinx/riscv64.patch
+++ b/python-jupyter-sphinx/riscv64.patch
@@ -1,0 +1,22 @@
+diff --git PKGBUILD PKGBUILD
+index b9120c0..958643b 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,8 +12,15 @@
+ makedepends=(python-build python-installer python-setuptools python-wheel)
+ checkdepends=(python-pytest)
+ #source=(https://pypi.io/packages/source/j/$_pipname/$_pipname-$pkgver.tar.gz) - doesn't include tests
+-source=(https://github.com/jupyter/jupyter-sphinx/archive/v$pkgver/$pkgname-$pkgver.tar.gz)
+-sha256sums=('85999a5f224281ee95263787313b5cbf48fb3c0f406a88ad5d9debcf1d4d06d4')
++source=(https://github.com/jupyter/jupyter-sphinx/archive/v$pkgver/$pkgname-$pkgver.tar.gz
++        remove-sphinx.testing.util.path.patch::https://github.com/jupyter/jupyter-sphinx/pull/233.diff)
++sha256sums=('85999a5f224281ee95263787313b5cbf48fb3c0f406a88ad5d9debcf1d4d06d4'
++            '0b4d6c1b4e07d1018a4229d77bd97b7a3e16110e6e47e9210535ae70656610d9')
++
++prepare() {
++  cd $_pipname-$pkgver
++  patch -Np1 -i ../remove-sphinx.testing.util.path.patch
++}
+ 
+ build() {
+   cd $_pipname-$pkgver


### PR DESCRIPTION
Fix check failure:
```text
[  100s] ==================================== ERRORS ====================================
[  100s] ____________________ ERROR collecting tests/test_execute.py ____________________
[  100s] ImportError while importing test module '/home/abuild/rpmbuild/BUILD/jupyter-sphinx-0.4.0/tests/test_execute.py'.
[  100s] Hint: make sure your test modules/packages have valid Python names.
[  100s] Traceback:
[  100s] /usr/lib64/python3.9/importlib/__init__.py:127: in import_module
[  100s]     return _bootstrap._gcd_import(name[level:], package, level)
[  100s] tests/test_execute.py:15: in <module>
[  100s]     from sphinx.testing.util import SphinxTestApp, assert_node, path
[  100s] E   ImportError: cannot import name 'path' from 'sphinx.testing.util' (/usr/lib/python3.9/site-packages/sphinx/testing/util.py)
[  100s] =========================== short test summary info ============================
[  100s] ERROR tests/test_execute.py
[  100s] !!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
[  100s] =============================== 1 error in 0.42s ===============================
```