### PR TITLE
updpatch: rust-bindgen 0.69.0-1.1

### DIFF
--- a/rust-bindgen/riscv64.patch
+++ b/rust-bindgen/riscv64.patch
@@ -1,10 +1,22 @@
+diff --git PKGBUILD PKGBUILD
+index d81a7ea..de9851a 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -16,7 +16,7 @@ sha512sums=('71e1ec6ce4933a7a5451aa5baa47f885b9ec6b692bf2a2b3d8c1f2cce2c3cd3d941
+@@ -11,12 +11,15 @@ depends=('gcc-libs' 'clang')
+ makedepends=('cargo')
+ arch=('x86_64')
+ license=('BSD')
+-source=("$pkgname-$pkgver.tar.gz::https://github.com/rust-lang/rust-bindgen/archive/v$pkgver.tar.gz")
+-sha512sums=('4ec403283cf26e09fb46182b35e2690bec7085bafb2469b4c3222c7b487eacf7000b4094acf8e85a98ae7c51988679f965359cae7abe07ef0ee6f5d9238ad8cc')
++source=("$pkgname-$pkgver.tar.gz::https://github.com/rust-lang/rust-bindgen/archive/v$pkgver.tar.gz"
++        $pkgname-fix-version.patch::https://github.com/rust-lang/rust-bindgen/pull/2678.diff)
++sha512sums=('4ec403283cf26e09fb46182b35e2690bec7085bafb2469b4c3222c7b487eacf7000b4094acf8e85a98ae7c51988679f965359cae7abe07ef0ee6f5d9238ad8cc'
++            'dbe1ab1094ca6b78e9de12127a4a42864bdd1f0c50a497832b60e57ca2a5bd7c7229d935c519ea1f6a4a1cc0f62cdfcfbe3c5fc4110adc0a4280e104040d9169')
  
  prepare() {
    cd $pkgname-$pkgver
 -  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  patch -p1 -i ../$pkgname-fix-version.patch
 +  cargo fetch --locked
    mkdir -p completions
  }


### PR DESCRIPTION
Apply patch to fix https://github.com/rust-lang/rust-bindgen/issues/2677 for building mesa.