### PR TITLE
updpatch: java11-openjdk 11.0.22.u7-1

### DIFF
--- a/java11-openjdk/riscv64.patch
+++ b/java11-openjdk/riscv64.patch
@@ -24,12 +24,3 @@
  build() {
    cd ${_jdkdir}
  
-@@ -98,7 +108,7 @@ build() {
-     --with-lcms=system \
-     --with-zlib=system \
-     --with-harfbuzz=system \
--    --with-jvm-features=zgc,shenandoahgc \
-+    --with-jvm-features=zgc \
-     --with-native-debug-symbols=internal \
-     --enable-unlimited-crypto \
-     --disable-warnings-as-errors \


### PR DESCRIPTION
Enable Shenandoah GC since current patch supports it.