### PR TITLE
updpatch: glibc 2.39+r52+gf8e4623421-1

### DIFF
--- a/glibc/riscv64.patch
+++ b/glibc/riscv64.patch
@@ -1,38 +1,55 @@
-diff --git PKGBUILD PKGBUILD
-index 4a30a22..793dfa8 100644
---- PKGBUILD
-+++ PKGBUILD
-@@ -14,12 +14,11 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 387a412..e2bbef6 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -7,19 +7,18 @@
+ # NOTE: valgrind requires rebuilt with each major glibc version
+ 
+ pkgbase=glibc
+-pkgname=(glibc lib32-glibc glibc-locales)
++pkgname=(glibc glibc-locales)
+ pkgver=2.39+r52+gf8e4623421
+ _commit=f8e462342189525e4605cf233b8f798d1c7f398d
+ pkgrel=1
  arch=(x86_64)
  url='https://www.gnu.org/software/libc'
  license=(GPL-2.0-or-later LGPL-2.1-or-later)
 -makedepends=(git gd lib32-gcc-libs python)
 +makedepends=(git gd python)
  options=(staticlibs !lto)
- source=(git+https://sourceware.org/git/glibc.git#commit=${_commit}
+ source=("git+https://sourceware.org/git/glibc.git#commit=${_commit}"
          locale.gen.txt
          locale-gen
 -        lib32-glibc.conf
          sdt.h sdt-config.h
  )
  validpgpkeys=(7273542B39962DF7B299931416792B4EA25340F8 # Carlos O'Donell
-@@ -27,7 +26,6 @@
- b2sums=('SKIP'
+@@ -27,7 +26,6 @@ validpgpkeys=(7273542B39962DF7B299931416792B4EA25340F8 # Carlos O'Donell
+ b2sums=('a37822e85d99b01b289950bbc3a6ba3c9f88cf2aafe6510a4e3aa9666c35ab4279377b8c706976545a04d94aae888e48e084da54ae117b5f1220cea50e5092bb'
          'c859bf2dfd361754c9e3bbd89f10de31f8e81fd95dc67b77d10cb44e23834b096ba3caa65fbc1bd655a8696c6450dfd5a096c476b3abf5c7e125123f97ae1a72'
          '04fbb3b0b28705f41ccc6c15ed5532faf0105370f22133a2b49867e790df0491f5a1255220ff6ebab91a462f088d0cf299491b3eb8ea53534cb8638a213e46e3'
 -        '7c265e6d36a5c0dff127093580827d15519b6c7205c2e1300e82f0fb5b9dd00b6accb40c56581f18179c4fbbc95bd2bf1b900ace867a83accde0969f7b609f8a'
          'a6a5e2f2a627cc0d13d11a82458cfd0aa75ec1c5a3c7647e5d5a3bb1d4c0770887a3909bfda1236803d5bc9801bfd6251e13483e9adf797e4725332cd0d91a0e'
          '214e995e84b342fe7b2a7704ce011b7c7fc74c2971f98eeb3b4e677b99c860addc0a7d91b8dc0f0b8be7537782ee331999e02ba48f4ccc1c331b60f27d715678')
  
-@@ -48,7 +46,6 @@
-       --enable-cet
+@@ -37,7 +35,7 @@ pkgver() {
+ }
+ 
+ prepare() {
+-  mkdir -p glibc-build lib32-glibc-build
++  mkdir -p glibc-build
+ 
+   [[ -d glibc-$pkgver ]] && ln -s glibc-$pkgver glibc
+   cd glibc
+@@ -52,7 +50,6 @@ build() {
+       --enable-bind-now
        --enable-fortify-source
        --enable-kernel=4.4
 -      --enable-multi-arch
        --enable-stack-protector=strong
        --enable-systemtap
        --disable-nscd
-@@ -80,25 +77,6 @@
+@@ -84,29 +81,6 @@ build() {
      make info
    )
  
@@ -40,6 +57,10 @@ index 4a30a22..793dfa8 100644
 -    cd lib32-glibc-build
 -    export CC="gcc -m32 -mstackrealign"
 -    export CXX="g++ -m32 -mstackrealign"
+-
+-    # remove frame pointer flags due to crashes of nvidia driver on steam starts
+-    # See https://gitlab.archlinux.org/archlinux/packaging/packages/glibc/-/issues/10
+-    CFLAGS=${CFLAGS/-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer/}
 -
 -    echo "slibdir=/usr/lib32" >> configparms
 -    echo "rtlddir=/usr/lib32" >> configparms
@@ -58,8 +79,8 @@ index 4a30a22..793dfa8 100644
    # pregenerate locales here instead of in package
    # functions because localedef does not like fakeroot
    make -C "${srcdir}"/glibc/localedata objdir="${srcdir}"/glibc-build \
-@@ -134,7 +112,7 @@
-   _skip_test tst-process_mrelease    sysdeps/unix/sysv/linux/Makefile
+@@ -141,7 +115,7 @@ check() (
+   _skip_test tst-shstk-legacy-1g     sysdeps/x86_64/Makefile
    _skip_test tst-adjtime             time/Makefile
  
 -  make -O check
@@ -67,9 +88,35 @@ index 4a30a22..793dfa8 100644
  )
  
  package_glibc() {
-@@ -217,3 +195,5 @@
-   # deduplicate locale data
-   hardlink -c "${pkgdir}"/usr/lib/locale
+@@ -190,31 +164,6 @@ package_glibc() {
+   install -Dm644 "${srcdir}"/sdt-config.h "${pkgdir}"/usr/include/sys/sdt-config.h
  }
-+
-+pkgname=( ${pkgname[*]/lib32-glibc} )
+ 
+-package_lib32-glibc() {
+-  pkgdesc='GNU C Library (32-bit)'
+-  depends=("glibc=$pkgver")
+-  options+=('!emptydirs')
+-  install=lib32-glibc.install
+-
+-  cd lib32-glibc-build
+-
+-  make DESTDIR="${pkgdir}" install
+-  rm -rf "${pkgdir}"/{etc,sbin,usr/{bin,sbin,share},var}
+-
+-  # We need to keep 32 bit specific header files
+-  find "${pkgdir}"/usr/include -type f -not -name '*-32.h' -delete
+-
+-  # Dynamic linker
+-  install -d "${pkgdir}"/usr/lib
+-  ln -s ../lib32/ld-linux.so.2 "${pkgdir}"/usr/lib/
+-
+-  # Add lib32 paths to the default library search path
+-  install -Dm644 "${srcdir}"/lib32-glibc.conf "${pkgdir}"/etc/ld.so.conf.d/lib32-glibc.conf
+-
+-  # Symlink /usr/lib32/locale to /usr/lib/locale
+-  ln -s ../lib/locale "${pkgdir}"/usr/lib32/locale
+-}
+-
+ package_glibc-locales() {
+   pkgdesc='Pregenerated locales for GNU C Library'
+   depends=("glibc=$pkgver")


### PR DESCRIPTION
Fix rotten patch. Needs to build on main branch:
https://gitlab.archlinux.org/archlinux/packaging/packages/glibc/-/commit/bedd2d1077b924843071787b546cf3c0457d80f7