### PR TITLE
updpatch: deno 1.43.3-1

### DIFF
--- a/deno/riscv64.patch
+++ b/deno/riscv64.patch
@@ -5,12 +5,12 @@
  depends=('gcc-libs')
  makedepends=('git' 'python' 'rust' 'nodejs' 'gn' 'ninja' 'clang' 'lld' 'cmake' 'protobuf')
 -source=("git+https://github.com/denoland/deno.git#commit=$_commit")
--sha512sums=('568d62b4a8b96c5f68e9391130080ab65cdf8f5d9e172c4433fd8a0503944e503f1a32c8406eb9bc7fbc1cddbff9de563b9d934c7c119eaea00f01d0cc120dcd')
+-sha512sums=('9d5ff9f6e40b43c0e26556a57dabfab9b94721e8c9a0d6fdddfad62694ce69afcaac555d8028a7d83306f4942e65c0c110ee86f39117158e8794cfa82cddaf8b')
 +source=("git+https://github.com/denoland/deno.git#commit=$_commit"
-+        "git+https://github.com/denoland/rusty_v8.git#commit=89fbf2a0511d9a5d6da69686543db1f021feb980"  # 0.89.0
++        "git+https://github.com/denoland/rusty_v8.git#commit=eb849c3b647c46d84f026a18f3523f150f4a132e"  # 0.91.1
 +        "add-rvb-flags.patch")
-+sha512sums=('568d62b4a8b96c5f68e9391130080ab65cdf8f5d9e172c4433fd8a0503944e503f1a32c8406eb9bc7fbc1cddbff9de563b9d934c7c119eaea00f01d0cc120dcd'
-+            'f53994139dfa6ca506fa9a17a112aef5849c239c5b9dc36668f9cdb3093ef17dd9845962b05a06f9f07a5c76240d7d256817a3c33dd1655a488d4ec8b0dd7cd9'
++sha512sums=('9d5ff9f6e40b43c0e26556a57dabfab9b94721e8c9a0d6fdddfad62694ce69afcaac555d8028a7d83306f4942e65c0c110ee86f39117158e8794cfa82cddaf8b'
++            'bd73cb58b8e6842f43dea5e5ba37a34cc00e60897ee596ea0bf3e23dcd526aa0b4cbd258116748189dcb40f9a493113565066531d34deec8d583f546edf14559'
 +            '262a2976faf3dc94fd0183c0b47e52e241bfaffaf16e2a1a54d079993c8cdacce5e9bd979aff41f9de3a7243444fa24cd6e9ea3ee69867bf4236d498203e15e0')
 +
 +prepare() {


### PR DESCRIPTION
Fix rotten patch again since upstream does not seem to update Chromium's build/ directory. Reported to https://github.com/denoland/rusty_v8/issues/1476.