### PR TITLE
updpatch: js91 91.13.0-2

### DIFF
--- a/js91/riscv64.patch
+++ b/js91/riscv64.patch
@@ -1,115 +1,84 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -12,9 +12,13 @@
- checkdepends=(mercurial git)
- options=(!lto debug)
- _relver=${pkgver}esr
--source=(https://archive.mozilla.org/pub/firefox/releases/$_relver/source/firefox-$_relver.source.tar.xz{,.asc})
-+source=(https://archive.mozilla.org/pub/firefox/releases/$_relver/source/firefox-$_relver.source.tar.xz{,.asc}
-+        tests-skip-some-tests-on-rv64.patch
-+        Disable-floating-pointcontraction.patch)
+@@ -32,6 +32,8 @@ _relver=${pkgver}esr
+ source=(
+   https://archive.mozilla.org/pub/firefox/releases/$_relver/source/firefox-$_relver.source.tar.xz{,.asc}
+   0001-Bug-1769631-Remove-U-from-mode-parameters-for-variou.patch
++  tests-skip-some-tests-on-rv64.patch
++  Disable-floating-pointcontraction.patch
+ )
+ validpgpkeys=(
+   # Mozilla Software Releases <release@mozilla.com>
+@@ -40,10 +42,14 @@ validpgpkeys=(
+ )
  sha256sums=('53be2bcde0b5ee3ec106bd8ba06b8ae95e7d489c484e881dfbe5360e4c920762'
--            'SKIP')
-+            'SKIP'
+             'SKIP'
+-            '1b6fcec05714c0fbc52549059d570dddd79302ca787dec9983b046d54fa7a6ff')
++            '1b6fcec05714c0fbc52549059d570dddd79302ca787dec9983b046d54fa7a6ff'
 +            '1518e134fd5448d48f960bedbe7db061d5a8b368d43db2cac7f4b1adf094c748'
 +            '5bf12327f40ba27b0d98cd8dbc14f79833c7f251ffc6d455cbc2a30a1d5b9f15')
- validpgpkeys=('14F26682D0916CDD81E37B6D61B7B526D98F0353') # Mozilla Software Releases <release@mozilla.com>
+ b2sums=('75d0daa512b3a2d41974a0169778be9ef19a100de2bd382add9831860ca93976585a41e760b6a7ec753268fb78f9f61049780fa7961834248bc8157cfdcc2827'
+         'SKIP'
+-        '216206c7f0356267f4f29880b8b8e8e388f9dd483a56cd427de57756d64ef26ea6d6b36e33ca96dbc54c45bf78bbf2b9a666aa8b2029fa28d07dc41342101158')
++        '216206c7f0356267f4f29880b8b8e8e388f9dd483a56cd427de57756d64ef26ea6d6b36e33ca96dbc54c45bf78bbf2b9a666aa8b2029fa28d07dc41342101158'
++        'cc2d8c25b0a5dac7f63d0569d8ca7a85f722c9171ba4c6ba6cea79db8289e53d16f616ba5fdb70b1fb867ac24f2e27edc656b4dbe9a7a1d7bc36919de8a27bf6'
++        '0851d87814421285513222aa428c7b2755b4aff0c7e970174231205c88ec1dacfdcfd68f801be58483c33b2c0d2af559bc8d130fe9b34fdaabd5a8423b229402')
  
  # Make sure the duplication between bin and lib is found
