### PR TITLE
qemu-user-blacklist: remove neovim-qt

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -74,7 +74,6 @@ menyoki
 mkvtoolnix
 mold
 neochat
-neovim-qt
 nextcloud-client
 ninja
 nodejs-lts-gallium


### PR DESCRIPTION
Arch removed `check()`: https://gitlab.archlinux.org/archlinux/packaging/packages/neovim-qt/-/commit/55a4a0c73d9ddc308448eb449e7202d31927042b