### PR TITLE
addpatch: libunwind 1.7.2-1

### DIFF
--- a/libunwind/riscv64.patch
+++ b/libunwind/riscv64.patch
@@ -1,0 +1,19 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -18,7 +18,7 @@ depends=(
+ )
+ makedepends=(texlive-binextra)
+ provides=(
+-  libunwind-{coredump,ptrace,setjmp,x86_64}.so
++  libunwind-{coredump,ptrace,setjmp,riscv}.so
+   libunwind.so
+ )
+ source=(
+@@ -42,6 +42,7 @@ build() {
+   )
+ 
+   cd libunwind-$pkgver
++  autoreconf -fi
+   ./configure "${configure_options[@]}"
+   sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool
+   make


### PR DESCRIPTION
- Replace x86_64 with riscv in provides to match actual file name
- Update config.{guess,sub}. Upstreamed to https://github.com/libunwind/libunwind/issues/654.