### PR TITLE
addpkg: cppcheck

### DIFF
--- a/cppcheck/riscv64.patch
+++ b/cppcheck/riscv64.patch
@@ -1,0 +1,30 @@
+diff --git PKGBUILD PKGBUILD
+index 0a01e5c..c4ccac1 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -34,11 +34,14 @@ _commit='f2f1fb0bca5f23aac8f02fb9c09e4529a7935749'
+ source=(
+   "$pkgname::git+https://github.com/danmar/cppcheck.git#commit=$_commit"
+   'translations-location.patch'
++  'improve-test-for-unsigned-char-platform.patch::https://patch-diff.githubusercontent.com/raw/danmar/cppcheck/pull/5524.diff'
+ )
+ sha512sums=('SKIP'
+-            'd3528834d719017ec3a0e08005a293089b556622928defa1b37f940e62cb01165dcbd741e6d5e989c0156fb8789f7e63702af8b2390738648b2300a92f4ab0ae')
++            'd3528834d719017ec3a0e08005a293089b556622928defa1b37f940e62cb01165dcbd741e6d5e989c0156fb8789f7e63702af8b2390738648b2300a92f4ab0ae'
++            '9435e7dddfdf678b4f369c754079e01c7c24c522688287703036fb0eadebeddec5de84d9a4d7017da7bfe5c9b113fa86e4af61d017a3adcab0ea7ae9c36d0b5f')
+ b2sums=('SKIP'
+-        '8156920eacc630cb5eceb2387937b747c84c6325bef906717cfbad68c122bdd27965da1e8070a560a0bed3a7b7c59ff5f0e116bb1d035c4c42f430c927a75b1f')
++        '8156920eacc630cb5eceb2387937b747c84c6325bef906717cfbad68c122bdd27965da1e8070a560a0bed3a7b7c59ff5f0e116bb1d035c4c42f430c927a75b1f'
++        'e7b92d185c83ac2fcff2be4f072a48942bebe59876ee3b9a89d2691a1eeea68be2210cb25fc65f3092ecc5796b46418a5c61c1b125ea61a5209e73649b4a9972')
+ 
+ pkgver() {
+   cd "$pkgname"
+@@ -52,6 +55,8 @@ prepare() {
+   # fix location of translations
+   patch -p1 -i "$srcdir/translations-location.patch"
+ 
++  patch -Np1 -i "$srcdir/improve-test-for-unsigned-char-platform.patch"
++
+   # https://github.com/danmar/cppcheck/pull/5350
+   git revert --no-commit 499f566e9dcdf7d033145c4eb613dd4a4738ab0a
+ }


### PR DESCRIPTION
Improve cppcheck testcases on `unsigned char` platform.

Upstreamed: https://github.com/danmar/cppcheck/pull/5524