### PR TITLE
upgpatch: gcc 13.2.1-4

### DIFF
--- a/gcc/riscv64.patch
+++ b/gcc/riscv64.patch
@@ -1,17 +1,17 @@
 diff --git PKGBUILD PKGBUILD
-index f716aff..4b1fba7 100644
+index 4ec7cb2..7435c46 100644
 --- PKGBUILD
 +++ PKGBUILD
 @@ -7,7 +7,7 @@
  # toolchain build order: linux-api-headers->glibc->binutils->gcc->glibc->binutils->gcc
  # NOTE: libtool requires rebuilt with each new gcc version
  
--pkgname=(gcc gcc-libs lib32-gcc-libs gcc-ada gcc-d gcc-fortran gcc-go gcc-objc lto-dump libgccjit)
-+pkgname=(gcc gcc-libs gcc-d gcc-fortran gcc-go gcc-objc lto-dump libgccjit)
+-pkgname=(gcc gcc-libs lib32-gcc-libs gcc-ada gcc-d gcc-fortran gcc-go gcc-m2 gcc-objc lto-dump libgccjit)
++pkgname=(gcc gcc-libs gcc-d gcc-fortran gcc-go gcc-m2 gcc-objc lto-dump libgccjit)
  pkgver=13.2.1
  _majorver=${pkgver%%.*}
  _commit=860b0f0ef787f756c0e293671b4c4622dff63a79
