### PR TITLE
updpatch: gopass 1.15.12-1

### DIFF
--- a/gopass/riscv64.patch
+++ b/gopass/riscv64.patch
@@ -1,10 +1,10 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -17,6 +17,7 @@ sha512sums=('7287731095afa9c3aa033e35752d2404fa8c6599879a0109cdf4f8730a94a917d58
+@@ -18,6 +18,7 @@ sha512sums=('d7e9e830bc37ca2513059f05ead85850705777ec06c6345586a0a141d97a02b8f32
  
  prepare(){
    sed -i 's|-gcflags="-trimpath=$(GOPATH)" -asmflags="-trimpath=$(GOPATH)"||' Makefile
-+  go get github.com/gen2brain/shm@f2460f5984f7701c29006dc35a46d0e36cdab0c5
++  sed -i 's|CGO_ENABLED=0||' Makefile
  }
  
  build(){


### PR DESCRIPTION
- Remove CGO_ENABLED=0 from Makefile. Upstreamed to https://gitlab.archlinux.org/archlinux/packaging/packages/gopass/-/merge_requests/1.
- Drop `go get` as upstream released fix.