### PR TITLE
updpatch: espflash 2.1.0-2

### DIFF
--- a/espflash/riscv64.patch
+++ b/espflash/riscv64.patch
@@ -1,13 +1,16 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -17,7 +17,9 @@ b2sums=('e7fb0b8abc7f0c6e0fd82b8b4b035174eb8ec56f9578d3d5b5f2477b5a1eac23cc68984
-
+@@ -27,6 +27,8 @@ b2sums=('f4361c5c8f7d31d10cf22c67723847b1597c6ca307c67aa76e9b1620e9f3bb0a18b9f03
+ 
  prepare() {
-   cd ${pkgbase}-${pkgver}
--  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
+   cd ${pkgname}-${pkgver}
 +  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
 +  cargo update -p ring
-+  cargo fetch --locked
+   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
  }
-
- build() {
+ 
+@@ -58,4 +60,3 @@ package() {
+   install -Dm 644 -t "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE-*
+ }
+ 
+-# vim: ts=2 sw=2 et:


### PR DESCRIPTION
Fix rotten. Upstream fixed ring, but new version has not been released yet.