### PR TITLE
updpatch: rustypaste 0.14.1-1

### DIFF
--- a/rustypaste/riscv64.patch
+++ b/rustypaste/riscv64.patch
@@ -1,12 +1,10 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -16,7 +16,9 @@ b2sums=('a46cae0327a32c3b3c4e70bf0fc8d5ae11e3b01e87f3240fd125264c6cada25129a9979
+@@ -16,7 +16,7 @@ b2sums=('78596373e79b9bc0dccd2de14c783d1d8b2a450cf9df97704812684061280645a9c2b0d
  
  prepare() {
    cd ${pkgname}-${pkgver}
 -  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
-+  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
-+  cargo update -p ring
 +  cargo fetch --locked
  }
  


### PR DESCRIPTION
- Remove 'ring patch' on v0.16.20, as upstream updated ring to v0.17.5. (Successfully built without 'ring v0.16.20 patch') 
  This fix `error: There are multiple 'ring' packages in your project` in log.