### PR TITLE
addpatch: goocanvas 3.0.0-5

### DIFF
--- a/goocanvas/goocanvas-fix-incompatible-pointer-types.patch
+++ b/goocanvas/goocanvas-fix-incompatible-pointer-types.patch
@@ -1,0 +1,13 @@
+diff --git a/src/goocanvasitemsimple.c b/src/goocanvasitemsimple.c
+index 19b3424..b603f93 100644
+--- a/src/goocanvasitemsimple.c
++++ b/src/goocanvasitemsimple.c
+@@ -1536,7 +1536,7 @@ goo_canvas_item_simple_set_model (GooCanvasItemSimple  *item,
+   goo_canvas_item_simple_free_data (item->simple_data);
+   g_slice_free (GooCanvasItemSimpleData, item->simple_data);
+ 
+-  item->model = g_object_ref (model);
++  item->model = (GooCanvasItemModelSimple*) g_object_ref (model);
+   item->simple_data = &item->model->simple_data;
+ 
+   if (accessibility_enabled)

--- a/goocanvas/riscv64.patch
+++ b/goocanvas/riscv64.patch
@@ -1,0 +1,26 @@
+diff --git PKGBUILD PKGBUILD
+index 917d3a7..148b3ef 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,8 +12,10 @@
+ depends=('gtk3')
+ makedepends=('git' 'gobject-introspection' 'gtk-doc' 'python-gobject' 'python-setuptools')
+ _commit=076c374ab05b9ee326e3b7905d3d72197429171e  # tags/3.0.0^0
+-source=("git+https://gitlab.gnome.org/GNOME/goocanvas.git#commit=$_commit")
+-sha256sums=('SKIP')
++source=("git+https://gitlab.gnome.org/GNOME/goocanvas.git#commit=$_commit"
++        "goocanvas-fix-incompatible-pointer-types.patch")
++sha256sums=('8576a84ab75e8578e444289a4a36001b372929745cd614ce6e0e0e5972012afa'
++            '66ed7002120bbe81c6f82417ceb116016a21d6683d25db78ca268a057b35a262')
+ 
+ pkgver() {
+   cd $pkgname
+@@ -30,6 +32,8 @@
+   cp docs/goocanvas2.types docs/goocanvas3.types
+ 
+   NOCONFIGURE=1 ./autogen.sh
++
++  patch -Np1 -i ../goocanvas-fix-incompatible-pointer-types.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
Fix incompatible-pointer-types.
GNOME upstream archived.
[Arch Linux issue](https://gitlab.archlinux.org/archlinux/packaging/packages/goocanvas/-/issues/1)