### PR TITLE
addpatch: electron31 31.0.1-1

### DIFF
--- a/electron31/Debian-fix-rust-linking.patch
+++ b/electron31/Debian-fix-rust-linking.patch
@@ -1,0 +1,49 @@
+Index: chromium-121.0.6167.75/build/toolchain/gcc_toolchain.gni
+===================================================================
+--- chromium-121.0.6167.75.orig/build/toolchain/gcc_toolchain.gni
++++ chromium-121.0.6167.75/build/toolchain/gcc_toolchain.gni
+@@ -464,7 +464,13 @@ template("single_gcc_toolchain") {
+         # -soname flag is not available on aix ld
+         soname_flag = "-Wl,-soname=\"$soname\""
+       }
+-      link_command = "$ld -shared $soname_flag {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" @\"$rspfile\" {{rlibs}}"
++      if (target_cpu == "riscv64") {
++        # Work around linker failures due to Rust libraries and the use of whole-archive
++        link_command = "$ld -shared $soname_flag -Wl,--start-group {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" @\"$rspfile\" {{rlibs}} -Wl,--end-group"
++      }
++      else {
++        link_command = "$ld -shared $soname_flag {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" @\"$rspfile\" {{rlibs}}"
++      }
+ 
+       # Generate a map file to be used for binary size analysis.
+       # Map file adds ~10% to the link time on a z620.
+@@ -576,7 +582,13 @@ template("single_gcc_toolchain") {
+         whole_archive_flag = "-Wl,--whole-archive"
+         no_whole_archive_flag = "-Wl,--no-whole-archive"
+       }
+-      command = "$ld -shared {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" $soname_flag @\"$rspfile\""
++      if (target_cpu == "riscv64") {
++        # Work around linker failures due to Rust libraries and the use of whole-archive
++        command = "$ld -shared -Wl,--start-group {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" $soname_flag @\"$rspfile\" -Wl,--end-group"
++      }
++      else {
++        command = "$ld -shared {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" $soname_flag @\"$rspfile\""
++      }
+ 
+       if (defined(invoker.strip)) {
+         strip_command = "${invoker.strip} -o \"$sofile\" \"$unstripped_sofile\""
+@@ -636,7 +648,13 @@ template("single_gcc_toolchain") {
+         start_group_flag = "-Wl,--start-group"
+         end_group_flag = "-Wl,--end-group "
+       }
+-      link_command = "$ld {{ldflags}}${extra_ldflags} -o \"$unstripped_outfile\" $start_group_flag @\"$rspfile\" {{solibs}} $end_group_flag {{libs}} {{rlibs}}"
++      if (target_cpu == "riscv64") {
++        # Work around linker failures due to Rust libraries and the use of whole-archive
++        link_command = "$ld -Wl,--start-group {{ldflags}}${extra_ldflags} -o \"$unstripped_outfile\" @\"$rspfile\" {{solibs}} {{libs}} {{rlibs}} -Wl,--end-group"
++      }
++      else {
++        link_command = "$ld {{ldflags}}${extra_ldflags} -o \"$unstripped_outfile\" $start_group_flag @\"$rspfile\" {{solibs}} $end_group_flag {{libs}} {{rlibs}}"
++      }
+ 
+       # Generate a map file to be used for binary size analysis.
+       # Map file adds ~10% to the link time on a z620.

--- a/electron31/riscv64.patch
+++ b/electron31/riscv64.patch
@@ -1,0 +1,124 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -51,6 +51,7 @@ makedepends=(clang
+              python-requests
+              python-six
+              rust
++             go
+              qt5-base
+              wget
+              yarn)
+@@ -61,7 +62,7 @@ optdepends=('kde-cli-tools: file deletion support (kioclient5)'
+             'trash-cli: file deletion support (trash-put)'
+             'xdg-utils: open URLs with desktop’s default (xdg-email, xdg-open)')
+ options=('!lto') # Electron adds its own flags for ThinLTO
+-source=("git+https://github.com/electron/electron.git#tag=v$pkgver"
++source=("git+https://github.com/riscv-forks/electron.git#branch=v$pkgver-riscv"
+         https://gitlab.com/Matt.Jolly/chromium-patches/-/archive/$_gcc_patches/chromium-patches-$_gcc_patches.tar.bz2
+         # Chromium
+         allow-ANGLEImplementation-kVulkan.patch
+@@ -74,6 +75,7 @@ source=("git+https://github.com/electron/electron.git#tag=v$pkgver"
+         electron.desktop
+         jinja-python-3.10.patch
+         use-system-libraries-in-node.patch
++        Debian-fix-rust-linking.patch
+         makepkg-source-roller.py
+         # BEGIN managed sources
+         chromium-mirror::git+https://github.com/chromium/chromium.git#tag=126.0.6478.36
+@@ -241,7 +243,7 @@ source=("git+https://github.com/electron/electron.git#tag=v$pkgver"
+ sha256sums=('dd052fd7062f56783f99ec52e42223b340b1910114130235b1e2fe83ab411951'
+             'daf0df74d2601c35fd66a746942d9ca3fc521ede92312f85af51d94c399fd6e0'
+             '8f81059d79040ec598b5fb077808ec69d26d6c9cbebf9c4f4ea48b388a2596c5'
+-            'b3de01b7df227478687d7517f61a777450dca765756002c80c4915f271e2d961'
++            '8e128dec0d9416029ea8124e14963c9e0caf897bf60d347a070e393edebdff1c'
+             '2654f5924e01c2b4cac1046d973b71614fb9d16fda659ddddd028d0b579174b4'
+             'a4a822e135b253c93089a80c679842cc470c6936742767ae09d952646889abd6'
+             'dd2d248831dd4944d385ebf008426e66efe61d6fdf66f8932c963a12167947b4'
+@@ -249,6 +251,7 @@ sha256sums=('dd052fd7062f56783f99ec52e42223b340b1910114130235b1e2fe83ab411951'
+             '4484200d90b76830b69eea3a471c103999a3ce86bb2c29e6c14c945bf4102bae'
+             '55dbe71dbc1f3ab60bf1fa79f7aea7ef1fe76436b1d7df48728a1f8227d2134e'
+             'ff588a8a4fd2f79eb8a4f11cf1aa151298ffb895be566c57cc355d47f161f53f'
++            '98b0fbe1318897954cb8891cafed65e985613c69192e65984ba6785579b29f80'
+             '2c8cd28cee0e1df1862e801794f210d2b7cac652f943cf94f43c2abe26f2a2f4'
+             'ff45dec4eb10be28cb411a0769c41f1536af7c6452ced295941512824b8f5951'
+             '0b7a546ee6913c49519c10c293ac530ff381641a8a465fa2e184d6dbe0fb784d'
+@@ -457,12 +460,22 @@ prepare() {
+   cp -r chromium-mirror_third_party_depot_tools depot_tools
+   export PATH+=":$PWD/depot_tools" DEPOT_TOOLS_UPDATE=0
+   #export VPYTHON_BYPASS='manually managed python not supported by chrome operations'
++  # Use a known commit that supports riscv64
++  git -C depot_tools checkout --detach 2a18f6d3245450d8c96c843a6584aaea561ef873
++  # Python 3.12 breaks gsutils
++  # Bundled wheels are not available for riscv64
++  sed -i '/wheel: </,$d' depot_tools/.vpython3
++  sed -i '/wheel: </,$d' depot_tools/gsutil.vpython3
++  # Manually install required wheels
++  vpython3 -m pip install httplib2==0.13.1 six==1.10.0 requests==2.31.0
+ 
+   echo "Putting together electron sources"
+   # Generate gclient gn args file and prepare-electron-source-tree.sh
+   python makepkg-source-roller.py generate electron/DEPS $pkgname
++  sed -i '/esbuild/d' prepare-electron-source-tree.sh
+   rbash prepare-electron-source-tree.sh "$CARCH"
+   mv electron src/electron
++  GOBIN=$(realpath src/third_party/devtools-frontend/src/third_party/esbuild/) go install "github.com/evanw/esbuild/cmd/esbuild@v0.14.13"
+ 
+   echo "Running hooks..."
+   # depot_tools/gclient.py runhooks
+@@ -493,6 +506,8 @@ prepare() {
+ 
+   echo "Applying local patches..."
+ 
++  patch -Np1 -i ../Debian-fix-rust-linking.patch
++
+   ## Upstream fixes
+   patch -Np1 -i ../allow-ANGLEImplementation-kVulkan.patch
+ 
+@@ -607,6 +622,10 @@ build() {
+   CFLAGS+='   -Wno-unknown-warning-option'
+   CXXFLAGS+=' -Wno-unknown-warning-option'
+ 
++  # Remove flags that are causing weird bugs on riscv64
++  CFLAGS=${CFLAGS/-Wp,-D_FORTIFY_SOURCE=2}
++  CXXFLAGS=${CXXFLAGS/-Wp,-D_FORTIFY_SOURCE=2}
++
+   # Let Chromium set its own symbol level
+   CFLAGS=${CFLAGS/-g }
+   CXXFLAGS=${CXXFLAGS/-g }
+@@ -654,3 +673,5 @@ package() {
+   install -Dm644 src/electron/default_app/icon.png \
+           "${pkgdir}/usr/share/pixmaps/${pkgname}.png"  # hicolor has no 1024x1024
+ }
++
++sha256sums[0]=SKIP
+diff --git compiler-rt-adjust-paths.patch compiler-rt-adjust-paths.patch
+index 0469220..8ee7f55 100644
+--- compiler-rt-adjust-paths.patch
++++ compiler-rt-adjust-paths.patch
+@@ -1,8 +1,6 @@
+-diff --git a/build/config/clang/BUILD.gn b/build/config/clang/BUILD.gn
+-index d4de2e0cca0..57359c32121 100644
+---- a/build/config/clang/BUILD.gn
+-+++ b/build/config/clang/BUILD.gn
+-@@ -130,12 +130,15 @@ template("clang_lib") {
++--- a/build/config/clang/BUILD.gn	2024-03-09 04:32:07.577338262 +0100
+++++ b/build/config/clang/BUILD.gn	2024-03-09 04:55:29.376410067 +0100
++@@ -124,14 +124,18 @@
+        } else if (is_linux || is_chromeos) {
+          if (current_cpu == "x64") {
+            _dir = "x86_64-unknown-linux-gnu"
+@@ -15,10 +13,13 @@ index d4de2e0cca0..57359c32121 100644
+          } else if (current_cpu == "arm64") {
+            _dir = "aarch64-unknown-linux-gnu"
+ +          _suffix = "-aarch64"
++         } else if (current_cpu == "riscv64") {
++           _dir = "riscv64-unknown-linux-gnu"
+++          _suffix = "-riscv64"
+          } else {
+            assert(false)  # Unhandled cpu type
+          }
+-@@ -166,6 +169,11 @@ template("clang_lib") {
++@@ -162,6 +166,11 @@
+          assert(false)  # Unhandled target platform
+        }
+  


### PR DESCRIPTION
Fix rotten PKGBUILD patch(compared to electron30).

electron RISC-V patch set changes from electron30: https://github.com/riscv-forks/electron/compare/7a826aeef60f0aceaad5cbbcf4e526324e72dcc5...v31.0.1-riscv