### PR TITLE
addpatch: pcre2

### DIFF
--- a/pcre2/riscv64.patch
+++ b/pcre2/riscv64.patch
@@ -1,0 +1,25 @@
+diff --git PKGBUILD PKGBUILD
+index 6979a2a..c0f2c31 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,11 +15,18 @@ license=('BSD')
+ depends=('readline' 'zlib' 'bzip2' 'bash')
+ provides=(libpcre2-{8,16,32,posix}.so)
+ options=(staticlibs)
+-source=("https://github.com/PhilipHazel/pcre2/releases/download/$pkgname-$pkgver/$pkgname-$pkgver.tar.bz2"{,.sig})
++source=("https://github.com/PhilipHazel/pcre2/releases/download/$pkgname-$pkgver/$pkgname-$pkgver.tar.bz2"{,.sig}
++        sljit-sv48.patch::https://github.com/zherczeg/sljit/pull/223.patch)
+ sha512sums=('72fbde87fecec3aa4b47225dd919ea1d55e97f2cbcf02aba26e5a0d3b1ffb58c25a80a9ef069eb99f9cf4e41ba9604ad06a7ec159870e1e875d86820e12256d3'
+-            'SKIP')
++            'SKIP'
++            '29d3337531c203a1f6521f44e98cd9730cd53d8ee5e0cc48183b43a51439bb491b7d7728373dbc5e4f8b674dbafeb5d8f7c6134abea8b7b6e989948d8e5b5f3a')
+ validpgpkeys=('45F68D54BBE23FB3039B46E59766E084FB0F43D8')  # Philip Hazel <ph10@hermes.cam.ac.uk>
+ 
++prepare() {
++  cd $pkgname-$pkgver/src/sljit
++  patch -Np2 -i "$srcdir"/sljit-sv48.patch
++}
++
+ build() {
+   cd $pkgname-$pkgver
+ 

--- a/qemu-user-makedepends-blacklist.txt
+++ b/qemu-user-makedepends-blacklist.txt
@@ -1,4 +1,3 @@
 cargo
 go
-pcre2
 rust


### PR DESCRIPTION
Apply a patch to fix sv48/sv57 crashes. Upstream hasn't confirmed the
fix [1] yet but at least the tests are passing now.

Thanks to @ksco !

[1] https://github.com/zherczeg/sljit/pull/223