### PR TITLE
qemu-user-makedepends-blacklist: add pcre2

### DIFF
--- a/qemu-user-makedepends-blacklist.txt
+++ b/qemu-user-makedepends-blacklist.txt
@@ -1,3 +1,4 @@
-go
-rust
 cargo
+go
+pcre2
+rust


### PR DESCRIPTION
pcre2 JIT fails with segment fault in current qemu-user (v8.1.2), any use of it will fail in qemu.

also tidy the file.