### PR TITLE
addpatch: rocminfo 5.7.1-1

### DIFF
--- a/rocminfo/riscv64.patch
+++ b/rocminfo/riscv64.patch
@@ -1,0 +1,22 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -13,10 +13,17 @@ url='https://github.com/RadeonOpenCompute/rocminfo'
+ license=('custom:NCSAOSL')
+ depends=('pciutils' 'python' 'hsa-rocr')
+ makedepends=('rocm-cmake')
+-source=("$pkgname-$pkgver.tar.gz::$url/archive/rocm-$pkgver.tar.gz")
+-sha256sums=('642dc2ec4254b3c30c43064e6690861486db820b25f4906ec78bdb47e68dcd0b')
++source=("$pkgname-$pkgver.tar.gz::$url/archive/rocm-$pkgver.tar.gz"
++        rocminfo_fix-cxx-flags.patch::https://github.com/RadeonOpenCompute/rocminfo/pull/63.diff)
++sha256sums=('642dc2ec4254b3c30c43064e6690861486db820b25f4906ec78bdb47e68dcd0b'
++            '423baa1e51a14987f472286f86eabe00533ccaa3ccfd294d153545f9abc61880')
+ _dirname="$(basename "$url")-$(basename "${source[0]}" .tar.gz)"
+ 
++prepare() {
++  # remove '-m64' c++ flag on architectures that don't support it.
++  patch -d "$_dirname" -Np1 -i ../rocminfo_fix-cxx-flags.patch
++}
++
+ build() {
+   # ROCRTST_BLD_TYPE=Release fixes a build error regarding _FORTIFY_SOURCE=2
+   cmake \


### PR DESCRIPTION
- Remove unneeded c++ flag `-m64` for riscv64, see riscv-collab/riscv-gnu-toolchain#670