### PR TITLE
addpatch: av1an 0.4.2-2

### DIFF
--- a/av1an/riscv64.patch
+++ b/av1an/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -25,6 +25,9 @@ sha256sums=('8762fc24ca444c7c1a527af436b66724cbb8c8618f549b3305c2d0c847f16e62'
+ prepare() {
+   cd "Av1an-${pkgver}"
+   patch -p1 -i ../6db39663.patch # Fix build with ffmpeg 7
++
++  echo -e "\n[patch.crates-io]\nffmpeg-the-third = { git = 'https://github.com/moui0/ffmpeg-the-third', tag = 'v2.0.1' }" >> Cargo.toml
++  cargo update -p ffmpeg-the-third
+ }
+ 
+ build() {


### PR DESCRIPTION
Temporarily vendor `ffmpeg-the-third` to fix signedness problem: https://github.com/shssoichiro/ffmpeg-the-third/pull/64