### PR TITLE
addpatch: libei

### DIFF
--- a/libei/riscv64.patch
+++ b/libei/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -25,7 +25,6 @@ makedepends=(
+ )
+ checkdepends=(
+   python-pytest-xdist
+-  valgrind
+ )
+ provides=(
+   lib{ei,eis,oeffis}.so


### PR DESCRIPTION
Disable Valgrind tests by removing valgrind from checkdepends.

Currently Valgrind won't work as on x86_64 due to lack of debuginfod server. Debug packages could be used, but I am afraid they are not included in the build environment.