### PR TITLE
addpatch: devtools 1:1.0.4-1

### DIFF
--- a/devtools-riscv64/PKGBUILD
+++ b/devtools-riscv64/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=devtools-riscv64
 epoch=1
-pkgver=1.0.4+patch1
+pkgver=1.0.4+patch2
 pkgrel=1
 pkgdesc='Tools for Arch Linux RISC-V package maintainers'
 arch=('x86_64' 'riscv64')
@@ -10,12 +10,14 @@ license=('GPL')
 url='https://github.com/felixonmars/archriscv-packages'
 depends=(devtools)
 depends_x86_64=(qemu-user-static)
-source=(makepkg-riscv64.patch
+source=(arch-nspawn-riscv64.patch
+        makepkg-riscv64.patch
         pacman-extra-riscv64.patch
         sogrep-riscv64.patch
         valid-repos-riscv64.sh)
 source_x86_64=(z-archriscv-qemu-riscv64.conf)
-sha256sums=('2abae300509c2fbae0246f195fb7ffa17c4ad240052f1e60b0bc504de6149685'
+sha256sums=('0e07a15b55c59f74fb19c6bc77d977f0419200bb65c459ea163d42609a96cb6d'
+            '2abae300509c2fbae0246f195fb7ffa17c4ad240052f1e60b0bc504de6149685'
             '5c80d7f727c4cca6c3ae515dbcb9b9a69d2cae952aa520a82df97cf37432c9cc'
             'c8e9bfc390e42d358007578ca54212bda1d44c754c976be9ef262944d4a0d83c'
             '94ee35597de8e46b1f0c09f95ced34c47ece2f95f92d1a7f2415373f2d129c63')
@@ -23,6 +25,10 @@ sha256sums_x86_64=('c59273c423e815e4c27e8486632d80a768adddd172119035d48f7c2fac98
 
 package() {
   install -Dm644 valid-repos-riscv64.sh -t "$pkgdir"/usr/share/devtools/lib
+
+  patch /usr/bin/arch-nspawn -i arch-nspawn-riscv64.patch -o arch-nspawn-riscv64
+  install -Dm755 arch-nspawn-riscv64 -t "$pkgdir"/usr/bin/
+
   patch /usr/bin/sogrep -i sogrep-riscv64.patch -o sogrep-riscv64
   install -Dm755 sogrep-riscv64 -t "$pkgdir"/usr/bin/
 

--- a/devtools-riscv64/arch-nspawn-riscv64.patch
+++ b/devtools-riscv64/arch-nspawn-riscv64.patch
@@ -1,0 +1,11 @@
+--- /usr/bin/arch-nspawn	2023-09-27 07:21:56.000000000 +0800
++++ arch-nspawn	2024-01-02 03:22:33.106553417 +0800
+@@ -70,7 +70,7 @@
+ fi
+ 
+ # shellcheck disable=2016
+-host_mirrors=($(pacman-conf --repo extra Server 2> /dev/null | sed -r 's#(.*/)extra/os/.*#\1$repo/os/$arch#'))
++host_mirrors=($(pacman-conf --repo extra Server 2> /dev/null | sed -r 's#(.*/)extra.*#\1\$repo#'))
+ 
+ for host_mirror in "${host_mirrors[@]}"; do
+ 	if [[ $host_mirror == *file://* ]]; then


### PR DESCRIPTION
Since Arch Linux RISC-V is using a different style of repo link. The correspondence `sed` regex in `arch-nspawn` also needs to be refit: from
  http://riscv.mirror.pkgbuild.com/repo/extra,
to
  http://riscv.mirror.pkgbuild.com/repo/$repo.

This fix sequence 404 errors while retrieving any package in clean chroot due to that `/etc/pacman.d/mirrorlist` still keep the form of 'Server = http[s]://**/repo/extra'.

At this time, any package build try in a claen chroots will result in fail if it has any make dependent packages not in group 'base-devel'.