### PR TITLE
qemu-user-makedepends-blacklist: remove rust/cargo

### DIFF
--- a/qemu-user-makedepends-blacklist.txt
+++ b/qemu-user-makedepends-blacklist.txt
@@ -1,4 +1,2 @@
-cargo
 go
 pcre2
-rust


### PR DESCRIPTION
halting rust builds in qemu-user are rare now, try to unblock it.