### PR TITLE
addpkg: sharutils

### DIFF
--- a/sharutils/riscv64.patch
+++ b/sharutils/riscv64.patch
@@ -1,15 +1,11 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -25,10 +25,12 @@ build() {
+@@ -19,6 +19,8 @@ sha256sums=('2b05cff7de5d7b646dc1669bc36c35fdac02ac6ae4b6c19cb3340d87ec553a9a'
+ prepare() {
  	cd "${srcdir}/${pkgname}-${pkgver}"
- 	CFLAGS+=' -fcommon' # https://wiki.gentoo.org/wiki/Gcc_10_porting_notes/fno_common
- 	CFLAGS+=' -Wno-format-security' # fix build with gettext function
-+	autoreconf -fi
- 	./configure \
- 		--prefix=/usr \
- 		--mandir=/usr/share/man \
- 		--infodir=/usr/share/info \
-+		--disable-dependency-tracking
- 
- 	make
+ 	sed 's/FUNC_FFLUSH_STDIN/-1/g' -i lib/fseeko.c
++	cp /usr/share/autoconf/build-aux/config.guess config.guess
++	cp /usr/share/autoconf/build-aux/config.sub config.sub
  }
+ 
+ build() {

--- a/sharutils/riscv64.patch
+++ b/sharutils/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -25,10 +25,12 @@ build() {
+ 	cd "${srcdir}/${pkgname}-${pkgver}"
+ 	CFLAGS+=' -fcommon' # https://wiki.gentoo.org/wiki/Gcc_10_porting_notes/fno_common
+ 	CFLAGS+=' -Wno-format-security' # fix build with gettext function
++	autoreconf -fi
+ 	./configure \
+ 		--prefix=/usr \
+ 		--mandir=/usr/share/man \
+ 		--infodir=/usr/share/info \
++		--disable-dependency-tracking
+ 
+ 	make
+ }


### PR DESCRIPTION
Will still get a permission denied issue when packaging, but it does not affect its outputted result.  
That issue can be reproduced in x86 packaging, reported in https://gitlab.archlinux.org/archlinux/packaging/packages/sharutils/-/issues/2.  
Outdated config.guess issue was reported in https://savannah.gnu.org/support/index.php?111077.  