### PR TITLE
updpatch: jumpy 0.10.0-1

### DIFF
--- a/jumpy/riscv64.patch
+++ b/jumpy/riscv64.patch
@@ -1,13 +1,22 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -19,7 +19,9 @@ options=('!lto')
+@@ -19,6 +19,19 @@ options=('!lto')
  
  prepare() {
    cd "$pkgname-$pkgver"
--  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
-+  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
-+  cargo update -p ring
-+  cargo fetch --locked
++
++  cat << EOF >> Cargo.toml
++[patch.'https://github.com/fishfolk/bones']
++bones_framework     = { git = "https://github.com/hack3ric/bones", branch = "archrv-0.3" }
++bones_bevy_renderer = { git = "https://github.com/hack3ric/bones", branch = "archrv-0.3" }
++
++[patch.crates-io]
++quinn = { git = "https://github.com/hack3ric/quinn", branch = "archrv-0.10" }
++quinn-udp = { git = "https://github.com/hack3ric/quinn", branch = "archrv-0.10" }
++EOF
++
++  cargo update -p bones_framework -p bones_bevy_renderer -p quinn -p quinn-udp
++
+   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
  }
  
- build() {


### PR DESCRIPTION
Update several dependencies to pull ring version to 0.17. Upstreamed to https://github.com/quinn-rs/quinn/pull/1751 and https://github.com/fishfolk/bones/pull/334.