### PR TITLE
updpatch: ldc 3:1.35.0-1

### DIFF
--- a/ldc/riscv64.patch
+++ b/ldc/riscv64.patch
@@ -1,31 +1,41 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -23,12 +23,14 @@ source=(
-     "ldc-druntime::git+https://github.com/ldc-developers/druntime.git"
-     "ldc-phobos::git+https://github.com/ldc-developers/phobos.git"
-     "ldc-testsuite::git+https://github.com/ldc-developers/dmd-testsuite.git"
-+    "disable-static-NaN-tests.patch"
- )
+@@ -7,14 +7,14 @@ groups=('dlang' 'dlang-ldc')
+ pkgver=1.35.0
+ _pkgcommit=9c1ae1efbbebcf21b73e7b710d508d0d5ca04454
+ _dversion=2.105.2
+-_clangversion=16 # related to where ldc2 looks for compiler-rt sanitizers
++_clangversion=14 # related to where ldc2 looks for compiler-rt sanitizers
+ epoch=3
+ pkgrel=1
+ pkgdesc="A D Compiler based on the LLVM Compiler Infrastructure including D runtime and libphobos2"
+ arch=('x86_64')
+ url="https://github.com/ldc-developers/ldc"
+ license=('BSD')
+-makedepends=('git' 'cmake' 'llvm' 'ldc' 'ninja')
++makedepends=('git' 'cmake' 'llvm14' 'ldc' 'ninja')
+ # Disable lto as linking the ldc2 binary fails
+ options=(!lto)
  
- sha256sums=('SKIP'
-             'SKIP'
-             'SKIP'
--            'SKIP')
-+            'SKIP'
-+            '22b9132b58dde320d6da3c22d2eeabbc0c4d6a079348e9e0fbe5172ef4b86aba')
+@@ -42,6 +42,7 @@ build() {
  
- prepare() {
-     cd "$srcdir/ldc"
-@@ -56,7 +58,7 @@ build() {
+     mkdir -p build && cd build
+ 
++    CXXFLAGS+=" -latomic"
+     cmake -GNinja \
+     -DCMAKE_INSTALL_PREFIX=/usr \
+     -DCMAKE_BUILD_TYPE=Release \
+@@ -50,7 +51,8 @@ build() {
      -DBUILD_SHARED_LIBS=BOTH \
      -DBUILD_LTO_LIBS=ON \
      -DLDC_WITH_LLD=OFF \
 -    -DD_COMPILER_FLAGS="-link-defaultlib-shared=false -linker=gold --flto=thin" \
-+    -DD_COMPILER_FLAGS="-link-defaultlib-shared=false" \
-     -DADDITIONAL_DEFAULT_LDC_SWITCHES="\"-link-defaultlib-shared\"" \
-     -DCMAKE_PREFIX_PATH=/usr/lib/llvm \
++    -DD_COMPILER_FLAGS="-link-defaultlib-shared=false -L=-latomic" \
++    -DLD_FLAGS="-Wl,--no-as-needed -latomic -Wl,--as-needed" \
+     -DADDITIONAL_DEFAULT_LDC_SWITCHES="\"-link-defaultlib-shared\"," \
      ..
-@@ -65,6 +67,7 @@ build() {
+     ninja
+@@ -58,11 +60,12 @@ build() {
  
  check() {
      cd "$srcdir/ldc/build"
@@ -33,3 +43,16 @@
      ninja all-test-runners
  }
  
+ package_ldc() {
+-    depends=('liblphobos' 'llvm-libs' 'gcc' 'compiler-rt')
++    depends=('liblphobos' 'llvm14-libs' 'gcc' 'compiler-rt14')
+     backup=('etc/ldc2.conf')
+     provides=("d-compiler=$_dversion")
+ 
+@@ -102,3 +105,6 @@ package_liblphobos() {
+     # licenses
+     install -D -m644 "$srcdir/ldc/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+ }
++
++source+=(disable-static-NaN-tests.patch)
++sha256sums+=('22b9132b58dde320d6da3c22d2eeabbc0c4d6a079348e9e0fbe5172ef4b86aba')


### PR DESCRIPTION
LDC is finally working again on riscv64. This is the first of two patches in order to realign LDC with current Arch environment.

- Link to LLVM 14 to match previously built version long ago. Will switch to LLVM 16 in the next patch.
- Add some temporary atomic hacks to make compiler happy, since previous GCC atomic hacks were replaced by actual upstream implementation.