### PR TITLE
updpatch: atuin 18.0.0-1

### DIFF
--- a/atuin/riscv64.patch
+++ b/atuin/riscv64.patch
@@ -1,11 +1,27 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -18,6 +18,8 @@ options=('!lto')
+@@ -18,6 +18,7 @@ options=('!lto')
  
  prepare() {
    cd "$pkgname-$pkgver"
-+  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }\n" >> Cargo.toml
-+  cargo update -p ring@0.16.20
++  patch -Np1 -i ../test-timeout.patch
    cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
    mkdir completions/
  }
+@@ -32,7 +33,7 @@ build() {
+ 
+ check() {
+   cd "$pkgname-$pkgver"
+-  cargo test --frozen --all-features --workspace --lib
++  ATUIN_TEST_SQLITE_STORE_TIMEOUT=1.0 cargo test --frozen --all-features --workspace --lib
+ }
+ 
+ package() {
+@@ -45,4 +46,7 @@ package() {
+   install -Dm 644 "completions/_$pkgname" -t "${pkgdir}/usr/share/zsh/site-functions"
+ }
+ 
++source+=("test-timeout.patch::https://github.com/atuinsh/atuin/pull/1703.diff")
++sha256sums+=('6eff082fdb4fbd09f342d6a98b8b72e8404899f458f7be7ebd531a6990e18b82')
++
+ # vim: ts=2 sw=2 et:


### PR DESCRIPTION
Remove ring patch and increase SQLite initialization timeout in tests. Upstreamed to https://github.com/atuinsh/atuin/pull/1703.