### PR TITLE
addpkg: dsq

### DIFF
--- a/dsq/riscv64.patch
+++ b/dsq/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -58,7 +58,7 @@ check() {
+   7z e testdata/taxi.csv.7z
+ 
+   # ensure chatter from systemd-nspawn doesn't modify expected stdout
+-  LC_ALL=C ./scripts/test.py
++  LC_ALL=C ./scripts/test.py -fo cach
+ }
+ 
+ package() {


### PR DESCRIPTION
fix test.py fails on caching duration.
The author suggests that this test case can be safely disabled. see issue https://github.com/multiprocessio/dsq/issues/80