### PR TITLE
addpatch: python-zict 2.2.0-2

### DIFF
--- a/python-zict/riscv64.patch
+++ b/python-zict/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -30,3 +30,11 @@ package() {
+   python setup.py install --prefix=/usr --root="${pkgdir}" --optimize=1 --skip-build
+   install -Dm644 LICENSE.txt -t "${pkgdir}"/usr/share/licenses/${pkgname}/
+ }
++
++source+=(fix-map-size.patch::https://github.com/hack3ric/zict/commit/8aac36794415536b77a1b8318ddffe74278a758f.diff)
++sha256sums+=('66c6c263405b64185acdbd0996d6751160a7f412e21c09cfde7c732385721cc8')
++
++prepare() {
++  cd ${_pkg}-${pkgver}
++  patch -Np1 -i ../fix-map-size.patch
++}


### PR DESCRIPTION
Backported map size fix from https://github.com/dask/zict/pull/111.