-@@ -28,6 +32,11 @@
+ COMPRESSZST+=(--long)
+@@ -56,6 +62,11 @@ prepare() {
    mkdir mozbuild
    cd firefox-$pkgver
  
 +  patch -Np1 -i "../tests-skip-some-tests-on-rv64.patch"
-+ 
-+ #https://bugzilla.mozilla.org/show_bug.cgi?id=1755531
++
++  # https://bugzilla.mozilla.org/show_bug.cgi?id=1755531
 +  patch -Np1 -i  "../Disable-floating-pointcontraction.patch"
 +
-   cat >../mozconfig <<END
- ac_add_options --enable-application=js
- mk_add_options MOZ_OBJDIR=${PWD@Q}/obj
-@@ -37,12 +46,13 @@
- ac_add_options --enable-hardening
- ac_add_options --enable-optimize
- ac_add_options --enable-rust-simd
--ac_add_options --enable-linker=lld
-+ac_add_options --enable-linker=bfd
- ac_add_options --disable-bootstrap
- ac_add_options --disable-debug
- ac_add_options --disable-debug-symbols
- ac_add_options --disable-jemalloc
- ac_add_options --disable-strip
-+ac_add_options --disable-jit
+   # Python 3.11
+   patch -Np1 -i ../0001-Bug-1769631-Remove-U-from-mode-parameters-for-variou.patch
  
- # System libraries
- ac_add_options --with-system-zlib
-@@ -63,43 +73,43 @@
-   export MOZBUILD_STATE_PATH="$srcdir/mozbuild"
-   export MACH_USE_SYSTEM_PYTHON=1
+@@ -99,42 +110,7 @@ build() {
+   CFLAGS="${CFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
+   CXXFLAGS="${CXXFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
  
 -  # Do 3-tier PGO
 -  echo "Building instrumented JS..."
-+  ## Do 3-tier PGO
-+  #echo "Building instrumented JS..."
-   cat >.mozconfig ../mozconfig - <<END
+-  cat >.mozconfig ../mozconfig - <<END
 -ac_add_options --enable-profile-generate=cross
-+#ac_add_options --enable-profile-generate=cross
- END
-   ./mach build
- 
+-END
+-  ./mach build
+-
 -  echo "Profiling instrumented JS..."
 -  (
 -    local js="$PWD/obj/dist/bin/js"
 -    export LLVM_PROFILE_FILE="$PWD/js-%p-%m.profraw"
-+  #echo "Profiling instrumented JS..."
-+  #(
-+  #  local js="$PWD/obj/dist/bin/js"
-+  #  export LLVM_PROFILE_FILE="$PWD/js-%p-%m.profraw"
- 
+-
 -    cd js/src/octane
 -    "$js" run.js
-+  #  cd js/src/octane
-+  #  "$js" run.js
- 
+-
 -    cd ../../../third_party/webkit/PerformanceTests/ARES-6
 -    "$js" cli.js
-+  #  cd ../../../third_party/webkit/PerformanceTests/ARES-6
-+  #  "$js" cli.js
- 
+-
 -    cd ../SunSpider/sunspider-0.9.1
 -    "$js" sunspider-standalone-driver.js
 -  )
-+  #  cd ../SunSpider/sunspider-0.9.1
-+  #  "$js" sunspider-standalone-driver.js
-+  #)
- 
+-
 -  llvm-profdata merge -o merged.profdata *.profraw
-+  #llvm-profdata merge -o merged.profdata *.profraw
- 
+-
 -  stat -c "Profile data found (%s bytes)" merged.profdata
 -  test -s merged.profdata
-+  #stat -c "Profile data found (%s bytes)" merged.profdata
-+  #test -s merged.profdata
- 
+-
 -  echo "Removing instrumented JS..."
 -  ./mach clobber
-+  #echo "Removing instrumented JS..."
-+  #./mach clobber
- 
+-
 -  echo "Building optimized JS..."
 -  cat >.mozconfig ../mozconfig - <<END
 -ac_add_options --enable-lto=cross
 -ac_add_options --enable-profile-use=cross
 -ac_add_options --with-pgo-profile-path=${PWD@Q}/merged.profdata
 -END
--  ./mach build
-+  #echo "Building optimized JS..."
-+  #cat >.mozconfig ../mozconfig - <<END
-+#ac_add_options --enable-lto=cross
-+#ac_add_options --enable-profile-use=cross
-+#ac_add_options --with-pgo-profile-path=${PWD@Q}/merged.profdata
-+#END
-+#  ./mach build
++  cat >.mozconfig ../mozconfig
+   ./mach build
  }
  
- check() {


### PR DESCRIPTION
Enable LLD and JIT. PGO is still disabled since Rust 1.62.0 from Rustup does not contain `profile_builtins`.