### PR TITLE
addpatch: snapshot

### DIFF
--- a/snapshot/fix-clippy-timeout.patch
+++ b/snapshot/fix-clippy-timeout.patch
@@ -1,0 +1,13 @@
+diff --git a/src/meson.build b/src/meson.build
+index 33ff42e..84ff637 100644
+--- a/src/meson.build
++++ b/src/meson.build
+@@ -63,7 +63,7 @@ test (
+   env: [
+     cargo_env,
+   ],
+-  timeout: 400, # cargo might take a bit of time sometimes
++  timeout: 1000, # cargo might take a bit of time sometimes
+ )
+ 
+ test (

--- a/snapshot/riscv64.patch
+++ b/snapshot/riscv64.patch
@@ -1,0 +1,20 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -27,11 +27,15 @@ makedepends=(
+   rust
+ )
+ _commit=10bd7f8d86897656b89d63b3fdbda74d34052ff0 # tags/45.1^0
+-source=("git+https://gitlab.gnome.org/GNOME/snapshot.git#commit=$_commit")
+-sha256sums=('SKIP')
++source=("git+https://gitlab.gnome.org/GNOME/snapshot.git#commit=$_commit"
++        "fix-clippy-timeout.patch")
++sha256sums=('SKIP'
++            '9cab1c3527f6566a48d898051f519016cf3c6d5212116570a1aef8dc33da4899')
+ 
+ prepare() {
+   cd ${pkgname}
++
++  patch -Np1 -i $srcdir/fix-clippy-timeout.patch
+ }
+ 
+ pkgver() {


### PR DESCRIPTION
Fix `Cargo clippy` timeout error, upstreamed to snapshot: https://gitlab.gnome.org/GNOME/snapshot/-/issues/111