### PR TITLE
qemu-user-blacklist.txt: add vbam

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -131,6 +131,7 @@ tpm2-tools
 tpm2-tss
 upower
 uutils-coreutils
+vbam
 vim
 wanderlust
 wayland


### PR DESCRIPTION
ICE because of stack overflow: https://gitlab.com/qemu-project/qemu/-/issues/1895

Could also be solved by exporting a large QEMU_STACK_SIZE value in makepkg config file.