### PR TITLE
addpatch: fceux 2.6.6-1

### DIFF
--- a/fceux/riscv64.patch
+++ b/fceux/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,6 +17,8 @@ b2sums=('SKIP')
+ 
+ prepare() {
+   cd $pkgname
++  git cherry-pick -n 396096223ec58ff7f437ec0de7275240946531c5
++  git cherry-pick -n d2ee6351c08518c866bb48d89f58a67bb36931fc
+   sed -i 's/-interim git//g' src/version.h
+   setconf scripts/genGitHdr.sh GIT_URL "'""${source:4:34}""'"
+   setconf scripts/genGitHdr.sh GIT_REV "${source#*=}"


### PR DESCRIPTION
Cherry-pick two of the upstream commits to make x86 `rdtsc` usage optional:
- https://github.com/TASEmulators/fceux/commit/396096223ec58ff7f437ec0de7275240946531c5
- https://github.com/TASEmulators/fceux/commit/d2ee6351c08518c866bb48d89f58a67bb36931fc