### PR TITLE
updpatch: nextcloud-app-notify_push 0.6.4-1

### DIFF
--- a/nextcloud-app-notify_push/riscv64.patch
+++ b/nextcloud-app-notify_push/riscv64.patch
@@ -6,7 +6,7 @@
  	cd "$_archive"
 -	cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
 +	echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
-+	cargo update -p ring
++	cargo update -p ring@0.16.20
 +	cargo fetch --locked
  	sed -i -e "s/@ARCH@/$CARCH/" "../$pkgname.service"
  }


### PR DESCRIPTION
Specify that ring 0.16.20 to be updated because there are multiple versions (0.17.3) of ring in the lock file.
