### PR TITLE
upgpatch: wasm-bindgen 0.2.90-1

### DIFF
--- a/wasm-bindgen/riscv64.patch
+++ b/wasm-bindgen/riscv64.patch
@@ -1,13 +1,12 @@
 diff --git PKGBUILD PKGBUILD
-index 7517a110..f7c1865d 100644
+index c9cec79..52d71bb 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -21,7 +21,7 @@ prepare() {
-   # https://github.com/rustwasm/wasm-bindgen/issues/1819
-   cp Cargo.lock "$pkgname-$pkgver"
-   cd "$pkgname-$pkgver/crates/cli"
--  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
-+  cargo fetch --locked
- }
+@@ -27,6 +27,7 @@
  
  build() {
+   cd "$pkgname-$pkgver/crates/cli"
++  export OPENSSL_NO_VENDOR=1
+   cargo build --frozen --release --all-features
+ }
+ 


### PR DESCRIPTION
Use system openssl instead of vendoring
[Upstreamed to Arch](https://gitlab.archlinux.org/archlinux/packaging/packages/wasm-bindgen/-/merge_requests/1)