### PR TITLE
updpatch: nushell 0.85.0-1

### DIFF
--- a/nushell/riscv64.patch
+++ b/nushell/riscv64.patch
@@ -1,13 +1,28 @@
-diff --git PKGBUILD PKGBUILD
-index e80bd6a..2853927 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -28,7 +28,7 @@
- 
+@@ -33,7 +33,7 @@ pkgver() {
  prepare() {
    cd "$pkgname"
+ 
 -  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
 +  cargo fetch --locked
  }
  
  build() {
+@@ -41,14 +41,14 @@ build() {
+ 
+   CFLAGS+=" -ffat-lto-objects"
+ 
+-  cargo build --release --frozen --workspace --features=extra,dataframe
++  cargo build --release --frozen --workspace --features=extra
+ }
+ 
+ check() {
+   cd "$pkgname"
+ 
+   # https://github.com/nushell/nushell/issues/10468
+-  cargo test --frozen --workspace --features=extra,dataframe -- \
++  cargo test --frozen --workspace --features=extra -- \
+     --skip commands::table::table_expand_exceed_overlap_0 \
+     --skip commands::table::table_expand_padding_not_default \
+     --skip commands::table::test_collapse_big_0 \


### PR DESCRIPTION
Disables `dataframe` feature that uses `simd-json`, which does not have fallback implementation and is hard to replace with something like `serde_json`.

See https://github.com/nushell/nushell/pull/9542.