### PR TITLE
updpatch: valgrind 3.22.0-3

### DIFF
--- a/valgrind/riscv64.patch
+++ b/valgrind/riscv64.patch
@@ -1,65 +1,63 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -21,29 +21,27 @@ arch=('x86_64')
- license=('GPL')
+@@ -20,47 +20,35 @@ arch=('x86_64')
+ license=('GPL-2.0-or-later')
  url='https://valgrind.org/'
  depends=('glibc' 'perl' 'debuginfod')
 -makedepends=('gdb' 'lib32-glibc' 'lib32-gcc-libs' 'docbook-xml'
-+makedepends=('gdb' 'docbook-xml'
-              'docbook-xsl' 'docbook-sgml')
+-             'docbook-xsl' 'docbook-sgml')
++makedepends=('gdb' 'docbook-xml' 'docbook-xsl' 'docbook-sgml')
  checkdepends=('procps-ng')
--optdepends=('lib32-glibc: 32-bit ABI support')
- provides=('valgrind-multilib')
- replaces=('valgrind-multilib')
+ optdepends=(
+-  'lib32-glibc: 32-bit ABI support'
+   'python: cg_* scripts'
+ )
+-provides=('valgrind-multilib')
+-replaces=('valgrind-multilib')
  options=('!emptydirs' '!strip')
 -source=(https://sourceware.org/pub/valgrind/valgrind-${pkgver}.tar.bz2{,.asc}
+-        valgrind-3.7.0-respect-flags.patch
+-        # https://sourceware.org/git/?p=valgrind.git;a=commit;h=372d09fd9a8d76847c81092ebff71c80fd6c145d
+-        # dropped changes to NEWS as that did not apply
+-        valgrind_3_22_0_s390x-linux_memfd_secret.patch
+-        valgrind_3_22_0_fchmodat2_syscall.patch)
 +_commit='71272b252977fe52f03ea4fa8306b457b098cca5'
