### PR TITLE
updpatch: ldc 3:1.37.0-1.1

### DIFF
--- a/ldc/riscv64.patch
+++ b/ldc/riscv64.patch
@@ -5,7 +5,7 @@
  url="https://github.com/ldc-developers/ldc"
  license=('BSD')
 -makedepends=('git' 'cmake' 'llvm' 'lld' 'ldc' 'ninja')
-+makedepends=('git' 'cmake' 'llvm' 'llvm16-libs' 'lld' 'ldc' 'ninja')
++makedepends=('git' 'cmake' 'llvm' 'ldc' 'ninja')
  # Disable lto as linking the ldc2 binary fails
  options=(!lto)
  


### PR DESCRIPTION
Remove `llvm16-libs` from makedepends. Also remove `lld` since it is not used.