### PR TITLE
qemu-user-blacklist: add gnutls

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -34,6 +34,7 @@ gdk-pixbuf2
 glib-perl
 glib2
 glibc
+gnutls
 go
 gpxsee
 grep


### PR DESCRIPTION
test-free fails on qemu-user:
```
qemu-riscv64-static: ../qemu-8.1.1/linux-user/mmap.c:801: mmap_reserve_or_unmap: Assertion `ret == 0' failed.
**
ERROR:../qemu-8.1.1/accel/tcg/cpu-exec.c:532:cpu_exec_longjmp_cleanup: assertion failed: (cpu == current_cpu)
Bail out! ERROR:../qemu-8.1.1/accel/tcg/cpu-exec.c:532:cpu_exec_longjmp_cleanup: assertion failed: (cpu == current_cpu)
FAIL test-free (exit status: 127)
```