-+source=(https://github.com/petrpavlu/valgrind-riscv64/archive/$_commit.tar.gz
-         valgrind-3.7.0-respect-flags.patch)
++source=(https://github.com/petrpavlu/valgrind-riscv64/archive/${_commit}.tar.gz
++        fix-riscv64-fp-ite-csel.patch::https://github.com/petrpavlu/valgrind-riscv64/pull/16.diff
++        valgrind-3.7.0-respect-flags.patch)
  validpgpkeys=(
    0E9FFD0C16A1856CF9C7C690BA0166E698FA6035 # Julian Seward <jseward@acm.org>
    EC3CFE88F6CA0788774F5C1D1AA44BE649DE760A # Mark Wielaard <mjw@gnu.org>
  )
 -sha512sums=('2904c13f68245bbafcea70998c6bd20725271300a7e94b6751ca00916943595fc3fac8557da7ea8db31b54a43f092823a0a947bc142829da811d074e1fe49777'
 -            'SKIP'
-+sha512sums=('5e0634ed81970c0b9d274511e622b505798c601886f25ee86a2c81614c7aae8ff0d663e725f1a4418d8590e39ad85cc195f9015185f342e1a06608feb1e2b978'
-             'e0cec39381cefeca09ae4794cca309dfac7c8693e6315e137e64f5c33684598726d41cfbb4edf764fe985503b13ff596184ca5fc32b159d500ec092e4cf8838c')
+-            'e0cec39381cefeca09ae4794cca309dfac7c8693e6315e137e64f5c33684598726d41cfbb4edf764fe985503b13ff596184ca5fc32b159d500ec092e4cf8838c'
+-            '6393ddf84eec93cc9b3e20f9c43a8f3ef37436980c9d91350ebd27d5c41057fe982308ba5d194feddaea4a75a4a9ef14fb404388cc9f4628edbe9ef58787afba'
+-            '1e22b75b95252583774916dab9dcbc8663495107e15dd1ddf397744b288265fcffd1f456d306bc610989a1f650ae66a8ebeb84d253be312db2ab9fdc9fe1407f')
 -b2sums=('80024371b3e70521996077fba24e233097a6190477ced1b311cd41fead687dcc2511ac0ef723792488f4af08867dff3e1f474816fda09c1604b89059e31c2514'
 -        'SKIP'
+-        'af556fdf3c02e37892bfe9afebc954cf2f1b2fa9b75c1caacfa9f3b456ebc02bf078475f9ee30079b3af5d150d41415a947c3d04235c1ea8412cf92b959c484a'
+-        '5af1f467c8d22334e14e6c2878120550ce5f1e36b61f8180601b8673493a85cca8a0c3a804c281ab51fb04fe5e3706edeb897bbd5486f87d9143f472cd4c46b5'
+-        '305234e118eeb389c95ca8afa45239b0386199dee6f5058a3ddca06a91b2069e1b9831ac5e31badf6d8bd0d43eef3f260d95b976a509d73284149a64d9ea0563')
++sha512sums=('5e0634ed81970c0b9d274511e622b505798c601886f25ee86a2c81614c7aae8ff0d663e725f1a4418d8590e39ad85cc195f9015185f342e1a06608feb1e2b978'
++            '1f69f4b472643886ed76f1c5dde77ad55bad749add67507f830fe205b4160414e4798db1af7df8b84b40bc452b31fd423f9560914c72d146c906bd704287c4d9'
++            'e0cec39381cefeca09ae4794cca309dfac7c8693e6315e137e64f5c33684598726d41cfbb4edf764fe985503b13ff596184ca5fc32b159d500ec092e4cf8838c')
 +b2sums=('48ba35d9710cc321ad695031873089065658c7dc6f3a0f97ad79be559371fe1d8d029a3b33420780e37ff322b185884491850acee32feb24369aa793f043daa4'
-         'af556fdf3c02e37892bfe9afebc954cf2f1b2fa9b75c1caacfa9f3b456ebc02bf078475f9ee30079b3af5d150d41415a947c3d04235c1ea8412cf92b959c484a')
++        '613f40328c104a2b7cd303859559e9e92bbac34a6ad3cf676a14a03262d6a4c2159db4f147381932c391aacbbce8a80609c05e4c58037f68f0e1c28b01d440bd'
++        'af556fdf3c02e37892bfe9afebc954cf2f1b2fa9b75c1caacfa9f3b456ebc02bf078475f9ee30079b3af5d150d41415a947c3d04235c1ea8412cf92b959c484a')
  options=(!lto) # https://bugs.kde.org/show_bug.cgi?id=338252
  
  prepare() {
--  cd valgrind-${pkgver}
-+  cd valgrind-riscv64-$_commit
++  mv valgrind-riscv64-${_commit} valgrind-${pkgver}
+   cd valgrind-${pkgver}
    patch -Np1 < ../valgrind-3.7.0-respect-flags.patch
    sed -i 's|sgml/docbook/xsl-stylesheets|xml/docbook/xsl-stylesheets-1.79.2-nons|' docs/Makefile.am
  
-@@ -56,7 +54,7 @@ build() {
-   CFLAGS=${CFLAGS/-fno-plt/}
-   CXXFLAGS=${CXXFLAGS/-fno-plt/}
+-  # can be dropped with the next release, see
+-  # https://gitlab.archlinux.org/archlinux/packaging/packages/valgrind/-/issues/2
+-  patch -Np1 < ../valgrind_3_22_0_s390x-linux_memfd_secret.patch
+-  patch -Np1 < ../valgrind_3_22_0_fchmodat2_syscall.patch
++  patch -Np1 < ../fix-riscv64-fp-ite-csel.patch
  
--  cd valgrind-${pkgver}
-+  cd valgrind-riscv64-$_commit
-   ./configure \
-     --prefix=/usr \
-     --sysconfdir=/etc \
-@@ -71,7 +69,7 @@ check() {
-   # only run if glibc-debug is supplied manually
-   if ! pacman -Q glibc-debug; then echo -e "\033[1;31mcheck() not run, supply glibc-debug if unintended!\033[0m"; return 0; fi
- 
--  cd valgrind-${pkgver}
-+  cd valgrind-riscv64-$_commit
- 
-   # Make sure a basic binary runs. There should be no errors.
-   ./vg-in-place --error-exitcode=1 /bin/true
-@@ -109,7 +107,7 @@ check() {
+   autoreconf -ifv
  }
- 
- package() {
--  cd valgrind-${pkgver}
-+  cd valgrind-riscv64-$_commit
-   make DESTDIR="${pkgdir}" install
- 
-   install -Dm644 docs/*.1 -t "$pkgdir/usr/share/man/man1"


### PR DESCRIPTION
Actual version is not changed (3.20.0).

- Tidy up patches, removing multilib `provides`
- Backport https://github.com/petrpavlu/valgrind-riscv64/pull/16 to try to fix some runtime errors
- Drop Arch Linux's 3.22.0 patches since they can't be applied