### PR TITLE
updpatch: lurk 0.3.4-1

### DIFF
--- a/lurk/riscv64.patch
+++ b/lurk/riscv64.patch
@@ -1,38 +1,33 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -9,16 +9,31 @@ arch=('x86_64')
+@@ -9,13 +9,26 @@ arch=('x86_64')
  url="https://github.com/JakWai01/lurk"
  license=('MIT' 'Apache')
  depends=('gcc-libs')
 -makedepends=('cargo')
+-source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
+-sha512sums=('f545b83f5f6fc84399419394c606e3d7c9c4a5ed094ae171f4f226768609ee7c1d364d13f862efd6aa2d21615cd7c14165dc3c4c4a2b2f9148fba4963b62f401')
 +makedepends=('cargo' 'git')
- source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz"
--        "$pkgname-$pkgver-fix-tests.patch::$url/commit/87eb4aa8bf9a551b24cec2146699cb2c22d62019.patch")
-+        "$pkgname-$pkgver-fix-tests.patch::$url/commit/87eb4aa8bf9a551b24cec2146699cb2c22d62019.patch"
-+        "$pkgname-add-riscv64-support.patch::https://github.com/hack3ric/lurk/commit/44cfa7df0caaae60d5a93ec52041f2da35612b7d.diff"
-+        "git+https://github.com/nix-rust/nix#tag=v0.26.2"
++source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz"
++        "add-riscv64-support.patch::https://github.com/JakWai01/lurk/commit/ac8aa8e548570ec419ffe55106503e1c04d4a4bc.diff"
++        "git+https://github.com/nix-rust/nix#tag=v0.27.1"
 +        "nix-add-ptrace-getregs.patch::https://patch-diff.githubusercontent.com/raw/nix-rust/nix/pull/2044.diff")
- sha512sums=('0f19b2a529e65e5f25c84cc30380dc3c83e56faf58e469a669ae8e904b6b0abd9507132ebbce4d3841870a8bdb3225dd402681848b46a3411a2b0065663d6d60'
--            '48861e66cfa466def8543b4edc8bb6e1b6e5ace5ae430129ca0602c231f2772fd4a8a6f041f31c5f60ea9ceac6ff731b22d3f6179c932f6a1f9c7e6ac34f8db7')
-+            '48861e66cfa466def8543b4edc8bb6e1b6e5ace5ae430129ca0602c231f2772fd4a8a6f041f31c5f60ea9ceac6ff731b22d3f6179c932f6a1f9c7e6ac34f8db7'
-+            '3e74ee03665fac053eae6ace51fb646f01127d6af9df5f6bfd20993db087510e3270219d773332a37169d59a11b52aff3acbc69463f4a1de8c7b6c389c728c15'
++sha512sums=('f545b83f5f6fc84399419394c606e3d7c9c4a5ed094ae171f4f226768609ee7c1d364d13f862efd6aa2d21615cd7c14165dc3c4c4a2b2f9148fba4963b62f401'
++            'dcf21e49a40a06fad81fc9b47bc61d8a0f1fc7f4a599836bbc533d31c5824151137b6504ac320ded4606c3e4c98331eab615539c3385d55c56b19b590b6ce657'
 +            'SKIP'
-+            'e0fa7da81ae9a337fe9f48f24ab38c6076130060cc2c836784244bc9e9274923f601dde7e703cd0c88b9a246dcb6208ef36cd3a7fdda872d56194f1905a9ea49')
++            '296d19da72f137b6a90e76b4b955372d8741991a89186f335619a3f65a81de07c71107fb3efe1137966ddbb3520f9e21d91d454e66f35eec90ace1a49bb85aa3')
  
  prepare() {
-+  pushd nix
++  cd nix
 +  git apply ../nix-add-ptrace-getregs.patch
-+  popd
++  cd ..
 +
    cd "$pkgname-$pkgver"
 -  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
 +  echo -e '\n[patch.crates-io]\nnix = { path = "../nix" }\n' >> Cargo.toml
 +  cargo update -p nix
-+  cargo update -p libc
-+  cargo update -p syscalls
 +  cargo fetch --locked
-   patch -Np1 -i "../$pkgname-$pkgver-fix-tests.patch"
-+  patch -Np1 -i "../$pkgname-add-riscv64-support.patch"
++  patch -Np1 -i ../add-riscv64-support.patch
  }
  
  build() {


### PR DESCRIPTION
- Refresh riscv64 patches to keep in sync with x86_64's changes
- Add new syscalls: cachestat, riscv_flush_icache and riscv_hwprobe