### PR TITLE
updpatch: helm 3.14.0-1

### DIFF
--- a/helm/add-riscv64-build.patch
+++ b/helm/add-riscv64-build.patch
@@ -57,24 +57,3 @@ index 39657b8c..f9ba5e35 100644
  github.com/karrick/godirwalk v1.16.1 h1:DynhcF+bztK8gooS0+NDJFrdNZjJ3gzVzC545UNA9iw=
  github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
  github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-diff --git a/pkg/plugin/plugin_test.go b/pkg/plugin/plugin_test.go
-index abbc90f7..1ec2d530 100644
---- a/pkg/plugin/plugin_test.go
-+++ b/pkg/plugin/plugin_test.go
-@@ -91,6 +91,7 @@ func TestPlatformPrepareCommand(t *testing.T) {
- 				{OperatingSystem: "linux", Architecture: "arm64", Command: "echo -n linux-arm64"},
- 				{OperatingSystem: "linux", Architecture: "ppc64le", Command: "echo -n linux-ppc64le"},
- 				{OperatingSystem: "linux", Architecture: "s390x", Command: "echo -n linux-s390x"},
-+				{OperatingSystem: "linux", Architecture: "riscv64", Command: "echo -n linux-riscv64"},
- 				{OperatingSystem: "windows", Architecture: "amd64", Command: "echo -n win-64"},
- 			},
- 		},
-@@ -108,6 +109,8 @@ func TestPlatformPrepareCommand(t *testing.T) {
- 		osStrCmp = "linux-ppc64le"
- 	} else if os == "linux" && arch == "s390x" {
- 		osStrCmp = "linux-s390x"
-+	} else if os == "linux" && arch == "riscv64" {
-+		osStrCmp = "linux-riscv64"
- 	} else if os == "windows" && arch == "amd64" {
- 		osStrCmp = "win-64"
- 	} else {

--- a/helm/riscv64.patch
+++ b/helm/riscv64.patch
@@ -13,7 +13,7 @@
                'F1261BDE929012C8FF2E501D6EA5D7598529A53E')
 -sha256sums=('SKIP')
 +sha256sums=('SKIP'
-+            '3a7c7c5a32ddd9667a9c6f80278dec75c03706b9bd953430acd528e5663f253f')
++            '0708ba6d62eae84d74c290ad13092ec997aa6883ef80b9854ec8080a5479a2ed')
  
  pkgver() {
    cd "${pkgname}"
@@ -25,3 +25,21 @@
    go mod tidy -compat=1.17
  }
  
+@@ -39,7 +42,7 @@ build() {
+     export CGO_CFLAGS="$CFLAGS"
+     export CGO_CXXFLAGS="$CXXFLAGS"
+     export CGO_CPPFLAGS="$CPPFLAGS"
+-    make EXT_LDFLAGS="-linkmode external" GOFLAGS="-buildmode=pie -trimpath"
++    make EXT_LDFLAGS="-linkmode external" GOFLAGS="-buildmode=pie -trimpath" CGO_ENABLED=1
+ }
+ 
+ check(){
+@@ -48,7 +51,7 @@ check(){
+     export CGO_CFLAGS="$CFLAGS"
+     export CGO_CXXFLAGS="$CXXFLAGS"
+     export CGO_CPPFLAGS="$CPPFLAGS"
+-    make LDFLAGS="-s -w -linkmode external" GOFLAGS="-buildmode=pie -trimpath" test-unit || true
++    make LDFLAGS="-s -w -linkmode external" GOFLAGS="-buildmode=pie -trimpath" CGO_ENABLED=1 test-unit || true
+ }
+ 
+ package(){


### PR DESCRIPTION
riscv go external linking needs CGO_ENABLED=1 explicitly.