### PR TITLE
addpatch: diffoscope

### DIFF
--- a/diffoscope/riscv64.patch
+++ b/diffoscope/riscv64.patch
@@ -1,0 +1,13 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -63,8 +63,8 @@ optdepends=(
+ makedepends=('help2man' 'python-docutils' 'git' 'python-setuptools')
+ checkdepends=(
+   'python-pytest' 'python-jsbeautifier' 'python-h5py' 'acl' 'binutils' 'bzip2' 'cdrtools' 'cpio' 'diffutils' 'e2fsprogs' 'enjarify'
+-  'hdf5' 'imagemagick' 'java-environment=11' 'fontforge' 'gettext' 'ghc' 'gnupg' 'mono' 'pgpdump' 'poppler' 'sqlite' 'squashfs-tools'
+-  'libxmlb' 'lz4' 'unzip' 'gzip' 'tar' 'tcpdump' 'vim' 'xz' 'llvm' 'colord' 'fpc' 'openssh' 'openssl' 'odt2txt' 'docx2txt' 'r' 'dtc'
++  'hdf5' 'imagemagick' 'java-environment=11' 'fontforge' 'gettext' 'ghc' 'gnupg' 'pgpdump' 'poppler' 'sqlite' 'squashfs-tools'
++  'libxmlb' 'lz4' 'unzip' 'gzip' 'tar' 'tcpdump' 'vim' 'xz' 'llvm' 'colord' 'openssh' 'openssl' 'odt2txt' 'docx2txt' 'r' 'dtc'
+   'giflib' 'gnumeric' 'python-progressbar' 'binwalk' 'python-argcomplete' 'zstd' 'uboot-tools')
+ source=(https://diffoscope.org/archive/diffoscope-${pkgver}.tar.bz2{,.asc})
+ sha512sums=('ebe3a40dd0a0325948ba44e8d67799229c2a868f8f1a7dfad2a138a254cfd144eb2890292d2b8c381edc7ca7ea92fb7f804f67f92aa16e6e90c2cf2231c3491e'


### PR DESCRIPTION
Remove mono and fpc from checkdepends because they are currently not available for riscv64.

The relevant tests are skipped automatically.