### PR TITLE
blacklist: yuzu

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -15,6 +15,7 @@ reaper
 teamspeak3
 teamspeak3-server
 vivaldi
+yuzu
 
 # No hardware support
 amd-ucode


### PR DESCRIPTION
I found that the following code snippet in yuzu-mainline `yuzu-mainline/src/core/hle/kernel/physical_core.cpp` stopped me from compiling.
```c++
PhysicalCore::PhysicalCore(std::size_t core_index, Core::System& system, KScheduler& scheduler)
    : m_core_index{core_index}, m_system{system}, m_scheduler{scheduler} {
#if defined(ARCHITECTURE_x86_64) || defined(ARCHITECTURE_arm64)
    // TODO(bunnei): Initialization relies on a core being available. We may later replace this with
    // a 32-bit instance of Dynarmic. This should be abstracted out to a CPU manager.
    auto& kernel = system.Kernel();
    m_arm_interface = std::make_unique<Core::ARM_Dynarmic_64>(
        system, kernel.IsMulticore(),
        reinterpret_cast<Core::DynarmicExclusiveMonitor&>(kernel.GetExclusiveMonitor()),
        m_core_index);
#else
#error Platform not supported yet.
#endif
```
I guess that means yuzu doesn't provide RISC-V support.
