### PR TITLE
addpkg: qqwing

### DIFF
--- a/qqwing/riscv64.patch
+++ b/qqwing/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,6 +14,7 @@ sha256sums=('1753736c31feea0085f5cfac33143743204f8a7e66b81ccd17e249ecafba802f')
+ 
+ build() {
+   cd $pkgname-$pkgver
++  autoreconf -fi
+   ./configure --prefix=/usr
+   sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool
+   make


### PR DESCRIPTION
This is an issue related to the outdated config script version. Due to regional restrictions, I am unable to create an account on the upstream platform to report this error. Therefore, I have sent a private message to inform them about the situation.