### PR TITLE
updpatch: refind 0.14.0.2-1

### DIFF
--- a/refind/riscv64.patch
+++ b/refind/riscv64.patch
@@ -22,9 +22,12 @@
    # remove the path prefix from the css reference, so that the css can live
    # in the same directory
    sed -e 's|../Styles/||g' -i docs/$pkgbase/*.html
-@@ -28,7 +32,7 @@ build() {
+@@ -26,9 +30,9 @@ prepare() {
+ 
+ build() {
    cd $pkgname-$pkgver
-   make
+-  make
++  make OMIT_SBAT=1
    make gptsync
 -  make fs
 +  make fs OMIT_SBAT=1


### PR DESCRIPTION
Add a missing flag to build `refind.efi`.
