### PR TITLE
addpatch: tracexec

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -125,6 +125,7 @@ tmuxp
 tpm2-openssl
 tpm2-tools
 tpm2-tss
+tracexec
 upower
 uutils-coreutils
 vbam

--- a/tracexec/riscv64.patch
+++ b/tracexec/riscv64.patch
@@ -1,0 +1,34 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -13,6 +13,15 @@ makedepends=('cargo' 'cargo-about' 'git')
+ source=("$pkgname-$pkgver::git+https://github.com/kxxt/tracexec.git#tag=v$pkgver")
+ b2sums=('8625c4ebaaf346585342bbab8c99917112b3f2de1caf884730efc552c3e3af77774b119b687e5ceef136ad0890bec2e1b4657c7c97c596438b17355826f08215')
+ 
++case "$CARCH" in
++  riscv64)
++    _feature_flags="--no-default-features"
++    ;;
++  *)
++    _feature_flags="--all-features"
++    ;;
++esac
++
+ prepare() {
+   cd "$pkgname-$pkgver"
+   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+@@ -21,13 +30,13 @@ prepare() {
+ build() {
+   cd "$pkgname-$pkgver"
+   # --bins: needed for test
+-  cargo build --bins --frozen --release --all-features
++  cargo build --bins --frozen --release $_feature_flags
+   cargo about generate -o THIRD_PARTY_LICENSES.HTML about.hbs
+ }
+ 
+ check() {
+   cd "$pkgname-$pkgver"
+-  RUST_TEST_THREADS=1 cargo test --frozen --release --all-features
++  RUST_TEST_THREADS=1 cargo test --frozen --release $_feature_flags
+ }
+ 
+ package() {


### PR DESCRIPTION
- Add to qemu-user blacklist because qemu doesn't implement ptrace so test will fail in qemu-user
- Disable seccomp-bpf feature because upstream seccompiler doesn't support riscv64 and it appears that they don't plan to merge my PR before riscv CI is setup: https://github.com/rust-vmm/seccompiler/pull/72
- I am the author of this software BTW :)