### PR TITLE
addpatch: bats 1.11.0-2

### DIFF
--- a/bats/riscv64.patch
+++ b/bats/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -41,7 +41,7 @@ prepare() {
+ 
+ check() {
+   cd "bats-core-${pkgver}"
+-  TERM=linux bin/bats --jobs "$(nproc)" --tap test
++  TERM=linux bin/bats --jobs 4 --tap test
+ }
+ 
+ package() {


### PR DESCRIPTION
Test suite hangs reproducibly on some builders with all cores full. Limit job count to 4 to mitigate this.