### PR TITLE
addpatch: python-pygdbmi 0.11.0.0-3

### DIFF
--- a/python-pygdbmi/riscv64.patch
+++ b/python-pygdbmi/riscv64.patch
@@ -1,0 +1,17 @@
+diff --git PKGBUILD PKGBUILD
+index 48f9d46..2157721 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -19,8 +19,12 @@ checkdepends=(python-pytest)
+ source=(https://github.com/cs01/pygdbmi/archive/v$pkgver/$pkgname-$pkgver.tar.gz)
+ sha256sums=('5c52a37211d55eeeaf5c06eacc8e8d49e9dacfd36a526d3534b4a5d5f5ee94d9')
+ 
++source+=("add-test-timeout.patch::https://github.com/cs01/pygdbmi/pull/103.patch")
++sha256sums+=('2e87f3397521fec15bb1421c9618e65e6c11e9a6d2bd628c53bd89e33930c78b')
++
+ build() {
+   cd $_pyname-$pkgver
++  patch -Np1 -i ../add-test-timeout.patch
+   python -m build --wheel --no-isolation
+ }
+ 


### PR DESCRIPTION
Increase timeout duration. Upstreamed: https://github.com/cs01/pygdbmi/pull/103

I think 10 seconds is enough because successfully packaged on four boards (Unmatched, VisionFive, Milk-V Pionner, Lichee Pi 4A)
