### PR TITLE
upgpatch: nodejs 21.1.0-1

### DIFF
--- a/nodejs/riscv64.patch
+++ b/nodejs/riscv64.patch
@@ -1,18 +1,19 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -40,12 +40,13 @@ build() {
-     # --shared-v8
-     # --shared-http-parser
+@@ -19,8 +19,14 @@ options=(!lto)
+ depends=('brotli' 'openssl' 'zlib' 'icu' 'libuv' 'libnghttp2' 'c-ares') # 'http-parser' 'v8')
+ makedepends=('git' 'python' 'procps-ng')
+ optdepends=('npm: nodejs package manager')
+-source=("git+https://github.com/nodejs/node.git#commit=$_commit")
+-sha512sums=('SKIP')
++source=("git+https://github.com/nodejs/node.git#commit=$_commit"
++        "node21-fix-v8.patch::https://github.com/nodejs/node/pull/50551.diff")
++sha512sums=('SKIP'
++            '97b47d493b3364695c150c5ba8e5991f5009260cc8c4931da7fd324bb0129b0f04b6fad73ffe156150a76a621b6f13d13dab8640fc4aa9499d19db2ac66411e0')
++
++prepare() {
++  patch -Np1 -d node < node21-fix-v8.patch
++}
  
--  make
-+  # -fno-strict-aliasing for gcc>=10: https://github.com/nodejs/node/issues/33899
-+  make CFLAGS="-fno-strict-aliasing $CFLAGS" CXXFLAGS="-fno-strict-aliasing $CXXFLAGS"
- }
- 
- check() {
+ build() {
    cd node
--  make test || :
-+  make CFLAGS="-fno-strict-aliasing $CFLAGS" CXXFLAGS="-fno-strict-aliasing $CXXFLAGS" test || :
- }
- 
- package() {


### PR DESCRIPTION
- Fix v8 compilation errors, upstreamed to nodejs: https://github.com/nodejs/node/pull/50552
- Remove the `-fno-strict-aliasing` flag addition. The relevant error no longer occurs. Actually, we never do this to nodejs-lts-hydrogen after nodejs 18 is packaged as nodejs-lts-hydrogen.