### PR TITLE
addpatch: festival 2.5.0-5

### DIFF
--- a/festival/riscv64.patch
+++ b/festival/riscv64.patch
@@ -1,0 +1,16 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -42,6 +42,13 @@ prepare() {
+ 
+   # Avoid make failure on making scripts and docs
+   sed -i "s|examples bin doc|examples|" festival/Makefile
++
++  cd speech_tools
++  autoreconf -fi
++  cd ..
++  cd festival
++  autoreconf -fi
++  cd ..
+ }
+ 
+ build() {


### PR DESCRIPTION
Outdated `config.guess` and `config.sub` in `festival` and `speech_tools` were reported to Arch Linux.  
The mail list of upstream seems down for several years. (Original upstream: http://festvox.org/maillists.html, I have tried to join and send mail.)
Issue: 
https://github.com/festvox/festival/issues/74
https://github.com/festvox/speech_tools/issues/56
