### PR TITLE
upgpatch: glibc 2.38-8

### DIFF
--- a/glibc/riscv64.patch
+++ b/glibc/riscv64.patch
@@ -1,23 +1,30 @@
+diff --git PKGBUILD PKGBUILD
+index 4a30a22..793dfa8 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -7,14 +7,14 @@
- # NOTE: valgrind requires rebuilt with each major glibc version
- 
- pkgbase=glibc
--pkgname=(glibc lib32-glibc glibc-locales)
-+pkgname=(glibc glibc-locales)
- pkgver=2.38
- _commit=750a45a783906a19591fb8ff6b7841470f1f5701
- pkgrel=7
+@@ -14,12 +14,11 @@
  arch=(x86_64)
  url='https://www.gnu.org/software/libc'
- license=(GPL LGPL)
+ license=(GPL-2.0-or-later LGPL-2.1-or-later)
 -makedepends=(git gd lib32-gcc-libs python)
 +makedepends=(git gd python)
  options=(staticlibs !lto)
  source=(git+https://sourceware.org/git/glibc.git#commit=${_commit}
          locale.gen.txt
-@@ -54,7 +54,6 @@ build() {
+         locale-gen
+-        lib32-glibc.conf
+         sdt.h sdt-config.h
+ )
+ validpgpkeys=(7273542B39962DF7B299931416792B4EA25340F8 # Carlos O'Donell
+@@ -27,7 +26,6 @@
+ b2sums=('SKIP'
+         'c859bf2dfd361754c9e3bbd89f10de31f8e81fd95dc67b77d10cb44e23834b096ba3caa65fbc1bd655a8696c6450dfd5a096c476b3abf5c7e125123f97ae1a72'
+         '04fbb3b0b28705f41ccc6c15ed5532faf0105370f22133a2b49867e790df0491f5a1255220ff6ebab91a462f088d0cf299491b3eb8ea53534cb8638a213e46e3'
+-        '7c265e6d36a5c0dff127093580827d15519b6c7205c2e1300e82f0fb5b9dd00b6accb40c56581f18179c4fbbc95bd2bf1b900ace867a83accde0969f7b609f8a'
+         'a6a5e2f2a627cc0d13d11a82458cfd0aa75ec1c5a3c7647e5d5a3bb1d4c0770887a3909bfda1236803d5bc9801bfd6251e13483e9adf797e4725332cd0d91a0e'
+         '214e995e84b342fe7b2a7704ce011b7c7fc74c2971f98eeb3b4e677b99c860addc0a7d91b8dc0f0b8be7537782ee331999e02ba48f4ccc1c331b60f27d715678')
+ 
+@@ -48,7 +46,6 @@
        --enable-cet
        --enable-fortify-source
        --enable-kernel=4.4
@@ -25,7 +32,7 @@
        --enable-stack-protector=strong
        --enable-systemtap
        --disable-nscd
-@@ -86,25 +85,7 @@ build() {
+@@ -80,25 +77,6 @@
      make info
    )
  
@@ -48,11 +55,10 @@
 -    make -O
 -  )
 -
-+  
    # pregenerate locales here instead of in package
    # functions because localedef does not like fakeroot
    make -C "${srcdir}"/glibc/localedata objdir="${srcdir}"/glibc-build \
-@@ -140,7 +121,7 @@ check() (
+@@ -134,7 +112,7 @@
    _skip_test tst-process_mrelease    sysdeps/unix/sysv/linux/Makefile
    _skip_test tst-adjtime             time/Makefile
  
@@ -61,3 +67,9 @@
  )
  
  package_glibc() {
+@@ -217,3 +195,5 @@
+   # deduplicate locale data
+   hardlink -c "${pkgdir}"/usr/lib/locale
+ }
++
++pkgname=( ${pkgname[*]/lib32-glibc} )


### PR DESCRIPTION
`--nocheck` still needed.
Place pkgname change at the bottom to avoid commit hash context.