### PR TITLE
addpatch: flip-link 0.1.7-1

### DIFF
--- a/flip-link/riscv64.patch
+++ b/flip-link/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,7 +14,7 @@ b2sums=('e1232cf0f173abe83eeb894b2062820394ce6ff20ed817f7af1cedf23320f508f57d23e
+ 
+ prepare() {
+   cd "${pkgname}-${pkgver}"
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  cargo fetch --locked
+ }
+ 
+ build() {


### PR DESCRIPTION
- Fix broken cargo target