### PR TITLE
updpatch: deno 1.38.0-1

### DIFF
--- a/deno/riscv64.patch
+++ b/deno/riscv64.patch
@@ -1,25 +1,17 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -11,7 +11,7 @@ url="https://deno.land"
+@@ -11,13 +11,26 @@ url="https://deno.land"
  license=('MIT')
  options=('!lto')
  depends=('gcc-libs')
--makedepends=('git' 'python' 'rust' 'nodejs')
-+makedepends=('git' 'python' 'rust' 'nodejs' 'gn' 'ninja' 'clang' 'lld')
+-makedepends=('git' 'python' 'rust' 'nodejs' 'cmake' 'protobuf')
++makedepends=('git' 'python' 'rust' 'nodejs' 'gn' 'ninja' 'clang' 'lld' 'cmake' 'protobuf')
  source=("git+https://github.com/denoland/deno.git#commit=$_commit")
  sha512sums=('SKIP')
  
-@@ -19,10 +19,25 @@ prepare() {
-   cd $pkgname
-   # https://github.com/denoland/deno/issues/19528
-   git cherry-pick -n c8dc6b14ec5c1b6de28118ed3b07d037eaaaf702
-+  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
-+  cargo update -p ring
- }
- 
  build() {
    cd $pkgname
-+
+ 
 +  local _extra_gn_args=(
 +    'custom_toolchain="//build/toolchain/linux/unbundle:default"'
 +    'host_toolchain="//build/toolchain/linux/unbundle:default"'
@@ -32,6 +24,7 @@
 +  export GN=/usr/bin/gn NINJA=/usr/bin/ninja
 +  export EXTRA_GN_ARGS="${_extra_gn_args[@]}"
 +  export NO_PRINT_GN_ARGS=1
-   cargo build --release
- }
- 
++
+   # this uses malloc_usable_size, which is incompatible with fortification level 3
+   export CFLAGS="${CFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
+   export CXXFLAGS="${CXXFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"


### PR DESCRIPTION
- Fix rotten
- Remove ring v0.16.20 patch as upstream is now using ring = "^0.17.0" (Successfully built without this)