### PR TITLE
upgpatch: cargo-semver-checks 0.28.0-1

### DIFF
--- a/cargo-semver-checks/riscv64.patch
+++ b/cargo-semver-checks/riscv64.patch
@@ -1,11 +1,21 @@
+diff --git PKGBUILD PKGBUILD
+index 187108c..5896e8a 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -19,7 +19,7 @@ options=('!lto')
+@@ -13,12 +13,15 @@
+ makedepends=('git' 'cmake')
+ source=(
+   "$pkgname::git+$url.git#commit=$_commit"
++  "cargo-semver-checks-disable-test-non-x86_64.patch::https://github.com/obi1kenobi/cargo-semver-checks/commit/d34b3bb2f98b93356d8fa75da317a18f40bafa2b.diff"
+ )
+-sha512sums=('SKIP')
++sha512sums=('SKIP'
++            'd23655521178e8831acbda237f540021acbda0e643ac2cfc57cacda4dec10858da209c7a0686d5d69de4663fdb2228b0301e16c563ea3a1e65f625543c04489a')
+ options=('!lto')
  
  prepare() {
    cd "$pkgname"
--  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
-+  cargo fetch --locked
++  patch -Np1 -i ../cargo-semver-checks-disable-test-non-x86_64.patch
+   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
  }
  
- build() {


### PR DESCRIPTION
Disable x86_64-specific tests on non-x86_64 platforms. 
upstreamed: https://github.com/obi1kenobi/cargo-semver-checks/pull/647