### PR TITLE
addpatch: hsa-rocr 5.7.1-1

### DIFF
--- a/hsa-rocr/riscv64.patch
+++ b/hsa-rocr/riscv64.patch
@@ -1,0 +1,18 @@
+diff --git PKGBUILD PKGBUILD
+index 076a129..18e75c2 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -20,6 +20,13 @@
+ _dirname="$(basename "$_git")-$(basename "${source[0]}" .tar.gz)"
+ options=(!lto)
+ 
++source+=("hsa-rocr-add-riscv.patch::https://github.com/RadeonOpenCompute/ROCR-Runtime/pull/172.patch")
++sha256sums+=('2106f1e8246ff7685c04355a85b0a5a94f0fbad4b8f71641e25c2d26aaba6677')
++
++prepare() {
++  patch -d $_dirname -Np1 -i ../hsa-rocr-add-riscv.patch
++}
++
+ build() {
+   # Silence warnings on optional libraries,
+   # https://github.com/RadeonOpenCompute/ROCR-Runtime/issues/89#issuecomment-613788944


### PR DESCRIPTION
Fix `rocm-dbgapi` compile error:
```text
In file included from /opt/rocm/include/hsa/amd_hsa_queue.h:47,
                 from /build/rocm-dbgapi/src/ROCdbgapi-rocm-5.7.1/src/queue.cpp:35:
/opt/rocm/include/hsa/hsa.h:93:2: error: #error "BIGENDIAN_CPU or LITTLEENDIAN_CPU must be defined"
   93 | #error "BIGENDIAN_CPU or LITTLEENDIAN_CPU must be defined"
      |  ^~~~~
```