### PR TITLE
addpkg: p2pool

### DIFF
--- a/p2pool/riscv64.patch
+++ b/p2pool/riscv64.patch
@@ -1,0 +1,31 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -10,8 +10,12 @@ license=('GPL-3.0-or-later')
+ url="https://github.com/SChernykh/p2pool"
+ depends=('curl' 'libuv' 'libsodium' 'zeromq')
+ makedepends=('cmake' 'git')
+-source=("${pkgname}"::"git+https://github.com/SChernykh/${pkgname}#commit=${_commit}")
+-b2sums=('SKIP')
++source=("${pkgname}"::"git+https://github.com/SChernykh/${pkgname}#commit=${_commit}"
++        "https://github.com/SChernykh/p2pool/commit/5daa2b9dfffcef72286b8429d4c3d65f535a70a8.patch"
++        "https://github.com/SChernykh/RandomX/commit/d5035cd9c50a5d34ae87ec3507314dc806343548.patch")
++b2sums=('SKIP'
++        'c5aa360cf5532476e415c2b30517c2bc2283b615d88c3dffcee5f06b303c0801c0e31f3e40959b167cc8d26c2df76c0cfbddf617c3571a04d2b5c3dcaca17d35'
++        '37bbeacd97303022b1ab2eee1e6aab0e8907372e04c01d706436436d93a912505a676c15d9826970275c73d1bda0e1089250144efeef8ca2aeb5642fcf249f4f')
+ options=(!lto)
+ 
+ prepare() {
+@@ -19,6 +23,13 @@ prepare() {
+   git submodule init
+   git submodule update
+   mkdir -p build
++
++  # remove -Wcast-align (see https://github.com/SChernykh/p2pool/issues/283)
++  patch -Np1 -i ../5daa2b9dfffcef72286b8429d4c3d65f535a70a8.patch
++
++  # fix wrong cast (see https://github.com/tevador/RandomX/issues/277)
++  cd external/src/RandomX
++  patch -Np1 -i ../../../../d5035cd9c50a5d34ae87ec3507314dc806343548.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
The author use plenty of casting like `(uint64_t*)arr` in which `arr` is a array of `uint8_t*`. Meanwhile, the author use compile option `Wcast-align` and `Werror`. I found it interesting that the warning isn't caused on x86_64 but it is on riscv64 so the build failed. So I use #pragma to block the warning temporarily from files which contain the type of cast. 

And there's another problem caused by cast-qual in the external project RandomX, which happens when cast from const to non-const. However it seems not necessary to remove the const qualifier, so I opened a issue: https://github.com/tevador/RandomX/issues/277 and the problem is fixed on the master branch. Maybe it will take effect in a future release.