### PR TITLE
addpatch: curl 8.7.1-5

### DIFF
--- a/curl/riscv64.patch
+++ b/curl/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -23,7 +23,6 @@ depends=('ca-certificates'
+          'zlib' 'libz.so'
+          'zstd' 'libzstd.so')
+ makedepends=('git' 'patchelf')
+-checkdepends=('valgrind')
+ validpgpkeys=('27EDEAF22F3ABCEB50DB9A125CC908FDB71E12C2') # Daniel Stenberg
+ source=("git+https://github.com/curl/curl.git#tag=curl-${pkgver//./_}?signed"
+         '0001-bump-version-to-match-last-tag.patch')


### PR DESCRIPTION
Valgrind tests all failed due to lack of glibc debuginfo.