### PR TITLE
addpatch: pnpm 8.15.2-2

### DIFF
--- a/pnpm/add-pnpm-linux-riscv64.patch
+++ b/pnpm/add-pnpm-linux-riscv64.patch
@@ -1,0 +1,108 @@
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index 7a25346fb..5160d2e5f 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -4692,6 +4692,9 @@ importers:
+       '@pnpm/linux-arm64':
+         specifier: workspace:*
+         version: link:../linux-arm64
++      '@pnpm/linux-riscv64':
++        specifier: workspace:*
++        version: link:../linux-riscv64
+       '@pnpm/linux-x64':
+         specifier: workspace:*
+         version: link:../linux-x64
+@@ -4721,6 +4724,12 @@ importers:
+         specifier: workspace:*
+         version: 'link:'
+ 
++  pnpm/artifacts/linux-riscv64:
++    devDependencies:
++      '@pnpm/linux-riscv64':
++        specifier: workspace:*
++        version: 'link:'
++
+   pnpm/artifacts/linux-x64:
+     devDependencies:
+       '@pnpm/linux-x64':
+diff --git a/pnpm/artifacts/exe/package.json b/pnpm/artifacts/exe/package.json
+index a0427ab7f..d27fd0daa 100644
+--- a/pnpm/artifacts/exe/package.json
++++ b/pnpm/artifacts/exe/package.json
+@@ -13,6 +13,7 @@
+   },
+   "optionalDependencies": {
+     "@pnpm/linux-arm64": "workspace:*",
++    "@pnpm/linux-riscv64": "workspace:*",
+     "@pnpm/linux-x64": "workspace:*",
+     "@pnpm/macos-arm64": "workspace:*",
+     "@pnpm/macos-x64": "workspace:*",
+diff --git a/pnpm/artifacts/linux-riscv64/.gitignore b/pnpm/artifacts/linux-riscv64/.gitignore
+new file mode 100644
+index 000000000..84e907ed6
+--- /dev/null
++++ b/pnpm/artifacts/linux-riscv64/.gitignore
+@@ -0,0 +1 @@
++pnpm
+\ No newline at end of file
+diff --git a/pnpm/artifacts/linux-riscv64/.npmignore b/pnpm/artifacts/linux-riscv64/.npmignore
+new file mode 100644
+index 000000000..3a2d9d511
+--- /dev/null
++++ b/pnpm/artifacts/linux-riscv64/.npmignore
+@@ -0,0 +1 @@
++nodes
+diff --git a/pnpm/artifacts/linux-riscv64/CHANGELOG.md b/pnpm/artifacts/linux-riscv64/CHANGELOG.md
+new file mode 100644
+index 000000000..e311adc93
+--- /dev/null
++++ b/pnpm/artifacts/linux-riscv64/CHANGELOG.md
+@@ -0,0 +1,7 @@
++# @pnpm/linux-riscv64
++
++## 7.1.8
++
++### Patch Changes
++
++- 7fb1ac0e4: Fix pre-compiled pnpm binaries crashing when NODE_MODULES is set.
+diff --git a/pnpm/artifacts/linux-riscv64/README.md b/pnpm/artifacts/linux-riscv64/README.md
+new file mode 100644
+index 000000000..4802615b1
+--- /dev/null
++++ b/pnpm/artifacts/linux-riscv64/README.md
+@@ -0,0 +1 @@
++# @pnpm/linux-riscv64
+diff --git a/pnpm/artifacts/linux-riscv64/package.json b/pnpm/artifacts/linux-riscv64/package.json
+new file mode 100644
+index 000000000..30c63d0c5
+--- /dev/null
++++ b/pnpm/artifacts/linux-riscv64/package.json
+@@ -0,0 +1,28 @@
++{
++  "name": "@pnpm/linux-riscv64",
++  "version": "8.15.2",
++  "license": "MIT",
++  "publishConfig": {
++    "bin": {
++      "pnpm": "pnpm"
++    },
++    "os": [
++      "linux"
++    ],
++    "cpu": [
++      "riscv64"
++    ]
++  },
++  "funding": "https://opencollective.com/pnpm",
++  "repository": "https://github.com/pnpm/pnpm/blob/master/packages/artifacts/linux-riscv64",
++  "homepage": "https://github.com/pnpm/pnpm/blob/master/packages/artifacts/linux-riscv64#readme",
++  "bugs": {
++    "url": "https://github.com/pnpm/pnpm/issues"
++  },
++  "keywords": [
++    "pnpm8"
++  ],
++  "devDependencies": {
++    "@pnpm/linux-riscv64": "workspace:*"
++  }
++}

--- a/pnpm/loosen-engine-restriction.patch
+++ b/pnpm/loosen-engine-restriction.patch
@@ -1,0 +1,236 @@
+diff --git a/package.json b/package.json
+index 8b55fedd3..9087d68fb 100644
+--- a/package.json
++++ b/package.json
+@@ -63,7 +63,7 @@
+     "verdaccio": "5.20.1"
+   },
+   "engines": {
+-    "pnpm": ">=8.6.10"
++    "pnpm": ">=8"
+   },
+   "packageManager": "pnpm@8.6.10",
+   "pnpm": {
+diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
+index b5e89fbe9..7a25346fb 100644
+--- a/pnpm-lock.yaml
++++ b/pnpm-lock.yaml
+@@ -61,7 +61,7 @@ overrides:
+   ts-api-utils: 1.0.0
+   socks: 2.7.3
+ 
+-packageExtensionsChecksum: 0d307d8212befbee1586c7f8acd8fba8
++packageExtensionsChecksum: bdee3e6383466510303165a46ed255f7
+ 
+ patchedDependencies:
+   graceful-fs@4.2.11:
+@@ -7861,7 +7861,7 @@ packages:
+     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+     dependencies:
+       '@jest/types': 29.6.3
+-      '@types/node': 18.14.6
++      '@types/node': 18.19.15
+       chalk: 4.1.2
+       jest-message-util: 29.7.0
+       jest-util: 29.7.0
+@@ -7882,14 +7882,14 @@ packages:
+       '@jest/test-result': 29.7.0
+       '@jest/transform': 29.7.0(@babel/types@7.23.3)
+       '@jest/types': 29.6.3
+-      '@types/node': 18.14.6
++      '@types/node': 18.19.15
+       ansi-escapes: 4.3.2
+       chalk: 4.1.2
+       ci-info: 3.9.0
+       exit: 0.1.2
+       graceful-fs: 4.2.11(patch_hash=ivtm2a2cfr5pomcfbedhmr5v2q)
+       jest-changed-files: 29.7.0
+-      jest-config: 29.7.0(@babel/types@7.23.3)(@types/node@18.14.6)(ts-node@10.9.2)
++      jest-config: 29.7.0(@babel/types@7.23.3)(@types/node@18.19.15)(ts-node@10.9.2)
+       jest-haste-map: 29.7.0
+       jest-message-util: 29.7.0
+       jest-regex-util: 29.6.3
+@@ -7918,7 +7918,7 @@ packages:
+     dependencies:
+       '@jest/fake-timers': 29.7.0
+       '@jest/types': 29.6.3
+-      '@types/node': 18.14.6
++      '@types/node': 18.19.15
+       jest-mock: 29.7.0
+     dev: true
+ 
+@@ -7945,7 +7945,7 @@ packages:
+     dependencies:
+       '@jest/types': 29.6.3
+       '@sinonjs/fake-timers': 10.3.0
+-      '@types/node': 18.14.6
++      '@types/node': 18.19.15
+       jest-message-util: 29.7.0
+       jest-mock: 29.7.0
+       jest-util: 29.7.0
+@@ -7978,7 +7978,7 @@ packages:
+       '@jest/transform': 29.7.0(@babel/types@7.23.3)
+       '@jest/types': 29.6.3
+       '@jridgewell/trace-mapping': 0.3.22
+-      '@types/node': 18.14.6
++      '@types/node': 18.19.15
+       chalk: 4.1.2
+       collect-v8-coverage: 1.0.2
+       exit: 0.1.2
+@@ -8068,7 +8068,7 @@ packages:
+       '@jest/schemas': 29.6.3
+       '@types/istanbul-lib-coverage': 2.0.6
+       '@types/istanbul-reports': 3.0.4
+-      '@types/node': 18.14.6
++      '@types/node': 18.19.15
+       '@types/yargs': 17.0.32
+       chalk: 4.1.2
+     dev: true
+@@ -9183,7 +9183,7 @@ packages:
+   /@types/ssri@7.1.5:
+     resolution: {integrity: sha512-odD/56S3B51liILSk5aXJlnYt99S6Rt9EFDDqGtJM26rKHApHcwyU/UoYHrzKkdkHMAIquGWCuHtQTbes+FRQw==}
+     dependencies:
+-      '@types/node': 18.14.6
++      '@types/node': 18.19.15
+     dev: true
+ 
+   /@types/stack-utils@2.0.3:
+@@ -9534,7 +9534,7 @@ packages:
+     resolution: {integrity: sha512-ZsYi6Y01yMJOLnJ5ISZgOFvCEXzp4EScrM91D7bvCx0lIfH3DZ40H4M5nGNeVFk7jXUHOXuJkNYlNoXixSconA==}
+     engines: {node: '>=14.15.0'}
+     peerDependencies:
+-      '@yarnpkg/fslib': 3.0.0-rc.45
++      '@yarnpkg/fslib': ^3.0.0-rc.45
+     dependencies:
+       '@types/emscripten': 1.39.10
+       '@yarnpkg/fslib': 3.0.0-rc.45
+@@ -13362,7 +13362,7 @@ packages:
+       '@jest/expect': 29.7.0
+       '@jest/test-result': 29.7.0
+       '@jest/types': 29.6.3
+-      '@types/node': 18.14.6
++      '@types/node': 18.19.15
+       chalk: 4.1.2
+       co: 4.6.0
+       dedent: 1.5.1
+@@ -13455,6 +13455,48 @@ packages:
+       - supports-color
+     dev: true
+ 
++  /jest-config@29.7.0(@babel/types@7.23.3)(@types/node@18.19.15)(ts-node@10.9.2):
++    resolution: {integrity: sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==}
++    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
++    peerDependencies:
++      '@types/node': '*'
++      ts-node: '>=9.0.0'
++    peerDependenciesMeta:
++      '@types/node':
++        optional: true
++      ts-node:
++        optional: true
++    dependencies:
++      '@babel/core': 7.23.3
++      '@jest/test-sequencer': 29.7.0
++      '@jest/types': 29.6.3
++      '@types/node': 18.19.15
++      babel-jest: 29.7.0(@babel/core@7.23.3)(@babel/types@7.23.3)
++      chalk: 4.1.2
++      ci-info: 3.9.0
++      deepmerge: 4.3.1
++      glob: 7.2.3
++      graceful-fs: 4.2.11(patch_hash=ivtm2a2cfr5pomcfbedhmr5v2q)
++      jest-circus: 29.7.0(@babel/types@7.23.3)
++      jest-environment-node: 29.7.0
++      jest-get-type: 29.6.3
++      jest-regex-util: 29.6.3
++      jest-resolve: 29.7.0
++      jest-runner: 29.7.0(@babel/types@7.23.3)
++      jest-util: 29.7.0
++      jest-validate: 29.7.0
++      micromatch: 4.0.5
++      parse-json: 5.2.0
++      pretty-format: 29.7.0
++      slash: 3.0.0
++      strip-json-comments: 3.1.1
++      ts-node: 10.9.2(@types/node@18.14.6)(typescript@5.3.3)
++    transitivePeerDependencies:
++      - '@babel/types'
++      - babel-plugin-macros
++      - supports-color
++    dev: true
++
+   /jest-diff@29.7.0:
+     resolution: {integrity: sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==}
+     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+@@ -13490,7 +13532,7 @@ packages:
+       '@jest/environment': 29.7.0
+       '@jest/fake-timers': 29.7.0
+       '@jest/types': 29.6.3
+-      '@types/node': 18.14.6
++      '@types/node': 18.19.15
+       jest-mock: 29.7.0
+       jest-util: 29.7.0
+     dev: true
+@@ -13506,7 +13548,7 @@ packages:
+     dependencies:
+       '@jest/types': 29.6.3
+       '@types/graceful-fs': 4.1.9
+-      '@types/node': 18.14.6
++      '@types/node': 18.19.15
+       anymatch: 3.1.3
+       fb-watchman: 2.0.2
+       graceful-fs: 4.2.11(patch_hash=ivtm2a2cfr5pomcfbedhmr5v2q)
+@@ -13557,7 +13599,7 @@ packages:
+     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+     dependencies:
+       '@jest/types': 29.6.3
+-      '@types/node': 18.14.6
++      '@types/node': 18.19.15
+       jest-util: 29.7.0
+     dev: true
+ 
+@@ -13612,7 +13654,7 @@ packages:
+       '@jest/test-result': 29.7.0
+       '@jest/transform': 29.7.0(@babel/types@7.23.3)
+       '@jest/types': 29.6.3
+-      '@types/node': 18.14.6
++      '@types/node': 18.19.15
+       chalk: 4.1.2
+       emittery: 0.13.1
+       graceful-fs: 4.2.11(patch_hash=ivtm2a2cfr5pomcfbedhmr5v2q)
+@@ -13644,7 +13686,7 @@ packages:
+       '@jest/test-result': 29.7.0
+       '@jest/transform': 29.7.0(@babel/types@7.23.3)
+       '@jest/types': 29.6.3
+-      '@types/node': 18.14.6
++      '@types/node': 18.19.15
+       chalk: 4.1.2
+       cjs-module-lexer: 1.2.3
+       collect-v8-coverage: 1.0.2
+@@ -13697,7 +13739,7 @@ packages:
+     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+     dependencies:
+       '@jest/types': 29.6.3
+-      '@types/node': 18.14.6
++      '@types/node': 18.19.15
+       chalk: 4.1.2
+       ci-info: 3.9.0
+       graceful-fs: 4.2.11(patch_hash=ivtm2a2cfr5pomcfbedhmr5v2q)
+@@ -13722,7 +13764,7 @@ packages:
+     dependencies:
+       '@jest/test-result': 29.7.0
+       '@jest/types': 29.6.3
+-      '@types/node': 18.14.6
++      '@types/node': 18.19.15
+       ansi-escapes: 4.3.2
+       chalk: 4.1.2
+       emittery: 0.13.1
+@@ -13734,7 +13776,7 @@ packages:
+     resolution: {integrity: sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==}
+     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+     dependencies:
+-      '@types/node': 18.14.6
++      '@types/node': 18.19.15
+       jest-util: 29.7.0
+       merge-stream: 2.0.0
+       supports-color: 8.1.1

--- a/pnpm/riscv64.patch
+++ b/pnpm/riscv64.patch
@@ -1,0 +1,28 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -11,14 +11,23 @@ url=https://pnpm.io
+ license=('MIT')
+ depends=('node-gyp')
+ makedepends=('git' 'pnpm')
+-source=("git+https://github.com/$pkgname/$pkgname.git#tag=v$pkgver?signed")
+-b2sums=('SKIP')
++source=("git+https://github.com/$pkgname/$pkgname.git#tag=v$pkgver?signed"
++        "loosen-engine-restriction.patch"
++        "add-pnpm-linux-riscv64.patch")
++b2sums=('SKIP'
++        '610617968a22fb6f29d2ddc4743cf1ac019d19331c6cbb7a3ba344d38d262b6097164a41842a5f5af616b85c8c074abf4fe7aeedaf18c6a16651cfa0230358e6'
++        'ed9b2d1f81bac9606487339796de750dc047227a1b5be0471906663bb9f30ebca443015a671e7fb1b6e366dee9ec6f5c77bca3fe90dd12b76c6a6daac869c43b')
+ validpgpkeys=('7B74D1299568B586BA9962B5649E4D4AF74E7DEC') # Zoltan Kochan <z@kochan.io>
+ 
+ build() {
+   cd $pkgname/$pkgname
+   git cherry-pick --no-commit 7f0aae82db3628581bc704a394ef025ab258ab28
+ 
++  cd ..
++  patch -Np1 -i ../loosen-engine-restriction.patch
++  patch -Np1 -i ../add-pnpm-linux-riscv64.patch
++  cd $pkgname
++
+   pnpm install --frozen-lockfile
+   pnpm run compile
+ }


### PR DESCRIPTION
- Lift pnpm engine restriction for now (>=8.6.10 -> >=8)
- Add @pnpm/linux-riscv64 package. To be upstreamed.