-@@ -19,11 +19,8 @@ url='https://gcc.gnu.org'
+@@ -19,11 +19,8 @@
  makedepends=(
    binutils
    doxygen
@@ -23,27 +23,27 @@ index f716aff..4b1fba7 100644
    libisl
    libmpc
    python
-@@ -41,6 +38,7 @@ _libdir=usr/lib/gcc/$CHOST/${pkgver%%+*}
- source=(git+https://sourceware.org/git/gcc.git#commit=${_commit}
+@@ -42,6 +39,7 @@
          c89 c99
          gcc-ada-repro.patch
+         https://github.com/llvm/llvm-project/commit/fb77ca05ffb4f8e666878f2f6718a9fb4d686839.patch
 +        unfilter-default-library-path.patch
  )
  validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
                86CFFCA918CF3AF47147588051E8B148A9999C34  # evangelos@foutrelis.com
-@@ -49,7 +47,8 @@ validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.
- sha256sums=('SKIP'
+@@ -51,7 +49,8 @@
              'de48736f6e4153f03d0a5d38ceb6c6fdb7f054e8f47ddd6af0a3dbf14f27b931'
              '2513c6d9984dd0a2058557bf00f06d8d5181734e41dcfe07be7ed86f2959622a'
--            '1773f5137f08ac1f48f0f7297e324d5d868d55201c03068670ee4602babdef2f')
-+            '1773f5137f08ac1f48f0f7297e324d5d868d55201c03068670ee4602babdef2f'
+             '1773f5137f08ac1f48f0f7297e324d5d868d55201c03068670ee4602babdef2f'
+-            '0fab2541ab06d281a0d9d6cfc256499ff0a8638228094f6797580b83704e6e7c')
++            '5ede1f5fec5b664428412a0849b28895be1c8d8982d3c0d246a4e95fd4730d65'
 +            '7183fdeea8fd148cf9dd03b0932f9d439b818a5ab3bc9a5e20d8e0b41c9e0efd')
  
  prepare() {
    [[ ! -d gcc ]] && ln -s gcc-${pkgver/+/-} gcc
-@@ -64,6 +63,15 @@ prepare() {
-   # Reproducible gcc-ada
-   patch -Np0 < "$srcdir/gcc-ada-repro.patch"
+@@ -69,6 +68,15 @@
+   #ASan: move allocator base to avoid conflict with high-entropy ASLR for x86-64 Linux'
+   patch -Np3 < "$srcdir/fb77ca05ffb4f8e666878f2f6718a9fb4d686839.patch" -d libsanitizer/
  
 +  # Remove codes filtering default library paths to make mold work correctly
 +  patch -Np1 < ../unfilter-default-library-path.patch
@@ -57,30 +57,25 @@ index f716aff..4b1fba7 100644
    mkdir -p "$srcdir/gcc-build"
    mkdir -p "$srcdir/libgccjit-build"
  }
-@@ -91,12 +99,12 @@ build() {
+@@ -96,7 +104,7 @@
        --enable-link-serialization=1
        --enable-linker-build-id
        --enable-lto
 -      --enable-multilib
++      --disable-multilib
        --enable-plugin
        --enable-shared
        --enable-threads=posix
-       --disable-libssp
-       --disable-libstdcxx-pch
-+      --disable-multilib
-       --disable-werror
-   )
- 
-@@ -109,7 +117,7 @@ build() {
+@@ -114,7 +122,7 @@
    CXXFLAGS=${CXXFLAGS/-Werror=format-security/}
  
    "$srcdir/gcc/configure" \
--    --enable-languages=ada,c,c++,d,fortran,go,lto,objc,obj-c++ \
-+    --enable-languages=c,c++,d,fortran,go,lto,objc,obj-c++ \
+-    --enable-languages=ada,c,c++,d,fortran,go,lto,m2,objc,obj-c++ \
++    --enable-languages=c,c++,d,fortran,go,lto,m2,objc,obj-c++ \
      --enable-bootstrap \
      "${_confflags[@]:?_confflags unset}"
  
-@@ -157,9 +165,9 @@ check() {
+@@ -162,9 +170,9 @@
  package_gcc-libs() {
    pkgdesc='Runtime libraries shipped by GCC'
    depends=('glibc>=2.27')
@@ -92,7 +87,7 @@ index f716aff..4b1fba7 100644
    replaces=($pkgname-multilib libgphobos)
  
    cd gcc-build
-@@ -172,9 +180,8 @@ package_gcc-libs() {
+@@ -177,9 +185,8 @@
               libgomp \
               libitm \
               libquadmath \
@@ -104,13 +99,7 @@ index f716aff..4b1fba7 100644
      make -C $CHOST/$lib DESTDIR="$pkgdir" install-toolexeclibLTLIBRARIES
    done
  
-@@ -191,18 +198,17 @@ package_gcc-libs() {
-     make -C $CHOST/$lib DESTDIR="$pkgdir" install-info
-   done
- 
--  # remove files provided by lib32-gcc-libs
--  rm -rf "$pkgdir"/usr/lib32/
--
+@@ -202,12 +209,14 @@
    # Install Runtime Library Exception
    install -Dm644 "$srcdir/gcc/COPYING.RUNTIME" \
      "$pkgdir/usr/share/licenses/gcc-libs/RUNTIME.LIBRARY.EXCEPTION"
@@ -126,7 +115,7 @@ index f716aff..4b1fba7 100644
    provides=($pkgname-multilib)
    replaces=($pkgname-multilib)
    options=(!emptydirs staticlibs)
-@@ -216,22 +222,18 @@ package_gcc() {
+@@ -221,22 +230,18 @@
    install -m755 -t "$pkgdir/${_libdir}/" gcc/{cc1,cc1plus,collect2,lto1}
  
    make -C $CHOST/libgcc DESTDIR="$pkgdir" install
@@ -151,7 +140,7 @@ index f716aff..4b1fba7 100644
  
    make DESTDIR="$pkgdir" install-fixincludes
    make -C gcc DESTDIR="$pkgdir" install-mkheaders
-@@ -246,16 +248,11 @@ package_gcc() {
+@@ -251,16 +256,11 @@
    make -C $CHOST/libquadmath DESTDIR="$pkgdir" install-nodist_libsubincludeHEADERS
    make -C $CHOST/libsanitizer DESTDIR="$pkgdir" install-nodist_{saninclude,toolexeclib}HEADERS
    make -C $CHOST/libsanitizer/asan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
@@ -169,29 +158,16 @@ index f716aff..4b1fba7 100644
  
    make -C libcpp DESTDIR="$pkgdir" install
    make -C gcc DESTDIR="$pkgdir" install-po
-@@ -264,9 +261,9 @@ package_gcc() {
-   ln -s gcc "$pkgdir"/usr/bin/cc
- 
+@@ -271,7 +271,7 @@
    # create cc-rs compatible symlinks
--  # https://github.com/rust-lang/cc-rs/blob/1.0.73/src/lib.rs#L2578-L2581
-+  # https://github.com/rust-lang/cc-rs/blob/1.0.73/src/lib.rs#L2624
+   # https://github.com/rust-lang/cc-rs/blob/1.0.73/src/lib.rs#L2578-L2581
    for binary in {c++,g++,gcc,gcc-ar,gcc-nm,gcc-ranlib}; do
 -    ln -s /usr/bin/${binary} "${pkgdir}"/usr/bin/x86_64-linux-gnu-${binary}
 +    ln -s /usr/bin/${binary} "${pkgdir}"/usr/bin/riscv64-linux-gnu-${binary}
    done
  
    # POSIX conformance launcher scripts for c89 and c99
-@@ -276,9 +273,6 @@ package_gcc() {
-   # install the libstdc++ man pages
-   make -C $CHOST/libstdc++-v3/doc DESTDIR="$pkgdir" doc-install-man
- 
--  # remove files provided by lib32-gcc-libs
--  rm -f "$pkgdir"/usr/lib32/lib{stdc++,gcc_s}.so
--
-   # byte-compile python libraries
-   python -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
-   python -O -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
-@@ -298,8 +292,6 @@ package_gcc-fortran() {
+@@ -303,8 +303,6 @@
    cd gcc-build
    make -C $CHOST/libgfortran DESTDIR="$pkgdir" install-cafexeclibLTLIBRARIES \
      install-{toolexeclibDATA,nodist_fincludeHEADERS,gfor_cHEADERS}
@@ -200,53 +176,20 @@ index f716aff..4b1fba7 100644
    make -C $CHOST/libgomp DESTDIR="$pkgdir" install-nodist_fincludeHEADERS
    make -C gcc DESTDIR="$pkgdir" fortran.install-{common,man,info}
    install -Dm755 gcc/f951 "$pkgdir/${_libdir}/f951"
-@@ -329,45 +321,6 @@ package_gcc-objc() {
-     "$pkgdir/usr/share/licenses/$pkgname/"
- }
+@@ -361,12 +359,6 @@
+   ln -s libgnat-${_majorver}.so "$pkgdir/usr/lib/libgnat.so"
+   rm -f "$pkgdir"/${_libdir}/adalib/libgna{rl,t}.so
  
--package_gcc-ada() {
--  pkgdesc='Ada front-end for GCC (GNAT)'
--  depends=("gcc=$pkgver-$pkgrel" libisl.so)
--  provides=($pkgname-multilib)
--  replaces=($pkgname-multilib)
--  options=(!emptydirs staticlibs)
--
--  cd gcc-build/gcc
--  make DESTDIR="$pkgdir" ada.install-{common,info}
--  install -m755 gnat1 "$pkgdir/${_libdir}"
--
--  cd "$srcdir"/gcc-build/$CHOST/libada
--  make DESTDIR="${pkgdir}" INSTALL="install" \
--    INSTALL_DATA="install -m644" install-libada
--
--  cd "$srcdir"/gcc-build/$CHOST/32/libada
--  make DESTDIR="${pkgdir}" INSTALL="install" \
--    INSTALL_DATA="install -m644" install-libada
--
--  ln -s gcc "$pkgdir/usr/bin/gnatgcc"
--
--  # insist on dynamic linking, but keep static libraries because gnatmake complains
--  mv "$pkgdir"/${_libdir}/adalib/libgna{rl,t}-${_majorver}.so "$pkgdir/usr/lib"
--  ln -s libgnarl-${_majorver}.so "$pkgdir/usr/lib/libgnarl.so"
--  ln -s libgnat-${_majorver}.so "$pkgdir/usr/lib/libgnat.so"
--  rm -f "$pkgdir"/${_libdir}/adalib/libgna{rl,t}.so
--
 -  install -d "$pkgdir/usr/lib32/"
 -  mv "$pkgdir"/${_libdir}/32/adalib/libgna{rl,t}-${_majorver}.so "$pkgdir/usr/lib32"
 -  ln -s libgnarl-${_majorver}.so "$pkgdir/usr/lib32/libgnarl.so"
 -  ln -s libgnat-${_majorver}.so "$pkgdir/usr/lib32/libgnat.so"
 -  rm -f "$pkgdir"/${_libdir}/32/adalib/libgna{rl,t}.so
 -
--  # Install Runtime Library Exception
--  install -d "$pkgdir/usr/share/licenses/$pkgname/"
--  ln -s /usr/share/licenses/gcc-libs/RUNTIME.LIBRARY.EXCEPTION \
--    "$pkgdir/usr/share/licenses/$pkgname/"
--}
--
- package_gcc-go() {
-   pkgdesc='Go front-end for GCC'
-   depends=("gcc=$pkgver-$pkgrel" libisl.so)
-@@ -377,11 +330,10 @@ package_gcc-go() {
+   # Install Runtime Library Exception
+   install -d "$pkgdir/usr/share/licenses/$pkgname/"
+   ln -s /usr/share/licenses/gcc-libs/RUNTIME.LIBRARY.EXCEPTION \
+@@ -382,7 +374,6 @@
  
    cd gcc-build
    make -C $CHOST/libgo DESTDIR="$pkgdir" install-exec-am
@@ -254,59 +197,3 @@ index f716aff..4b1fba7 100644
    make DESTDIR="$pkgdir" install-gotools
    make -C gcc DESTDIR="$pkgdir" go.install-{common,man,info}
  
--  rm -f "$pkgdir"/usr/lib{,32}/libgo.so*
-+  rm -f "$pkgdir"/usr/lib/libgo.so*
-   install -Dm755 gcc/go1 "$pkgdir/${_libdir}/go1"
- 
-   # Install Runtime Library Exception
-@@ -390,42 +342,6 @@ package_gcc-go() {
-     "$pkgdir/usr/share/licenses/$pkgname/"
- }
- 
--package_lib32-gcc-libs() {
--  pkgdesc='32-bit runtime libraries shipped by GCC'
--  depends=('lib32-glibc>=2.27')
--  provides=(libgo.so libgfortran.so libubsan.so libasan.so)
--  options=(!emptydirs !strip)
--
--  cd gcc-build
--
--  make -C $CHOST/32/libgcc DESTDIR="$pkgdir" install-shared
--  rm -f "$pkgdir/$_libdir/32/libgcc_eh.a"
--
--  for lib in libatomic \
--             libgfortran \
--             libgo \
--             libgomp \
--             libitm \
--             libquadmath \
--             libsanitizer/{a,l,ub}san \
--             libstdc++-v3/src \
--             libvtv; do
--    make -C $CHOST/32/$lib DESTDIR="$pkgdir" install-toolexeclibLTLIBRARIES
--  done
--
--  make -C $CHOST/32/libobjc DESTDIR="$pkgdir" install-libs
--
--  make -C $CHOST/libphobos DESTDIR="$pkgdir" install
--  rm -f "$pkgdir"/usr/lib32/libgphobos.spec
--
--  # remove files provided by gcc-libs
--  rm -rf "$pkgdir"/usr/lib
--
--  # Install Runtime Library Exception
--  install -Dm644 "$srcdir/gcc/COPYING.RUNTIME" \
--    "$pkgdir/usr/share/licenses/lib32-gcc-libs/RUNTIME.LIBRARY.EXCEPTION"
--}
--
- package_gcc-d() {
-   pkgdesc="D frontend for GCC"
-   depends=("gcc=$pkgver-$pkgrel" libisl.so)
-@@ -441,7 +357,6 @@ package_gcc-d() {
- 
-   make -C $CHOST/libphobos DESTDIR="$pkgdir" install
-   rm -f "$pkgdir/usr/lib/"lib{gphobos,gdruntime}.so*
--  rm -f "$pkgdir/usr/lib32/"lib{gphobos,gdruntime}.so*
- 
-   # Install Runtime Library Exception
-   install -d "$pkgdir/usr/share/licenses/$pkgname/"


### PR DESCRIPTION
Leave some `rm -f` multilib stuff that don't cause failures as-is, to make patch less likely to be rotten.