### PR TITLE
addpkg: maude

### DIFF
--- a/maude/riscv64.patch
+++ b/maude/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -25,7 +25,7 @@ prepare() {
+   # Always enabled in CVC4 1.8: https://github.com/CVC4/CVC4/pull/4519
+   sed -i '/rewrite-divk/d' src/Mixfix/cvc4_Bindings.cc
+ 
+-  autoreconf -i
++  autoreconf -fiv
+ 
+   mkdir -p build
+ }


### PR DESCRIPTION
Update the outdated config.guess file.

Perhaps there is no need to report to upstream, because maude is going to use CMake instread of Autotools: https://github.com/SRI-CSL/Maude/pull/10 ?