### PR TITLE
upgpatch: openmpi 5.0.2-2

### DIFF
--- a/openmpi/riscv64.patch
+++ b/openmpi/riscv64.patch
@@ -1,29 +1,31 @@
+diff --git PKGBUILD PKGBUILD
+index 9f20f76..8ef9db8 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -21,18 +21,15 @@ depends=(
-   zlib
- )
+@@ -15,7 +15,6 @@
+ url='https://www.open-mpi.org'
+ license=('BSD-3-Clause AND LicenseRef-MPICH')
  makedepends=(
 -  cuda
    gcc-fortran
-   inetutils
-   valgrind
- )
- optdepends=(
--  'cuda: cuda support'
-   'gcc-fortran: fortran support'
-   'perl: for aggregate_profile.pl and profile2mat.pl'
- )
- provides=(
--  libmca_common_cuda.so
-   libmca_common_monitoring.so
-   libmca_common_ompio.so
-   libmca_common_sm.so
-@@ -70,7 +67,6 @@ build() {
+   gcc-libs
+   glibc
+@@ -62,10 +61,6 @@
      --enable-pretty-print-stacktrace
      --libdir=/usr/lib
-     --sysconfdir=/etc/$pkgname
+     --sysconfdir=/etc/$pkgbase
 -    --with-cuda=/opt/cuda
+-    # this tricks the configure script to look for /usr/lib/pkgconfig/cuda.pc
+-    # instead of /opt/cuda/lib/pkgconfig/cuda.pc
+-    --with-cuda-libdir=/usr/lib
+     --with-rocm=/opt/rocm
      --with-hwloc=external
      --with-libevent=external
-     --with-pmix=external
+@@ -105,7 +100,6 @@
+     zlib
+   )
+   optdepends=(
+-    'cuda: cuda support'
+     'hip-runtime-amd: ROCm support'
+     'gcc-fortran: fortran support'
+   )


### PR DESCRIPTION
Build after #3533 (hip-runtime-amd) builds.