### PR TITLE
addpatch: pycharm-community-edition 2023.3.4-1

### DIFF
--- a/pycharm-community-edition/intellij-riscv64.patch
+++ b/pycharm-community-edition/intellij-riscv64.patch
@@ -1,0 +1,344 @@
+--- platform/util/src/com/intellij/util/system/CpuArch.java.orig	2024-03-10 23:22:32.793159479 -0400
++++ platform/util/src/com/intellij/util/system/CpuArch.java	2024-03-10 23:24:10.739939803 -0400
+@@ -12,7 +12,7 @@
+ import org.jetbrains.annotations.Nullable;
+ 
+ public enum CpuArch {
+-  X86(32), X86_64(64), ARM32(32), ARM64(64), OTHER(0), UNKNOWN(0);
++  X86(32), X86_64(64), ARM32(32), ARM64(64), RISCV64(64), OTHER(0), UNKNOWN(0);
+ 
+   /**
+    * Machine word size, in bits.
+@@ -40,6 +40,7 @@
+     if ("x86_64".equals(arch) || "amd64".equals(arch)) return X86_64;
+     if ("i386".equals(arch) || "x86".equals(arch)) return X86;
+     if ("aarch64".equals(arch) || "arm64".equals(arch)) return ARM64;
++    if ("riscv64".equals(arch)) return RISCV64;
+     return arch == null || arch.trim().isEmpty() ? UNKNOWN : OTHER;
+   }
+ 
+@@ -47,6 +48,7 @@
+   public static boolean isIntel64() { return CURRENT == X86_64; }
+   public static boolean isArm32() { return CURRENT == ARM32; }
+   public static boolean isArm64() { return CURRENT == ARM64; }
++  public static boolean isRiscv64() { return CURRENT == RISCV64; }
+ 
+   public static boolean is32Bit() { return CURRENT.width == 32; }
+ 
+--- platform/build-scripts/src/org/jetbrains/intellij/build/JvmArchitecture.kt.orig	2024-03-10 23:18:39.236221794 -0400
++++ platform/build-scripts/src/org/jetbrains/intellij/build/JvmArchitecture.kt	2024-03-10 23:27:41.616851170 -0400
+@@ -5,7 +5,7 @@
+ 
+ @Suppress("EnumEntryName")
+ enum class JvmArchitecture(@JvmField val archName: String, @JvmField val fileSuffix: String, @JvmField val dirName: String) {
+-  x64("X86_64", "64", "amd64"), aarch64("AArch64", "aarch64", "aarch64");
++  x64("X86_64", "64", "amd64"), aarch64("AArch64", "aarch64", "aarch64"), riscv64("RISC-V64", "riscv64", "riscv64");
+ 
+   companion object {
+     @JvmField
+@@ -15,6 +15,7 @@
+     val currentJvmArch: JvmArchitecture = when {
+       CpuArch.isArm64() -> aarch64
+       CpuArch.isIntel64() -> x64
++      CpuArch.isRiscv64() -> riscv64
+       else -> throw IllegalStateException("Unsupported arch: " + CpuArch.CURRENT)
+     }
+   }
+--- platform/build-scripts/src/org/jetbrains/intellij/build/product-info.schema.json.orig	2024-03-11 08:35:18.271942803 -0400
++++ platform/build-scripts/src/org/jetbrains/intellij/build/product-info.schema.json	2024-03-11 08:35:38.298631506 -0400
+@@ -59,7 +59,7 @@
+           "arch": {
+             "description": "CPU Architecture this launch method is supposed to be used for",
+             "type": "string",
+-            "enum": ["amd64", "aarch64"]
++            "enum": ["amd64", "aarch64", "riscv64"]
+           },
+           "launcherPath": {
+             "description": "Path to an executable file which starts the IDE (relative to the parent directory of this file, '/' as a separator, may start with '../'), e.g. 'bin/idea.sh'",
+--- platform/build-scripts/src/org/jetbrains/intellij/build/impl/LinuxDistributionBuilder.kt.orig	2024-03-11 10:48:52.277534601 -0400
++++ platform/build-scripts/src/org/jetbrains/intellij/build/impl/LinuxDistributionBuilder.kt	2024-03-11 08:13:33.247172780 -0400
+@@ -47,7 +47,7 @@
+       withContext(Dispatchers.IO) {
+         val distBinDir = targetPath.resolve("bin")
+         val sourceBinDir = context.paths.communityHomeDir.resolve("bin/linux")
+-        copyFileToDir(NativeBinaryDownloader.downloadRestarter(context = context, os = OsFamily.LINUX, arch = arch), distBinDir)
++        copyFileToDir(sourceBinDir.resolve("../../native/restarter/target/release/restarter"), distBinDir)
+         copyFileToDir(sourceBinDir.resolve("${arch.dirName}/fsnotifier"), distBinDir)
+         copyFileToDir(sourceBinDir.resolve("${arch.dirName}/libdbm.so"), distBinDir)
+         generateBuildTxt(context, targetPath)
+@@ -91,33 +91,6 @@
+           }
+         }
+       }
+-
+-      val runtimeDir = context.bundledRuntime.extract(os = OsFamily.LINUX, arch = arch)
+-      updateExecutablePermissions(runtimeDir, executableFileMatchers)
+-      val tarGzPath = buildTarGz(arch = arch, runtimeDir = runtimeDir, unixDistPath = osAndArchSpecificDistPath, suffix = suffix(arch))
+-      launch {
+-        if (arch == JvmArchitecture.x64) {
+-          buildSnapPackage(runtimeDir = runtimeDir, unixDistPath = osAndArchSpecificDistPath, arch = arch)
+-        }
+-        else {
+-          // TODO: Add snap for aarch64
+-          Span.current().addEvent("skip building Snap packages for non-x64 arch")
+-        }
+-      }
+-
+-      if (!context.isStepSkipped(BuildOptions.REPAIR_UTILITY_BUNDLE_STEP)) {
+-        val tempTar = Files.createTempDirectory(context.paths.tempDir, "tar-")
+-        try {
+-          unTar(tarGzPath, tempTar)
+-          RepairUtilityBuilder.generateManifest(context = context,
+-                                                unpackedDistribution = tempTar.resolve(rootDirectoryName),
+-                                                os = OsFamily.LINUX,
+-                                                arch = arch)
+-        }
+-        finally {
+-          NioFiles.deleteRecursively(tempTar)
+-        }
+-      }
+     }
+   }
+ 
+--- platform/build-scripts/src/org/jetbrains/intellij/build/impl/MacDistributionBuilder.kt.orig	2024-03-10 23:55:33.418786750 -0400
++++ platform/build-scripts/src/org/jetbrains/intellij/build/impl/MacDistributionBuilder.kt	2024-03-10 23:56:30.068851572 -0400
+@@ -555,6 +555,7 @@
+   else when (arch) {
+     JvmArchitecture.x64 -> listOf("x86_64")
+     JvmArchitecture.aarch64 -> listOf("arm64")
++    JvmArchitecture.riscv64 -> listOf("riscv64")
+   }).joinToString(separator = "\n      ") { "<string>${it}</string>" }
+ 
+   val todayYear = LocalDate.now().year.toString()
+@@ -587,4 +588,4 @@
+ }
+ 
+ internal val ProductProperties.targetIcnsFileName: String
+-  get() = "$baseFileName.icns"
+\ No newline at end of file
++  get() = "$baseFileName.icns"
+--- platform/build-scripts/src/org/jetbrains/intellij/build/impl/BundledRuntimeImpl.kt.orig	2024-03-10 23:40:04.994380447 -0400
++++ platform/build-scripts/src/org/jetbrains/intellij/build/impl/BundledRuntimeImpl.kt	2024-03-10 23:40:41.921089963 -0400
+@@ -167,6 +167,7 @@
+   return when (arch) {
+     JvmArchitecture.x64 -> "x64"
+     JvmArchitecture.aarch64 -> "aarch64"
++    JvmArchitecture.riscv64 -> "riscv64"
+   }
+ }
+ 
+@@ -222,4 +223,4 @@
+       return FileVisitResult.CONTINUE
+     }
+   })
+-}
+\ No newline at end of file
++}
+--- platform/build-scripts/src/org/jetbrains/intellij/build/impl/nativeLib.kt.orig	2024-03-11 05:45:43.374533754 -0400
++++ platform/build-scripts/src/org/jetbrains/intellij/build/impl/nativeLib.kt	2024-03-11 05:49:28.201418594 -0400
+@@ -146,7 +146,7 @@
+  * Represent CPU architecture for which native code was built.
+  */
+ private enum class NativeFileArchitecture(val jvmArch: JvmArchitecture?) {
+-  X_64(JvmArchitecture.x64), AARCH_64(JvmArchitecture.aarch64),
++  X_64(JvmArchitecture.x64), AARCH_64(JvmArchitecture.aarch64), RISCV_64(JvmArchitecture.riscv64),
+ 
+   // Universal native file can be used by any platform
+   UNIVERSAL(null);
+@@ -161,6 +161,9 @@
+   val osAndArch = path.indexOf('/').takeIf { it != -1 }?.let { path.substring(0, it) }
+   if (osAndArch != null) {
+     when {
++      osAndArch.endsWith("-riscv64") || path.contains("/riscv64/") -> {
++        return RISCV_64
++      }
+       osAndArch.endsWith("-aarch64") || path.contains("/aarch64/") -> {
+         return AARCH_64
+       }
+@@ -180,6 +183,9 @@
+   // try to detect architecture from file name e.g. "libskiko-macos-arm64.dylib"
+   // otherwise return null
+   return when {
++    fileName.contains("riscv64") -> {
++      return RISCV_64
++    }
+     fileName.contains("arm64") -> {
+       return AARCH_64
+     }
+--- platform/build-scripts/src/org/jetbrains/intellij/build/impl/BuildTasksImpl.kt.orig	2024-03-11 05:48:52.391383843 -0400
++++ platform/build-scripts/src/org/jetbrains/intellij/build/impl/BuildTasksImpl.kt	2024-03-11 05:52:42.934941428 -0400
+@@ -180,6 +180,7 @@
+   SupportedDistribution(os = OsFamily.WINDOWS, arch = JvmArchitecture.aarch64),
+   SupportedDistribution(os = OsFamily.LINUX, arch = JvmArchitecture.x64),
+   SupportedDistribution(os = OsFamily.LINUX, arch = JvmArchitecture.aarch64),
++  SupportedDistribution(os = OsFamily.LINUX, arch = JvmArchitecture.riscv64),
+ )
+ 
+ private fun isSourceFile(path: String): Boolean {
+--- platform/build-scripts/src/org/jetbrains/intellij/build/impl/sbom/SoftwareBillOfMaterialsImpl.kt.orig	2024-03-10 23:41:22.504470389 -0400
++++ platform/build-scripts/src/org/jetbrains/intellij/build/impl/sbom/SoftwareBillOfMaterialsImpl.kt	2024-03-11 08:58:34.520145791 -0400
+@@ -273,14 +273,17 @@
+       OsFamily.LINUX -> when (arch) {
+         JvmArchitecture.aarch64 -> "linuxarm64"
+         JvmArchitecture.x64 -> "linux64"
++        JvmArchitecture.riscv64 -> "linuxriscv64"
+       }
+       OsFamily.MACOS -> when (arch) {
+         JvmArchitecture.aarch64 -> "macosarm64"
+         JvmArchitecture.x64 -> "macosx64"
++        JvmArchitecture.riscv64 -> "macosriscv64"
+       }
+       OsFamily.WINDOWS -> when (arch) {
+         JvmArchitecture.aarch64 -> "windowsarm64"
+         JvmArchitecture.x64 -> "windows64"
++        JvmArchitecture.riscv64 -> "windowsriscv64"
+       }
+     }
+     val cefArchive = "cef_binary_${cefVersion}_$cefSuffix.tar.bz2"
+@@ -348,7 +351,7 @@
+       document.documentDescribes.add(rootPackage)
+       generate(
+         document, rootPackage,
+-        runtimePackage = document.runtimePackage(os, arch),
++        runtimePackage = null,
+         distributionDir = distributionDir,
+         // distributions weren't built
+         claimContainedFiles = false
+@@ -821,4 +824,4 @@
+       }
+     }
+   }
+-}
+\ No newline at end of file
++}
+--- platform/build-scripts/downloader/src/org/jetbrains/intellij/build/dependencies/JdkDownloader.kt.orig	2024-03-11 00:15:03.856779724 -0400
++++ platform/build-scripts/downloader/src/org/jetbrains/intellij/build/dependencies/JdkDownloader.kt	2024-03-11 00:32:19.094598626 -0400
+@@ -1,9 +1,11 @@
+ // Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+ package org.jetbrains.intellij.build.dependencies
+ 
++import java.lang.System;
+ import java.net.URI
+ import java.nio.file.Files
+ import java.nio.file.Path
++import java.nio.file.Paths
+ import java.util.logging.Logger
+ 
+ /**
+@@ -26,17 +28,8 @@
+ 
+   fun getJdkHome(communityRoot: BuildDependenciesCommunityRoot, os: OS, arch: Arch, infoLog: (String) -> Unit): Path {
+     val jdkUrl = getUrl(communityRoot, os, arch)
+-    val jdkArchive = BuildDependenciesDownloader.downloadFileToCacheLocation(communityRoot, jdkUrl)
+-    val jdkExtracted = BuildDependenciesDownloader.extractFileToCacheLocation(
+-      communityRoot, jdkArchive, BuildDependenciesExtractOptions.STRIP_ROOT)
+-    infoLog("jps-bootstrap JDK is at $jdkExtracted")
+ 
+-    val jdkHome: Path = if (os == OS.MACOSX) {
+-      jdkExtracted.resolve("Contents").resolve("Home")
+-    }
+-    else {
+-      jdkExtracted
+-    }
++    val jdkHome: Path = Paths.get(System.getenv("JAVA_HOME"))
+     val executable = getJavaExecutable(jdkHome)
+     infoLog("JDK home is at $jdkHome, executable at $executable")
+     return jdkHome
+@@ -63,6 +56,7 @@
+     val archString: String = when (arch) {
+       Arch.X86_64 -> "x64"
+       Arch.ARM64 -> "aarch64"
++      Arch.RISCV64 -> "riscv64"
+     }
+ 
+     val dependenciesProperties = BuildDependenciesDownloader.getDependenciesProperties(communityRoot)
+@@ -97,7 +91,8 @@
+ 
+   enum class Arch {
+     X86_64,
+-    ARM64;
++    ARM64,
++    RISCV64;
+ 
+     companion object {
+       val current: Arch
+@@ -105,6 +100,7 @@
+           val arch = System.getProperty("os.arch").lowercase()
+           if ("x86_64" == arch || "amd64" == arch) return X86_64
+           if ("aarch64" == arch || "arm64" == arch) return ARM64
++          if ("riscv64" == arch) return RISCV64;
+           throw IllegalStateException("Only X86_64 and ARM64 are supported, current arch: $arch")
+         }
+     }
+--- platform/jps-bootstrap/jps-bootstrap.sh.orig	2024-03-10 21:46:03.369699281 -0400
++++ platform/jps-bootstrap/jps-bootstrap.sh	2024-03-10 21:55:48.790397679 -0400
+@@ -96,6 +96,9 @@
+       aarch64)
+         JBR_ARCH=linux-aarch64
+         ;;
++      riscv64)
++        JBR_ARCH=linux-riscv64
++        ;;
+       *)
+         die "Unknown architecture $(uname -m)"
+         ;;
+@@ -111,31 +114,10 @@
+     # Everything is up-to-date in $JVM_TARGET_DIR, do nothing
+     true
+ else
+-  JVM_TEMP_FILE=$(mktemp "$JPS_BOOTSTRAP_PREPARE_DIR/jvm.tar.gz.XXXXXXXXX")
+-  trap 'echo "Removing $JVM_TEMP_FILE"; rm -f "$JVM_TEMP_FILE"; trap - EXIT' EXIT INT HUP
+-
+-  warn "Downloading $JVM_URL to $JVM_TEMP_FILE"
+-
+-  if command -v curl >/dev/null 2>&1; then
+-      if [ -t 1 ]; then CURL_PROGRESS="--progress-bar"; else CURL_PROGRESS=""; fi
+-      CURL_OPTIONS="-fsSL"
+-      if [ "${JBR_DOWNLOAD_CURL_VERBOSE:-false}" = "true" ]; then CURL_OPTIONS="-fvL"; fi
+-      # CURL_PROGRESS may be empty, with quotes this interpreted by curl as malformed URL
+-      # shellcheck disable=SC2086
+-      expBackOffRetry curl "$CURL_OPTIONS" $CURL_PROGRESS --output "${JVM_TEMP_FILE}" "$JVM_URL"
+-  elif command -v wget >/dev/null 2>&1; then
+-      if [ -t 1 ]; then WGET_PROGRESS=""; else WGET_PROGRESS="-nv"; fi
+-      expBackOffRetry wget $WGET_PROGRESS -O "${JVM_TEMP_FILE}" "$JVM_URL"
+-  else
+-      die "ERROR: Please install wget or curl"
+-  fi
+-
+-  warn "Extracting $JVM_TEMP_FILE to $JVM_TARGET_DIR"
+   rm -rf "$JVM_TARGET_DIR"
+   mkdir -p "$JVM_TARGET_DIR"
+ 
+-  tar -x -f "$JVM_TEMP_FILE" -C "$JVM_TARGET_DIR"
+-  rm -f "$JVM_TEMP_FILE"
++  ln -sf /usr/lib/jvm/java-17-openjdk "$JVM_TARGET_DIR"
+ 
+   echo "$JVM_URL" >"$JVM_TARGET_DIR/.flag"
+ fi
+--- platform/sqlite/make.sh.orig	2024-03-11 10:30:57.012981543 -0400
++++ platform/sqlite/make.sh	2024-03-11 10:31:57.739717024 -0400
+@@ -27,7 +27,7 @@
+   libFilename="libsqliteij.so"
+ 
+   # cannot compile arm - unable to find library -lgcc, so, use dock cross
+-  if [ "$ARCH" == "aarch64" ]; then
++  if [ "$ARCH" == "aarch64" ] || [ "$ARCH" == "riscv64" ]; then
+     linkFlags+=" -shared"
+   else
+     cFlags+=" --target=$ARCH-unknown-linux-gnu --sysroot=target/linux-$ARCH"
+--- native/LinuxGlobalMenu/CMakeLists.txt.orig	2024-03-11 07:19:01.466968628 -0400
++++ native/LinuxGlobalMenu/CMakeLists.txt	2024-03-11 07:25:13.334027472 -0400
+@@ -29,10 +29,10 @@
+ find_library(LIB_GOBJ NAMES libgobject-2.0.so.0)
+ MESSAGE("LIB_GOBJ: " ${LIB_GOBJ})
+ 
+-# use patched library, you may build it from https://github.com/JetBrains/libdbusmenu
+-set(LIB_DBUSMENU "${PROJECT_SOURCE_DIR}/libdbusmenu-glib.a")
++find_library(LIB_DBUSMENU NAMES libdbusmenu-glib.so.4)
++MESSAGE("LIB_DBUSMENU: " ${LIB_DBUSMENU})
+ 
+-set(GLIB_INCLUDE_DIRS /usr/include/glib-2.0 /usr/lib64/glib-2.0/include)
++set(GLIB_INCLUDE_DIRS /usr/include/glib-2.0 /usr/lib64/glib-2.0/include /usr/lib/glib-2.0/include)
+ set(DBUSMENU_GLIB_INCLUDE_DIRS /usr/include/libdbusmenu-glib-0.4)
+ 
+ include_directories(

--- a/pycharm-community-edition/riscv64.patch
+++ b/pycharm-community-edition/riscv64.patch
@@ -1,0 +1,127 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -32,21 +32,46 @@ makedepends=(
+   git
+   "java-environment-openjdk=${_jdkver}"
+   python-setuptools
++  cargo
++  cmake
++  libx11 # header only
+ )
+ source=(
+   "git+https://github.com/JetBrains/intellij-community.git#tag=pycharm/${_build}"
+   idea-android::"git+https://github.com/JetBrains/android.git#tag=pycharm/${_build}"
+   pycharm.desktop
+   pycharm.sh
+-  # enable-no-jdr.patch
++  enable-no-jdr.patch
++  intellij-riscv64.patch
++  # Who knows which commit Jetbrain is using? The following commit works anyway.
++  git+https://github.com/JetBrains/pty4j.git#commit=673a524230c1a46782211e77b1750877b3aa71f7
+ )
+ sha256sums=('SKIP'
+             'SKIP'
+             '70ae8df10243db2dbc454c0d8e273235707ecb1821a9e8a2e70669a1739fc1af'
+-            '447714bf41a215b38f8c31418e09bf65145bb3d9427d6966772c9b2b8ae16f1d')
++            '447714bf41a215b38f8c31418e09bf65145bb3d9427d6966772c9b2b8ae16f1d'
++            'b7858737346fb08423ee7fd177f9e59180d2173d988dd8622b84d58426fcb3a7'
++            '002ebbcef2d9bfc734e025d2dde5e44fdf3d1de1b1a2f41ccddcd50f8cd6ff0e'
++            'SKIP')
++case "$CARCH" in
++  x86_64)
++      _arch=amd64
++      _alt_arch=x86-64
++      _suffix=""
++      ;;
++  *)
++      _arch="$CARCH"
++      _alt_arch="$CARCH"
++      _suffix="-$CARCH"
++      ;;
++esac
+ 
+ prepare() {
+   cd intellij-community
++  patch -Np0 -i ../intellij-riscv64.patch
++  pushd native/restarter
++  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
++  popd
+ 
+   echo ${_build} > build.txt
+   mv "${srcdir}"/idea-android android
+@@ -60,23 +85,54 @@ prepare() {
+   # Fix pycharm python/installer.cmd & python/plugin.cmd
+   # sed 's|intellij.pycharm.community.build|"$(cd "$(dirname "$0")"; pwd)/../" intellij.pycharm.community.build|' -i python/installers.cmd
+   #sed 's|intellij.pycharm.community.build|"$(cd "$(dirname "$0")"; pwd)/../" intellij.pycharm.community.build|' -i python/plugin.cmd
+-  #patch -Np1 < "${srcdir}/enable-no-jdr.patch"
++  patch -Np1 < "${srcdir}/enable-no-jdr.patch"
+   # https://youtrack.jetbrains.com/issue/IDEA-343872/Community-build-performanceTesting-plugin-raises-exceptions
+   git cherry-pick -n -m1 "c2d297177eb31f7fbbc13fdbfb9c8fce48e51014"
+ 
+ }
+ 
+ build() {
++  pushd pty4j/native
++  # That Makefile is a mess and only intended for cross. Let's build manually
++  _cc="gcc $CFLAGS $CPPFLAGS -I.  -D_REENTRANT -D_GNU_SOURCE -fPIC"
++  $_cc -c -o exec_pty.o exec_pty.c
++  $_cc -c -o openpty.o openpty.c
++  $_cc -c -o pfind.o pfind.c
++  gcc $LDFLAGS $CFLAGS -g -shared -Wl,-soname,libpty.so -o libpty.so *.o
++  popd
++
+   cd intellij-community
+ 
++  mkdir -p bin/linux/$_arch
++
++  pushd native/restarter
++  cargo build --frozen --release
++  popd
++  export CC=gcc
++  pushd native/fsNotifier/linux
++  ./make.sh
++  cp fsnotifier ../../../bin/linux/$_arch
++  popd
++
++  pushd native/LinuxGlobalMenu
++  cmake .
++  make
++  cp libdbm.so ../../bin/linux/$_arch
++  popd
++
++  pushd platform/sqlite
++  OS=linux ARCH=$CARCH ./make.sh
++  popd
++
+   export JAVA_HOME="/usr/lib/jvm/java-${_jdkver}-openjdk"
+   export PATH="/usr/lib/jvm/java-${_jdkver}-openjdk/bin:$PATH"
+   export MAVEN_REPOSITORY=/build/.m2/repository
+ 
+-  ./python/installers.cmd -Dintellij.build.use.compiled.classes=false -Dintellij.build.target.os=linux
++  ./python/installers.cmd -Dintellij.build.use.compiled.classes=false -Dintellij.build.target.os=linux \
++    -Dintellij.build.target.arch=${_arch} -Dintellij.build.linux_tar_gz_without_jre=true
+   #./python/plugin.cmd -Dintellij.build.target.os=linux
+ 
+-  tar -xf out/pycharm-ce/artifacts/pycharmPC-${_build}.tar.gz -C "${srcdir}"
++  tar -xf out/pycharm-ce/artifacts/pycharmPC-${_build}-no-jbr${_suffix}.tar.gz -C "${srcdir}"
+ 
+   # Issues with cython and 3.11 -> https://youtrack.jetbrains.com/issues/PY?q=cython%203.11
+   # cd ../pycharm-community-${pkgver}
+@@ -90,11 +146,16 @@ package() {
+   sed -i 's/lcd/on/' bin/*.vmoptions
+ 
+   install -dm 755 "${pkgdir}"/usr/share/{licenses,pixmaps,pycharm}
+-  cp -dr --no-preserve='ownership' bin lib plugins jbr "${pkgdir}"/usr/share/pycharm/
++  cp -dr --no-preserve='ownership' bin lib plugins "${pkgdir}"/usr/share/pycharm/
+   cp -dr --no-preserve='ownership' license "${pkgdir}"/usr/share/licenses/pycharm/
+   ln -s /usr/share/pycharm/bin/pycharm.png "${pkgdir}"/usr/share/pixmaps/
+   install -Dm 644 ../pycharm.desktop -t "${pkgdir}"/usr/share/applications/
+   install -Dm 755 ../pycharm.sh "${pkgdir}"/usr/bin/pycharm
++
++  # riscv64 missing parts
++  install -Dm 755 ../pty4j/native/libpty.so -t "${pkgdir}"/usr/share/pycharm/lib/pty4j/linux/${_alt_arch}
++  install -Dm 755 ../intellij-community/platform/sqlite/target/sqlite/linux-${CARCH}/libsqliteij.so \
++     -t "${pkgdir}"/usr/share/pycharm/lib/native/linux-${CARCH}/
+ }
+ 
+ # vim: ts=2 sw=2 et:


### PR DESCRIPTION
This PR is nearly identical to #3596, except that
Arch is using bundled JBR explicitly, but we have to use system JDK.

Tested on centiskorch

![image](https://github.com/felixonmars/archriscv-packages/assets/18085551/44feb905-f33b-4709-b3e6-adc36caf267c)
