### PR TITLE
addpatch: glycin 1.0.1-1

### DIFF
--- a/glycin/riscv64.patch
+++ b/glycin/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -72,7 +72,7 @@ build() {
+ }
+ 
+ check() {
+-  RUST_BACKTRACE=1 meson test -v -C build --print-errorlogs
++  RUST_BACKTRACE=1 meson test -v -C build --print-errorlogs --timeout-multiplier 10
+ }
+ 
+ package() {


### PR DESCRIPTION
Extend test timeout due to test containing a Rust crate building process.