### PR TITLE
addpatch: nmon

### DIFF
--- a/nmon/riscv64.patch
+++ b/nmon/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,8 +12,7 @@ source=("https://downloads.sourceforge.net/$pkgname/lmon$pkgver.c")
+ sha256sums=('5dc6045f6725e3249a969918fae69663a1d669162087720babcdb90fce9e6b2a')
+ 
+ build() {
+-  cd "$srcdir"
+-  cc -o nmon nmon$pkgver.c $LDFLAGS $CFLAGS -g -O3 -lncurses -lm -D X86
++  cc -o nmon lmon$pkgver.c $LDFLAGS $CFLAGS -g -O3 -lncurses -lm -D X86
+ }
+ 
+ package() {


### PR DESCRIPTION
- The downloaded file is a C file, so there's no need for `cd $srcdir`.
- The file being operated on is "lmon16p.c" not "nmon16p.c".
(I also suspected that the downloaded file should have been "nmon16p.c," but upon checking the official website, I discovered that they had discontinued the download path for "nmon16p.c." I attempted to find "nmon16p.c" through alternative means, but ultimately, I couldn't locate it. Therefore, I used "lmon16p.c.")