### PR TITLE
updpatch: jumpy 0.8.2-1

### DIFF
--- a/jumpy/riscv64.patch
+++ b/jumpy/riscv64.patch
@@ -1,13 +1,12 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -17,7 +17,10 @@ options=('!lto')
+@@ -19,7 +19,9 @@ options=('!lto')
  
  prepare() {
    cd "$pkgname-$pkgver"
 -  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
-+  echo -e "ring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
++  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
 +  cargo update -p ring
-+  cargo update -p mimalloc --precise 0.1.36
 +  cargo fetch --locked
  }
  


### PR DESCRIPTION
- There's no need to fix the version of `mimalloc`, as it was removed in upstream commit https://github.com/fishfolk/jumpy/commit/1343ad16a50603fc05b91e5d927cfd01c73d676f#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L92