### PR TITLE
updpatch: cdparanoia

### DIFF
--- a/cdparanoia/riscv64.patch
+++ b/cdparanoia/riscv64.patch
@@ -1,17 +1,10 @@
-Index: PKGBUILD
-===================================================================
---- PKGBUILD	(revision 422631)
-+++ PKGBUILD	(working copy)
-@@ -18,10 +18,12 @@
- prepare() {
-   cd cdparanoia-III-$pkgver
-   patch -p0 -i "$srcdir"/gcc.patch
+--- PKGBUILD
++++ PKGBUILD
+@@ -27,6 +27,7 @@ prepare() {
+   patch -p1 -i "$srcdir"/cdparanoia-10.2-format-security.patch
+   # Use LDFLAGS
+   patch -p1 -i "$srcdir"/cdparanoia-10.2-ldflags.patch
 +  cp /usr/share/autoconf/build-aux/config.guess ./configure.guess
  }
  
  build() {
-   cd cdparanoia-III-$pkgver
-+  export CFLAGS=${CFLAGS/-Werror=format-security/}
-   ./configure --prefix=/usr --mandir=/usr/share/man
-   make
- }


### PR DESCRIPTION
- Fix rotten
- Successfully build without removing the `format-security` compiler flag