### PR TITLE
addpatch: spring 106.0-2

### DIFF
--- a/spring/add-missing-header.patch
+++ b/spring/add-missing-header.patch
@@ -1,0 +1,83 @@
+diff --git a/AI/Skirmish/CircuitAI/src/circuit/util/MaskHandler.h b/AI/Skirmish/CircuitAI/src/circuit/util/MaskHandler.h
+index 7bde5c3..78a3215 100644
+--- a/AI/Skirmish/CircuitAI/src/circuit/util/MaskHandler.h
++++ b/AI/Skirmish/CircuitAI/src/circuit/util/MaskHandler.h
+@@ -11,6 +11,7 @@
+ #include <string>
+ #include <vector>
+ #include <unordered_map>
++#include <cstdint>
+ 
+ namespace circuit {
+ 
+diff --git a/rts/Sim/Misc/BuildingMaskMap.h b/rts/Sim/Misc/BuildingMaskMap.h
+index 89351a3..c2608da 100644
+--- a/rts/Sim/Misc/BuildingMaskMap.h
++++ b/rts/Sim/Misc/BuildingMaskMap.h
+@@ -4,6 +4,7 @@
+ #define BUILDINGMASKMAP_H
+ 
+ #include <vector>
++#include <cstdint>
+ 
+ #include "System/creg/creg_cond.h"
+ 
+diff --git a/rts/System/CRC.h b/rts/System/CRC.h
+index 1abde22..ee25b24 100644
+--- a/rts/System/CRC.h
++++ b/rts/System/CRC.h
+@@ -3,6 +3,7 @@
+ #ifndef CRC_H
+ #define CRC_H
+ 
++#include <cstdint>
+ #include <string>
+ 
+ /** @brief An updateable CRC-32 checksum. */
+diff --git a/rts/System/Platform/Misc.h b/rts/System/Platform/Misc.h
+index 37bb44f..e71e3d2 100644
+--- a/rts/System/Platform/Misc.h
++++ b/rts/System/Platform/Misc.h
+@@ -3,6 +3,7 @@
+ #ifndef PLATFORM_MISC_H
+ #define PLATFORM_MISC_H
+ 
++#include <cstdint>
+ #include <string>
+ #include <array>
+ 
+diff --git a/rts/System/SpringHashSet.hpp b/rts/System/SpringHashSet.hpp
+index 071a6c3..75d8174 100644
+--- a/rts/System/SpringHashSet.hpp
++++ b/rts/System/SpringHashSet.hpp
+@@ -6,6 +6,7 @@
+ 
+ #pragma once
+ 
++#include <cstdint>
+ #include <cstdlib> // malloc
+ #include <iterator>
+ #include <utility>
+diff --git a/rts/System/StringUtil.h b/rts/System/StringUtil.h
+index e9ba35b..2298f4c 100644
+--- a/rts/System/StringUtil.h
++++ b/rts/System/StringUtil.h
+@@ -4,6 +4,7 @@
+ #define STRING_UTIL_H
+ 
+ #include <algorithm>
++#include <cstdint>
+ #include <cstring>
+ #include <string>
+ #include <sstream>
+diff --git a/rts/lib/luasocket/src/restrictions.h b/rts/lib/luasocket/src/restrictions.h
+index a6bb1ba..83e0115 100644
+--- a/rts/lib/luasocket/src/restrictions.h
++++ b/rts/lib/luasocket/src/restrictions.h
+@@ -1,5 +1,6 @@
+ /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+ 
++#include <cstdint>
+ #include <list>
+ #include <string>
+ #include <utility>

--- a/spring/disable-streflop-for-cutils.patch
+++ b/spring/disable-streflop-for-cutils.patch
@@ -1,0 +1,17 @@
+diff --git a/AI/Interfaces/Java/CMakeLists.txt b/AI/Interfaces/Java/CMakeLists.txt
+index 7738190..decaae5 100644
+--- a/AI/Interfaces/Java/CMakeLists.txt
++++ b/AI/Interfaces/Java/CMakeLists.txt
+@@ -539,8 +539,10 @@ if    (BUILD_${myName}_AIINTERFACE)
+ 	include_directories(BEFORE "${rts}/lib/streflop" "${myNativeSourceDir}" "${myNativeGeneratedSourceDir}")
+ 	add_library(${myNativeTarget} MODULE ${myNativeSources} ${myNativeGeneratedSources} ${ai_common_SRC} ${myVersionDepFile})
+ 	add_dependencies(${myNativeTarget} generateVersionFiles)
+-	target_link_libraries(${myNativeTarget} CUtils streflop)
+-	set_target_properties(${myNativeTarget} PROPERTIES COMPILE_FLAGS "-DUSING_STREFLOP")
++	if (ENABLE_STREFLOP)
++		target_link_libraries(${myNativeTarget} CUtils streflop)
++		set_target_properties(${myNativeTarget} PROPERTIES COMPILE_FLAGS "-DUSING_STREFLOP")
++	endif()
+ 	set_target_properties(${myNativeTarget} PROPERTIES OUTPUT_NAME   "AIInterface")
+ 	fix_lib_name(${myNativeTarget})
+ 

--- a/spring/riscv64.patch
+++ b/spring/riscv64.patch
@@ -1,0 +1,58 @@
+diff --git PKGBUILD PKGBUILD
+index 4665b74..5ec8c12 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -11,18 +11,30 @@ url="http://springrts.com/"
+ license=('GPL')
+ depends=('openal' 'glew' 'minizip' 'freetype2' 'devil' 'libvorbis' 'sdl2' 'libunwind'
+          'libxcursor' 'curl' 'shared-mime-info' 'desktop-file-utils' 'libx11' 'jsoncpp')
+-makedepends=('cmake' 'zip' 'xz' 'p7zip' 'python' 'jdk8-openjdk' 'mesa')
++makedepends=('cmake' 'zip' 'xz' 'p7zip' 'python' 'jdk8-openjdk' 'mesa' 'simde')
+ optdepends=('python: python-based bots'
+             'java-runtime: java-based bots')
+ source=("https://springrts.com/dl/buildbot/default/master/106.0/source/spring_106.0_src.tar.gz"
+-         spring-gcc12.patch)
++         spring-gcc12.patch
++         add-missing-header.patch
++         disable-streflop-for-cutils.patch
++         support-riscv64-build.patch
++         use-simde.patch)
+ sha512sums=('d76bec4cc106ed23f09699d702b9d14b76e32f4e34beac2313268c2ef29f6379a970efaee209d4db5dc7c6323d1a47882b10c5c4faa0744087fada227ed91f7b'
+-            '68bbffe545fe5200ab7273954a1aad7fdc67ba904a0a3d86f9fb6b02cd2e716ab9623da8b8bf92c1efda269b161ee28432aa7e0f8899ad914491648fae13e34a')
++            '68bbffe545fe5200ab7273954a1aad7fdc67ba904a0a3d86f9fb6b02cd2e716ab9623da8b8bf92c1efda269b161ee28432aa7e0f8899ad914491648fae13e34a'
++            '9e3a02ea320ffc3265ab7e0778df8193e6583a1d7f08e3826df717131ab79d776ad245ec6ae2bf98ae85c95f903baf1d12753013d0b423c1a92ae4be4b35eee9'
++            '9fc1ecdcfba4df8135b02ea59d09873372ea0381e6e9c465cc2d5c7f822bc128108028359054367c9ebc4abffafc0016d7509d75755e65b179e7edef611584bd'
++            'd546cd7e9848dfdbdfc74d2a9a84f797c662117de318ef3d271b964445b825248f45ce97aeefb225edb902d8cc857cc91cd18580eaebab61e7fd5c6ee72bc268'
++            'dd885fbec0b6423c4c7667e05babeb2f6a48c878661fd502236b1f1743cb6f7a47f702f7e22030a684bfbd8d4190980999a0bf13e74cff3d2138782c884be8c6')
+ 
+ prepare() {
+   cd spring_$pkgver
+ 
+   patch -Np1 -i ../spring-gcc12.patch
++  patch -Np1 -i ../add-missing-header.patch
++  patch -Np1 -i ../disable-streflop-for-cutils.patch
++  patch -Np1 -i ../support-riscv64-build.patch
++  patch -Np1 -i ../use-simde.patch
+   #remove bundled libraries
+   rm -r tools/pr-downloader/src/lib/jsoncpp
+   rm -r tools/pr-downloader/src/lib/minizip
+@@ -31,13 +43,18 @@ prepare() {
+ build() {
+   cd spring_$pkgver
+ 
++  # disable streflop, remove arch-specific flags
++  # https://springrts.com/mantis/view.php?id=1846
++  # https://springrts.com/mantis/view.php?id=1788
+   cmake	\
+     -Bbuild \
+     -DCMAKE_INSTALL_PREFIX=/usr \
+     -DDATADIR=share/spring \
+     -DJAVA_HOME=/usr/lib/jvm/java-8-openjdk \
+     -DCMAKE_SKIP_RPATH=ON \
+-    -DPRD_JSONCPP_INTERNAL=OFF
++    -DPRD_JSONCPP_INTERNAL=OFF \
++    -DENABLE_STREFLOP=OFF \
++    -DMARCH_FLAG=rv64gc
+   make -C build
+ }
+ 

--- a/spring/support-riscv64-build.patch
+++ b/spring/support-riscv64-build.patch
@@ -1,0 +1,22 @@
+diff --git a/rts/System/MainDefines.h b/rts/System/MainDefines.h
+index 8ad6cad..0b10f8a 100644
+--- a/rts/System/MainDefines.h
++++ b/rts/System/MainDefines.h
+@@ -23,7 +23,7 @@
+ #endif
+ 
+ 
+-#if (defined(__alpha__) || defined(__arm__) || defined(__aarch64__) || defined(__mips__) || defined(__powerpc__) || defined(__sparc__) || defined(__m68k__) || defined(__ia64__) || defined(__e2k__))
++#if (defined(__alpha__) || defined(__arm__) || defined(__aarch64__) || defined(__riscv) || defined(__mips__) || defined(__powerpc__) || defined(__sparc__) || defined(__m68k__) || defined(__ia64__) || defined(__e2k__))
+ #define __is_x86_arch__ 0
+ #elif (defined(__i386__) || defined(__x86_64__) || defined(__amd64__) || defined(_M_AMD64) || defined(_M_IX86) || defined(_M_X64))
+ #define __is_x86_arch__ 1
+@@ -33,7 +33,7 @@
+ 
+ 
+ /* define a common indicator for 32bit or 64bit-ness */
+-#if defined _WIN64 || defined __LP64__ || defined __ppc64__ || defined __ILP64__ || defined __SILP64__ || defined __LLP64__ || defined(__sparcv9) || defined(__e2k__)
++#if defined _WIN64 || defined __LP64__ || defined __ppc64__ || defined __ILP64__ || defined __SILP64__ || defined __LLP64__ || defined(__sparcv9) || defined(__e2k__) || (defined(__riscv_xlen) && __riscv_xlen == 64)
+ #define __arch64__
+ #define __archBits__ 64
+ #else

--- a/spring/use-simde.patch
+++ b/spring/use-simde.patch
@@ -1,0 +1,80 @@
+diff --git a/include/SDL2/SDL_cpuinfo.h b/include/SDL2/SDL_cpuinfo.h
+index 6d72bbb..aecc892 100644
+--- a/include/SDL2/SDL_cpuinfo.h
++++ b/include/SDL2/SDL_cpuinfo.h
+@@ -51,15 +51,24 @@
+ #endif
+ #ifdef __MMX__
+ #include <mmintrin.h>
++#else
++#define SIMDE_ENABLE_NATIVE_ALIASES 1
++#include <simde/x86/mmx.h>
+ #endif
+ #ifdef __3dNOW__
+ #include <mm3dnow.h>
+ #endif
+ #ifdef __SSE__
+ #include <xmmintrin.h>
++#else
++#define SIMDE_ENABLE_NATIVE_ALIASES 1
++#include <simde/x86/sse.h>
+ #endif
+ #ifdef __SSE2__
+ #include <emmintrin.h>
++#else
++#define SIMDE_ENABLE_NATIVE_ALIASES 1
++#include <simde/x86/sse2.h>
+ #endif
+ #endif
+ 
+diff --git a/rts/System/FastMath.h b/rts/System/FastMath.h
+index 6377f87..e8f5193 100644
+--- a/rts/System/FastMath.h
++++ b/rts/System/FastMath.h
+@@ -4,7 +4,12 @@
+ #define FASTMATH_H
+ 
+ #ifndef DEDICATED_NOSSE
++#ifdef __SSE1__
+ #include <xmmintrin.h>
++#else
++#define SIMDE_ENABLE_NATIVE_ALIASES 1
++#include <simde/x86/sse.h>
++#endif
+ #endif
+ #include <cinttypes>
+ 
+diff --git a/rts/System/Matrix44f.h b/rts/System/Matrix44f.h
+index 423c764..e7fd1f3 100644
+--- a/rts/System/Matrix44f.h
++++ b/rts/System/Matrix44f.h
+@@ -6,6 +6,13 @@
+ #include "System/float3.h"
+ #include "System/float4.h"
+ 
++#ifdef __SSE1__
++#include <xmmintrin.h>
++#else
++#define SIMDE_ENABLE_NATIVE_ALIASES 1
++#include <simde/x86/sse.h>
++#endif
++
+ class CMatrix44f
+ {
+ public:
+diff --git a/test/engine/System/testMatrix44f.cpp b/test/engine/System/testMatrix44f.cpp
+index 2ebccfc..92ff77f 100644
+--- a/test/engine/System/testMatrix44f.cpp
++++ b/test/engine/System/testMatrix44f.cpp
+@@ -1,6 +1,11 @@
+ /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+ 
++#ifdef __SSE1__
+ #include <xmmintrin.h> //SSE1
++#else
++#define SIMDE_ENABLE_NATIVE_ALIASES 1
++#include <simde/x86/sse.h>
++#endif
+ 
+ #include "System/Matrix44f.h"
+ #include "System/float4.h"


### PR DESCRIPTION
- support riscv64
- add missing header
- disable streflop: https://springrts.com/mantis/view.php?id=1846
- remove arch-specific flags: https://springrts.com/mantis/view.php?id=1788
- use simde to provide SSE intrinsics