### PR TITLE
updpatch: gcc 14.1.1+r1+g43b730b9134-1

### DIFF
--- a/gcc/riscv64.patch
+++ b/gcc/riscv64.patch
@@ -1,17 +1,15 @@
-diff --git PKGBUILD PKGBUILD
-index 439849e..7c0a046 100644
 --- PKGBUILD
 +++ PKGBUILD
 @@ -7,7 +7,7 @@
  # toolchain build order: linux-api-headers->glibc->binutils->gcc->glibc->binutils->gcc
  # NOTE: libtool requires rebuilt with each new gcc version
  
--pkgname=(gcc gcc-libs lib32-gcc-libs gcc-ada gcc-d gcc-fortran gcc-go gcc-m2 gcc-objc lto-dump libgccjit)
-+pkgname=(gcc gcc-libs gcc-d gcc-fortran gcc-go gcc-m2 gcc-objc lto-dump libgccjit)
- pkgver=13.2.1
- _majorver=${pkgver%%.*}
- _commit=860b0f0ef787f756c0e293671b4c4622dff63a79
-@@ -19,11 +19,8 @@
+-pkgname=(gcc gcc-libs lib32-gcc-libs gcc-ada gcc-d gcc-fortran gcc-go gcc-m2 gcc-objc gcc-rust lto-dump libgccjit)
++pkgname=(gcc gcc-libs gcc-d gcc-fortran gcc-go gcc-m2 gcc-objc gcc-rust lto-dump libgccjit)
+ pkgver=14.1.1+r1+g43b730b9134
+ _commit=43b730b9134af60a8f1c5b107d625f7127ff23c5
+ pkgrel=1
+@@ -18,11 +18,8 @@ url='https://gcc.gnu.org'
  makedepends=(
    binutils
    doxygen
@@ -23,27 +21,27 @@ index 439849e..7c0a046 100644
    libisl
    libmpc
    python
-@@ -42,6 +39,7 @@
+@@ -41,6 +38,7 @@ _libdir=usr/lib/gcc/$CHOST/${pkgver%%+*}
+ source=(git+https://sourceware.org/git/gcc.git#commit=${_commit}
          c89 c99
          gcc-ada-repro.patch
-         fix-asan-allocator-aslr.patch
 +        unfilter-default-library-path.patch
  )
  validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
                86CFFCA918CF3AF47147588051E8B148A9999C34  # evangelos@foutrelis.com
-@@ -51,7 +49,8 @@
+@@ -49,7 +47,8 @@ validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.
+ sha256sums=('51024affcbc17f4ba5528ad9aad112a9b4d367d796a44b0bc59e3403a4c82ddd'
              'de48736f6e4153f03d0a5d38ceb6c6fdb7f054e8f47ddd6af0a3dbf14f27b931'
              '2513c6d9984dd0a2058557bf00f06d8d5181734e41dcfe07be7ed86f2959622a'
-             '1773f5137f08ac1f48f0f7297e324d5d868d55201c03068670ee4602babdef2f'
--            '5ede1f5fec5b664428412a0849b28895be1c8d8982d3c0d246a4e95fd4730d65')
-+            '5ede1f5fec5b664428412a0849b28895be1c8d8982d3c0d246a4e95fd4730d65'
+-            '1773f5137f08ac1f48f0f7297e324d5d868d55201c03068670ee4602babdef2f')
++            '1773f5137f08ac1f48f0f7297e324d5d868d55201c03068670ee4602babdef2f'
 +            '7183fdeea8fd148cf9dd03b0932f9d439b818a5ab3bc9a5e20d8e0b41c9e0efd')
