### PR TITLE
addpatch: k9s

### DIFF
--- a/k9s/riscv64.patch
+++ b/k9s/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -22,6 +22,7 @@ pkgver() {
+ 
+ build() {
+   cd $pkgname
++  export CGO_ENABLED=1
+   export CGO_LDFLAGS="${LDFLAGS}"
+   export CGO_CFLAGS="${CFLAGS}"
+   export CGO_CPPFLAGS="${CPPFLAGS}"


### PR DESCRIPTION
need to explicitly set `CGO_ENABLED=1` under riscv for external linking