### PR TITLE
addpatch: hip-runtime-amd 6.0.0-1

### DIFF
--- a/hip-runtime-amd/hip-runtime-amd-rv64gc.patch
+++ b/hip-runtime-amd/hip-runtime-amd-rv64gc.patch
@@ -1,0 +1,12 @@
+diff '--color=auto' -Naur clr-rocm-6.0.0.orig/hipamd/src/hiprtc/CMakeLists.txt clr-rocm-6.0.0/hipamd/src/hiprtc/CMakeLists.txt
+--- clr-rocm-6.0.0.orig/hipamd/src/hiprtc/CMakeLists.txt	2024-02-16 10:53:57.198846626 -0500
++++ clr-rocm-6.0.0/hipamd/src/hiprtc/CMakeLists.txt	2024-02-16 10:56:30.945780069 -0500
+@@ -171,7 +171,7 @@
+   DEPENDS clang ${HIPRTC_GEN_HEADER})
+ add_custom_command(
+   OUTPUT ${HIPRTC_GEN_OBJ}
+-  COMMAND $<TARGET_FILE:llvm-mc> -o ${HIPRTC_GEN_OBJ} ${HIPRTC_GEN_MCIN} --filetype=obj
++  COMMAND $<TARGET_FILE:llvm-mc> -o ${HIPRTC_GEN_OBJ} ${HIPRTC_GEN_MCIN} --filetype=obj -mattr=+m,a,f,d,c
+   DEPENDS llvm-mc ${HIPRTC_GEN_PREPROCESSED} ${HIPRTC_GEN_MCIN})
+ 
+ # Create hiprtc-builtins library.

--- a/hip-runtime-amd/riscv64.patch
+++ b/hip-runtime-amd/riscv64.patch
@@ -1,0 +1,29 @@
+diff --git PKGBUILD PKGBUILD
+index 41b48ab..452f7fb 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -27,6 +27,16 @@
+ _dirclr="$(basename "$_clr")-$(basename "${source[1]}" ".tar.gz")"
+ _dirhipcc="$(basename "$_hipcc")-$(basename "${source[2]}" ".tar.gz")"
+ 
++source+=("$pkgname-disable-immintrin.patch::https://github.com/ROCm/clr/commit/12461dbd6a26e02d03b572399b6d629f44b0a318.diff"
++         "$pkgname-rv64gc.patch")
++sha256sums+=('bf4fcef96619cbed5ec0f3f8ef02767347acfc883b6b67d300ccbe5e0e596efb'
++             'b8d9643df110fd016796fe5e3ffda0b13bfe6ba430304322684a691bc35b84ff')
++
++prepare() {
++  patch -Np1 -d "$srcdir/$_dirclr" -i "$srcdir/$pkgname-disable-immintrin.patch"
++  patch -Np1 -d "$srcdir/$_dirclr" -i "$srcdir/$pkgname-rv64gc.patch"
++}
++
+ build() {
+   local hipcc_args=(
+     -Wno-dev
+@@ -48,6 +58,7 @@
+     -DHIP_CATCH_TEST=0
+     -DCLR_BUILD_HIP=ON
+     -DCLR_BUILD_OCL=OFF
++    -D__HIP_ENABLE_PCH=OFF
+   )
+   cmake "${hip_args[@]}"
+   cmake --build build


### PR DESCRIPTION
- Backport https://github.com/ROCm/clr/commit/12461dbd6a26e02d03b572399b6d629f44b0a318
- Disable precompiled header which hardcoded x86 assembly
- Let `llvm-mc` use lp64d ABI
    - I'd like to upstream later. This needs a better way and some discussion with upstream, like adding arch-specific flags.