### PR TITLE
addpatch: tilix 1.9.6-1

### DIFF
--- a/tilix/riscv64.patch
+++ b/tilix/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -26,7 +26,6 @@ build() {
+   # Build with LDC
+   export DC=ldc
+   export LDFLAGS="$(echo -ne $LDFLAGS | sed -e 's/-flto=auto//')"
+-  export DFLAGS="--flto=full"
+ 
+   arch-meson ../$pkgname-$pkgver
+ 


### PR DESCRIPTION
LTO failed (both full and thin):

```
/usr/bin/ld: /tmp/lto-llvm-ea1ef0.o: can't link soft-float modules with double-float modules
/usr/bin/ld: failed to merge target specific data of file /tmp/lto-llvm-ea1ef0.o
```