### PR TITLE
updpatch: helm 3.14.2-1

### DIFF
--- a/helm/riscv64.patch
+++ b/helm/riscv64.patch
@@ -25,21 +25,3 @@
    go mod tidy -compat=1.17
  }
  
-@@ -39,7 +42,7 @@ build() {
-     export CGO_CFLAGS="$CFLAGS"
-     export CGO_CXXFLAGS="$CXXFLAGS"
-     export CGO_CPPFLAGS="$CPPFLAGS"
--    make EXT_LDFLAGS="-linkmode external" GOFLAGS="-buildmode=pie -trimpath"
-+    make EXT_LDFLAGS="-linkmode external" GOFLAGS="-buildmode=pie -trimpath" CGO_ENABLED=1
- }
- 
- check(){
-@@ -48,7 +51,7 @@ check(){
-     export CGO_CFLAGS="$CFLAGS"
-     export CGO_CXXFLAGS="$CXXFLAGS"
-     export CGO_CPPFLAGS="$CPPFLAGS"
--    make LDFLAGS="-s -w -linkmode external" GOFLAGS="-buildmode=pie -trimpath" test-unit || true
-+    make LDFLAGS="-s -w -linkmode external" GOFLAGS="-buildmode=pie -trimpath" CGO_ENABLED=1 test-unit || true
- }
- 
- package(){


### PR DESCRIPTION
- Arch x86_64 PM added `export CGO_ENABLED=1`