### PR TITLE
updpatch: ncrack

### DIFF
--- a/ncrack/riscv64.patch
+++ b/ncrack/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -25,9 +25,11 @@ prepare() {
+ build() {
+   cd ${pkgname}-${pkgver}
+   CFLAGS+=' -fcommon' # https://wiki.gentoo.org/wiki/Gcc_10_porting_notes/fno_common
++  autoreconf -fi
+   ./configure \
+     --prefix=/usr \
+-    --without-openssl-header-check
++    --without-openssl-header-check \
++    --without-zlib-version-check
+   make
+ }
+ 


### PR DESCRIPTION
This is the link: https://github.com/nmap/ncrack/issues/130
Resolve the issue detected during the compilation of opensshlib, where the configure script identifies that the zlib version on your system is outdated and contains acknowledged security vulnerabilities.