### PR TITLE
qemu-user-blacklist.txt: add gradle{,7}

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -37,6 +37,8 @@ glibc
 gnutls
 go
 gpxsee
+gradle
+gradle7
 grep
 gssdp
 gtest


### PR DESCRIPTION
Qemu 8.1.0 regression(2d708164): https://gitlab.com/qemu-project/qemu/-/issues/1908

JVM crash when starting gradle daemon in qemu-user: https://paste.rs/0ykPK