### PR TITLE
addpatch: mkinitcpio

### DIFF
--- a/mkinitcpio/riscv64.patch
+++ b/mkinitcpio/riscv64.patch
@@ -1,0 +1,31 @@
+diff --git PKGBUILD PKGBUILD
+index cf4eae5..3e41958 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -21,15 +21,23 @@ optdepends=('gzip: Use gzip compression for the initramfs image'
+             'mkinitcpio-nfs-utils: Support for root filesystem on NFS')
+ provides=('initramfs')
+ backup=('etc/mkinitcpio.conf')
+-source=("https://sources.archlinux.org/other/$pkgname/$pkgname-$pkgver.tar.gz"{,.sig})
++source=("https://sources.archlinux.org/other/$pkgname/$pkgname-$pkgver.tar.gz"{,.sig}
++        $pkgname-pci-controller.patch::https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/merge_requests/264.patch)
+ install=mkinitcpio.install
+ sha512sums=('f13cfdfee62dc1a344b75413fde8f35eb594c4c372d4a2ed8bbc22f2c01d93ea59d423807d06d19a6d1789e47b35286845daffeffef0fec4bae022e0e92b7b64'
+-            'SKIP')
++            'SKIP'
++            '65f85d1a69dfe9f42b093a185686a1a790a5b3cea170a3128027a72d1a515d389ae063a11f445b57bff4b3db0b981321ef1dc24a01a905114b19be03d5341a2f')
+ b2sums=('b60d8e61a15167df3316a7336467740efd4888784228dd6a08b1d974c54c479c082ba142eb60d3f356b06053e5c472f747e0ca830d50bed9f31c13d52b549ca1'
+-        'SKIP')
++        'SKIP'
++        'b888c6ded798021ecccd7a2dd96097110fec9b45b696a6d0e598838b522f2a79a290e6a9c4ed0d2f492651cbf28b457fccb829321bb4c383b40506b18c9ca0dd')
+ validpgpkeys=('ECCAC84C1BA08A6CC8E63FBBF22FB1D78A77AEAB'    # Giancarlo Razzolini
+               'C100346676634E80C940FB9E9C02FF419FECBE16')   # Morten Linderud
+ 
++prepare() {
++  cd "$pkgname-$pkgver"
++  patch -Np1 -i ../$pkgname-pci-controller.patch
++}
++
+ check() {
+   make -C "$pkgname-$pkgver" check
+ }


### PR DESCRIPTION
Add patch to include PCI controllers for QEMU 'virt' machine. Fixes virtio-blk device not found issue with libvirt generated config.