### PR TITLE
updpatch: eslint 9.5.0-1

### DIFF
--- a/eslint/riscv64.patch
+++ b/eslint/riscv64.patch
@@ -1,8 +1,14 @@
-diff --git PKGBUILD PKGBUILD
-index c86e6fe..525ddf8 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -21,7 +21,7 @@ prepare() {
+@@ -16,6 +16,7 @@ makedepends=(
+   git
+   jq
+   npm
++  python
+ )
+ options=('!emptydirs')
+ source=("git+https://github.com/$pkgname/$pkgname.git#tag=v$pkgver")
+@@ -28,7 +29,7 @@ prepare() {
  
  check() {
    cd $pkgname


### PR DESCRIPTION
We need `python` for `node-gyp` to build [node-re2](https://github.com/uhop/node-re2) for riscv64.

(Currently still need some workaround to upstream CI/CD for prebuilt riscv64 release.)