### PR TITLE
addpatch: rocm-hip-sdk 6.0.0-1

### DIFF
--- a/rocm-hip-sdk/riscv64.patch
+++ b/rocm-hip-sdk/riscv64.patch
@@ -1,0 +1,20 @@
+diff --git PKGBUILD PKGBUILD
+index 78ca5d9..1bac19d 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -1,13 +1,9 @@
+ # Maintainer: Torsten Keßler <tpkessler at archlinux dot org>
+ 
+ pkgbase=rocm-hip-sdk
+-pkgname=(rocm-hip-sdk
+-         rocm-hip-libraries
+-         rocm-opencl-sdk
++pkgname=(rocm-opencl-sdk
+          rocm-hip-runtime
+-         rocm-language-runtime
+-         rocm-ml-sdk
+-         rocm-ml-libraries)
++         rocm-language-runtime)
+ pkgver=6.0.0
+ pkgrel=1
+ arch=('x86_64')


### PR DESCRIPTION
Only enable the split packages we can have currently, as our `rocm-llvm` is broken and we will not have the full sdk for a while.
This can unblock packages like `openmpi`.