### PR TITLE
upgpatch: atuin

### DIFF
--- a/atuin/riscv64.patch
+++ b/atuin/riscv64.patch
@@ -6,7 +6,7 @@
    cd "$pkgname-$pkgver"
 -  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
 +  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }\n" >> Cargo.toml
-+  cargo update -p ring
++  cargo update -p ring@0.16.20
 +  cargo fetch --locked
    mkdir completions/
  }


### PR DESCRIPTION
Specify that ring 0.16.20 to be updated because there are multiple versions (0.17.5) of ring in the lock file.