### PR TITLE
addpatch: bitwarden

### DIFF
--- a/bitwarden/app-builder-lib+23.6.0.patch
+++ b/bitwarden/app-builder-lib+23.6.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/app-builder-lib/out/linuxPackager.js b/node_modules/app-builder-lib/out/linuxPackager.js
+index 4f179fc..13f0e6c 100644
+--- a/node_modules/app-builder-lib/out/linuxPackager.js
++++ b/node_modules/app-builder-lib/out/linuxPackager.js
+@@ -68,6 +68,8 @@ function toAppImageOrSnapArch(arch) {
+             return "arm";
+         case builder_util_1.Arch.arm64:
+             return "arm_aarch64";
++        case builder_util_1.Arch.riscv64:
++            return "riscv64";
+         default:
+             throw new Error(`Unsupported arch ${arch}`);
+     }

--- a/bitwarden/bitwarden-napi-riscv64.patch
+++ b/bitwarden/bitwarden-napi-riscv64.patch
@@ -1,0 +1,25 @@
+diff --git a/apps/desktop/desktop_native/index.js b/apps/desktop/desktop_native/index.js
+index 1cf7ea943..9c748d4b6 100644
+--- a/apps/desktop/desktop_native/index.js
++++ b/apps/desktop/desktop_native/index.js
+@@ -149,6 +149,20 @@ switch (platform) {
+     break
+   case 'linux':
+     switch (arch) {
++      case 'riscv64':
++        localFileExisted = existsSync(
++          join(__dirname, 'desktop_native.linux-riscv64-gnu.node')
++        )
++        try {
++          if (localFileExisted) {
++            nativeBinding = require('./desktop_native.linux-riscv64-gnu.node')
++          } else {
++            nativeBinding = require('@bitwarden/desktop-native-linux-riscv64-gnu')
++          }
++        } catch (e) {
++          loadError = e
++        }
++        break
+       case 'x64':
+         localFileExisted = existsSync(
+           join(__dirname, 'desktop_native.linux-x64-musl.node')

--- a/bitwarden/builder-util+23.6.0.patch
+++ b/bitwarden/builder-util+23.6.0.patch
@@ -1,0 +1,162 @@
+diff --git a/node_modules/builder-util/out/arch.js b/node_modules/builder-util/out/arch.js
+index a8827f5..2f5a626 100644
+--- a/node_modules/builder-util/out/arch.js
++++ b/node_modules/builder-util/out/arch.js
+@@ -8,6 +8,7 @@ var Arch;
+     Arch[Arch["armv7l"] = 2] = "armv7l";
+     Arch[Arch["arm64"] = 3] = "arm64";
+     Arch[Arch["universal"] = 4] = "universal";
++    Arch[Arch["riscv64"] = 5] = "riscv64";
+ })(Arch = exports.Arch || (exports.Arch = {}));
+ function toLinuxArchString(arch, targetName) {
+     switch (arch) {
+@@ -19,13 +20,15 @@ function toLinuxArchString(arch, targetName) {
+             return targetName === "snap" || targetName === "deb" ? "armhf" : targetName === "flatpak" ? "arm" : "armv7l";
+         case Arch.arm64:
+             return targetName === "pacman" || targetName === "flatpak" ? "aarch64" : "arm64";
++        case Arch.riscv64:
++            return "riscv64";
+         default:
+             throw new Error(`Unsupported arch ${arch}`);
+     }
+ }
+ exports.toLinuxArchString = toLinuxArchString;
+ function getArchCliNames() {
+-    return [Arch[Arch.ia32], Arch[Arch.x64], Arch[Arch.armv7l], Arch[Arch.arm64]];
++    return [Arch[Arch.ia32], Arch[Arch.x64], Arch[Arch.armv7l], Arch[Arch.arm64], Arch[Arch.riscv64]];
+ }
+ exports.getArchCliNames = getArchCliNames;
+ function getArchSuffix(arch, defaultArch) {
+@@ -45,6 +48,8 @@ function archFromString(name) {
+             return Arch.armv7l;
+         case "universal":
+             return Arch.universal;
++        case "riscv64":
++            return Arch.riscv64;
+         default:
+             throw new Error(`Unsupported arch ${name}`);
+     }
+diff --git a/node_modules/builder-util/out/arch.js.orig b/node_modules/builder-util/out/arch.js.orig
+new file mode 100644
+index 0000000..a8827f5
+--- /dev/null
++++ b/node_modules/builder-util/out/arch.js.orig
+@@ -0,0 +1,92 @@
++"use strict";
++Object.defineProperty(exports, "__esModule", { value: true });
++exports.getArtifactArchName = exports.defaultArchFromString = exports.archFromString = exports.getArchSuffix = exports.getArchCliNames = exports.toLinuxArchString = exports.Arch = void 0;
++var Arch;
++(function (Arch) {
++    Arch[Arch["ia32"] = 0] = "ia32";
++    Arch[Arch["x64"] = 1] = "x64";
++    Arch[Arch["armv7l"] = 2] = "armv7l";
++    Arch[Arch["arm64"] = 3] = "arm64";
++    Arch[Arch["universal"] = 4] = "universal";
++})(Arch = exports.Arch || (exports.Arch = {}));
++function toLinuxArchString(arch, targetName) {
++    switch (arch) {
++        case Arch.x64:
++            return targetName === "flatpak" ? "x86_64" : "amd64";
++        case Arch.ia32:
++            return targetName === "pacman" ? "i686" : "i386";
++        case Arch.armv7l:
++            return targetName === "snap" || targetName === "deb" ? "armhf" : targetName === "flatpak" ? "arm" : "armv7l";
++        case Arch.arm64:
++            return targetName === "pacman" || targetName === "flatpak" ? "aarch64" : "arm64";
++        default:
++            throw new Error(`Unsupported arch ${arch}`);
++    }
++}
++exports.toLinuxArchString = toLinuxArchString;
++function getArchCliNames() {
++    return [Arch[Arch.ia32], Arch[Arch.x64], Arch[Arch.armv7l], Arch[Arch.arm64]];
++}
++exports.getArchCliNames = getArchCliNames;
++function getArchSuffix(arch, defaultArch) {
++    return arch === defaultArchFromString(defaultArch) ? "" : `-${Arch[arch]}`;
++}
++exports.getArchSuffix = getArchSuffix;
++function archFromString(name) {
++    switch (name) {
++        case "x64":
++            return Arch.x64;
++        case "ia32":
++            return Arch.ia32;
++        case "arm64":
++            return Arch.arm64;
++        case "arm":
++        case "armv7l":
++            return Arch.armv7l;
++        case "universal":
++            return Arch.universal;
++        default:
++            throw new Error(`Unsupported arch ${name}`);
++    }
++}
++exports.archFromString = archFromString;
++function defaultArchFromString(name) {
++    return name ? archFromString(name) : Arch.x64;
++}
++exports.defaultArchFromString = defaultArchFromString;
++function getArtifactArchName(arch, ext) {
++    let archName = Arch[arch];
++    const isAppImage = ext === "AppImage" || ext === "appimage";
++    if (arch === Arch.x64) {
++        if (isAppImage || ext === "rpm" || ext === "flatpak") {
++            archName = "x86_64";
++        }
++        else if (ext === "deb" || ext === "snap") {
++            archName = "amd64";
++        }
++    }
++    else if (arch === Arch.ia32) {
++        if (ext === "deb" || isAppImage || ext === "snap" || ext === "flatpak") {
++            archName = "i386";
++        }
++        else if (ext === "pacman" || ext === "rpm") {
++            archName = "i686";
++        }
++    }
++    else if (arch === Arch.armv7l) {
++        if (ext === "snap") {
++            archName = "armhf";
++        }
++        else if (ext === "flatpak") {
++            archName = "arm";
++        }
++    }
++    else if (arch === Arch.arm64) {
++        if (ext === "pacman" || ext === "rpm" || ext === "flatpak") {
++            archName = "aarch64";
++        }
++    }
++    return archName;
++}
++exports.getArtifactArchName = getArtifactArchName;
++//# sourceMappingURL=arch.js.map
+\ No newline at end of file
+diff --git a/node_modules/builder-util/out/arch.js.rej b/node_modules/builder-util/out/arch.js.rej
+new file mode 100644
+index 0000000..1f2ad9c
+--- /dev/null
++++ b/node_modules/builder-util/out/arch.js.rej
+@@ -0,0 +1,19 @@
++--- node_modules/builder-util/out/arch.js
+++++ node_modules/builder-util/out/arch.js
++@@ -20,13 +21,15 @@ function toLinuxArchString(arch, targetName) {
++             return targetName === "snap" || targetName === "deb" ? "armhf" : targetName === "flatpak" ? "arm" : "armv7l";
++         case Arch.arm64:
++             return targetName === "pacman" || targetName === "rpm" || targetName === "flatpak" ? "aarch64" : "arm64";
+++        case Arch.riscv64:
+++            return "riscv64";
++         default:
++             throw new Error(`Unsupported arch ${arch}`);
++     }
++ }
++ exports.toLinuxArchString = toLinuxArchString;
++ function getArchCliNames() {
++-    return [Arch[Arch.ia32], Arch[Arch.x64], Arch[Arch.armv7l], Arch[Arch.arm64]];
+++    return [Arch[Arch.ia32], Arch[Arch.x64], Arch[Arch.armv7l], Arch[Arch.arm64], Arch[Arch.riscv64]];
++ }
++ exports.getArchCliNames = getArchCliNames;
++ function getArchSuffix(arch, defaultArch) {

--- a/bitwarden/electron-builder+23.6.0.patch
+++ b/bitwarden/electron-builder+23.6.0.patch
@@ -1,0 +1,34 @@
+diff --git a/node_modules/electron-builder/out/builder.js b/node_modules/electron-builder/out/builder.js
+index 1e1490e..8c4e10a 100644
+--- a/node_modules/electron-builder/out/builder.js
++++ b/node_modules/electron-builder/out/builder.js
+@@ -20,6 +20,9 @@ function normalizeOptions(args) {
+     function processTargets(platform, types) {
+         function commonArch(currentIfNotSpecified) {
+             const result = Array();
++            if (args.riscv64) {
++                result.push(builder_util_1.Arch.riscv64);
++            }
+             if (args.x64) {
+                 result.push(builder_util_1.Arch.x64);
+             }
+@@ -94,6 +97,7 @@ function normalizeOptions(args) {
+     delete r.p;
+     delete r.pd;
+     delete result.ia32;
++    delete result.riscv64;
+     delete result.x64;
+     delete result.armv7l;
+     delete result.arm64;
+@@ -206,6 +210,11 @@ function configureBuildCommand(yargs) {
+         alias: ["w", "windows"],
+         description: `Build for Windows, accepts target list (see ${chalk.underline("https://goo.gl/jYsTEJ")})`,
+         type: "array",
++    })
++        .option("riscv64", {
++        group: buildGroup,
++        description: "Build for riscv64",
++        type: "boolean",
+     })
+         .option("x64", {
+         group: buildGroup,

--- a/bitwarden/riscv64.patch
+++ b/bitwarden/riscv64.patch
@@ -1,0 +1,76 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -10,19 +10,32 @@ arch=('x86_64')
+ url='https://github.com/bitwarden/clients/tree/master/apps/desktop'
+ license=('GPL3')
+ depends=("electron$_electronversion" 'libnotify' 'libsecret' 'libxtst' 'libxss' 'libnss_nis')
+-makedepends=('git' 'npm' 'python' 'node-gyp' 'nodejs-lts-hydrogen' 'jq' 'rust')
++makedepends=('git' 'npm' 'python' 'node-gyp' 'nodejs-lts-hydrogen' 'jq' 'rust' 'go' 'p7zip')
+ source=(bitwarden::git+https://github.com/bitwarden/clients.git#tag=desktop-v$pkgver
+         messaging.main.ts.patch
+         nativelib.patch
+         ${pkgname}.sh
+-        ${pkgname}.desktop)
++        ${pkgname}.desktop
++	bitwarden-napi-riscv64.patch
++	builder-util+23.6.0.patch
++	app-builder-lib+23.6.0.patch
++	electron-builder+23.6.0.patch
++	git+https://github.com/develar/app-builder.git#commit=c92c3a2899b5887662321878a0a8681d122742bb
++)
+ sha512sums=('SKIP'
+             'babcae0dba4d036e5d2cd04d8932b63253bc7b27b14d090932066e9d39383f7565c06d72dae9f96e741b494ef7e50a1fe7ec33905aa3124b427a8bf404df5762'
+             '88610cba9dea99aefdfea51139f5770f04f1e877d75e86f2eea3470c99880282c5ff91060cb08d92cdf00d0a1b3bd40c5f3ee887cee11946dd31ca06da978272'
+             '98d2860bef2283fd09710fbbc5362d7ef2cd8eca26f35805ea258f2dacba78bd6aab14c834388a5089a8150eb0f32a82577aab10f8ad68e1a6371959b2802ad4'
+-            'fdc047aadc1cb947209d7ae999d8a7f5f10ae46bf71687080bc13bc3082cc5166bbbe88c8f506b78adb5d772f5366ec671b04a2f761e7d7f249ebe5726681e30')
++            'fdc047aadc1cb947209d7ae999d8a7f5f10ae46bf71687080bc13bc3082cc5166bbbe88c8f506b78adb5d772f5366ec671b04a2f761e7d7f249ebe5726681e30'
++            '4087cd10bbaad8c44917eba6a74ea26ad9d38a3c5f6ad920cb6804e4526e5e66f75c71eab60ba48997daf2f1e199b2a170c070d900cba599e4947eb48474da0c'
++            'a7d87843bc31b94ebe47af10c7dbf0d7ed2b6507cc39f4140363d37d549eea940f4d9d5bb71b1a836751a37d20931faa80631aec511d5c1329803339c35a1b4c'
++            '2d76b117eba66fad8053270e18b75790aab09ba73ef03d48bce493ae2ac2d14bf229a6da888bbcd541408175635b3a3c1528bb4622d5aaf32a6d4b285cec89f0'
++            '6dc694e0c37c126419838622560380a5e5195c49e687ee5398305bd3c0b237c0d335ff97cfa10c3a65b3683d81ad8c56e350f67b01f679d17b7347dbdb2f46bf'
++            'SKIP')
+ 
+ prepare() {
++	cp "${srcdir}"/{builder-util+23.6.0.patch,app-builder-lib+23.6.0.patch,electron-builder+23.6.0.patch} bitwarden/patches/
++	patch -Np1 -d bitwarden < bitwarden-napi-riscv64.patch
+ 	cd bitwarden/apps/desktop
+ 
+ 	export npm_config_build_from_source=true
+@@ -43,6 +56,12 @@ prepare() {
+ 	cd ../../
+ 	patch --strip=1 apps/desktop/desktop_native/index.js "$srcdir/nativelib.patch"
+ 	npm ci
++	local _builder_bin=node_modules/app-builder-bin/linux/riscv64
++	mkdir "$_builder_bin"
++	go build -C ../app-builder
++	cp ../app-builder/app-builder "$_builder_bin"
++	mkdir -p  node_modules/7zip-bin/linux/riscv64
++	ln -s /usr/bin/7za node_modules/7zip-bin/linux/riscv64/7za
+ }
+ 
+ build() {
+@@ -53,19 +72,20 @@ build() {
+ 	export npm_config_cache="$srcdir/npm_cache"
+ 	export ELECTRON_SKIP_BINARY_DOWNLOAD=1
+ 	pushd desktop_native/
+-	npm run build
++	cargo build --release --locked
++	mv target/release/libdesktop_native.so desktop_native.linux-riscv64-gnu.node
+ 	popd
+ 	npm run build
+ 	npm run clean:dist 
+-	npm exec -c "electron-builder --linux --x64 --dir -c.electronDist=$electronDist \
++	npm exec -c "electron-builder --linux --riscv64 --dir -c.electronDist=$electronDist \
+ 	             -c.electronVersion=$electronVer"
+ }
+ 
+ package(){
+ 	cd bitwarden/apps/desktop
+-	install -vDm644 dist/linux-unpacked/resources/app.asar -t "${pkgdir}/usr/lib/${pkgname}"
++	install -vDm644 dist/linux-riscv64-unpacked/resources/app.asar -t "${pkgdir}/usr/lib/${pkgname}"
+ 	install -vDm644 build/package.json -t "${pkgdir}/usr/lib/${pkgname}"
+-	cp -vr dist/linux-unpacked/resources/app.asar.unpacked -t "${pkgdir}/usr/lib/${pkgname}"
++	cp -vr dist/linux-riscv64-unpacked/resources/app.asar.unpacked -t "${pkgdir}/usr/lib/${pkgname}"
+ 
+ 	for i in 16 32 64 128 256 512 1024; do
+ 		install -vDm644 resources/icons/${i}x${i}.png "${pkgdir}/usr/share/icons/hicolor/${i}x${i}/apps/${pkgname}.png"

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -3,6 +3,7 @@ asio
 bat
 bear
 beatslash-lv2
+bitwarden
 bmake
 caps
 cargo-audit


### PR DESCRIPTION
- Patch napi binding file for riscv64 support. This could be removed
  once upstream upgrades napi-rs to 3.0(which is not stable yet).
- Build app-builder riscv64 and use system 7za.
- Patch electron builder related packages for riscv64 support. Previous upstream
  PR got rejected.
- Build native node module manually instead of using napi-rs/cli to
  avoid hitting v8 bug: https://bugs.chromium.org/p/v8/issues/detail?id=13930
- Add it to qemu-user-blacklist because `electron24 --version` can't run inside qemu-user.
- Other trival changes.

Note that this package can't be built on sg2042 because a strange SIGILL happens in node during the build.