### PR TITLE
updpatch: mkinitcpio 38-4

### DIFF
--- a/mkinitcpio/riscv64.patch
+++ b/mkinitcpio/riscv64.patch
@@ -1,31 +1,31 @@
-diff --git PKGBUILD PKGBUILD
-index cf4eae5..3e41958 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -21,15 +21,23 @@ optdepends=('gzip: Use gzip compression for the initramfs image'
-             'mkinitcpio-nfs-utils: Support for root filesystem on NFS')
+@@ -28,14 +28,17 @@ optdepends=('gzip: Use gzip compression for the initramfs image'
  provides=('initramfs')
  backup=('etc/mkinitcpio.conf')
--source=("https://sources.archlinux.org/other/$pkgname/$pkgname-$pkgver.tar.gz"{,.sig})
-+source=("https://sources.archlinux.org/other/$pkgname/$pkgname-$pkgver.tar.gz"{,.sig}
-+        $pkgname-pci-controller.patch::https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/merge_requests/264.patch)
+ source=("https://sources.archlinux.org/other/$pkgname/$pkgname-$pkgver.tar.gz"{,.sig}
+-        "$pkgname-fix-path.patch::https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/commit/aced07e06b9b274439eeb90e235edf42780b4a7a.patch")
++        "$pkgname-fix-path.patch::https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/commit/aced07e06b9b274439eeb90e235edf42780b4a7a.patch"
++        "fix-bash-completion-for-non-x86.patch::https://gitlab.archlinux.org/archlinux/mkinitcpio/mkinitcpio/-/commit/6df111b1d41b44895685ffc8d5edebafaa3af446.patch")
  install=mkinitcpio.install
- sha512sums=('f13cfdfee62dc1a344b75413fde8f35eb594c4c372d4a2ed8bbc22f2c01d93ea59d423807d06d19a6d1789e47b35286845daffeffef0fec4bae022e0e92b7b64'
--            'SKIP')
-+            'SKIP'
-+            '65f85d1a69dfe9f42b093a185686a1a790a5b3cea170a3128027a72d1a515d389ae063a11f445b57bff4b3db0b981321ef1dc24a01a905114b19be03d5341a2f')
- b2sums=('b60d8e61a15167df3316a7336467740efd4888784228dd6a08b1d974c54c479c082ba142eb60d3f356b06053e5c472f747e0ca830d50bed9f31c13d52b549ca1'
--        'SKIP')
-+        'SKIP'
-+        'b888c6ded798021ecccd7a2dd96097110fec9b45b696a6d0e598838b522f2a79a290e6a9c4ed0d2f492651cbf28b457fccb829321bb4c383b40506b18c9ca0dd')
+ sha512sums=('ad1a4895e5cc3a01637f71d96ddb79d7f45708ec7305ffdb874403a1eb3c1743d121f28d93273b91792298eb21bcc0c5d9ef1ab3a3773083d60da5bdaee59d6e'
+             'SKIP'
+-            'b1387deab0199fdb4e4a417b009467cb6f95b2a3f8074858f8a85b46492ebaf420ac028f13d81acb5a675382cccb896cac62f42e26edd82dc1c3a7f48d4d822b')
++            'b1387deab0199fdb4e4a417b009467cb6f95b2a3f8074858f8a85b46492ebaf420ac028f13d81acb5a675382cccb896cac62f42e26edd82dc1c3a7f48d4d822b'
++            'aac1edf8d96807fb86fb029a5dc30bfc8ead77764c37a0a994a581bb007c0c76a92f87bdea4614eabf07c5c5e44bd31ab7d72d49d566ddbe6c5198de05af0f76')
+ b2sums=('4bc50da7196a69dc0ab7e7de345684baebbb655f9a07def9ac36a7f1c9aec752cf41c62134d6bbf240d8f49c6492a211f152bab062ec09457791d7ab030f1bc5'
+         'SKIP'
+-        '4530828b559c08aa14f3663b8a078c71bb739adcbd1dfbf21947cfe837ec51fc8ed7e7586c53a4e0ee4b7d86784acab5edf916c387e7385a78fe98c825177fa9')
++        '4530828b559c08aa14f3663b8a078c71bb739adcbd1dfbf21947cfe837ec51fc8ed7e7586c53a4e0ee4b7d86784acab5edf916c387e7385a78fe98c825177fa9'
++        '6dac1d159d28bcccdc90b8189ccab1ba665586ab95c317fd0b1c39ddbb47af11629f0918d63056ce0543a235ee72f38c0441c8ba52e59dc9063461e580f13e33')
  validpgpkeys=('ECCAC84C1BA08A6CC8E63FBBF22FB1D78A77AEAB'    # Giancarlo Razzolini
                'C100346676634E80C940FB9E9C02FF419FECBE16')   # Morten Linderud
  
-+prepare() {
-+  cd "$pkgname-$pkgver"
-+  patch -Np1 -i ../$pkgname-pci-controller.patch
-+}
-+
- check() {
-   make -C "$pkgname-$pkgver" check
+@@ -43,6 +46,7 @@ validpgpkeys=('ECCAC84C1BA08A6CC8E63FBBF22FB1D78A77AEAB'    # Giancarlo Razzolin
+ prepare() {
+   cd "${pkgname}-${pkgver}"
+   patch -Np1 < "$srcdir/mkinitcpio-fix-path.patch"
++  patch -Np1 < "$srcdir/fix-bash-completion-for-non-x86.patch"
  }
+ 
+ check() {


### PR DESCRIPTION
- Remove merged pci controller patch.
- Backport to fix bash-completion test.