### PR TITLE
updpatch: zig 0.11.0-1

### DIFF
--- a/zig/disable-macho-link-tests.patch
+++ b/zig/disable-macho-link-tests.patch
@@ -1,0 +1,112 @@
+--- zig-0.11.0/test/link.zig.orig	2023-11-22 10:45:40.666337735 +0200
++++ zig-0.11.0/test/link.zig	2023-11-22 10:46:00.534125211 +0200
+@@ -83,109 +83,4 @@
+         .import = @import("link/wasm/type/build.zig"),
+     },
+ 
+-    // Mach-O Cases
+-    .{
+-        .build_root = "test/link/macho/bugs/13056",
+-        .import = @import("link/macho/bugs/13056/build.zig"),
+-    },
+-    .{
+-        .build_root = "test/link/macho/bugs/13457",
+-        .import = @import("link/macho/bugs/13457/build.zig"),
+-    },
+-    .{
+-        .build_root = "test/link/macho/bugs/16308",
+-        .import = @import("link/macho/bugs/16308/build.zig"),
+-    },
+-    .{
+-        .build_root = "test/link/macho/bugs/16628",
+-        .import = @import("link/macho/bugs/16628/build.zig"),
+-    },
+-    .{
+-        .build_root = "test/link/macho/dead_strip",
+-        .import = @import("link/macho/dead_strip/build.zig"),
+-    },
+-    .{
+-        .build_root = "test/link/macho/dead_strip_dylibs",
+-        .import = @import("link/macho/dead_strip_dylibs/build.zig"),
+-    },
+-    .{
+-        .build_root = "test/link/macho/dylib",
+-        .import = @import("link/macho/dylib/build.zig"),
+-    },
+-    .{
+-        .build_root = "test/link/macho/empty",
+-        .import = @import("link/macho/empty/build.zig"),
+-    },
+-    .{
+-        .build_root = "test/link/macho/entry",
+-        .import = @import("link/macho/entry/build.zig"),
+-    },
+-    .{
+-        .build_root = "test/link/macho/entry_in_archive",
+-        .import = @import("link/macho/entry_in_archive/build.zig"),
+-    },
+-    .{
+-        .build_root = "test/link/macho/entry_in_dylib",
+-        .import = @import("link/macho/entry_in_dylib/build.zig"),
+-    },
+-    .{
+-        .build_root = "test/link/macho/headerpad",
+-        .import = @import("link/macho/headerpad/build.zig"),
+-    },
+-    .{
+-        .build_root = "test/link/macho/linksection",
+-        .import = @import("link/macho/linksection/build.zig"),
+-    },
+-    .{
+-        .build_root = "test/link/macho/needed_framework",
+-        .import = @import("link/macho/needed_framework/build.zig"),
+-    },
+-    .{
+-        .build_root = "test/link/macho/needed_library",
+-        .import = @import("link/macho/needed_library/build.zig"),
+-    },
+-    .{
+-        .build_root = "test/link/macho/objc",
+-        .import = @import("link/macho/objc/build.zig"),
+-    },
+-    .{
+-        .build_root = "test/link/macho/objcpp",
+-        .import = @import("link/macho/objcpp/build.zig"),
+-    },
+-    .{
+-        .build_root = "test/link/macho/pagezero",
+-        .import = @import("link/macho/pagezero/build.zig"),
+-    },
+-    .{
+-        .build_root = "test/link/macho/search_strategy",
+-        .import = @import("link/macho/search_strategy/build.zig"),
+-    },
+-    .{
+-        .build_root = "test/link/macho/stack_size",
+-        .import = @import("link/macho/stack_size/build.zig"),
+-    },
+-    .{
+-        .build_root = "test/link/macho/strict_validation",
+-        .import = @import("link/macho/strict_validation/build.zig"),
+-    },
+-    .{
+-        .build_root = "test/link/macho/tbdv3",
+-        .import = @import("link/macho/tbdv3/build.zig"),
+-    },
+-    .{
+-        .build_root = "test/link/macho/tls",
+-        .import = @import("link/macho/tls/build.zig"),
+-    },
+-    .{
+-        .build_root = "test/link/macho/unwind_info",
+-        .import = @import("link/macho/unwind_info/build.zig"),
+-    },
+-    .{
+-        .build_root = "test/link/macho/weak_library",
+-        .import = @import("link/macho/weak_library/build.zig"),
+-    },
+-    .{
+-        .build_root = "test/link/macho/weak_framework",
+-        .import = @import("link/macho/weak_framework/build.zig"),
+-    },
+ };

--- a/zig/riscv64.patch
+++ b/zig/riscv64.patch
@@ -1,12 +1,26 @@
-Index: PKGBUILD
-===================================================================
---- PKGBUILD	(revision 1142351)
-+++ PKGBUILD	(working copy)
-@@ -10,7 +10,6 @@
- license=('MIT')
- depends=('clang' 'llvm-libs' 'lld')
+diff --git PKGBUILD PKGBUILD
+index 2602c6c..4d1e164 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -11,16 +11,18 @@ license=('MIT')
+ options=('!lto')
+ depends=('clang' 'lld' 'llvm-libs')
  makedepends=('cmake' 'llvm')
 -checkdepends=('lib32-glibc')
  source=("https://ziglang.org/download/$pkgver/zig-$pkgver.tar.xz"
-         "resolve_DNS.patch")
- sha256sums=('cd1be83b12f8269cc5965e59877b49fdd8fa638efb6995ac61eb4cea36a2e381'
+-        "skip-localhost-test.patch")
++        "skip-localhost-test.patch"
++        "disable-macho-link-tests.patch")
+ sha256sums=('ead029cfe474d9bf0413332d0e9d3bdfb5990cadce238f44f35ba32d92169295'
+-            'eeb5f0f72035c52bf558ffc77a171a3ddf93eac7d663ef0c82826007763717a8')
++            'eeb5f0f72035c52bf558ffc77a171a3ddf93eac7d663ef0c82826007763717a8'
++            'e70f2a61c2543414d7f7a0fbcec4fc88fcca0b2f80368c4a6e6ad9ea76ed917d')
+ 
+ prepare() {
+     cd "$pkgname-$pkgver"
+ 
+     patch -p1 -i ../skip-localhost-test.patch
++    patch -p1 -i ../disable-macho-link-tests.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
Skip macho link tests because they don't build on riscv64.

`nocheck` is still required and test failures have been reported to https://github.com/ziglang/zig/issues/18018