### PR TITLE
updpatch: nodejs 22.2.0-1

### DIFF
--- a/nodejs/fix-trap-handler.patch
+++ b/nodejs/fix-trap-handler.patch
@@ -1,0 +1,37 @@
+From 2674676fe3b01cc9652a5922badc9b044080fce7 Mon Sep 17 00:00:00 2001
+From: Lu Yahan <yahan@iscas.ac.cn>
+Date: Wed, 8 May 2024 16:34:24 +0800
+Subject: [PATCH] tools: fix riscv64 build failed
+
+---
+ tools/v8_gypfiles/v8.gyp | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/tools/v8_gypfiles/v8.gyp b/tools/v8_gypfiles/v8.gyp
+index 1e2b3645132aab..ab96e0c7d2c1f2 100644
+--- a/tools/v8_gypfiles/v8.gyp
++++ b/tools/v8_gypfiles/v8.gyp
+@@ -1150,6 +1150,23 @@
+           'sources': [
+             '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "\\"v8_base_without_compiler.*?v8_enable_wasm_gdb_remote_debugging.*?v8_current_cpu == \\"riscv64\\".*?sources \\+= ")',
+           ],
++          'conditions': [
++            ['v8_enable_webassembly==1', {
++              'conditions': [
++                ['(_toolset=="host" and host_arch=="arm64" or _toolset=="target" and target_arch=="arm64") or (_toolset=="host" and host_arch=="riscv64" or _toolset=="target" and target_arch=="riscv64") or (_toolset=="host" and host_arch=="x64" or _toolset=="target" and target_arch=="x64")', {
++                  'sources': [
++                    '<(V8_ROOT)/src/trap-handler/handler-inside-posix.cc',
++                    '<(V8_ROOT)/src/trap-handler/handler-outside-posix.cc',
++                  ],
++                }],
++                ['(_toolset=="host" and host_arch=="x64" or _toolset=="target" and target_arch=="x64") and (OS=="linux" or OS=="mac" or OS=="win")', {
++                  'sources': [
++                    '<(V8_ROOT)/src/trap-handler/handler-outside-simulator.cc',
++                  ],
++                }],
++              ],
++            }],
++          ],
+         }],
+         ['v8_target_arch=="loong64"', {
+           'sources': [

--- a/nodejs/riscv64.patch
+++ b/nodejs/riscv64.patch
@@ -1,33 +1,22 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -22,7 +22,16 @@ optdepends=('npm: nodejs package manager')
- source=("git+https://github.com/nodejs/node.git#commit=$_commit")
- sha512sums=('c863de81eb5d45d0e271d8828c52395216bbfc9ac736c90d561234b5724454b95dd759cd96ff5435e43c2debd356f966c14cf8b68a81421601d21b611e2e1f80')
+@@ -18,10 +18,17 @@ options=(!lto)
+ depends=('icu' 'libuv' 'libnghttp2' 'libnghttp3' 'libngtcp2' 'openssl' 'zlib' 'brotli' 'c-ares') # 'http-parser' 'v8')
+ makedepends=('git' 'python' 'procps-ng')
+ optdepends=('npm: nodejs package manager')
+-source=("git+https://github.com/nodejs/node.git#tag=v$pkgver?signed")
+-sha512sums=('9603c736e5f0fb976507413ecec5d3ab5b62fb7eec53635a7a376c2c9b41cc89ab3830a61b6b0f923aa7c62dff7b29a7150000d7db85c43c7e286a42c8beb408')
++source=("git+https://github.com/nodejs/node.git#tag=v$pkgver?signed"
++        "fix-trap-handler.patch")
++sha512sums=('9603c736e5f0fb976507413ecec5d3ab5b62fb7eec53635a7a376c2c9b41cc89ab3830a61b6b0f923aa7c62dff7b29a7150000d7db85c43c7e286a42c8beb408'
++            'f2ff6da8cf5dcc994a7a20342e2928dc1821fbbf42891009a6234b6051277e0200d7e3fbba63b9a2773887591d0ad5ceb1bb3d25e5efeb557f6d00109a80253c')
+ validpgpkeys=('8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600') # Michaël Zasso (Targos) <targos@protonmail.com>
  
-+makedepends+=(clang)
-+
-+_set_compilation_env() {
-+  # https://bugs.chromium.org/p/v8/issues/detail?id=14547
-+  export CC=/usr/bin/clang
-+  export CXX=/usr/bin/clang++
++prepare() {
++  cd node
++  patch -Np1 -i ../fix-trap-handler.patch
 +}
 +
  build() {
-+  _set_compilation_env
    cd node
  
-   # /usr/lib/libnode.so uses malloc_usable_size, which is incompatible with fortification level 3
-@@ -48,11 +57,13 @@ build() {
- }
- 
- check() {
-+  _set_compilation_env
-   cd node
-   make test || :
- }
- 
- package() {
-+  _set_compilation_env
-   cd node
-   make DESTDIR="$pkgdir" install
-   install -Dm644 LICENSE -t "$pkgdir"/usr/share/licenses/nodejs/


### PR DESCRIPTION
- Backport https://github.com/nodejs/node/pull/52888
- Seems crash when building with gcc had fixed, use GCC again.