### PR TITLE
addpatch: typescript 5.3.3-1

### DIFF
--- a/typescript/increase-timeout.patch
+++ b/typescript/increase-timeout.patch
@@ -1,0 +1,13 @@
+diff --git a/scripts/build/options.mjs b/scripts/build/options.mjs
+index be5ef5ae4ea..2c0d62212ca 100644
+--- a/scripts/build/options.mjs
++++ b/scripts/build/options.mjs
+@@ -26,7 +26,7 @@ const parsed = minimist(process.argv.slice(2), {
+         inspect: process.env.inspect || process.env["inspect-brk"] || process.env.i,
+         host: process.env.TYPESCRIPT_HOST || process.env.host || "node",
+         browser: process.env.browser || process.env.b || (os.platform() === "win32" ? "edge" : "chrome"),
+-        timeout: +(process.env.timeout ?? 0) || 40000,
++        timeout: +(process.env.timeout ?? 0) || 4000000,
+         tests: process.env.test || process.env.tests || process.env.t,
+         runners: process.env.runners || process.env.runner || process.env.ru,
+         light: process.env.light === undefined || process.env.light !== "false",

--- a/typescript/remove-dprint.patch
+++ b/typescript/remove-dprint.patch
@@ -1,0 +1,287 @@
+diff --git a/Herebyfile.mjs b/Herebyfile.mjs
+index b9b59d408c9..89ac94da340 100644
+--- a/Herebyfile.mjs
++++ b/Herebyfile.mjs
+@@ -528,13 +528,13 @@ export const lint = task({
+ export const format = task({
+     name: "format",
+     description: "Formats the codebase.",
+-    run: () => exec(process.execPath, ["node_modules/dprint/bin.js", "fmt"]),
++    run: () => {},
+ });
+ 
+ export const checkFormat = task({
+     name: "check-format",
+     description: "Checks that the codebase is formatted.",
+-    run: () => exec(process.execPath, ["node_modules/dprint/bin.js", "check"], { ignoreStdout: true }),
++    run: () => {},
+ });
+ 
+ const { main: cancellationToken, watch: watchCancellationToken } = entrypointBuildTask({
+diff --git a/package-lock.json b/package-lock.json
+index de764a5f20a..d248f39cea5 100644
+--- a/package-lock.json
++++ b/package-lock.json
+@@ -33,7 +33,6 @@
+                 "chalk": "^4.1.2",
+                 "chokidar": "^3.5.3",
+                 "diff": "^5.1.0",
+-                "dprint": "^0.42.3",
+                 "esbuild": "^0.19.0",
+                 "eslint": "^8.22.0",
+                 "eslint-formatter-autolinkable-stylish": "^1.2.0",
+@@ -74,97 +73,6 @@
+             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+             "dev": true
+         },
+-        "node_modules/@dprint/darwin-arm64": {
+-            "version": "0.42.5",
+-            "resolved": "https://registry.npmjs.org/@dprint/darwin-arm64/-/darwin-arm64-0.42.5.tgz",
+-            "integrity": "sha512-3bBBlaAXQ9WTC+jvd2/iyj7cVp0G58/v5R7+YADUl5K9xF+Ah+xLFm6xw4Iwq+zsYaWDimRmLnM5iRSJC9qv1Q==",
+-            "cpu": [
+-                "arm64"
+-            ],
+-            "dev": true,
+-            "optional": true,
+-            "os": [
+-                "darwin"
+-            ]
+-        },
+-        "node_modules/@dprint/darwin-x64": {
+-            "version": "0.42.5",
+-            "resolved": "https://registry.npmjs.org/@dprint/darwin-x64/-/darwin-x64-0.42.5.tgz",
+-            "integrity": "sha512-gwx6lODOckU3xGv0zVFad/SMMtwBleiBAzm3UVw/WkGiCVo3XrIZ6EdLr4zCmB4A2R+SOxODU70WtONCF0dGnQ==",
+-            "cpu": [
+-                "x64"
+-            ],
+-            "dev": true,
+-            "optional": true,
+-            "os": [
+-                "darwin"
+-            ]
+-        },
+-        "node_modules/@dprint/linux-arm64-glibc": {
+-            "version": "0.42.5",
+-            "resolved": "https://registry.npmjs.org/@dprint/linux-arm64-glibc/-/linux-arm64-glibc-0.42.5.tgz",
+-            "integrity": "sha512-ijJm+zOxHK3Chnis3y5kVzvBr21Ugyodqpz1chClNWkaR+0/BYDik+lxZVrbxZw8gxqPu8iisOceCQQC42Bkzg==",
+-            "cpu": [
+-                "arm64"
+-            ],
+-            "dev": true,
+-            "optional": true,
+-            "os": [
+-                "linux"
+-            ]
+-        },
+-        "node_modules/@dprint/linux-arm64-musl": {
+-            "version": "0.42.5",
+-            "resolved": "https://registry.npmjs.org/@dprint/linux-arm64-musl/-/linux-arm64-musl-0.42.5.tgz",
+-            "integrity": "sha512-OLbJgv14AvJRVBi+ZCXBH0rsMSIdCZi/z1hCTRUb901VB2OVf81k5vvBn7HS5S9wMQ2HIG8GFOyckBg0qhEgAQ==",
+-            "cpu": [
+-                "arm64"
+-            ],
+-            "dev": true,
+-            "optional": true,
+-            "os": [
+-                "linux"
+-            ]
+-        },
+-        "node_modules/@dprint/linux-x64-glibc": {
+-            "version": "0.42.5",
+-            "resolved": "https://registry.npmjs.org/@dprint/linux-x64-glibc/-/linux-x64-glibc-0.42.5.tgz",
+-            "integrity": "sha512-tWh1kMbTi/lxS6hQJCDnriZonzGYN6FcN2AqF1C/TdRNjacFVvQnxZTdHPLJbgw0mSujHPinl3NtvllZ9CwVqA==",
+-            "cpu": [
+-                "x64"
+-            ],
+-            "dev": true,
+-            "optional": true,
+-            "os": [
+-                "linux"
+-            ]
+-        },
+-        "node_modules/@dprint/linux-x64-musl": {
+-            "version": "0.42.5",
+-            "resolved": "https://registry.npmjs.org/@dprint/linux-x64-musl/-/linux-x64-musl-0.42.5.tgz",
+-            "integrity": "sha512-GObJlhUqQpaXKRMTUUEkdYgWgS1aVyMUQZFn3dBmLycl4F2gXWxKgYB6R47ESVeejsEvE9fTTuxlpK6fOHjaKQ==",
+-            "cpu": [
+-                "x64"
+-            ],
+-            "dev": true,
+-            "optional": true,
+-            "os": [
+-                "linux"
+-            ]
+-        },
+-        "node_modules/@dprint/win32-x64": {
+-            "version": "0.42.5",
+-            "resolved": "https://registry.npmjs.org/@dprint/win32-x64/-/win32-x64-0.42.5.tgz",
+-            "integrity": "sha512-N2N1FlmbEFbH/WqoKGdsZplBpfq9qdhfkJHQH1poVG3KxqT0dq01oqAfnC3ZQaSBoBrBfp5GyRtj7KwCxdqxXA==",
+-            "cpu": [
+-                "x64"
+-            ],
+-            "dev": true,
+-            "optional": true,
+-            "os": [
+-                "win32"
+-            ]
+-        },
+         "node_modules/@esbuild/android-arm": {
+             "version": "0.19.5",
+             "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.5.tgz",
+@@ -1755,25 +1663,6 @@
+                 "node": ">=6.0.0"
+             }
+         },
+-        "node_modules/dprint": {
+-            "version": "0.42.5",
+-            "resolved": "https://registry.npmjs.org/dprint/-/dprint-0.42.5.tgz",
+-            "integrity": "sha512-GvC3Hpsm/GKBZe6UjOZVKLb3u86puWc2lm+F+Bqgkk4fjQ9tpvZhENFra9al1rz01qfxsc3+6JZN/E9eJIME5Q==",
+-            "dev": true,
+-            "hasInstallScript": true,
+-            "bin": {
+-                "dprint": "bin.js"
+-            },
+-            "optionalDependencies": {
+-                "@dprint/darwin-arm64": "0.42.5",
+-                "@dprint/darwin-x64": "0.42.5",
+-                "@dprint/linux-arm64-glibc": "0.42.5",
+-                "@dprint/linux-arm64-musl": "0.42.5",
+-                "@dprint/linux-x64-glibc": "0.42.5",
+-                "@dprint/linux-x64-musl": "0.42.5",
+-                "@dprint/win32-x64": "0.42.5"
+-            }
+-        },
+         "node_modules/emoji-regex": {
+             "version": "8.0.0",
+             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+@@ -4013,55 +3902,6 @@
+             "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+             "dev": true
+         },
+-        "@dprint/darwin-arm64": {
+-            "version": "0.42.5",
+-            "resolved": "https://registry.npmjs.org/@dprint/darwin-arm64/-/darwin-arm64-0.42.5.tgz",
+-            "integrity": "sha512-3bBBlaAXQ9WTC+jvd2/iyj7cVp0G58/v5R7+YADUl5K9xF+Ah+xLFm6xw4Iwq+zsYaWDimRmLnM5iRSJC9qv1Q==",
+-            "dev": true,
+-            "optional": true
+-        },
+-        "@dprint/darwin-x64": {
+-            "version": "0.42.5",
+-            "resolved": "https://registry.npmjs.org/@dprint/darwin-x64/-/darwin-x64-0.42.5.tgz",
+-            "integrity": "sha512-gwx6lODOckU3xGv0zVFad/SMMtwBleiBAzm3UVw/WkGiCVo3XrIZ6EdLr4zCmB4A2R+SOxODU70WtONCF0dGnQ==",
+-            "dev": true,
+-            "optional": true
+-        },
+-        "@dprint/linux-arm64-glibc": {
+-            "version": "0.42.5",
+-            "resolved": "https://registry.npmjs.org/@dprint/linux-arm64-glibc/-/linux-arm64-glibc-0.42.5.tgz",
+-            "integrity": "sha512-ijJm+zOxHK3Chnis3y5kVzvBr21Ugyodqpz1chClNWkaR+0/BYDik+lxZVrbxZw8gxqPu8iisOceCQQC42Bkzg==",
+-            "dev": true,
+-            "optional": true
+-        },
+-        "@dprint/linux-arm64-musl": {
+-            "version": "0.42.5",
+-            "resolved": "https://registry.npmjs.org/@dprint/linux-arm64-musl/-/linux-arm64-musl-0.42.5.tgz",
+-            "integrity": "sha512-OLbJgv14AvJRVBi+ZCXBH0rsMSIdCZi/z1hCTRUb901VB2OVf81k5vvBn7HS5S9wMQ2HIG8GFOyckBg0qhEgAQ==",
+-            "dev": true,
+-            "optional": true
+-        },
+-        "@dprint/linux-x64-glibc": {
+-            "version": "0.42.5",
+-            "resolved": "https://registry.npmjs.org/@dprint/linux-x64-glibc/-/linux-x64-glibc-0.42.5.tgz",
+-            "integrity": "sha512-tWh1kMbTi/lxS6hQJCDnriZonzGYN6FcN2AqF1C/TdRNjacFVvQnxZTdHPLJbgw0mSujHPinl3NtvllZ9CwVqA==",
+-            "dev": true,
+-            "optional": true
+-        },
+-        "@dprint/linux-x64-musl": {
+-            "version": "0.42.5",
+-            "resolved": "https://registry.npmjs.org/@dprint/linux-x64-musl/-/linux-x64-musl-0.42.5.tgz",
+-            "integrity": "sha512-GObJlhUqQpaXKRMTUUEkdYgWgS1aVyMUQZFn3dBmLycl4F2gXWxKgYB6R47ESVeejsEvE9fTTuxlpK6fOHjaKQ==",
+-            "dev": true,
+-            "optional": true
+-        },
+-        "@dprint/win32-x64": {
+-            "version": "0.42.5",
+-            "resolved": "https://registry.npmjs.org/@dprint/win32-x64/-/win32-x64-0.42.5.tgz",
+-            "integrity": "sha512-N2N1FlmbEFbH/WqoKGdsZplBpfq9qdhfkJHQH1poVG3KxqT0dq01oqAfnC3ZQaSBoBrBfp5GyRtj7KwCxdqxXA==",
+-            "dev": true,
+-            "optional": true
+-        },
+         "@esbuild/android-arm": {
+             "version": "0.19.5",
+             "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.5.tgz",
+@@ -5142,21 +4982,6 @@
+                 "esutils": "^2.0.2"
+             }
+         },
+-        "dprint": {
+-            "version": "0.42.5",
+-            "resolved": "https://registry.npmjs.org/dprint/-/dprint-0.42.5.tgz",
+-            "integrity": "sha512-GvC3Hpsm/GKBZe6UjOZVKLb3u86puWc2lm+F+Bqgkk4fjQ9tpvZhENFra9al1rz01qfxsc3+6JZN/E9eJIME5Q==",
+-            "dev": true,
+-            "requires": {
+-                "@dprint/darwin-arm64": "0.42.5",
+-                "@dprint/darwin-x64": "0.42.5",
+-                "@dprint/linux-arm64-glibc": "0.42.5",
+-                "@dprint/linux-arm64-musl": "0.42.5",
+-                "@dprint/linux-x64-glibc": "0.42.5",
+-                "@dprint/linux-x64-musl": "0.42.5",
+-                "@dprint/win32-x64": "0.42.5"
+-            }
+-        },
+         "emoji-regex": {
+             "version": "8.0.0",
+             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+diff --git a/package.json b/package.json
+index 20f449beaa8..1833c61d2e9 100644
+--- a/package.json
++++ b/package.json
+@@ -59,7 +59,6 @@
+         "chalk": "^4.1.2",
+         "chokidar": "^3.5.3",
+         "diff": "^5.1.0",
+-        "dprint": "^0.42.3",
+         "esbuild": "^0.19.0",
+         "eslint": "^8.22.0",
+         "eslint-formatter-autolinkable-stylish": "^1.2.0",
+@@ -95,7 +94,7 @@
+         "clean": "hereby clean",
+         "gulp": "hereby",
+         "lint": "hereby lint",
+-        "format": "dprint fmt",
++        "format": ":",
+         "setup-hooks": "node scripts/link-hooks.mjs"
+     },
+     "browser": {
+diff --git a/scripts/dtsBundler.mjs b/scripts/dtsBundler.mjs
+index 7edbc635e71..f12c5047496 100644
+--- a/scripts/dtsBundler.mjs
++++ b/scripts/dtsBundler.mjs
+@@ -410,25 +410,5 @@ if (publicContents.includes("@internal")) {
+     console.error("Output includes untrimmed @internal nodes!");
+ }
+ 
+-const dprintPath = path.resolve(__dirname, "..", "node_modules", "dprint", "bin.js");
+-
+-/**
+- * @param {string} contents
+- * @returns {string}
+- */
+-function dprint(contents) {
+-    const result = cp.execFileSync(
+-        process.execPath,
+-        [dprintPath, "fmt", "--stdin", "ts"],
+-        {
+-            stdio: ["pipe", "pipe", "inherit"],
+-            encoding: "utf-8",
+-            input: contents,
+-            maxBuffer: 100 * 1024 * 1024, // 100 MB "ought to be enough for anyone"; https://github.com/nodejs/node/issues/9829
+-        },
+-    );
+-    return result.replace(/\r\n/g, "\n");
+-}
+-
+-fs.writeFileSync(output, dprint(publicContents));
+-fs.writeFileSync(internalOutput, dprint(internalContents));
++fs.writeFileSync(output, publicContents);
++fs.writeFileSync(internalOutput, internalContents);

--- a/typescript/remove-typescript.d.ts-baseline-check.patch
+++ b/typescript/remove-typescript.d.ts-baseline-check.patch
@@ -1,0 +1,15 @@
+diff --git a/src/testRunner/unittests/publicApi.ts b/src/testRunner/unittests/publicApi.ts
+index 1b5ab93f0a1..bff42f0b028 100644
+--- a/src/testRunner/unittests/publicApi.ts
++++ b/src/testRunner/unittests/publicApi.ts
+@@ -20,10 +20,6 @@ describe("unittests:: Public APIs", () => {
+         });
+     }
+ 
+-    describe("for the language service and compiler", () => {
+-        verifyApi("typescript.d.ts");
+-    });
+-
+     describe("for the language server", () => {
+         verifyApi("tsserverlibrary.d.ts");
+     });

--- a/typescript/riscv64.patch
+++ b/typescript/riscv64.patch
@@ -1,0 +1,35 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,11 +12,30 @@ url=http://www.typescriptlang.org
+ license=('Apache')
+ depends=('nodejs')
+ makedepends=('git' 'npm' 'rsync')
+-source=("git+https://github.com/microsoft/$_name.git#tag=v$pkgver")
+-b2sums=('SKIP')
++source=("git+https://github.com/microsoft/$_name.git#tag=v$pkgver"
++        "remove-dprint.patch"
++        "increase-timeout.patch"
++        "remove-typescript.d.ts-baseline-check.patch")
++b2sums=('SKIP'
++        '5bfb527f07c4cc573b80887df8e9220f890e697f2c6d0b22675018d963e2e48d97a00a50590151463ddb7267a2c53b00145f27ec6e9e04567819e06a9d0dfa0a'
++        '216abfce117ae52b4dbc49bd94eac6096c1606a1b50fab90af94f6611acad8e33e4ef497c6f8002af078caa9297ac84a2c4291b620836b4007b02f4add28bc98'
++        '38dc4bfd4a53613eb6406b4966d39a7c26f49fdb3eee626739773a0f16bd177e0ba735e70a34b8fb4bfbdd745392a0ac09429d2e21086e04bd28ba6cbaa080ef')
+ 
+ prepare() {
+   cd $_name
++
++  # Remove dprint from dependencies and disable formatting when building code
++  # dprint itself requires prebuilt binary available, and some of its plugins uses prebuilts as well
++  # Building dprint from source from NPM package is upstreamed to https://github.com/dprint/dprint/pull/820
++  patch -Np1 -i ../remove-dprint.patch
++
++  # Increase test timeout from 40s to 4000s
++  patch -Np1 -i ../increase-timeout.patch
++
++  # Disable baseline check for typescript.d.ts
++  # This should not affect functionality since the diffs are solely code format variations
++  patch -Np1 -i ../remove-typescript.d.ts-baseline-check.patch
++
+   npm ci
+ }
+ 


### PR DESCRIPTION
Remove dprint from TypeScript's dependencies and building processes since dprint itself and its native plugins (non-WebAssembly ones) relies on prebuilt binaries.

Attempt to enable dprint using https://github.com/dprint/dprint/pull/820 and disable its native Prettier plugins (only used to format YAML files) did not succeed, as [dprint-plugin-typescript (a WebAssembly plugin) produced inconsistent typescript.d.ts between riscv64 and x86_64](https://gist.github.com/hack3ric/bd7dd2364cadba4b01d6c834396ad06f). It is probably caused by immature Cranelift JIT implementation on RISC-V. The difference is only cosmetic though, therefore we can safely ignore the test for now.