### PR TITLE
blacklist: add hsa-amd-aqlprofile-bin

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -4,6 +4,7 @@ cudnn
 dart
 discord
 discord-canary
+hsa-amd-aqlprofile-bin
 nvidia
 nvidia-cg-toolkit
 nvidia-dkms


### PR DESCRIPTION
It is not open-source. https://github.com/ROCm/ROCm/issues/1781