### PR TITLE
upgpatch: devtools-riscv64 1:1.1.0+patch2-1

### DIFF
--- a/devtools-riscv64/PKGBUILD
+++ b/devtools-riscv64/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=devtools-riscv64
 epoch=1
-pkgver=1.1.0+patch1
+pkgver=1.1.0+patch2
 pkgrel=1
 pkgdesc='Tools for Arch Linux RISC-V package maintainers'
 arch=('x86_64' 'riscv64')
@@ -15,7 +15,7 @@ source=(makepkg-riscv64.patch
         sogrep-riscv64.patch
         valid-repos-riscv64.sh)
 source_x86_64=(z-archriscv-qemu-riscv64.conf)
-sha256sums=('9125ba2f479e57d634deea76ee036569dbd3d8a54d81e8d0f5a4e7aef75b9a48'
+sha256sums=('3e79aaf0c4d9f94c56768fc15cf88665dbe206be9ef2c00fb1dba96f7da1b7b4'
             '5c80d7f727c4cca6c3ae515dbcb9b9a69d2cae952aa520a82df97cf37432c9cc'
             'c8e9bfc390e42d358007578ca54212bda1d44c754c976be9ef262944d4a0d83c'
             '94ee35597de8e46b1f0c09f95ced34c47ece2f95f92d1a7f2415373f2d129c63')

--- a/devtools-riscv64/makepkg-riscv64.patch
+++ b/devtools-riscv64/makepkg-riscv64.patch
@@ -1,6 +1,6 @@
 --- /usr/share/devtools/makepkg.conf.d/x86_64.conf	2024-02-10 08:01:05.000000000 +0800
-+++ riscv64.conf	2024-02-11 00:37:44.643963368 +0800
-@@ -35,14 +35,14 @@
++++ riscv64.conf	2024-02-12 10:07:10.892146821 +0800
+@@ -35,17 +35,16 @@
  # ARCHITECTURE, COMPILE FLAGS
  #########################################################################
  #
@@ -17,5 +17,9 @@
 -        -fstack-clash-protection -fcf-protection"
 +        -fstack-clash-protection"
  CXXFLAGS="$CFLAGS -Wp,-D_GLIBCXX_ASSERTIONS"
- LDFLAGS="-Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now \
-          -Wl,-z,pack-relative-relocs"
+-LDFLAGS="-Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now \
+-         -Wl,-z,pack-relative-relocs"
++LDFLAGS="-Wl,-O1 -Wl,--sort-common -Wl,--as-needed -Wl,-z,relro -Wl,-z,now"
+ LTOFLAGS="-flto=auto"
+ RUSTFLAGS=""
+ #-- Make Flags: change this for DistCC/SMP systems


### PR DESCRIPTION
Remove unsupported `-Wl,-z,pack-relative-relocs` from LDFLAGS.