### PR TITLE
upgpatch: v2ray

### DIFF
--- a/v2ray/riscv64.patch
+++ b/v2ray/riscv64.patch
@@ -1,15 +1,22 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -12,12 +12,17 @@ license=('MIT')
+@@ -12,12 +12,31 @@ license=('MIT')
  depends=('glibc' 'v2ray-domain-list-community' 'v2ray-geoip')
  makedepends=('go' 'git')
  backup=(etc/v2ray/config.json)
 -source=("git+https://github.com/v2fly/v2ray-core.git#commit=$_commit")
 -sha512sums=('SKIP')
 +source=("git+https://github.com/v2fly/v2ray-core.git#commit=$_commit"
-+        "$pkgname-InitializeServerConfig-sleep.patch::https://github.com/v2fly/v2ray-core/pull/1786.patch")
++        "$pkgname-InitializeServerConfig-sleep.patch::https://github.com/v2fly/v2ray-core/pull/1786.patch"
++        "v2ray-testTCPConn2-timeout.patch"
++        "v2ray-testVMessKCP.patch"
++        "v2ray-kcpTest.patch")
++
 +sha512sums=('SKIP'
-+            '36553288b92bbf7d1ae65cc9efec95f1ca695f73e17804a72270e96382c685dea1dcae69ecfd9603bf7af0cf730080ac59c61c4b91cb724191e985032d5a5a03')
++            '36553288b92bbf7d1ae65cc9efec95f1ca695f73e17804a72270e96382c685dea1dcae69ecfd9603bf7af0cf730080ac59c61c4b91cb724191e985032d5a5a03'
++            'd681916026c2a224097c715cf21bfa53b0d61f496de828a38c94170d1a115081917e42cf3848f94ca76bdd5491be97c56f84cb6996584f204561f8f10796ce78'
++            '247d22813eddccca5585efa0be3f6b3a4b00e5ca31f0ace3f8ad71015b688a4b41b7b65d639ca1632bb788849ff3e7c26cf6469fa39ffd0e728f23244d2714d6'
++            '1949b4082a7a710619b8d46c50b19f002f9dc68a77d1ccde368a7e8bac872292f14fb60d34088776fdfeef5eea800ca68a0f86e0a0454f096c1df9e73f67b76c')
  
  prepare() {
    cd v2ray-core
@@ -17,6 +24,13 @@
 +
 +  # wait enough time for v2ray to start
 +  patch -Np1 -i $srcdir/$pkgname-InitializeServerConfig-sleep.patch
++
++  # reported to upstream as https://github.com/v2fly/v2ray-core/issues/1830
++  patch -Np1 -i $srcdir/v2ray-testTCPConn2-timeout.patch
++
++  # reported to upstream as https://github.com/v2fly/v2ray-core/issues/2720
++  patch -Np1 -i $srcdir/v2ray-testVMessKCP.patch
++  patch -Np1 -i $srcdir/v2ray-kcpTest.patch
  }
  
  build() {

--- a/v2ray/v2ray-kcpTest.patch
+++ b/v2ray/v2ray-kcpTest.patch
@@ -1,0 +1,13 @@
+diff --git a/transport/internet/kcp/kcp_test.go b/transport/internet/kcp/kcp_test.go
+index d10534a2..43ea9db3 100644
+--- a/transport/internet/kcp/kcp_test.go
++++ b/transport/internet/kcp/kcp_test.go
+@@ -77,7 +77,7 @@ func TestDialAndListen(t *testing.T) {
+ 	}
+ 
+ 	for i := 0; i < 60 && listener.ActiveConnections() > 0; i++ {
+-		time.Sleep(500 * time.Millisecond)
++		time.Sleep(1000 * time.Millisecond)
+ 	}
+ 	if v := listener.ActiveConnections(); v != 0 {
+ 		t.Error("active connections: ", v)

--- a/v2ray/v2ray-testTCPConn2-timeout.patch
+++ b/v2ray/v2ray-testTCPConn2-timeout.patch
@@ -1,0 +1,13 @@
+diff --git a/testing/scenarios/common.go b/testing/scenarios/common.go
+index ffa00006..c15a34a1 100644
+--- a/testing/scenarios/common.go
++++ b/testing/scenarios/common.go
+@@ -201,6 +201,8 @@ func testUDPConn(port net.Port, payloadSize int, timeout time.Duration) func() e
+ }
+ 
+ func testTCPConn2(conn net.Conn, payloadSize int, timeout time.Duration) func() error {
++	timeout *= 20
++
+ 	return func() (err1 error) {
+ 		start := time.Now()
+ 		defer func() {

--- a/v2ray/v2ray-testVMessKCP.patch
+++ b/v2ray/v2ray-testVMessKCP.patch
@@ -1,0 +1,12 @@
+diff --git a/testing/scenarios/vmess_test.go b/testing/scenarios/vmess_test.go
+index e1acd455..7dfc8466 100644
+--- a/testing/scenarios/vmess_test.go
++++ b/testing/scenarios/vmess_test.go
+@@ -806,6 +806,7 @@ func TestVMessKCP(t *testing.T) {
+ 
+ 	var errg errgroup.Group
+ 	for i := 0; i < 10; i++ {
++		time.Sleep(time.Second * 8)
+ 		errg.Go(testTCPConn(clientPort, 10240*1024, time.Minute*2))
+ 	}
+ 	if err := errg.Wait(); err != nil {


### PR DESCRIPTION
Resolved `go test` error; however, due to the current incompatibility of v2ray-core 5.7.0 with go version 1.21, the compilation is still failing.

This patch has been reported to the upstream as issue [v2ray/v2ray-core#2720](https://github.com/v2fly/v2ray-core/issues/2720)