### PR TITLE
fixpatch: glibc

### DIFF
--- a/glibc/riscv64.patch
+++ b/glibc/riscv64.patch
@@ -1,7 +1,7 @@
 diff --git a/PKGBUILD b/PKGBUILD
 index 387a412..e2bbef6 100644
---- a/PKGBUILD
-+++ b/PKGBUILD
+--- PKGBUILD
++++ PKGBUILD
 @@ -7,19 +7,18 @@
  # NOTE: valgrind requires rebuilt with each major glibc version
  


### PR DESCRIPTION
fix missing `--no-prefix`