### PR TITLE
addpatch: afl

### DIFF
--- a/afl/riscv64.patch
+++ b/afl/riscv64.patch
@@ -1,0 +1,23 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,10 +14,10 @@ optdepends=('gcc: gcc instrumentation support'
+             'clang14: clang instrumentation support'
+             'llvm14: experimental clang-fast instrumentation support'
+             'gnuplot: graph plotting support')
+-makedepends=('clang14' 'llvm14' 'gcc' 'wget' 'python' 'lib32-glibc')
++makedepends=('clang14' 'llvm14' 'gcc' 'wget' 'python')
+ provides=('american-fuzzy-lop')
+ replaces=('american-fuzzy-lop')
+-options=('!emptydirs' '!strip')
++options=('!emptydirs' '!strip' '!lto')
+ source=(https://github.com/google/AFL/archive/v${pkgver}/${pkgname}-${pkgver}.tar.gz
+         llvm13.patch
+         llvm14.patch
+@@ -48,6 +48,7 @@ prepare() {
+ 
+ build() {
+   cd AFL-${pkgver}
++  export AFL_NO_X86=1
+   make PREFIX=/usr
+   make -C llvm_mode PREFIX=/usr \
+     LLVM_CONFIG=llvm-config-14 CC=/usr/lib/llvm14/bin/clang


### PR DESCRIPTION
- Build without lib32-glibc
- Set `AFL_NO_X86`.
- Disable LTO.

I tried to fix LTO but encountered the following problem:

/usr/sbin/ld: error: LLVM gold plugin: linking module flags 'SmallDataLimit': IDs have conflicting values in '../afl-llvm-rt.o' and 'ld-temp.o'

It is also seen in https://github.com/civetweb/civetweb/issues/951 (no answer).