### PR TITLE
addpatch: js80p

### DIFF
--- a/js80p/riscv64.patch
+++ b/js80p/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -34,7 +34,7 @@ build() {
+   make \
+     SYS_LIB_PATH=/usr/lib \
+     TARGET_PLATFORM="$CARCH-gpp" \
+-    INSTRUCTION_SET=sse2 \
++    INSTRUCTION_SET=none \
+     VERSION_STR=$(git describe --tags) \
+     VERSION_INT=$(git describe --tags | sed "s/[^0-9]//g") \
+     vst3


### PR DESCRIPTION
disable sse2 or avx for riscv64 explicitly