### PR TITLE
upgpatch: upx 4.2.0-1

### DIFF
--- a/upx/riscv64.patch
+++ b/upx/riscv64.patch
@@ -1,21 +1,11 @@
-diff --git PKGBUILD PKGBUILD
-index 545977f..bc8fd8f 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -29,12 +29,16 @@ b2sums=('SKIP'
-         'SKIP'
-         'SKIP')
- 
-+source+=("ptr_reinterpret_cast.patch::https://github.com/upx/upx/commit/38a676f6f78e82ca0c2f08ef16446bc3e66cd453.patch")
-+b2sums+=('7519c5f29e05ea67096932b01ecf1bce37b90fede9b134ad8a520c22ae3f7fd48f8d7a5d1dde0d839bacdf2e84a2be1aeaca6085cd051d49d83a8cae7357aecb')
-+
- prepare() {
-   cd $pkgname
-   # Set up symbolic links for the vendor repos.
+@@ -35,6 +35,8 @@ prepare() {
    for x in doctest lzma-sdk ucl valgrind zlib; do
      rm -frv vendor/$x && ln -s "$srcdir/upx-vendor-$x" vendor/$x
    done
-+  patch -Np1 -i ../ptr_reinterpret_cast.patch
++
++  git cherry-pick -n 38a676f6f78e82ca0c2f08ef16446bc3e66cd453
  }
  
  build() {


### PR DESCRIPTION
Use cherry-pick instead of patch to avoid validity check failure