### PR TITLE
addpatch: wpewebkit 2.42.4-1

### DIFF
--- a/wpewebkit/riscv64.patch
+++ b/wpewebkit/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -76,6 +76,7 @@ validpgpkeys=(
+   'D7FCF61CF9A2DEAB31D81BD3F3D322D0EC4582C3'  # Carlos Garcia Campos <cgarcia@igalia.com>
+   '5AA3BC334FD7E3369E7C77B291C559DBE4C9123B'  # Adrián Pérez de Castro <aperez@igalia.com>
+ )
++options=('!lto')
+ 
+ prepare() {
+   cd wpewebkit-$pkgver


### PR DESCRIPTION
Disable LTO:

```
ld.lld: error: linking module flags 'SmallDataLimit': IDs have conflicting values in 'Source/WTF/wtf/CMakeFiles/WTF.dir/./ASCIICType.cpp.o' and 'ld-temp.o'
clang-16: error: linker command failed with exit code 1 (use -v to see invocation)
```

This is probably the same issue as https://github.com/felixonmars/archriscv-packages/pull/3121.