### PR TITLE
qemu-user-blacklist: neovim-qt

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -71,6 +71,7 @@ menyoki
 mkvtoolnix
 mold
 neochat
+neovim-qt
 nextcloud-client
 ninja
 nodejs-lts-gallium


### PR DESCRIPTION
On qemu-user:

```
FAIL!  : NeovimQt::TestQSettings::GuiFont() Compared values are not the same
   Actual   (window.shell()->fontDesc()): "Monospace:h11"
   Expected (fontDesc)                  : "DejaVu Sans Mono:h20"
   Loc: [/usr/src/debug/neovim-qt/neovim-qt/test/tst_qsettings.cpp(106)]
```

All tests pass on unmatched.