### PR TITLE
updpatch: libredefender 0.7.0-1

### DIFF
--- a/libredefender/riscv64.patch
+++ b/libredefender/riscv64.patch
@@ -1,12 +1,11 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -20,8 +20,9 @@ validpgpkeys=("64B13F7117D6E07D661BBCE0FE763A64F5E54FD6")
+@@ -18,7 +18,9 @@ validpgpkeys=("64B13F7117D6E07D661BBCE0FE763A64F5E54FD6")
  
  prepare() {
    cd "${pkgname}-${pkgver}"
--  patch -i ../clamav-1.0.patch
 -  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
-+  echo -e '\n[patch.crates-io]\nclamav-rs = { git = "https://github.com/losynix/clamav-rs.git", branch = "patches" }' >> Cargo.toml
++  echo -e "\n[patch.'https://github.com/kpcyrd/clamav-rs']\nclamav-rs = { git = 'https://github.com/aimixsaka/clamav-rs', branch = 'riscv-clamav-1.2' }" >> Cargo.toml
 +  cargo update -p clamav-rs
 +  cargo fetch --locked
  }


### PR DESCRIPTION
- use `[patch.'repo-url']` instead of `[patch.crates-io]` to override, as upstream uses dependency that isn't loaded from `crates-io`.
  See https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#overriding-repository-url
- fixed `type mismatch` error, upstreamed: https://github.com/kpcyrd/clamav-rs/pull/1