### PR TITLE
upgpatch: go 2:1.22.0-1

### DIFF
--- a/go/riscv64.patch
+++ b/go/riscv64.patch
@@ -1,6 +1,8 @@
+diff --git PKGBUILD PKGBUILD
+index 1508dca..ba2529b 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -30,8 +30,7 @@ sha256sums=('4d196c3d41a0d6c1dfc64d04e3cc1f608b0c436bd87b7060ce3e23234e1f4d5c'
+@@ -30,8 +30,7 @@
              'SKIP')
  
  build() {
@@ -10,7 +12,7 @@
    export GOROOT_FINAL=/usr/lib/go
    export GOROOT_BOOTSTRAP=/usr/lib/go
  
-@@ -50,7 +49,7 @@ package() {
+@@ -50,7 +49,7 @@
    cd "$pkgname"
  
    install -d "$pkgdir/usr/bin" "$pkgdir/usr/lib/go" "$pkgdir/usr/share/doc/go" \
@@ -19,3 +21,15 @@
  
    cp -a bin pkg src lib misc api test "$pkgdir/usr/lib/go"
    # We can't strip all binaries and libraries,
+@@ -77,4 +76,11 @@
+   install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+ }
+ 
++source+=(go-generate-local-text-symbols-for-R_RISCV_CALL.patch.base64::https://go-review.googlesource.com/changes/go~567375/revisions/1/patch?download)
++sha256sums+=('cbd6ed24a58512121b61d828730a1d0be0a8541a916dd5d0842b23af250863eb')
++
++prepare() {
++  base64 -d go-generate-local-text-symbols-for-R_RISCV_CALL.patch.base64 | patch -Np1 -d "$pkgname"
++}
++
+ # vim: ts=2 sw=2 et


### PR DESCRIPTION
Backport https://go-review.googlesource.com/c/go/+/567375

Fixes the following error for many packages:
```text
# command-line-arguments
failed to find text symbol for HI20 relocation at 16198024 (f72988)
github.com/aws/aws-sdk-go/aws/endpoints.init: unsupported obj reloc 62 (R_RISCV_CALL)/8 to runtime.morestack_noctxt
failed to find text symbol for HI20 relocation at 16198076 (f729bc)
github.com/aws/aws-sdk-go/aws/endpoints.init: unsupported obj reloc 62 (R_RISCV_CALL)/8 to regexp.MustCompile
failed to find text symbol for HI20 relocation at 16198096 (f729d0)
github.com/aws/aws-sdk-go/aws/endpoints.init: unsupported obj reloc 62 (R_RISCV_CALL)/8 to runtime.gcWriteBarrier2
failed to find text symbol for HI20 relocation at 16198128 (f729f0)
github.com/aws/aws-sdk-go/aws/endpoints.init: unsupported obj reloc 62 (R_RISCV_CALL)/8 to github.com/aws/aws-sdk-go/aws/endpoints.map.init.0
failed to find text symbol for HI20 relocation at 16198136 (f729f8)
github.com/aws/aws-sdk-go/aws/endpoints.init: unsupported obj reloc 62 (R_RISCV_CALL)/8 to github.com/aws/aws-sdk-go/aws/endpoints.init.func1
failed to find text symbol for HI20 relocation at 16198156 (f72a0c)
github.com/aws/aws-sdk-go/aws/endpoints.init: unsupported obj reloc 62 (R_RISCV_CALL)/8 to runtime.gcWriteBarrier2
failed to find text symbol for HI20 relocation at 16198188 (f72a2c)
github.com/aws/aws-sdk-go/aws/endpoints.init: unsupported obj reloc 62 (R_RISCV_CALL)/8 to runtime.makemap_small
failed to find text symbol for HI20 relocation at 16198228 (f72a54)
github.com/aws/aws-sdk-go/aws/endpoints.init: unsupported obj reloc 62 (R_RISCV_CALL)/8 to runtime.duffzero
failed to find text symbol for HI20 relocation at 16198280 (f72a88)
github.com/aws/aws-sdk-go/aws/endpoints.init: unsupported obj reloc 62 (R_RISCV_CALL)/8 to runtime.newobject
failed to find text symbol for HI20 relocation at 16198356 (f72ad4)
github.com/aws/aws-sdk-go/aws/endpoints.init: unsupported obj reloc 62 (R_RISCV_CALL)/8 to runtime.newobject
failed to find text symbol for HI20 relocation at 16198448 (f72b30)
/usr/lib/go/pkg/tool/linux_riscv64/link: too many errors
```