### PR TITLE
updpatch: rustypaste

### DIFF
--- a/rustypaste/riscv64.patch
+++ b/rustypaste/riscv64.patch
@@ -1,12 +1,12 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -16,7 +16,9 @@ b2sums=('a46cae0327a32c3b3c4e70bf0fc8d5ae11e3b01e87f3240fd125264c6cada25129a9979
+@@ -16,7 +16,9 @@ b2sums=('78596373e79b9bc0dccd2de14c783d1d8b2a450cf9df97704812684061280645a9c2b0d
  
  prepare() {
    cd ${pkgname}-${pkgver}
 -  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
 +  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
-+  cargo update -p ring
++  cargo update -p ring@0.16.20
 +  cargo fetch --locked
  }
  


### PR DESCRIPTION
- Fix the version of `ring` to `0.16.0` as there are multiple versions in Cargo.lock