### PR TITLE
addpatch: ollama 0.1.31-1

### DIFF
--- a/ollama/riscv64.patch
+++ b/ollama/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -38,6 +38,9 @@ prepare() {
+ 
+   # Display a more helpful error message
+   sed -i "s|could not connect to ollama server, run 'ollama serve' to start it|ollama is not running, try 'systemctl start ollama'|g" cmd/cmd.go
++
++  go mod edit -replace github.com/chewxy/math32@v1.0.8=github.com/chewxy/math32@8e68659b6eeb81aaeb87ddcf85216f3d3096f234
++  go mod tidy
+ }
+ 
+ build() {


### PR DESCRIPTION
Use current master branch of https://github.com/chewxy/math32 where stub_riscv64.s is disabled, enabling Go fallback.