### PR TITLE
Revert "qemu-user-makedepends-blacklist: remove rust/cargo"

### DIFF
--- a/qemu-user-makedepends-blacklist.txt
+++ b/qemu-user-makedepends-blacklist.txt
@@ -1,2 +1,4 @@
+cargo
 go
 pcre2
+rust


### PR DESCRIPTION
`deno` makes the rust deadlock nearly 100% reproducible on qemu-user. Adding back the blacklist entries.

This reverts commit 7a10432fbe6ba5959a8e7ac885a6032c8b110f81.