### PR TITLE
updpatch: nodejs 22.2.0-1

### DIFF
--- a/nodejs/riscv64.patch
+++ b/nodejs/riscv64.patch
@@ -1,22 +1,34 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -18,10 +18,17 @@ options=(!lto)
+@@ -18,10 +18,21 @@ options=(!lto)
  depends=('icu' 'libuv' 'libnghttp2' 'libnghttp3' 'libngtcp2' 'openssl' 'zlib' 'brotli' 'c-ares') # 'http-parser' 'v8')
  makedepends=('git' 'python' 'procps-ng')
  optdepends=('npm: nodejs package manager')
 -source=("git+https://github.com/nodejs/node.git#tag=v$pkgver?signed")
--sha512sums=('9603c736e5f0fb976507413ecec5d3ab5b62fb7eec53635a7a376c2c9b41cc89ab3830a61b6b0f923aa7c62dff7b29a7150000d7db85c43c7e286a42c8beb408')
 +source=("git+https://github.com/nodejs/node.git#tag=v$pkgver?signed"
-+        "fix-trap-handler.patch")
-+sha512sums=('9603c736e5f0fb976507413ecec5d3ab5b62fb7eec53635a7a376c2c9b41cc89ab3830a61b6b0f923aa7c62dff7b29a7150000d7db85c43c7e286a42c8beb408'
-+            'f2ff6da8cf5dcc994a7a20342e2928dc1821fbbf42891009a6234b6051277e0200d7e3fbba63b9a2773887591d0ad5ceb1bb3d25e5efeb557f6d00109a80253c')
++        "fix-trap-handler.patch"
++        "https://github.com/riscv-forks/electron/raw/610e905b10f11a0844576b04b034015cfe407315/patches/v8/Skip-check-sv57-when-enable-pointer-compress.patch"
++        "https://github.com/riscv-forks/electron/raw/610e905b10f11a0844576b04b034015cfe407315/patches/v8/avoid-cpu-probing-in-li_ptr.patch")
+ sha512sums=('9603c736e5f0fb976507413ecec5d3ab5b62fb7eec53635a7a376c2c9b41cc89ab3830a61b6b0f923aa7c62dff7b29a7150000d7db85c43c7e286a42c8beb408')
  validpgpkeys=('8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600') # Michaël Zasso (Targos) <targos@protonmail.com>
  
 +prepare() {
 +  cd node
 +  patch -Np1 -i ../fix-trap-handler.patch
++  cd deps/v8
++  patch -Np1 -i "${srcdir}"/Skip-check-sv57-when-enable-pointer-compress.patch
++  patch -Np1 -i "${srcdir}"/avoid-cpu-probing-in-li_ptr.patch
 +}
 +
  build() {
    cd node
  
+@@ -58,4 +69,8 @@ package() {
+   install -Dm644 LICENSE -t "$pkgdir"/usr/share/licenses/nodejs/
+ }
+ 
++sha512sums+=('f2ff6da8cf5dcc994a7a20342e2928dc1821fbbf42891009a6234b6051277e0200d7e3fbba63b9a2773887591d0ad5ceb1bb3d25e5efeb557f6d00109a80253c'
++             'c4567c0220a0604129aab8731e7ff2825f856abc93ef6aaccb7e98dfac7d3592ed29a9b026d2f636baba9d113636ac4dfed7db75989eb8d1b460fe623520615f'
++             'eb3ece4b859a241677ef5d92a5a9a1fb3393cbe7e14f73f0860c3552553a5b52af5263a73a9073417b7dc2447264d3f5dd9ae8d0b63ef49da97c02b519b56afe')
++
+ # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
Fix performance regression bisected in https://github.com/riscv-forks/electron/issues/1 . 
Upstreamed to V8: https://chromium-review.googlesource.com/c/v8/v8/+/5612950 .
Will upstream it to nodejs once the V8 change is merged.