### PR TITLE
addpatch: ot-urchin 1.0.0-1

### DIFF
--- a/ot-urchin/riscv64.patch
+++ b/ot-urchin/riscv64.patch
@@ -1,0 +1,20 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -43,8 +43,16 @@ b2sums=('274fd49d0eaae0b9cc1b9e04650f2bb5dba9c4283565e7d292fc6a4fc82deda5fec9b35
+         'd34311025c69665beb59bfe35a3051c6c5a3c8896de97b091c9aac0f9c3cb27e39476374288d7ed54e64d4a660c6429c85bf417bc5b17658c0d967329d4846f3')
+ 
+ prepare() {
++  # need to override dependency workspace members
++  cat >>Cargo.toml <<"EOF"
++[patch."https://github.com/robbert-vdh/nih-plug.git"]
++nih_plug = { git = "https://github.com/aimixsaka/nih-plug.git", branch = "riscv" }
++nih_plug_egui = { git = "https://github.com/aimixsaka/nih-plug.git", branch = "riscv" }
++nih_plug_xtask = { git = "https://github.com/aimixsaka/nih-plug.git", branch = "riscv" }
++EOF
++  cargo update nih_plug
+   # download dependencies
+-  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
++  cargo fetch --locked
+ }
+ 
+ build() {


### PR DESCRIPTION
- Fix broken cargo target
- Use forked repo to support riscv: https://github.com/aimixsaka/nih-plug/tree/riscv
- Upstreamed: https://github.com/robbert-vdh/nih-plug/pull/95