### PR TITLE
addpatch: python-ansible-compat 4.1.11-1

### DIFF
--- a/python-ansible-compat/riscv64.patch
+++ b/python-ansible-compat/riscv64.patch
@@ -1,0 +1,8 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -63,3 +63,5 @@ package() {
+   install -vDm 644 README.md -t "$pkgdir/usr/share/doc/$pkgname/"
+   install -vDm 644 LICENSE -t "$pkgdir/usr/share/licenses/$pkgname/"
+ }
++
++checkdepends+=(cargo)


### PR DESCRIPTION
Test compiles Rust code (possibly due to riscv64 prebuilt not available), add cargo to checkdepends