### PR TITLE
addpatch: deepin-font-manager 6.0.1-1

### DIFF
--- a/deepin-font-manager/riscv64.patch
+++ b/deepin-font-manager/riscv64.patch
@@ -1,0 +1,25 @@
+diff --git PKGBUILD PKGBUILD
+index 7f4f474..0ce7735 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -11,14 +11,18 @@
+ makedepends=('cmake' 'deepin-file-manager' 'ninja' 'qt5-tools')
+ optdepends=('deepin-file-manager: font preview in file manager')
+ groups=('deepin-extra')
+-source=("https://github.com/linuxdeepin/deepin-font-manager/archive/$pkgver/$pkgname-$pkgver.tar.gz")
+-sha512sums=('63750b2dd290ae138d0ad17d98726387d60f6bd422f279a07880e5777d0ee9215ee814742d70830d70726319612a1b4c43fae03ea52a9fbd35cfab9ddbcfb9a6')
++source=("https://github.com/linuxdeepin/deepin-font-manager/archive/$pkgver/$pkgname-$pkgver.tar.gz"
++        "adapt-new-dde-file-manager.patch::https://github.com/linuxdeepin/deepin-font-manager/commit/89c46df1de0012b609779f97d09dfdcd5a99e3b2.diff")
++sha512sums=('63750b2dd290ae138d0ad17d98726387d60f6bd422f279a07880e5777d0ee9215ee814742d70830d70726319612a1b4c43fae03ea52a9fbd35cfab9ddbcfb9a6'
++            '20ce3b5df04349c508ae6b11a6bd41ef2b92a0a91fb154e42cb6a81793bc1e25add8152f6c18f1c0e9bd3c8f92d328b584c5c8e3dec294b18b0afcd8a7501a9e')
+ 
+ prepare() {
+   cd deepin-font-manager-$pkgver
+ 
+   # Fix linker flags
+   sed -i 's/CMAKE_EXE_LINKER_FLAGS "-pie"/CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie"/' deepin-font-manager/CMakeLists.txt
++  # Fix "None of the required 'dde-file-manager' found"
++  patch -Np1 -i ../adapt-new-dde-file-manager.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
Backport https://github.com/linuxdeepin/deepin-font-manager/commit/89c46df1de0012b609779f97d09dfdcd5a99e3b2
[Arch bug report](https://bugs.archlinux.org/task/80003)