### PR TITLE
upgpatch: zettlr

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -135,6 +135,5 @@ wanderlust
 wayland
 xmonk.lv2
 zeromq
-zettlr
 zram-generator
 zsh

--- a/zettlr/riscv64.patch
+++ b/zettlr/riscv64.patch
@@ -1,42 +1,27 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -23,22 +23,32 @@ makedepends=(gendesk
-              nodejs-lts-gallium # grep NODE_VERSION .github/workflows/build.yml
-              node-gyp
-              yarn
--             jq)
-+             jq zip)
- optdepends=('texlive-bin: For Latex support')
- # Migration path for soon to be deleted AUR package; remove if ever reinstated
- replaces=(zettlr-bin)
- _archive="$_pkgname-$_pkgver"
- source=("$_url/archive/v$_pkgver/$_archive.tar.gz"
-         "$pkgname.sh"
--        "$pkgname.xml")
-+        "$pkgname.xml"
-+        "liblzma-fix.patch::https://github.com/addaleax/lzma-native/pull/135.patch"
-+        "electron-packager-riscv64.patch")
- sha256sums=('487635be4c8940dde3306290c891ec039ed392cbc8c1af329786553eafc336fb'
-             'e300f2cac217f98ab5c365dccc7581410bc296f2842d52f7f1520dd6679d20cf'
--            'c3ecbb490a1d4fa5bc42f7166cc375e5629a452d25bb1d4facb5541938681292')
-+            'c3ecbb490a1d4fa5bc42f7166cc375e5629a452d25bb1d4facb5541938681292'
-+            '066f050457349873ff36375b547dd7de482ecce182ed9d9ad2514db8fc81c75b'
-+            '52b8f1250740402821c62d717aaf60b84acddfae456e3eeea99649c1b7c062c8')
+@@ -36,8 +36,19 @@ sha256sums=('96ad5f6871bb15a9a02e23cc576bc0d6fd62a8d705a3714b641dbcd5ca774a24'
  
  #_yarnargs="--cache-folder '$srcdir/cache' --link-folder '$srcdir/link'"
  
++makedepends+=(zip)
++source+=("liblzma-fix.patch::https://github.com/addaleax/lzma-native/pull/135.patch"
++         "electron-packager-riscv64.patch")
++sha256sums+=('066f050457349873ff36375b547dd7de482ecce182ed9d9ad2514db8fc81c75b'
++             '52b8f1250740402821c62d717aaf60b84acddfae456e3eeea99649c1b7c062c8')
++
  prepare() {
- 	local _electronVersion=$($_electron --version | sed -e 's/^v//')
+-	local _electronVersion=$($_electron --version | sed -e 's/^v//')
++	local _electronVersion=$( <"/usr/lib/$_electron/version")
 +	local _hash=$(echo -n "https://github.com/electron/electron/releases/download/v$_electronVersion" | sha256sum | cut -d ' ' -f 1)
 +	local _electron_zip="electron-v$_electronVersion-linux-riscv64.zip"
 +	cd "/usr/lib/$_electron" && zip -r "/tmp/$_electron_zip" ./ && cd -
 +	local _cache_dir="$HOME/.cache/electron/$_hash"
 +	mkdir -p "$_cache_dir" && mv "/tmp/$_electron_zip" "$_cache_dir"
-+	
  	gendesk -q -f -n \
  		--pkgname "$pkgname" \
  		--pkgdesc "$pkgdesc" \
-@@ -52,14 +62,19 @@ prepare() {
+@@ -51,14 +62,19 @@ prepare() {
  	sed -i "s/\([\^ :]\)${_oldElectron[0]}/\1$_electronVersion/"  package.json yarn.lock
  	echo -ne '#!/usr/bin/env bash\n\nexit 0' > scripts/get-pandoc.sh
  	sed -e "s/@ELECTRON@/$_electron/" "../${source[1]}" > $pkgname.sh
@@ -59,7 +44,7 @@
  }
  
  package() {
-@@ -68,8 +83,8 @@ package() {
+@@ -67,8 +83,8 @@ package() {
  	install -Dm0755 "$pkgname.sh" "$pkgdir/usr/bin/$pkgname"
  	local _destdir="usr/lib/$pkgname"
  	install -Dm0644 -t "$pkgdir/$_destdir/" \


### PR DESCRIPTION
- Fix rotten and make it less likely to rot.
- Read electron version from `/usr/lib/electron$ver/version` and remove this package from qemu-user-blacklist.txt