### PR TITLE
addpatch: distrho-ports 2021.03.15-3

### DIFF
--- a/distrho-ports/riscv64.patch
+++ b/distrho-ports/riscv64.patch
@@ -1,0 +1,34 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -19,14 +19,17 @@ makedepends=(
+   libxext
+   lv2
+   meson
++  simde
+ )
+ checkdepends=(
+   kxstudio-lv2-extensions
+   lv2lint
+   xorg-server-xvfb
+ )
+-source=(git+$url#tag=${pkgver//./-}?signed)
+-b2sums=('SKIP')
++source=(git+$url#tag=${pkgver//./-}?signed
++        use-simde.patch)
++b2sums=('SKIP'
++        'dfb57a90d6e2df7b386f52e66404399f996079595ad155e1d84e466e6a5241ab42e1661c3da53bdcd02585aa28670701a4998474f9e66d189ebf9a1bb4a77ea6')
+ validpgpkeys=('62B11043D2F6EB6672D93103CDBAA37ABC74FBA0') # falkTX <falktx@falktx.com>
+ 
+ _pick() {
+@@ -39,6 +42,11 @@ _pick() {
+   done
+ }
+ 
++prepare() {
++  cd $pkgname
++  patch -Np1 -i ../use-simde.patch
++}
++
+ build() {
+   arch-meson build $pkgname
+   ninja -C build

--- a/distrho-ports/use-simde.patch
+++ b/distrho-ports/use-simde.patch
@@ -1,0 +1,42 @@
+diff --git a/ports-legacy/pitchedDelay/source/dsp/BandLimit.cpp b/ports-legacy/pitchedDelay/source/dsp/BandLimit.cpp
+index 7d8759be..663799f0 100644
+--- a/ports-legacy/pitchedDelay/source/dsp/BandLimit.cpp
++++ b/ports-legacy/pitchedDelay/source/dsp/BandLimit.cpp
+@@ -2,7 +2,7 @@
+ #if defined(__x86_64__) || defined(__i386__)
+ #include <emmintrin.h>
+ #include <mmintrin.h>
+-#else
++#elseif defined(__aarch64__) || defined(__arm__)
+ #include <arm_neon.h>
+ typedef float32x4_t __m128;
+ #define _mm_load_ps  vld1q_f32
+@@ -10,6 +10,9 @@ typedef float32x4_t __m128;
+ #define _mm_add_ps vaddq_f32
+ #define _mm_sub_ps vsubq_f32
+ #define _mm_mul_ps vmulq_f32
++#else
++#define SIMDE_ENABLE_NATIVE_ALIASES 1
++#include <simde/x86/sse2.h>
+ #endif
+ 
+ CAllPassFilterPair::CAllPassFilterPair(double coeff_A, double coeff_B)
+diff --git a/ports/vitalium/source/synthesis/framework/poly_values.h b/ports/vitalium/source/synthesis/framework/poly_values.h
+index fd90a8f9..4581e220 100644
+--- a/ports/vitalium/source/synthesis/framework/poly_values.h
++++ b/ports/vitalium/source/synthesis/framework/poly_values.h
+@@ -31,10 +31,12 @@
+     #define NEON_ARM32 1
+   #endif
+ #else
+-  static_assert(false, "No SIMD Intrinsics found which are necessary for compilation");
++  #define VITAL_SSE2 1
++  #define SIMDE_ENABLE_NATIVE_ALIASES 1
++  #include <simde/x86/sse2.h>
+ #endif
+ 
+-#if VITAL_SSE2
++#if VITAL_SSE2 && __SSE2__
+   #include <immintrin.h>
+ #elif VITAL_NEON
+   #include <arm_neon.h>


### PR DESCRIPTION
Use simde to provide SSE2 intrinsics.