### PR TITLE
addpatch: prometheus-postgres-exporter 0.15.0-2

### DIFF
--- a/prometheus-postgres-exporter/riscv64.patch
+++ b/prometheus-postgres-exporter/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index 242c732..f517455 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -51,7 +51,7 @@
+ check() {
+     cd "postgres_exporter-${pkgver}"
+ 
+-    go test -race  ./...
++    go test ./...
+ }
+ 
+ package() {


### PR DESCRIPTION
`go test -race` unsupported on riscv.