### PR TITLE
addpatch: gitoxide 0.32.0-1

### DIFF
--- a/gitoxide/riscv64.patch
+++ b/gitoxide/riscv64.patch
@@ -1,14 +1,12 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -15,7 +15,11 @@ b2sums=('18432893bc3fa7bf94b7a32566ea548c5abd228e646a63e5c82f1af30f777980d6f6974
+@@ -15,7 +15,9 @@ b2sums=('9c21b9bfa4e96c6504414e172bee3029251f454908626893650ff77636c3c66a7b7fb73
  
  prepare() {
    cd "${pkgname}-${pkgver}"
 -  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
-+
-+  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
-+  cargo update -p ring
-+
++  cargo update -p rustls@0.21.7
++  cargo update -p sct
 +  cargo fetch --locked
  }
  


### PR DESCRIPTION
Remove `ring@0.16.20` patch by updating indirect dependences (https://github.com/Byron/gitoxide/pull/1175).
