### PR TITLE
upgpatch: java11-openjdk

### DIFF
--- a/java11-openjdk/riscv64.patch
+++ b/java11-openjdk/riscv64.patch
@@ -1,21 +1,6 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -32,15 +32,20 @@ options=(!lto)
- source=(https://github.com/openjdk/jdk${_majorver}u/archive/${_git_tag}.tar.gz
-         freedesktop-java.desktop
-         freedesktop-jconsole.desktop
--        freedesktop-jshell.desktop)
-+        freedesktop-jshell.desktop
-+
-+        # see https://build.opensuse.org/package/show/home:Andreas_Schwab:riscv:java/java-11-openjdk
-+        java11-riscv64.patch)
- sha256sums=('b2a37ef209ae7eaf8f34182b7c9aa3252af20a214d02970f96ce62242c805479'
-             '575587ad58dfa9908f046d307b9afc7b0b2eb20a1eb454f8fdbbd539ea7b3d01'
-             '2f57b7c7dd671eabe9fa10c4f1283573e99d7f7c36eccd82c95b705979a2e8cb'
--            'f271618a8c2a892b554caf26857af41efdf0d8bcb95d57ce7ba535d6979e96da')
-+            'f271618a8c2a892b554caf26857af41efdf0d8bcb95d57ce7ba535d6979e96da'
-+            '2eeedc01389f0301639a7daaaa27c90c798030a6a5e41d8c6b2eed6c36fa54de')
- 
+@@ -41,6 +41,7 @@ sha256sums=('982322667a9e5cb6a2e063bbab3c0bda43907cf9c6099b80888d41499823f1a3'
  case "${CARCH}" in
    x86_64) _JARCH='x86_64';;
    i686)   _JARCH='x86';;
@@ -23,10 +8,14 @@
  esac
  
  _jvmdir=/usr/lib/jvm/java-${_majorver}-openjdk
-@@ -52,6 +57,11 @@ _nonheadless=(lib/libawt_xawt.so
+@@ -52,6 +53,15 @@ _nonheadless=(lib/libawt_xawt.so
                lib/libjsound.so
                lib/libsplashscreen.so)
  
++# see https://build.opensuse.org/package/show/home:Andreas_Schwab:riscv:java/java-11-openjdk
++source+=(java11-riscv64.patch)
++sha256sums+=('2eeedc01389f0301639a7daaaa27c90c798030a6a5e41d8c6b2eed6c36fa54de')
++
 +prepare() {
 +  cd "$srcdir/$_jdkdir"
 +  patch -Np1 -i "$srcdir"/java11-riscv64.patch


### PR DESCRIPTION
Fix rotten and make it less likely to rot.