### PR TITLE
updpatch: d-stdx-allocator 3.0.2-21

### DIFF
--- a/d-stdx-allocator/riscv64.patch
+++ b/d-stdx-allocator/riscv64.patch
@@ -1,20 +1,6 @@
-diff --git PKGBUILD PKGBUILD
-index 6d45b0e56..fb1afc3b0 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -11,14 +11,17 @@ license=('Boost')
- depends=('liblphobos' 'd-mir-core')
- makedepends=('meson' 'ldc')
- source=("$_pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz"
--        "add-dependency.patch::https://github.com/dlang-community/stdx-allocator/commit/676b4c782ba9c484864075508c27ef44399396f7.patch")
-+        "add-dependency.patch::https://github.com/dlang-community/stdx-allocator/commit/676b4c782ba9c484864075508c27ef44399396f7.patch"
-+        "support-riscv64.patch")
- sha512sums=('f4dc887225926cc4530314976e5e236c696a54c6e2ccdb48271b97b0c0a70882b70e92768c94c2932ccc9bd2282c3e953b27cf72088904458f7fc15234dca4be'
--            '13d52d3bb4d90e7b5fb3163f1761c20a57a59be1306ac665fea0eb9331864821d77e790f8ca6027b1936a6930085d2ccca7a1d49d4bd139a939e2c58f03bd47a')
-+            '13d52d3bb4d90e7b5fb3163f1761c20a57a59be1306ac665fea0eb9331864821d77e790f8ca6027b1936a6930085d2ccca7a1d49d4bd139a939e2c58f03bd47a'
-+            '3da013d6027527180f529155ab90e23a6c0e2f218dcf237de040d2bfb75acb9b95a94e417240bdfd058dfaf859cb87b3cdeacce0af8916b62526a8052d00fa7f')
- 
- prepare() {
+@@ -19,6 +19,7 @@ prepare() {
    cd $_pkgname-$pkgver
  
    patch -p1 < ../add-dependency.patch
@@ -22,12 +8,19 @@ index 6d45b0e56..fb1afc3b0 100644
  }
  
  build() {
-@@ -26,7 +29,7 @@ build() {
+@@ -26,7 +27,7 @@ build() {
    cd $_pkgname-$pkgver/build
  
    export DC=ldc
--  export LDFLAGS="$(echo -ne $LDFLAGS | sed -e 's/-flto=auto/--flto=full/')"
+-  export LDFLAGS="$(echo -ne $LDFLAGS | sed -e 's/-flto=auto/-flto=full/')"
 +  export LDFLAGS="$(echo -ne $LDFLAGS | sed -e 's/-flto=auto//')"
  
    arch-meson ..
  
+@@ -44,3 +45,6 @@ package() {
+ 
+   DESTDIR="$pkgdir" ninja install
+ }
++
++source+=("support-riscv64.patch")
++sha512sums+=('3da013d6027527180f529155ab90e23a6c0e2f218dcf237de040d2bfb75acb9b95a94e417240bdfd058dfaf859cb87b3cdeacce0af8916b62526a8052d00fa7f')


### PR DESCRIPTION
Fix rotten. (https://github.com/dlang-community/stdx-allocator/pull/35)
