### PR TITLE
addpatch: liburing 2.6-1

### DIFF
--- a/liburing/riscv64.patch
+++ b/liburing/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index d35462d..2d3c035 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -7,7 +7,7 @@
+ pkgrel=1
+ pkgdesc="Linux-native io_uring I/O access library"
+ arch=(x86_64)
+-url="https://git.kernel.dk/cgit/liburing"
++url="https://git.kernel.dk/liburing"
+ license=(
+   'GPL-2.0-only WITH Linux-syscall-note OR MIT'
+   LGPL-2.0-or-later


### PR DESCRIPTION
Fix source git not found. [Upstream MR](https://gitlab.archlinux.org/archlinux/packaging/packages/liburing/-/merge_requests/1)