### PR TITLE
updpatch: electron{28,29}

### DIFF
--- a/electron28/riscv64.patch
+++ b/electron28/riscv64.patch
@@ -26,7 +26,7 @@
          # BEGIN managed sources
          chromium-mirror::git+https://github.com/chromium/chromium.git#tag=120.0.6099.291
 @@ -231,7 +233,7 @@ source=("git+https://github.com/electron/electron.git#tag=v$pkgver"
- sha256sums=('SKIP'
+ sha256sums=('6bbf9f35a03f60153091e195adc4d8729e9d290d220d6e347f42c2343684a2f0'
              'ffee1082fbe3d0c9e79dacb8405d5a0e1aa94d6745089a30b093f647354894d2'
              '3bd35dab1ded5d9e1befa10d5c6c4555fe0a76d909fb724ac57d0bf10cb666c1'
 -            'b3de01b7df227478687d7517f61a777450dca765756002c80c4915f271e2d961'
@@ -34,14 +34,14 @@
              'dd2d248831dd4944d385ebf008426e66efe61d6fdf66f8932c963a12167947b4'
              'b0ac3422a6ab04859b40d4d7c0fd5f703c893c9ec145c9894c468fbc0a4d457c'
              '4484200d90b76830b69eea3a471c103999a3ce86bb2c29e6c14c945bf4102bae'
-@@ -239,6 +241,7 @@ sha256sums=('SKIP'
+@@ -239,6 +241,7 @@ sha256sums=('6bbf9f35a03f60153091e195adc4d8729e9d290d220d6e347f42c2343684a2f0'
              '55dbe71dbc1f3ab60bf1fa79f7aea7ef1fe76436b1d7df48728a1f8227d2134e'
              '1808df5ba4d1e2f9efa07ac6b510bec866fa6d60e44505d82aea3f6072105a71'
              'ff588a8a4fd2f79eb8a4f11cf1aa151298ffb895be566c57cc355d47f161f53f'
 +            '98b0fbe1318897954cb8891cafed65e985613c69192e65984ba6785579b29f80'
              '3ae82375ba212c31fd4ba6f1fa4e2445eeca8eb8c952176131ad57c0258db224'
-             'SKIP'
-             'SKIP'
+             '69ed3ac42b71f327c921971e1bef8a04f561f549ad89b4023e6742e4718c6df2'
+             '0b7a546ee6913c49519c10c293ac530ff381641a8a465fa2e184d6dbe0fb784d'
 @@ -437,12 +440,16 @@ prepare() {
    cp -r chromium-mirror_third_party_depot_tools depot_tools
    export PATH+=":$PWD/depot_tools" DEPOT_TOOLS_UPDATE=0
@@ -89,6 +89,11 @@
    # Let Chromium set its own symbol level
    CFLAGS=${CFLAGS/-g }
    CXXFLAGS=${CXXFLAGS/-g }
+@@ -627,3 +641,4 @@ package() {
+   install -Dm644 src/electron/default_app/icon.png \
+           "${pkgdir}/usr/share/pixmaps/${pkgname}.png"  # hicolor has no 1024x1024
+ }
++sha256sums[0]=SKIP
 diff --git compiler-rt-adjust-paths.patch compiler-rt-adjust-paths.patch
 index 0469220..8ee7f55 100644
 --- compiler-rt-adjust-paths.patch

--- a/electron29/riscv64.patch
+++ b/electron29/riscv64.patch
@@ -24,7 +24,7 @@
          # Electron
          default_app-icon.patch
          electron-launcher.sh
-@@ -234,7 +236,8 @@ sha256sums=('SKIP'
+@@ -234,7 +236,8 @@ sha256sums=('0f976ce06a917b3bb49e79e1ac7cd4cc080c6cfc0a0675d97146b41c801ea63b'
              '8c256b2a9498a63706a6e7a55eadbeb8cc814be66a75e49aec3716c6be450c6c'
              '3bd35dab1ded5d9e1befa10d5c6c4555fe0a76d909fb724ac57d0bf10cb666c1'
              'ff588a8a4fd2f79eb8a4f11cf1aa151298ffb895be566c57cc355d47f161f53f'
@@ -71,6 +71,12 @@
    # Let Chromium set its own symbol level
    CFLAGS=${CFLAGS/-g }
    CXXFLAGS=${CXXFLAGS/-g }
+@@ -632,3 +645,5 @@ package() {
+   install -Dm644 src/electron/default_app/icon.png \
+           "${pkgdir}/usr/share/pixmaps/${pkgname}.png"  # hicolor has no 1024x1024
+ }
++
++sha256sums[0]=SKIP
 diff --git compiler-rt-adjust-paths.patch compiler-rt-adjust-paths.patch
 index 0469220..8ee7f55 100644
 --- compiler-rt-adjust-paths.patch


### PR DESCRIPTION
Fix sha256sums[0] with VCS source checksumming,
hopefully in a way that it won't become rotten on every future release.