### PR TITLE
addpatch: netdata 1.45.5-2

### DIFF
--- a/netdata/riscv64.patch
+++ b/netdata/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index 57aeb4a..c1f1563 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -35,7 +35,7 @@ prepare() {
+   sed -i "s|usr/libexec|usr/lib|g" CMakeLists.txt
+ 
+   # libbpf sources for eBPF.plugin
+-  CFLAGS="${CFLAGS} -fPIC" "packaging/bundle-libbpf.sh" "../netdata-v${pkgver}" "other"
++  CFLAGS="${CFLAGS} -fPIC" LIBDIR=/usr/lib "packaging/bundle-libbpf.sh" "../netdata-v${pkgver}" "other"
+   CFLAGS="${CFLAGS} -fPIC" "packaging/bundle-ebpf-co-re.sh" "../netdata-v${pkgver}"
+ }
+ 


### PR DESCRIPTION
[`libbpf`](https://github.com/netdata/libbpf/blob/89aecd2188fa525718cb88d2777ba0e08defd286/src/Makefile#L83-L100) is installed in `/usr/lib64` by default on 64-bit machines, but [`bundle-libbpf.sh`](https://github.com/netdata/netdata/blob/10dd98a45d23b0267bb78d5c224ed3f446fc535f/packaging/bundle-libbpf.sh#L24-L25) looks for `libbpf` in `/usr/lib` on non-x86_64 platforms.

Fix by specifying `LIBDIR=/usr/lib`.