### PR TITLE
addpatch: csound 6.18.1-4

### DIFF
--- a/csound/riscv64.patch
+++ b/csound/riscv64.patch
@@ -1,0 +1,34 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -46,19 +46,29 @@ source=(
+   $pkgbase.sh
+   https://github.com/$pkgbase/$pkgbase/releases/download/$_manual_pkgver/Csound${_manual_pkgver}_manual_html.zip
+   https://github.com/$pkgbase/$pkgbase/releases/download/$_manual_pkgver/Csound${_manual_pkgver}_manual_pdf.zip
++  fix-liblo-calls.patch::https://github.com/$pkgbase/$pkgbase/commit/596667daba1ed99eda048e491ff8f36200f09429.diff
++  fix-type-mismatch.patch::https://github.com/$pkgbase/$pkgbase/commit/2a071ae8ca89bc21b5c80037f8c95a01bb670ac9.diff
+ )
+ sha512sums=('4ea4dccb36017c96482389a8d139f6f55c79c5ceb9cc34e6d2bfabcb930b4833d0301be4a4b21929db27b2d8ce30754b5c5867acd2ea5a849135e1b8d1506acf'
+             '53a8ae1e61db2a3a492930ef0f0881b613ae47108c5e8de0a6e2aa28bcf7a5c93c7fea8b7fc2bbae29ab92e1e68bf94ba406be1255ad8ab5725ea9078c1fd6dc'
+             'ff2098828e51e78aa80b10736ea162d90c0b1bef3265e469951a5df63250d283e852490cb2a6599dcb1b8a5c185cf4f0b9534f501e4cb755b9da67ecfb1f4ba6'
+-            'bf664bab1dec073b48853ccf7519086c55ad74af33db86ac7f95746231c18fb10d46a485047788050094e412d27bbd0df65e238d31b01b435989f2fd734189a6')
++            'bf664bab1dec073b48853ccf7519086c55ad74af33db86ac7f95746231c18fb10d46a485047788050094e412d27bbd0df65e238d31b01b435989f2fd734189a6'
++            '7e91a1d389c6969ce17bc9256d77b1a75cccbd5e8c4a867dcf2a74532581a83e1540af36bcb778e9718ef5dfc7f21ab083119d0ce3e6ceaf2ea9bf8d2ee9cd25'
++            '951d7e2cf0ea329e45fcfe8385b5b58c2bdeeb5371ea1c0717c64d230f2e85f71b1f4e9887ac33b73c1e10370b55308816289fb1787e558fce399eeae9869be2')
+ b2sums=('1b258724dd986eea63921e36b43235eb05702729ee31e40ef724f7e7644755adeb5a3abdca9188d65296882d5f532693c0f9fc742ee5d39ccc7fbed860ec0bf4'
+         '8a556685d0f9ee55c4de521b3d76fc729936e98e991e8ea860d64b29a1b09d142ab0a51548b2dddadb41ecb796e84ba1f8ed114494b4c67d7d6d8ab3475b2ede'
+         '3148a60a398d49d6932864d84b2ee37ddf86d5389b91c99443b2c64f7c3b270d040b83ac88b80ebc772c198223682452da1618391fcc8963fe63151b7837037e'
+-        'c0210f2fb97a6707ae6cd0a0cf38cd374f4d4c973b188ee8d418a7efd5c98dc1d4e61867de021ed2859bd8264cc0876b46deb565c358b6efea42f471d39671a9')
++        'c0210f2fb97a6707ae6cd0a0cf38cd374f4d4c973b188ee8d418a7efd5c98dc1d4e61867de021ed2859bd8264cc0876b46deb565c358b6efea42f471d39671a9'
++        'f5faf34871884432d22e7b9fdd43137c64c71e8942f200ce7f119d14be1dd264df575143886df3532a92c79cd31954a9b766130f51adeeed843669c3c81439b2'
++        '81b8697277e7088de3d74e4fd14ac4d412d8bbd37dcbc1211267706473564ef5b3c447877b12ce08531f1c6e221d421f326854cd507754acdfc3c56213a34838')
+ 
+ prepare() {
+   # fix file permissions in html manual
+   find html/ -type f -exec chmod -c 644 {} \;
++
++  cd $pkgbase-$pkgver
++  patch -Np1 -i ../fix-liblo-calls.patch
++  patch -Np1 -i ../fix-type-mismatch.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
Backport fixes of incompatible pointer types. Upstreamed to https://github.com/csound/csound/pull/1887.