### PR TITLE
addpatch: cloudflared 2024.1.5-1

### DIFF
--- a/cloudflared/riscv64.patch
+++ b/cloudflared/riscv64.patch
@@ -1,0 +1,20 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -54,7 +54,7 @@ build() {
+     -modcacherw \
+     -ldflags "-compressdwarf=false \
+     -linkmode external \
+-    -extldflags ${LDFLAGS} \
++    -extldflags \"${LDFLAGS}\" \
+       -X main.Version=${pkgver} \
+       -X main.BuildTime=${build_time} \
+       -X github.com/cloudflare/cloudflared/cmd/cloudflared/updater.BuiltForPackageManager=pacman" \
+@@ -65,7 +65,7 @@ build() {
+ check() {
+   cd "$pkgname"
+ 
+-  go test -v -mod=vendor -race ./...
++  go test -v -mod=vendor ./...
+ }
+ 
+ package() {


### PR DESCRIPTION
- ~~Drop `-extldflags` since Go linker on riscv64 does not support most of it~~
- Fix LDFLAGS issue. Upstreamed to https://gitlab.archlinux.org/archlinux/packaging/packages/cloudflared/-/merge_requests/1.
- Remove unsupported `-race` from go test