### PR TITLE
addpatch: vue-language-server 1.8.22-1

### DIFF
--- a/vue-language-server/increase-test-timeout.patch
+++ b/vue-language-server/increase-test-timeout.patch
@@ -1,0 +1,12 @@
+diff --git a/packages/tsc/tests/index.spec.ts b/packages/tsc/tests/index.spec.ts
+index b50b76984..9ae29c5bf 100644
+--- a/packages/tsc/tests/index.spec.ts
++++ b/packages/tsc/tests/index.spec.ts
+@@ -75,6 +75,6 @@ function runVueTsc(cwd: string) {
+ 
+ describe(`vue-tsc`, () => {
+ 	for (const [path, isRoot] of tests) {
+-		it(`vue-tsc no errors (${prettyPath(path, isRoot)})`, () => runVueTsc(path), 40_000);
++		it(`vue-tsc no errors (${prettyPath(path, isRoot)})`, () => runVueTsc(path), 40_0000);
+ 	}
+ });

--- a/vue-language-server/riscv64.patch
+++ b/vue-language-server/riscv64.patch
@@ -1,0 +1,19 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,11 +12,14 @@ license=('MIT')
+ depends=('nodejs')
+ makedepends=('git' 'npm' 'pnpm')
+ optdepends=('typescript: for use in typescript.tsdk')
+-source=("$_name::git+https://github.com/vuejs/language-tools.git#tag=v$pkgver")
+-b2sums=('SKIP')
++source=("$_name::git+https://github.com/vuejs/language-tools.git#tag=v$pkgver"
++        increase-test-timeout.patch::https://patch-diff.githubusercontent.com/raw/vuejs/language-tools/pull/3721.diff)
++b2sums=('SKIP'
++        '0b06f7106b544d6498292bb4a7ff465b8dc30def6bc81dbbb087301bde5086a321bf003cdd255d3bd66cbd48b9b71033603fb6f69c3b5dfe33f07feaf67eb5e6')
+ 
+ prepare() {
+   cd $_name
++  patch -Np1 -i ../increase-test-timeout.patch
+   pnpm install --frozen-lockfile
+ }
+ 


### PR DESCRIPTION
Increase timeout to pass test in `check()`.
Upstream: https://github.com/vuejs/language-tools/pull/3721.
