### PR TITLE
addpatch: python-leather 0.4.0

### DIFF
--- a/python-leather/riscv64.patch
+++ b/python-leather/riscv64.patch
@@ -1,0 +1,29 @@
+From 4c9a1608edfa6c571a3f783f9fa9bb9dc467a2fb Mon Sep 17 00:00:00 2001
+From: Kanak Shilledar <kanakshilledar111@protonmail.com>
+Date: Sun, 19 May 2024 12:45:20 +0530
+Subject: [PATCH] fix: python-leather checksum
+
+fix checksum mismatch error for the python-leather package.
+successfully building and passed checks.
+
+Signed-off-by: Kanak Shilledar <kanakshilledar111@protonmail.com>
+---
+ PKGBUILD | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/PKGBUILD b/PKGBUILD
+index 3b6d2eb..5c8d3ed 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,7 +17,7 @@ checkdepends=(python-cssselect
+               python-lxml)
+ _archive="$_pyname-$pkgver"
+ source=("$_archive.tar.gz::https://github.com/wireservice/$_pyname/archive/$pkgver.tar.gz")
+-sha256sums=('2bc92e77a2db43b0a0aabdc9ce0893d0728ce0c8098897a55e4c2244bbdc5b0f')
++sha256sums=('5b4d698e97534a2600150837c2beb446278b7ef276a699768efc5488c88290c3')
+ 
+ build() {
+ 	cd "$_archive"
+-- 
+2.34.1
+


### PR DESCRIPTION
fix checksum mismatch error.
successfully passing the tests.