### PR TITLE
updpatch: prusa-slicer 2.7.0-1

### DIFF
--- a/prusa-slicer/riscv64.patch
+++ b/prusa-slicer/riscv64.patch
@@ -2,7 +2,7 @@
 +++ PKGBUILD
 @@ -15,6 +15,19 @@ options=('!makeflags')
  source=(https://github.com/prusa3d/PrusaSlicer/archive/version_${pkgver}/${pkgname}-${pkgver}.tar.gz)
- sha256sums=('516eb34835cd8f301e639fa77f9f12297300ce012ebc3b7b6a73275c6245011d')
+ sha256sums=('18b4e9e656a03bc0ae5f382b207ace07bc8944c3db7c252a6c1c5b67da169f64')
  
 +source+=(onetbb-fix.patch::https://patch-diff.githubusercontent.com/raw/oneapi-src/oneTBB/pull/550.patch
 +         $pkgname-tbbfix.patch)
@@ -11,7 +11,7 @@
 +
 +
 +prepare() {
-+  cd PrusaSlicer-version_${pkgver}/deps/TBB
++  cd PrusaSlicer-version_${pkgver}/deps/+TBB
 +
 +  cp ${srcdir}/onetbb-fix.patch ./
 +  patch -Np0 -i ${srcdir}/$pkgname-tbbfix.patch


### PR DESCRIPTION
- Fix source path name. `TBB` -> `+TBB`