### PR TITLE
addpatch: sharutils 4.15.2-5

### DIFF
--- a/sharutils/riscv64.patch
+++ b/sharutils/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -19,6 +19,8 @@ sha256sums=('2b05cff7de5d7b646dc1669bc36c35fdac02ac6ae4b6c19cb3340d87ec553a9a'
+ prepare() {
+ 	cd "${srcdir}/${pkgname}-${pkgver}"
+ 	sed 's/FUNC_FFLUSH_STDIN/-1/g' -i lib/fseeko.c
++	cp /usr/share/autoconf/build-aux/config.guess config.guess
++	cp /usr/share/autoconf/build-aux/config.sub config.sub
+ }
+ 
+ build() {


### PR DESCRIPTION
Fix outdated `config.guess`.  
https://savannah.gnu.org/support/index.php?111077  
https://savannah.gnu.org/support/index.php?111078  

The previous pr was closed by accident.