### PR TITLE
addpatch: rocm-opencl-runtime 5.7.1-1

### DIFF
--- a/rocm-opencl-runtime/riscv64.patch
+++ b/rocm-opencl-runtime/riscv64.patch
@@ -1,0 +1,23 @@
+diff --git PKGBUILD PKGBUILD
+index 0168ea3..b0666d5 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,10 +12,16 @@
+ depends=('hsakmt-roct' 'hsa-rocr' 'comgr' 'mesa' 'opencl-icd-loader' 'opencl-headers')
+ makedepends=('rocm-cmake')
+ provides=('opencl-driver')
+-source=("$pkgname-$pkgver.tar.gz::$url/archive/rocm-$pkgver.tar.gz")
+-sha256sums=('c78490335233a11b4d8a5426ace7417c555f5e2325de10422df06c0f0f00f7eb')
++source=("$pkgname-$pkgver.tar.gz::$url/archive/rocm-$pkgver.tar.gz"
++        "$pkgname-only-enable-SIMD-on-x86.patch::https://github.com/ROCm-Developer-Tools/clr/commit/4c3450cccd8f4064b1e011e6b84e7ca4567121a3.diff")
++sha256sums=('c78490335233a11b4d8a5426ace7417c555f5e2325de10422df06c0f0f00f7eb'
++            'b20e8678851331093bf99d9d202b221f5ffd144e9ceb153728434e750df5349e')
+ _dirname="$(basename "$url")-$(basename "${source[0]}" .tar.gz)"
+ 
++prepare() {
++  patch -Np1 -d $_dirname -i ../$pkgname-only-enable-SIMD-on-x86.patch
++}
++
+ build() {
+   local cmake_args=(
+     -Wno-dev


### PR DESCRIPTION
Fix `immintrin.h` ENOENT.

Upstream: https://github.com/ROCm-Developer-Tools/clr/pull/35