### PR TITLE
updpatch: guitarix 0.44.1-5

### DIFF
--- a/guitarix/riscv64.patch
+++ b/guitarix/riscv64.patch
@@ -1,10 +1,20 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -26,6 +26,7 @@ build() {
+@@ -9,7 +9,7 @@ url="https://guitarix.org"
+ license=(GPL3)
+ groups=(ladspa-plugins lv2-plugins pro-audio)
+ depends=(atkmm bluez-libs cairo cairomm gcc-libs glibc glibmm gtkmm3 libsigc++
+-libx11 pangomm ttf-roboto)
++libx11 pangomm ttf-roboto libsndfile.so)
+ makedepends=(avahi boost curl gdk-pixbuf2 eigen faust fftw glib2 gperf gtk3
+ intltool jack ladspa liblo liblrdf lilv lv2 pango sassc waf zita-convolver
+ zita-resampler)
+@@ -58,7 +58,7 @@ package() {
+   depends+=(libavahi-common.so libavahi-gobject.so libboost_iostreams.so
+   libcurl.so libfftw3f.so libgdk-3.so libgdk_pixbuf-2.0.so libgio-2.0.so
+   libglib-2.0.so libgobject-2.0.so libjack.so liblilv-0.so liblo.so liblrdf.so
+-  libpangocairo-1.0.so libpango-1.0.so libsndfile.so libzita-convolver.so
++  libpangocairo-1.0.so libpango-1.0.so libzita-convolver.so
+   libzita-resampler.so)
+ 
    cd $pkgname-$pkgver
-   export LINKFLAGS="$LDFLAGS"
-   waf configure --prefix=/usr \
-+                --disable-sse \
-                 --enable-nls \
-                 --ladspa \
-                 --new-ladspa \


### PR DESCRIPTION
Remove unused `--disable-sse`, because upstream won't use `-msse` for non-x86 architectures: https://github.com/brummer10/guitarix/blob/efccbd14afb5a85be142319b94be088b9cf1d5fd/trunk/src/LV2/wscript#L6-L26

Make libsndfile as a dependency for both build and run. Arch: https://bugs.archlinux.org/task/80175