### PR TITLE
addpatch: azure-cli 2.58.0-1

### DIFF
--- a/azure-cli/riscv64.patch
+++ b/azure-cli/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -8,6 +8,7 @@ pkgdesc="Command-line tools for Azure."
+ arch=('any')
+ url="https://github.com/Azure/azure-cli"
+ license=('MIT')
++makedepends=('cargo')
+ depends=("python")
+ source=("install.py"
+         "install.response"


### PR DESCRIPTION
Python package `cryptography` and `bcrypt` need to build from source since there are no riscv64 prebuilt available.