### PR TITLE
addpkg: xdg-desktop-portal-wlr

### DIFF
--- a/xdg-desktop-portal-wlr/riscv64.patch
+++ b/xdg-desktop-portal-wlr/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -11,7 +11,7 @@ arch=('x86_64')
+ license=('MIT')
+ provides=('xdg-desktop-portal-impl')
+ depends=('xdg-desktop-portal' 'pipewire' 'pipewire-session-manager' 'libinih')
+-makedepends=('meson' 'wayland-protocols' 'wayland' 'scdoc')
++makedepends=('meson' 'wayland-protocols' 'wayland' 'scdoc' 'gdm')
+ optdepends=(
+     'slurp: to choose which output to screencast using slurp'
+     'wofi: to choose which output to screencast using wofi'


### PR DESCRIPTION
The issue "Dependency 'gbm' not found" has been resolved.