### PR TITLE
updpatch: cargo-nextest 0.9.64-1

### DIFF
--- a/cargo-nextest/riscv64.patch
+++ b/cargo-nextest/riscv64.patch
@@ -1,12 +1,10 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -18,7 +18,9 @@ options=('!lto')
+@@ -18,7 +18,7 @@ options=('!lto')
  prepare() {
    mv "nextest-$pkgname-$pkgver" "$pkgname-$pkgver"
    cd "$pkgname-$pkgver"
 -  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
-+  echo -e "[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
-+  cargo update -p ring
 +  cargo fetch --locked
  }
  


### PR DESCRIPTION
Successfully built without ring patch