### PR TITLE
addpkg: librustls

### DIFF
--- a/librustls/riscv64.patch
+++ b/librustls/riscv64.patch
@@ -1,0 +1,22 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -25,14 +25,17 @@ prepare() {
+   cd rustls-ffi-${pkgver}
+   [ ! -e Cargo.lock ] # remove Cargo.lock from source= after next release
+   cp ../Cargo.lock .
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  cargo fetch --locked
+   patch -Np1 -i ../shared-linking.patch
++  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
++  cargo update -p ring
+ }
+ 
+ build() {
+   cd rustls-ffi-${pkgver}
+   RUSTC_BOOTSTRAP=1 cargo cbuild --release --frozen --prefix=/usr
+-  patchelf --set-soname "librustls.so.${pkgver}" "target/$CARCH-unknown-linux-gnu/release/librustls.so"
++  # see: https://github.com/felixonmars/archriscv-packages/issues/670
++  patchelf --set-soname "librustls.so.${pkgver}" "target/$(rustc -vV | awk '/^host:/ { print $2 }')/release/librustls.so"
+ }
+ 
+ package() {


### PR DESCRIPTION
- Fix broken rust target.
- Fix ring issue.
- Fix `patchelf` target path in RV64: `riscv64gc` instead of `riscv64`.