### PR TITLE
addpatch: geogram 1.8.3-1

### DIFF
--- a/geogram/geogram-riscv64.patch
+++ b/geogram/geogram-riscv64.patch
@@ -1,0 +1,86 @@
+diff --git a/cmake/geo_detect_platform.cmake b/cmake/geo_detect_platform.cmake
+index c5bb6be09..853464e1e 100644
+--- a/cmake/geo_detect_platform.cmake
++++ b/cmake/geo_detect_platform.cmake
+@@ -7,10 +7,18 @@
+ # - Use CheckCXXCompilerFlag to enable compiler-specific flags
+ #
+ if(CMAKE_SYSTEM_NAME MATCHES Linux)
+-    if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+-        set(VORPALINE_PLATFORM "Linux64-gcc-dynamic" CACHE STRING "")
+-    elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+-        set(VORPALINE_PLATFORM "Linux64-clang-dynamic" CACHE STRING "")
++    if(CMAKE_SYSTEM_PROCESSOR MATCHES x86_64)
++        if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
++            set(VORPALINE_PLATFORM "Linux64-gcc-dynamic" CACHE STRING "")
++        elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
++            set(VORPALINE_PLATFORM "Linux64-clang-dynamic" CACHE STRING "")
++        endif()
++    else()
++        if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
++            set(VORPALINE_PLATFORM "Linux64-nonx86-gcc-dynamic" CACHE STRING "")
++        elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
++            set(VORPALINE_PLATFORM "Linux64-nonx86-clang-dynamic" CACHE STRING "")
++        endif()
+     endif()
+ elseif(CMAKE_SYSTEM_NAME MATCHES Darwin)
+     set(VORPALINE_PLATFORM "Darwin-clang-dynamic" CACHE STRING "")
+diff --git a/cmake/platforms/Linux64-nonx86-clang-dynamic/config.cmake b/cmake/platforms/Linux64-nonx86-clang-dynamic/config.cmake
+new file mode 100644
+index 000000000..a053bb244
+--- /dev/null
++++ b/cmake/platforms/Linux64-nonx86-clang-dynamic/config.cmake
+@@ -0,0 +1,6 @@
++set(VORPALINE_ARCH_64 true)
++set(VORPALINE_BUILD_DYNAMIC true)
++include(${GEOGRAM_SOURCE_DIR}/cmake/platforms/Linux-clang.cmake)
++add_flags(CMAKE_CXX_FLAGS -m64)
++add_flags(CMAKE_C_FLAGS -m64)
++
+diff --git a/cmake/platforms/Linux64-nonx86-clang-dynamic/setvars.sh b/cmake/platforms/Linux64-nonx86-clang-dynamic/setvars.sh
+new file mode 100644
+index 000000000..030414bce
+--- /dev/null
++++ b/cmake/platforms/Linux64-nonx86-clang-dynamic/setvars.sh
+@@ -0,0 +1,2 @@
++export CC=clang
++export CXX=clang++ 
+diff --git a/cmake/platforms/Linux64-nonx86-gcc-dynamic/config.cmake b/cmake/platforms/Linux64-nonx86-gcc-dynamic/config.cmake
+new file mode 100644
+index 000000000..32a6fa296
+--- /dev/null
++++ b/cmake/platforms/Linux64-nonx86-gcc-dynamic/config.cmake
+@@ -0,0 +1,3 @@
++set(VORPALINE_ARCH_64 true)
++set(VORPALINE_BUILD_DYNAMIC true)
++include(${GEOGRAM_SOURCE_DIR}/cmake/platforms/Linux-gcc.cmake)
+diff --git a/cmake/platforms/Linux64-nonx86-gcc-dynamic/setvars.sh b/cmake/platforms/Linux64-nonx86-gcc-dynamic/setvars.sh
+new file mode 100644
+index 000000000..e69de29bb
+diff --git a/configure.sh b/configure.sh
+index c1ef489d8..14acb24f6 100755
+--- a/configure.sh
++++ b/configure.sh
+@@ -128,6 +128,9 @@ if [ -z "$os" ]; then
+         Linux*aarch64*)
+             os=Linux64-gcc-aarch64
+             ;;
++        Linux*riscv64*)
++            os=Linux64-nonx86-gcc-riscv64
++            ;;
+         Darwin*)
+             os=Darwin-clang-dynamic
+             ;;
+diff --git a/src/lib/geogram/basic/common.h b/src/lib/geogram/basic/common.h
+index bf4e9ed7f..a43780a29 100644
+--- a/src/lib/geogram/basic/common.h
++++ b/src/lib/geogram/basic/common.h
+@@ -258,7 +258,7 @@ namespace GEO {
+ #  error "Unsupported compiler"
+ #endif
+ 
+-#if defined(__x86_64) || defined(__ppc64__) || defined(__arm64__) || defined(__aarch64__)
++#if defined(__x86_64) || defined(__ppc64__) || defined(__arm64__) || defined(__aarch64__) || (defined(__riscv) && __riscv_xlen == 64)
+ #  define GEO_ARCH_64
+ #else
+ #  define GEO_ARCH_32

--- a/geogram/impl-riscv-spinlocks.patch
+++ b/geogram/impl-riscv-spinlocks.patch
@@ -1,0 +1,185 @@
+diff --git a/src/lib/geogram/basic/atomics.h b/src/lib/geogram/basic/atomics.h
+index f923c92..d445a15 100644
+--- a/src/lib/geogram/basic/atomics.h
++++ b/src/lib/geogram/basic/atomics.h
+@@ -55,6 +55,8 @@
+ #    define GEO_USE_ARM32_ATOMICS
+ #  elif defined(GEO_OS_ANDROID)
+ #    define GEO_USE_ANDROID_ATOMICS
++#  elif defined(__riscv)
++#    define GEO_USE_RISCV_ATOMICS
+ #  else
+ #    define GEO_USE_X86_ATOMICS
+ #  endif
+@@ -107,6 +109,35 @@ inline void send_event_android() {
+     /* TODO */    
+ }
+ 
++#elif defined(GEO_USE_RISCV_ATOMICS)
++
++/** A mutex for RISC-V */
++typedef GEO::Numeric::uint32 riscv_mutex_t;
++
++inline void geo_pause() {
++    __asm__ __volatile__ ( ".4byte 0x100000F" ); // pause encoding for harts w/o Zihintpause
++}
++
++inline void lock_mutex_riscv(volatile riscv_mutex_t* lock) {
++    while(__sync_lock_test_and_set(lock, 1) != 0);
++}
++
++inline void unlock_mutex_riscv(volatile riscv_mutex_t* lock) {
++    __sync_lock_release(lock);
++}
++
++inline unsigned int atomic_bitset_riscv(volatile unsigned int* ptr, unsigned int bit) {
++    return __sync_fetch_and_or(ptr, 1u << bit) & (1u << bit);
++}
++
++inline unsigned int atomic_bitreset_riscv(volatile unsigned int* ptr, unsigned int bit) {
++    return __sync_fetch_and_and(ptr, ~(1u << bit)) & (1u << bit);
++}
++
++inline void memory_barrier_riscv() {
++    __asm__ __volatile__ ( "fence" ::: "memory");
++}
++
+ #elif defined(GEO_USE_ARM32_ATOMICS)
+ 
+ /** A mutex for ARM processors */
+diff --git a/src/lib/geogram/basic/thread_sync.h b/src/lib/geogram/basic/thread_sync.h
+index 56956f5..5f9a87d 100644
+--- a/src/lib/geogram/basic/thread_sync.h
++++ b/src/lib/geogram/basic/thread_sync.h
+@@ -97,7 +97,30 @@ namespace GEO {
+         inline void release_spinlock(spinlock& x) {
+             unlock_mutex_arm32(&x);
+         }
++
++#elif defined(__riscv)
+ 	
++        /** A lightweight synchronization structure. */
++        typedef riscv_mutex_t spinlock;
++
++        /** The initialization value of a spin lock. */
++#       define GEOGRAM_SPINLOCK_INIT 0
++        /**
++         * \brief Loops until \p x is available then reserves it.
++         * \param[in] x a spinlock that should be available.
++         */
++        inline void acquire_spinlock(spinlock& x) {
++            lock_mutex_riscv(&x);
++        }
++
++        /**
++         * \brief Makes \p x available to other threads.
++         * \param[in] x a spinlock that should be reserved.
++         */
++        inline void release_spinlock(spinlock& x) {
++            unlock_mutex_riscv(&x);
++        }
++
+ #elif defined(GEO_OS_ANDROID)
+ 
+         /** A lightweight synchronization structure. */
+@@ -397,6 +420,100 @@ namespace GEO {
+             index_t size_;
+         };
+ 	
++#elif defined(GEO_USE_RISCV_ATOMICS) 
++
++        /**
++         * \brief An array of light-weight synchronisation
++         *  primitives (spinlocks).
++         *
++         * \details In this implementation, storage is optimized so that
++         * a single bit per spinlock is used.
++         *
++         */
++        class SpinLockArray {
++        public:
++            /**
++             * \brief Internal representation of SpinLockArray elements.
++             * \details Each word_t represents 32 spinlocks.
++             */
++            typedef Numeric::uint32 word_t;
++
++            /**
++             * \brief Constructs a new SpinLockArray of size 0.
++             */
++            SpinLockArray() : size_(0) {
++            }
++
++            /**
++             * \brief Constructs a new SpinLockArray of size \p size_in.
++             * \param[in] size_in number of spinlocks in the array.
++             */
++            SpinLockArray(index_t size_in) : size_(0) {
++                resize(size_in);
++            }
++
++            /**
++             * \brief Resizes a SpinLockArray.
++             * \details All the spinlocks are reset to 0.
++             * \param[in] size_in The desired new size.
++             */
++            void resize(index_t size_in) {
++                if(size_ != size_in) {
++                    size_ = size_in;
++                    index_t nb_words = (size_ >> 5) + 1;
++                    spinlocks_.assign(nb_words, 0);
++                }
++            }
++
++            /**
++             * \brief Gets the number of spinlocks in this array.
++             */
++            index_t size() const {
++                return size_;
++            }
++
++            /**
++             * \brief Resets size to 0 and clears all the memory.
++             */
++            void clear() {
++                spinlocks_.clear();
++            }
++
++            /**
++             * \brief Acquires a spinlock at a given index
++             * \details Loops until spinlock at index \p i is available then
++             * reserve it.
++             * \param[in] i index of the spinlock
++             */
++            void acquire_spinlock(index_t i) {
++                geo_thread_sync_assert(i < size());
++                index_t w = i >> 5;
++                word_t b = word_t(i & 31);
++                // Loop while previously stored value has its bit set.
++                while((atomic_bitset_riscv(&spinlocks_[w], b)) != 0) {
++                    geo_pause();
++                }
++                memory_barrier_riscv();
++            }
++
++            /**
++             * \brief Releases a spinlock at a given index
++             * \details Makes spinlock at index \p i available to other threads.
++             * \param[in] i index of the spinlock
++             */
++            void release_spinlock(index_t i) {
++                geo_thread_sync_assert(i < size());
++                memory_barrier_riscv();
++                index_t w = i >> 5;
++                word_t b = word_t(i & 31);
++                atomic_bitreset_riscv(&spinlocks_[w], b);
++            }
++
++        private:
++            std::vector<word_t> spinlocks_;
++            index_t size_;
++        };
++
+ #elif defined(GEO_OS_ANDROID) 
+ 
+         /**

--- a/geogram/libf2c-riscv-fpu-control.patch
+++ b/geogram/libf2c-riscv-fpu-control.patch
@@ -1,0 +1,19 @@
+diff --git a/src/lib/third_party/numerics/LIBF2C/libf2c_uninit.c b/src/lib/third_party/numerics/LIBF2C/libf2c_uninit.c
+index 3525ba73a..00ca4f80c 100644
+--- a/src/lib/third_party/numerics/LIBF2C/libf2c_uninit.c
++++ b/src/lib/third_party/numerics/LIBF2C/libf2c_uninit.c
+@@ -282,7 +282,13 @@ which we want*/
+ 
+ #endif /*Can_use__setfpucw*/
+ 
+-#else /* !(mc68000||powerpc) */
++#elif (defined(__riscv)) /* !(mc68000||powerpc) */
++	__fpu_control = _FPU_DEFAULT;
++	__fpu_control |= (1 << 0);    // NV
++	__fpu_control |= (1 << 2);    // OF
++	__fpu_control |= (1 << 3);    // UF
++	_FPU_SETCW(__fpu_control);
++#else /* !(mc68000||powerpc||riscv) */
+ 
+ #ifdef _FPU_IEEE
+ #ifndef _FPU_EXTENDED /* e.g., ARM processor under Linux */

--- a/geogram/riscv64.patch
+++ b/geogram/riscv64.patch
@@ -1,0 +1,26 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -9,8 +9,21 @@ url="https://github.com/BrunoLevy/geogram"
+ license=('BSD')
+ depends=('glu' 'glfw-x11')
+ makedepends=('cmake' 'ninja')
+-source=("https://github.com/BrunoLevy/geogram/releases/download/v${pkgver}/geogram_${pkgver}.tar.gz")
+-sha256sums=('f75ab433fe2402bd14a165ce4081184b555b80443f17810139f244f55af56e7c')
++source=("https://github.com/BrunoLevy/geogram/releases/download/v${pkgver}/geogram_${pkgver}.tar.gz"
++        geogram-riscv64.patch
++        impl-riscv-spinlocks.patch
++        libf2c-riscv-fpu-control.patch)
++sha256sums=('f75ab433fe2402bd14a165ce4081184b555b80443f17810139f244f55af56e7c'
++            '89b64fd88eba1f292d6ca50a11465baa078b983c9ed4437b239e37036bda3201'
++            'a4193f52ec3cd97e3a9e79dba1cbe41af18143477596ad50c52c97e6bcce15f3'
++            '1cf90f1e3d67fbdc47135dfdcabd8b79d1d4935f665467397e2decc3a25426c8')
++
++prepare() {
++  cd ${pkgname}_${pkgver}
++  patch -Np1 -i ../geogram-riscv64.patch
++  patch -Np1 -i ../libf2c-riscv-fpu-control.patch
++  patch -Np1 -i ../impl-riscv-spinlocks.patch
++}
+ 
+ build() {
+   cd ${pkgname}_${pkgver}


### PR DESCRIPTION
Updated patch from #2084

https://github.com/BrunoLevy/geogram/pull/138

Patches are sent to upstream except impl-riscv-spinlocks.patch, because upstream now uses a portable spinlock implementation.