### PR TITLE
addpatch: age-plugin-tpm

### DIFF
--- a/age-plugin-tpm/riscv64.patch
+++ b/age-plugin-tpm/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -33,3 +33,9 @@ package(){
+     install -Dm755 -t "${pkgdir}/usr/bin/" age-plugin-tpm
+     install -Dm644 -t "${pkgdir}/usr/share/licenses/${pkgname}/" LICENSE
+ }
++
++prepare() {
++  cd "${pkgname}-${pkgver}"
++  echo -e '\nreplace github.com/google/go-tpm-tools => github.com/aimixsaka/go-tpm-tools riscv\n' >> go.mod
++  go mod tidy
++}


### PR DESCRIPTION
- patch [go-tpm-tools](https://github.com/google/go-tpm-tools) to support RISC V
- upstreamed: https://github.com/google/go-tpm-tools/pull/407
- check will timeout on luxio, while centiskorch is ok