### PR TITLE
addpatch: lcdproc 0.5.9-9

### DIFF
--- a/lcdproc/riscv64.patch
+++ b/lcdproc/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -28,10 +28,12 @@ sha512sums=('48e11a587570376b9524591f4c23deace9ac1609b83ba9e17f2a4e950d5598f8f88
+             '2a230cf311699f5d30a36d73784e9539c6a018b281282f341a167a0f946212a9d156b23efdf7f921f5ed8941f7dc6f68878ec2d87247727bec78230eb04eda0f'
+             'b1fc6b6e682d6aa28d0809af788f2530e867e6a2c66041048b311a75d620b1ea8a5ead326799ddb39ff084e324ecb3611c0e78a26fd9ba7b09c2676a5cbec275'
+             'b77725c5b100d5041b1715fec29d32a2066c5508f3edee3f94970e9df1632aae522ed164163c32acb1139e4fa95dc76a329a307b24c76a41b73bdf844dd7d036')
++options=(!lto)
+ 
+ prepare() {
+     cd "$pkgname-$pkgver"
+     patch -p1 -i "$srcdir/lcdproc-0.5.9-fix-fno-common-build.patch"
++    autoreconf -fi
+ }
+ 
+ build() {


### PR DESCRIPTION
- Update config.{sub,guess}. Upstreamed to https://github.com/lcdproc/lcdproc/issues/212.
- Disable LTO due to lto-wrapper fails on unreachable x86 inline assembly:

```
In function ‘port_out’,
    inlined from ‘t6963_low_dsp_ready’ at t6963_low.c:181:3:
port.h:351:9: error: impossible constraint in ‘asm’
  351 |         __asm__ volatile ("outb %0,%1\n"::"a" (val), "d"(port)
      |         ^
make[4]: *** [/tmp/cca6TJKK.mk:2: /tmp/ccT5025n.ltrans0.ltrans.o] Error 1
lto-wrapper: fatal error: make returned 2 exit status
```