### PR TITLE
addpatch: buildbot

### DIFF
--- a/buildbot/riscv64.patch
+++ b/buildbot/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -46,8 +46,12 @@ _buildbot_www_modules_with_tests=(base waterfall_view console_view grid_view wsg
+ _buildbot_www_react_modules_with_tests=(react-base react-console_view react-grid_view)
+ _buildbot_www_modules=(${_buildbot_www_modules_with_tests[@]} ${_buildbot_www_react_modules_with_tests[@]} badges)
+ 
++source+=("increase-test_start-timeout.patch::https://github.com/buildbot/buildbot/commit/5326923eb7174f5593a103838d7a52c0c73dec3e.patch")
++sha256sums+=('2ba44e931ff4240fad16ca6697395622bf8868be9e5717eb8e2df95e6c41dc3d')
++
+ prepare() {
+   cd buildbot-$pkgver
++  patch -Np1 -i ../increase-test_start-timeout.patch
+ 
+   # Some master tests use scripts from contrib
+   ln -s ../../buildbot-contrib/master/contrib master/contrib

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -4,6 +4,7 @@ bat
 bear
 beatslash-lv2
 bmake
+buildbot
 caps
 cargo-audit
 cargo-generate-rpm


### PR DESCRIPTION
- Increase test timeout of `start_test` by backporting upstream commit. We can probably remove this patch at the next release.
- Add to qemu blacklist because chromium can't execute in qemu: https://www.mail-archive.com/qemu-devel@nongnu.org/msg803994.html