### PR TITLE
updpatch: echoping

### DIFF
--- a/echoping/riscv64.patch
+++ b/echoping/riscv64.patch
@@ -1,14 +1,6 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -6,6 +6,7 @@ pkgrel=12
- pkgdesc="tests performance of a remote host by sending HTTP, TCP and UDP requests"
- arch=('x86_64')
- url="http://echoping.sourceforge.net/"
-+options=(!lto)
- license=('GPL')
- depends=(libidn popt libldap)
- #source=(https://sourceforge.net/projects/$pkgname/files/$pkgname/$pkgver/$pkgname-$pkgver.tar.gz)
-@@ -18,6 +19,7 @@ sha256sums=('1dfa4c45bf461b2379ff91773ed7136176e2abac9e85c26bc9654942b5155eac'
+@@ -18,6 +18,7 @@ sha256sums=('1dfa4c45bf461b2379ff91773ed7136176e2abac9e85c26bc9654942b5155eac'
  
  prepare() {
    cd "$srcdir/$pkgname-$pkgver"


### PR DESCRIPTION
LTO problem(e4b6fe22b1dd05fd0f81792690ef771379493f9b) fixed by https://gitlab.archlinux.org/archlinux/packaging/packages/echoping/-/commit/db8372edad3d1b43176d5563db65a4eef764fa6c