### PR TITLE
updpatch: linux 6.9.4.arch1-1

### DIFF
--- a/linux/riscv64.patch
+++ b/linux/riscv64.patch
@@ -1,33 +1,36 @@
 diff --git PKGBUILD PKGBUILD
-index 6f4fa71..15b195d 100644
+index c0b5c4e..6b6546a 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -35,6 +35,7 @@
+@@ -35,6 +35,8 @@ source=(
    https://cdn.kernel.org/pub/linux/kernel/v${pkgver%%.*}.x/${_srcname}.tar.{xz,sign}
    $url/releases/download/$_srctag/linux-$_srctag.patch.zst{,.sig}
    config  # the main kernel config file
 +  riscv64.config-patch
++  timer-sun4i-d1-regression.patch
  )
  validpgpkeys=(
    ABAF11C65A2970B130ABE3C479BE3E4300411886  # Linus Torvalds
-@@ -46,12 +47,14 @@
+@@ -46,12 +48,16 @@ sha256sums=('272800e0d1a7d01a78bce95a3aaf5c80816f50eb15c517d7003e58355760ecc2'
              'SKIP'
-             'cf11fe18d60f2bf85fa0dd61a2fb1d59bf40f98db48dfae2244c5839c1281919'
+             'fbd9a98f741c5793b584e8d59b65fde2fb27f40528a8a6b6db05f8a2e20a45b0'
              'SKIP'
--            '3acffee6493e810bd13f042b0a8e97e2b66a977b8ae7ec7c25a604446271860f')
-+            '3acffee6493e810bd13f042b0a8e97e2b66a977b8ae7ec7c25a604446271860f'
-+            'e9f9d87dec7e28fd998da79c403e64be0d35870bcbebe1c7c8dfe3fb941f312a')
- b2sums=('8d8fe931d304458bcaa8c8b9572a5354ad272d88d1e0642e76b37247ce13bf70c49c8de6d8843fbb3037ee074ebc6cc94f0cc2b5b7e7187385a9dd0b0e2e250d'
+-            '54150ccad92d9a3e3383148c30326643773d2bfc92adf5649f37d62050f0c649')
++            '54150ccad92d9a3e3383148c30326643773d2bfc92adf5649f37d62050f0c649'
++            'e9f9d87dec7e28fd998da79c403e64be0d35870bcbebe1c7c8dfe3fb941f312a'
++            '87637edacf2e3bdf68f389d06a242ab162404aef90d1e78306b6a04e09f62c0f')
+ b2sums=('5579aef00f38e87ee9a9878ad4340aebc9c2590d8e813e2e106af59c6739e39a37267672ab7aff56160c8519d3014d139e6c849f33b9292c6fba019bc88d09da'
          'SKIP'
-         'd6751841d7cd9448f1483af1b5dd717503206c0fb3bb4027976bfafe45b2318318add551eb35625cf09be2833cd433ef06104f1775f65e86712ea94b2ee95ef3'
+         'd9c3c74bab1b3acc3fd25825ce169b5052f8751d96d52006b8dcc2bdb9c43c6db59ebfa9f86fee9a6c5c64aae63cf03deb2acae1e595824dfcab8d254a96e3a1'
          'SKIP'
--        '8a125f2584507a3645aef2ee75d728b1a8afe643de367c26c29fc91e48e570339a295d585ce3c4419cf39c2b2f3329a53ce7287fd92efbe7eb9a01a99e5d1d49')
-+        '8a125f2584507a3645aef2ee75d728b1a8afe643de367c26c29fc91e48e570339a295d585ce3c4419cf39c2b2f3329a53ce7287fd92efbe7eb9a01a99e5d1d49'
-+        'a2ea0612add119c6dba72736aeac8f33b8812fadcf1654e0d8daae35c6ab13d930868773175a6266319802d6f2eadd0f5935c5738cc32ff5197dc7ce283b83a6')
+-        '83a625cebd3f954b89c8836a6dc9350798b6f7878d29ecba134ddbd625988c54ed34eb6327a87e5e1518b938c3eb5c60881a7cc602628547b6e0bdadeb6a6987')
++        '83a625cebd3f954b89c8836a6dc9350798b6f7878d29ecba134ddbd625988c54ed34eb6327a87e5e1518b938c3eb5c60881a7cc602628547b6e0bdadeb6a6987'
++        'a2ea0612add119c6dba72736aeac8f33b8812fadcf1654e0d8daae35c6ab13d930868773175a6266319802d6f2eadd0f5935c5738cc32ff5197dc7ce283b83a6'
++        '6049506a3b300e6cf4eaf68ec326a862eea1cac7bc3c2f8223edd2087afe91400dbba6c4b59184bfb8701a514f14875b8f8cec079cdf10a7fa22b6da923c848d')
  
  export KBUILD_BUILD_HOST=archlinux
  export KBUILD_BUILD_USER=$pkgbase
