### PR TITLE
addpatch: nodejs-lts-hydrogen

### DIFF
--- a/nodejs-lts-hydrogen/riscv64.patch
+++ b/nodejs-lts-hydrogen/riscv64.patch
@@ -1,0 +1,17 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -29,6 +29,14 @@ validpgpkeys=(C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8  # Myles Borins <mylesbor
+               74F12602B6F1C4E913FAA37AD3A89613643B6201  # Danielle Adams <adamzdanielle@gmail.com>
+               61FC681DFB92A079F1685E77973F295594EC4689) # Juan José Arboleda <soyjuanarbol@gmail.com>
+ 
++source+=(nodejs18-fix-vite.patch::https://github.com/v8/v8/commit/70caf337c3f69b16ac9ffec0d9a776aa95f896fc.diff)
++sha256sums+=(fd68d81e9b559cdbc7df6b232e06dd0c127025883ac9dd03a86212812174078d)
++
++prepare() {
++  cd node-v${pkgver}/deps/v8
++  patch -Np1 -i "${srcdir}/nodejs18-fix-vite.patch"
++}
++
+ build() {
+   cd node-v${pkgver}
+ 


### PR DESCRIPTION
Backport `[riscv64] Fix the StaticStackFrameSize` to fix vite.

- Upstream issue: https://github.com/nodejs/node/issues/50503
- Upstream PR: https://github.com/nodejs/node/pull/50506