### PR TITLE
addpatch: rocm-smi-lib

### DIFF
--- a/rocm-smi-lib/riscv64.patch
+++ b/rocm-smi-lib/riscv64.patch
@@ -1,0 +1,24 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -11,11 +11,19 @@ license=('custom:NCSAOSL')
+ depends=('hsa-rocr' 'python')
+ makedepends=('cmake')
+ _git='https://github.com/RadeonOpenCompute/rocm_smi_lib'
+-source=("$pkgname-$pkgver.tar.gz::$_git/archive/rocm-$pkgver.tar.gz")
+-sha256sums=('4d79cb0482b2f801cc7824172743e3dd2b44b9f6784d1ca2e5067f2fbb4ef803')
++source=("$pkgname-$pkgver.tar.gz::$_git/archive/rocm-$pkgver.tar.gz"
++        rocm-smi-lib_fix-cxx-flags.patch)
++sha256sums=('4d79cb0482b2f801cc7824172743e3dd2b44b9f6784d1ca2e5067f2fbb4ef803'
++            '98517844cbf9c0237b37b0bcedb2d29362d4307606d78898e9a19610ce923942')
+ options=(!lto)
+ _dirname="$(basename "$_git")-$(basename "${source[0]}" .tar.gz)"
+ 
++prepare() {
++  # remove '-m64 -msse -msse2' c++ flags on architectures that don't support it.
++  # backport from https://github.com/RadeonOpenCompute/rocm_smi_lib/commit/1cf05dd9c704f0fad0f535330ee1955914a4fe86
++  patch -d "$_dirname" -Np1 -i ../rocm-smi-lib_fix-cxx-flags.patch
++}
++
+ build() {
+   cmake \
+     -Wno-dev \

--- a/rocm-smi-lib/rocm-smi-lib_fix-cxx-flags.patch
+++ b/rocm-smi-lib/rocm-smi-lib_fix-cxx-flags.patch
@@ -1,0 +1,24 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4199ef5..c568621 100755
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -70,7 +70,7 @@ endif()
+ 
+ ## Compiler flags
+ set(CMAKE_CXX_FLAGS
+- "${CMAKE_CXX_FLAGS} -Wall -Wextra -fno-rtti -m64 -msse -msse2 -std=c++11 ")
++ "${CMAKE_CXX_FLAGS} -Wall -Wextra -fno-rtti -std=c++11 ")
+ # Security options
+ set(CMAKE_CXX_FLAGS
+  "${CMAKE_CXX_FLAGS} -Wconversion -Wcast-align ")
+@@ -80,6 +80,10 @@ set(CMAKE_CXX_FLAGS
+ set(CMAKE_CXX_FLAGS
+  "${CMAKE_CXX_FLAGS}  -Woverloaded-virtual -Wreorder ")
+ 
++if((${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "x86_64") OR (${CMAKE_HOST_SYSTEM_PROCESSOR} STREQUAL "AMD64"))
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64 -msse -msse2")
++endif()
++
+ # Clang does not set the build-id
+ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+     set (CMAKE_SHARED_LINKER_FLAGS "-Wl,--build-id=sha1")


### PR DESCRIPTION
- remove unneeded c++ flag `-m64` and unsupported flags `-msse -msse2` for riscv64