### PR TITLE
updpatch: neovide 0.12.0-1

### DIFF
--- a/neovide/riscv64.patch
+++ b/neovide/riscv64.patch
@@ -1,15 +1,8 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -15,23 +15,31 @@ depends=(gcc-libs
-          hicolor-icon-theme
-          libglvnd
+@@ -18,17 +18,26 @@ depends=(gcc-libs
           neovim
--         sndio)
-+         sndio
-+         libz.so
-+         libexpat.so
-+         libpng16.so
-+         libjpeg.so)
+          sndio)
  makedepends=(cargo
 -             cmake)
 +             cmake
@@ -22,25 +15,21 @@
              'libxkbcommon-x11: run on X11 (not needed for wayland)')
  _archive=("$pkgname-$pkgver")
  source=("$url/archive/$pkgver/$_archive.tar.gz")
- sha256sums=('62e973a5407a6bfc731ce78e0495d2ed10930d33b22fe94cfe23acccbf789ae9')
+ sha256sums=('8770dd6977605f9bafa990a60cf8f2ebeba7df16417dab2e8c5583d279ec86ef')
 +options=(!lto)
  
  prepare() {
  	cd "$_archive"
--	sed -r -i \
--		-e '/^incremental/a opt-level = 3' \
--		-e '/wayland/s/\]/, "embed-icudtl"]/g' \
--		-e '/wayland/a no-default-features = true' \
--		Cargo.toml
+ 	sed -r -i -e '/^incremental/a opt-level = 3' Cargo.toml
 -	cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
-+	sed -i -e '/^incremental/a opt-level = 3' Cargo.toml
-+	echo -e "\n[patch.crates-io]\nskia-bindings = { git = 'https://github.com/hack3ric/rust-skia', branch = 'archrv-0.62.0' }\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
-+	cargo update -p skia-bindings -p ring
++	echo -e "\n[patch.crates-io]\nskia-bindings = { git = 'https://github.com/aimixsaka/rust-skia', branch = 'riscv-skia-bindings-0.68.0' }" >> Cargo.toml
++
++	cargo update -p skia-bindings
 +	cargo fetch --locked
  }
  
  build() {
-@@ -42,6 +50,9 @@ build() {
+@@ -39,6 +48,9 @@ build() {
  	export CXXFLAGS="${CXXFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
  	CFLAGS+=' -ffat-lto-objects'
  	export SKIA_USE_SYSTEM_LIBRARIES=true


### PR DESCRIPTION
- Remove unneeded depends
- Remove ring 0.16 patch as upstream updated to 0.17
- Bump `rust-skia` to self-forked `0.68.0` [1] to catch up upstream [2]. This fix: 
```
 warning: Patch `SOMETHING` was not used in the crate graph. 
 Check that the patched package version and available features 
 are compatible with the dependency requirements 
```
- Backport rust-skia/rust-skia#916 to fix rust-skia/rust-skia#913

- Remaining relevant pr/issue:
  - https://github.com/google/skia/pull/146
  - https://gitlab.archlinux.org/archlinux/packaging/packages/neovide/-/issues/1

[1]: https://github.com/aimixsaka/rust-skia/tree/riscv-skia-bindings-0.68.0
[2]: https://github.com/neovide/neovide/blob/af9869bd6d8d3434b187e29f85032ee74e40b536/Cargo.toml#L59C68-L59C68