- 
- prepare() {
-   [[ ! -d gcc ]] && ln -s gcc-${pkgver/+/-} gcc
-@@ -69,6 +68,15 @@
-   #ASan: move allocator base to avoid conflict with high-entropy ASLR for x86-64 Linux'
-   patch -Np3 < "$srcdir/fix-asan-allocator-aslr.patch" -d libsanitizer/
+ pkgver() {
+   cd gcc
+   echo "$(cat gcc/BASE-VER)+$(git describe --tags | sed 's/[^-]*-[^-]*-//;s/[^-]*-/r&/;s/-/+/g;s/_/./')"
+@@ -68,6 +67,15 @@ prepare() {
+   # Reproducible gcc-ada
+   patch -Np0 < "$srcdir/gcc-ada-repro.patch"
  
 +  # Remove codes filtering default library paths to make mold work correctly
 +  patch -Np1 < ../unfilter-default-library-path.patch
@@ -57,7 +55,7 @@ index 439849e..7c0a046 100644
    mkdir -p "$srcdir/gcc-build"
    mkdir -p "$srcdir/libgccjit-build"
  }
-@@ -96,7 +104,7 @@
+@@ -95,7 +103,7 @@ build() {
        --enable-link-serialization=1
        --enable-linker-build-id
        --enable-lto
@@ -66,16 +64,16 @@ index 439849e..7c0a046 100644
        --enable-plugin
        --enable-shared
        --enable-threads=posix
-@@ -114,7 +122,7 @@
+@@ -113,7 +121,7 @@ build() {
    CXXFLAGS=${CXXFLAGS/-Werror=format-security/}
  
    "$srcdir/gcc/configure" \
--    --enable-languages=ada,c,c++,d,fortran,go,lto,m2,objc,obj-c++ \
-+    --enable-languages=c,c++,d,fortran,go,lto,m2,objc,obj-c++ \
+-    --enable-languages=ada,c,c++,d,fortran,go,lto,m2,objc,obj-c++,rust \
++    --enable-languages=c,c++,d,fortran,go,lto,m2,objc,obj-c++,rust \
      --enable-bootstrap \
      "${_confflags[@]:?_confflags unset}"
  
-@@ -162,9 +170,9 @@
+@@ -161,9 +169,9 @@ check() {
  package_gcc-libs() {
    pkgdesc='Runtime libraries shipped by GCC'
    depends=('glibc>=2.27')
@@ -87,7 +85,7 @@ index 439849e..7c0a046 100644
    replaces=($pkgname-multilib libgphobos)
  
    cd gcc-build
-@@ -177,9 +185,8 @@
+@@ -176,9 +184,8 @@ package_gcc-libs() {
               libgomp \
               libitm \
               libquadmath \
@@ -99,7 +97,13 @@ index 439849e..7c0a046 100644
      make -C $CHOST/$lib DESTDIR="$pkgdir" install-toolexeclibLTLIBRARIES
    done
  
-@@ -202,12 +209,14 @@
+@@ -195,18 +202,17 @@ package_gcc-libs() {
+     make -C $CHOST/$lib DESTDIR="$pkgdir" install-info
+   done
+ 
+-  # remove files provided by lib32-gcc-libs
+-  rm -rf "$pkgdir"/usr/lib32/
+-
    # Install Runtime Library Exception
    install -Dm644 "$srcdir/gcc/COPYING.RUNTIME" \
      "$pkgdir/usr/share/licenses/gcc-libs/RUNTIME.LIBRARY.EXCEPTION"
@@ -115,7 +119,7 @@ index 439849e..7c0a046 100644
    provides=($pkgname-multilib)
    replaces=($pkgname-multilib)
    options=(!emptydirs staticlibs)
-@@ -221,22 +230,18 @@
+@@ -220,22 +226,18 @@ package_gcc() {
    install -m755 -t "$pkgdir/${_libdir}/" gcc/{cc1,cc1plus,collect2,lto1}
  
    make -C $CHOST/libgcc DESTDIR="$pkgdir" install
@@ -140,7 +144,7 @@ index 439849e..7c0a046 100644
  
    make DESTDIR="$pkgdir" install-fixincludes
    make -C gcc DESTDIR="$pkgdir" install-mkheaders
-@@ -251,16 +256,11 @@
+@@ -250,16 +252,11 @@ package_gcc() {
    make -C $CHOST/libquadmath DESTDIR="$pkgdir" install-nodist_libsubincludeHEADERS
    make -C $CHOST/libsanitizer DESTDIR="$pkgdir" install-nodist_{saninclude,toolexeclib}HEADERS
    make -C $CHOST/libsanitizer/asan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
@@ -153,12 +157,12 @@ index 439849e..7c0a046 100644
  
    make -C gcc DESTDIR="$pkgdir" install-man install-info
    rm "$pkgdir"/usr/share/man/man1/{gccgo,gfortran,lto-dump,gdc,gm2}.1
--  rm "$pkgdir"/usr/share/info/{gccgo,gfortran,gnat-style,gnat_rm,gnat_ugn,gdc}.info
-+  rm "$pkgdir"/usr/share/info/{gccgo,gfortran,gdc}.info
+-  rm "$pkgdir"/usr/share/info/{gccgo,gfortran,gnat-style,gnat_rm,gnat_ugn,gdc,m2}.info
++  rm "$pkgdir"/usr/share/info/{gccgo,gfortran,gdc,m2}.info
  
    make -C libcpp DESTDIR="$pkgdir" install
    make -C gcc DESTDIR="$pkgdir" install-po
-@@ -271,7 +271,7 @@
+@@ -270,7 +267,7 @@ package_gcc() {
    # create cc-rs compatible symlinks
    # https://github.com/rust-lang/cc-rs/blob/1.0.73/src/lib.rs#L2578-L2581
    for binary in {c++,g++,gcc,gcc-ar,gcc-nm,gcc-ranlib}; do
@@ -167,7 +171,17 @@ index 439849e..7c0a046 100644
    done
  
    # POSIX conformance launcher scripts for c89 and c99
-@@ -303,8 +303,6 @@
+@@ -280,9 +277,6 @@ package_gcc() {
+   # install the libstdc++ man pages
+   make -C $CHOST/libstdc++-v3/doc DESTDIR="$pkgdir" doc-install-man
+ 
+-  # remove files provided by lib32-gcc-libs
+-  rm -f "$pkgdir"/usr/lib32/lib{stdc++,gcc_s}.so
+-
+   # byte-compile python libraries
+   python -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
+   python -O -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
+@@ -302,8 +296,6 @@ package_gcc-fortran() {
    cd gcc-build
    make -C $CHOST/libgfortran DESTDIR="$pkgdir" install-cafexeclibLTLIBRARIES \
      install-{toolexeclibDATA,nodist_fincludeHEADERS,gfor_cHEADERS}
@@ -176,20 +190,7 @@ index 439849e..7c0a046 100644
    make -C $CHOST/libgomp DESTDIR="$pkgdir" install-nodist_fincludeHEADERS
    make -C gcc DESTDIR="$pkgdir" fortran.install-{common,man,info}
    install -Dm755 gcc/f951 "$pkgdir/${_libdir}/f951"
-@@ -361,12 +359,6 @@
-   ln -s libgnat-${_majorver}.so "$pkgdir/usr/lib/libgnat.so"
-   rm -f "$pkgdir"/${_libdir}/adalib/libgna{rl,t}.so
- 
--  install -d "$pkgdir/usr/lib32/"
--  mv "$pkgdir"/${_libdir}/32/adalib/libgna{rl,t}-${_majorver}.so "$pkgdir/usr/lib32"
--  ln -s libgnarl-${_majorver}.so "$pkgdir/usr/lib32/libgnarl.so"
--  ln -s libgnat-${_majorver}.so "$pkgdir/usr/lib32/libgnat.so"
--  rm -f "$pkgdir"/${_libdir}/32/adalib/libgna{rl,t}.so
--
-   # Install Runtime Library Exception
-   install -d "$pkgdir/usr/share/licenses/$pkgname/"
-   ln -s /usr/share/licenses/gcc-libs/RUNTIME.LIBRARY.EXCEPTION \
-@@ -382,7 +374,6 @@
+@@ -381,7 +373,6 @@ package_gcc-go() {
  
    cd gcc-build
    make -C $CHOST/libgo DESTDIR="$pkgdir" install-exec-am


### PR DESCRIPTION
Fix rotten.

Built from main branch as there are additional fixes:

commit ae17258e5726c1d920ce504496688053ccd07a76 (HEAD -> main, origin/main, origin/HEAD)
Author: Frederik Schwan <freswa@archlinux.org>
Date:   Thu May 9 15:12:50 2024 +0200

fix rust compile missing crab1 binary

fixes #11

commit 2008427fb8f910027ecf23ee0f3d5a031566e8dc
Author: Frederik Schwan <freswa@archlinux.org>
Date:   Thu May 9 09:48:34 2024 +0200

remove duplicate m2.info from gcc

fixes #10

commit b6ae46d51dc01102eb2189e7ec01316b42e7a226 (tag: 14.1.1+r1+g43b730b9134-1)
Author: Frederik Schwan <freswa@archlinux.org>
Date:   Tue May 7 22:16:52 2024 +0200

upgpkg: 14.1.1+r1+g43b730b9134-1