-@@ -79,6 +82,12 @@
+@@ -79,6 +85,12 @@ prepare() {
    make olddefconfig
    diff -u ../config .config || :
  
@@ -40,7 +43,7 @@ index 6f4fa71..15b195d 100644
    make -s kernelrelease > version
    echo "Prepared $pkgbase version $(<version)"
  }
-@@ -126,6 +135,9 @@
+@@ -126,6 +138,9 @@ _package() {
    ZSTD_CLEVEL=19 make INSTALL_MOD_PATH="$pkgdir/usr" INSTALL_MOD_STRIP=1 \
      DEPMOD=/doesnt/exist modules_install  # Suppress depmod
  
@@ -50,7 +53,7 @@ index 6f4fa71..15b195d 100644
    # remove build link
    rm "$modulesdir"/build
  }
-@@ -141,19 +153,16 @@
+@@ -141,19 +156,16 @@ _package-headers() {
    install -Dt "$builddir" -m644 .config Makefile Module.symvers System.map \
      localversion.* version vmlinux tools/bpf/bpftool/vmlinux.h
    install -Dt "$builddir/kernel" -m644 kernel/Makefile
@@ -73,7 +76,7 @@ index 6f4fa71..15b195d 100644
  
    install -Dt "$builddir/drivers/md" -m644 drivers/md/*.h
    install -Dt "$builddir/net/mac80211" -m644 net/mac80211/*.h
-@@ -175,7 +184,7 @@
+@@ -175,7 +187,7 @@ _package-headers() {
    echo "Removing unneeded architectures..."
    local arch
    for arch in "$builddir"/arch/*/; do

--- a/linux/timer-sun4i-d1-regression.patch
+++ b/linux/timer-sun4i-d1-regression.patch
@@ -1,0 +1,64 @@
+Commit 8ec99b033147 ("irqchip/sifive-plic: Convert PLIC driver into a
+platform driver") broke the MMIO timer on the Allwinner D1 SoC because
+the IRQ domain is no longer available when timer_probe() is called:
+
+  [    0.000000] irq: no irq domain found for interrupt-controller@10000000 !
+  [    0.000000] Failed to map interrupt for /soc/timer@2050000
+  [    0.000000] Failed to initialize '/soc/timer@2050000': -22
+
+Fix this by wrapping the timer initialization in a platform driver.
+builtin_platform_driver_probe() must be used because the driver uses
+timer_of_init(), which is marked as __init. Only convert the sun8i
+variants of the hardware, because some older SoCs still need the timer
+probed early for sched_clock().
+
+Fixes: 8ec99b033147 ("irqchip/sifive-plic: Convert PLIC driver into a platform driver")
+Signed-off-by: Samuel Holland <samuel.holland@sifive.com>
+---
+
+ drivers/clocksource/timer-sun4i.c | 24 ++++++++++++++++++++----
+ 1 file changed, 20 insertions(+), 4 deletions(-)
+
+diff --git a/drivers/clocksource/timer-sun4i.c b/drivers/clocksource/timer-sun4i.c
+index 7bdcc60ad43c..728dac2baa84 100644
+--- a/drivers/clocksource/timer-sun4i.c
++++ b/drivers/clocksource/timer-sun4i.c
+@@ -20,6 +20,7 @@
+ #include <linux/of.h>
+ #include <linux/of_address.h>
+ #include <linux/of_irq.h>
++#include <linux/platform_device.h>
+ 
+ #include "timer-of.h"
+ 
+@@ -218,9 +219,24 @@ static int __init sun4i_timer_init(struct device_node *node)
+ }
+ TIMER_OF_DECLARE(sun4i, "allwinner,sun4i-a10-timer",
+ 		       sun4i_timer_init);
+-TIMER_OF_DECLARE(sun8i_a23, "allwinner,sun8i-a23-timer",
+-		 sun4i_timer_init);
+-TIMER_OF_DECLARE(sun8i_v3s, "allwinner,sun8i-v3s-timer",
+-		 sun4i_timer_init);
+ TIMER_OF_DECLARE(suniv, "allwinner,suniv-f1c100s-timer",
+ 		       sun4i_timer_init);
++
++static int __init sun4i_timer_probe(struct platform_device *pdev)
++{
++	return sun4i_timer_init(dev_of_node(&pdev->dev));
++}
++
++static const struct of_device_id sun4i_timer_of_match[] = {
++	{ .compatible = "allwinner,sun8i-a23-timer" },
++	{ .compatible = "allwinner,sun8i-v3s-timer" },
++	{ /* sentinel */ }
++};
++
++static struct platform_driver sun4i_timer_driver = {
++	.driver	= {
++		.name		= "sun4i-timer",
++		.of_match_table	= sun4i_timer_of_match,
++	},
++};
++builtin_platform_driver_probe(sun4i_timer_driver, sun4i_timer_probe);
+-- 
+2.43.1


### PR DESCRIPTION
Apply a patch to fix regression of sifive-plic which broke Allwinner D1.