### PR TITLE
addpatch: browserpass 3.1.0-2

### DIFF
--- a/browserpass/riscv64.patch
+++ b/browserpass/riscv64.patch
@@ -1,0 +1,23 @@
+diff --git PKGBUILD PKGBUILD
+index c3c0323..164dc0a 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,13 +14,16 @@
+ optdepends=('browserpass-chromium: Chromium extension for Browserpass'
+             'browserpass-firefox: Firefox extension for Browserpass')
+ source=("${pkgname}-${pkgver}.tar.gz::${url}/releases/download/${pkgver}/${_name}-${pkgver}-src.tar.gz"
+-        "${pkgname}-${pkgver}.tar.gz.asc::${url}/releases/download/${pkgver}/${_name}-${pkgver}-src.tar.gz.asc")
++        "${pkgname}-${pkgver}.tar.gz.asc::${url}/releases/download/${pkgver}/${_name}-${pkgver}-src.tar.gz.asc"
++        "${pkgname}-enable-cgo-riscv64.patch::https://github.com/browserpass/browserpass-native/commit/faa95eb0e01c6d5950b00400f7765d246ea490f9.diff")
+ sha256sums=('7ab92d04aa136c69d993e3c2d81ee2d395480ab6556be3d45f5694edcc8024b5'
+-            'SKIP')
++            'SKIP'
++            'a9b83bae57b63bbcf21a0cee1cc666328cffeae17a02d2d63a85c86a75e72fca')
+ validpgpkeys=('56C3E775E72B0C8B1C0C1BD0B5DB77409B11B601')
+ 
+ prepare() {
+     cd "${_name}-${pkgver}"
++    patch -Np1 -i ../"${pkgname}-enable-cgo-riscv64.patch"
+     make configure
+ }
+ 


### PR DESCRIPTION
Enable CGO on riscv64.
[Upstream PR](https://github.com/browserpass/browserpass-native/pull/148)