### PR TITLE
addpatch: docker 1:25.0.2-1

### DIFF
--- a/docker/riscv64.patch
+++ b/docker/riscv64.patch
@@ -1,0 +1,12 @@
+diff --git PKGBUILD PKGBUILD
+index 398f3a5..447acc9 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -75,6 +75,7 @@
+   export LDFLAGS=''
+   export GOFLAGS='-buildmode=pie -trimpath -mod=readonly -modcacherw -ldflags=-linkmode=external'
+   export GO111MODULE=off
++  export CGO_ENABLED=1
+   export DISABLE_WARN_OUTSIDE_CONTAINER=1
+ 
+   ### cli


### PR DESCRIPTION
riscv go external linking needs `CGO_ENABLED=1` explicitly.