### PR TITLE
addpatch: libwacom 2.12.1-1

### DIFF
--- a/libwacom/riscv64.patch
+++ b/libwacom/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -27,7 +27,7 @@ build() {
+ }
+ 
+ check() {
+-  meson test -C build --print-errorlogs
++  meson test -C build --print-errorlogs -t 10
+ }
+ 
+ package() {


### PR DESCRIPTION
Increase test timeout due to a large number of hardware models checked in test_udev_rules.py.