### PR TITLE
addpatch: afl++ 4.21c

### DIFF
--- a/afl++/change-test-timeout.patch
+++ b/afl++/change-test-timeout.patch
@@ -1,0 +1,20 @@
+--- test/test-custom-mutators.sh        2024-07-06 15:29:38.493323600 +0800
++++ test/test-custom-mutators-patched.sh        2024-07-06 15:30:10.335953600 +0800
+@@ -58,7 +58,7 @@
+     # Run afl-fuzz w/ multiple C mutators
+     $ECHO "$GREY[*] running afl-fuzz with multiple custom C mutators, this will take approx 10 seconds"
+     {
+-      AFL_CUSTOM_MUTATOR_LIBRARY="./libexamplemutator.so;./libexamplemutator2.so" AFL_CUSTOM_MUTATOR_ONLY=1 ../afl-fuzz -V07 -m ${MEM_LIMIT} -i in -o out -d -- ./test-multiple-mutators >>errors 2>&1
++      AFL_CUSTOM_MUTATOR_LIBRARY="./libexamplemutator.so;./libexamplemutator2.so" AFL_CUSTOM_MUTATOR_ONLY=1 ../afl-fuzz -V30 -m ${MEM_LIMIT} -i in -o out -d -- ./test-multiple-mutators >>errors 2>&1
+     } >>errors 2>&1
+
+     test -n "$( ls out/default/crashes/id:000000* 2>/dev/null )" && {  # TODO: update here
+@@ -88,7 +88,7 @@
+       {
+         export PYTHONPATH=${CUSTOM_MUTATOR_PATH}
+         export AFL_PYTHON_MODULE=example
+-        AFL_CUSTOM_MUTATOR_ONLY=1 ../afl-fuzz -V07 -m ${MEM_LIMIT} -i in -o out -- ./test-custom-mutator >>errors 2>&1
++        AFL_CUSTOM_MUTATOR_ONLY=1 ../afl-fuzz -V30 -m ${MEM_LIMIT} -i in -o out -- ./test-custom-mutator >>errors 2>&1
+         unset PYTHONPATH
+         unset AFL_PYTHON_MODULE
+       } >>errors 2>&1

--- a/afl++/riscv64.patch
+++ b/afl++/riscv64.patch
@@ -1,0 +1,32 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -41,9 +41,18 @@ replaces=(
+   afl
+   aflplusplus
+ )
+-source=("https://github.com/AFLplusplus/AFLplusplus/archive/refs/tags/v${pkgver}/${pkgname}-${pkgver}.tar.gz")
+-sha256sums=('11f7c77d37cff6e7f65ac7cc55bab7901e0c6208e845a38764394d04ed567b30')
+-b2sums=('c182260ba25a8a7a87b91ece5b3ea6aafba09b3361259361d9be24b7c5dd90430403a3170ed9397edaa714a45f62de26f324aab005a27a44fffce2708bb366e5')
++source=(
++  "https://github.com/AFLplusplus/AFLplusplus/archive/refs/tags/v${pkgver}/${pkgname}-${pkgver}.tar.gz"
++  'change-test-timeout.patch'
++)
++sha256sums=(
++  '11f7c77d37cff6e7f65ac7cc55bab7901e0c6208e845a38764394d04ed567b30'
++  'a4b4ea87b3bb0d4a7b20b9e77941b0157388bc8ab01ed7bdc4c4193a1add7323'
++)
++b2sums=(
++  'c182260ba25a8a7a87b91ece5b3ea6aafba09b3361259361d9be24b7c5dd90430403a3170ed9397edaa714a45f62de26f324aab005a27a44fffce2708bb366e5'
++  '04d69ade554451b3d6e7c16ec3013eea41c5a63ab7dd680a4f8ab87042add30d2ae7b646c68b4629f4b2d8112db799dbb01dad224876a63e31702df6495323bb'
++)
+ 
+ build() {
+   cd "AFLplusplus-${pkgver}"
+@@ -53,6 +62,7 @@ build() {
+ 
+ check() {
+   cd "AFLplusplus-${pkgver}"
++  patch -p0 -i "${srcdir}/change-test-timeout.patch"
+   # Unset our CFLAGS/CXXFLAGS for the tests since these may
+   # interact in unexpected ways with afl-cc instrumentation.
+   CFLAGS= CXXFLAGS= make test

--- a/afl++/riscv64.patch
+++ b/afl++/riscv64.patch
@@ -1,24 +1,18 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -41,9 +41,23 @@ replaces=(
+@@ -41,9 +41,17 @@ replaces=(
    afl
    aflplusplus
  )
 -source=("https://github.com/AFLplusplus/AFLplusplus/archive/refs/tags/v${pkgver}/${pkgname}-${pkgver}.tar.gz")
 -sha256sums=('11f7c77d37cff6e7f65ac7cc55bab7901e0c6208e845a38764394d04ed567b30')
 -b2sums=('c182260ba25a8a7a87b91ece5b3ea6aafba09b3361259361d9be24b7c5dd90430403a3170ed9397edaa714a45f62de26f324aab005a27a44fffce2708bb366e5')
-+source=(
-+  "https://github.com/AFLplusplus/AFLplusplus/archive/refs/tags/v${pkgver}/${pkgname}-${pkgver}.tar.gz"
-+  'change-test-timeout.patch'
-+)
-+sha256sums=(
-+  '11f7c77d37cff6e7f65ac7cc55bab7901e0c6208e845a38764394d04ed567b30'
-+  'a4b4ea87b3bb0d4a7b20b9e77941b0157388bc8ab01ed7bdc4c4193a1add7323'
-+)
-+b2sums=(
-+  'c182260ba25a8a7a87b91ece5b3ea6aafba09b3361259361d9be24b7c5dd90430403a3170ed9397edaa714a45f62de26f324aab005a27a44fffce2708bb366e5'
-+  '04d69ade554451b3d6e7c16ec3013eea41c5a63ab7dd680a4f8ab87042add30d2ae7b646c68b4629f4b2d8112db799dbb01dad224876a63e31702df6495323bb'
-+)
++source=("https://github.com/AFLplusplus/AFLplusplus/archive/refs/tags/v${pkgver}/${pkgname}-${pkgver}.tar.gz"
++        "change-test-timeout.patch")
++sha256sums=('11f7c77d37cff6e7f65ac7cc55bab7901e0c6208e845a38764394d04ed567b30'
++            'a4b4ea87b3bb0d4a7b20b9e77941b0157388bc8ab01ed7bdc4c4193a1add7323')
++b2sums=('c182260ba25a8a7a87b91ece5b3ea6aafba09b3361259361d9be24b7c5dd90430403a3170ed9397edaa714a45f62de26f324aab005a27a44fffce2708bb366e5'
++        '04d69ade554451b3d6e7c16ec3013eea41c5a63ab7dd680a4f8ab87042add30d2ae7b646c68b4629f4b2d8112db799dbb01dad224876a63e31702df6495323bb')
 +
 +prepare() {
 +  cd "AFLplusplus-${pkgver}"

--- a/afl++/riscv64.patch
+++ b/afl++/riscv64.patch
@@ -1,6 +1,6 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -41,9 +41,18 @@ replaces=(
+@@ -41,9 +41,23 @@ replaces=(
    afl
    aflplusplus
  )
@@ -19,14 +19,11 @@
 +  'c182260ba25a8a7a87b91ece5b3ea6aafba09b3361259361d9be24b7c5dd90430403a3170ed9397edaa714a45f62de26f324aab005a27a44fffce2708bb366e5'
 +  '04d69ade554451b3d6e7c16ec3013eea41c5a63ab7dd680a4f8ab87042add30d2ae7b646c68b4629f4b2d8112db799dbb01dad224876a63e31702df6495323bb'
 +)
++
++prepare() {
++  cd "AFLplusplus-${pkgver}"
++  patch -p0 -i "${srcdir}/change-test-timeout.patch"
++}
  
  build() {
    cd "AFLplusplus-${pkgver}"
-@@ -53,6 +62,7 @@ build() {
- 
- check() {
-   cd "AFLplusplus-${pkgver}"
-+  patch -p0 -i "${srcdir}/change-test-timeout.patch"
-   # Unset our CFLAGS/CXXFLAGS for the tests since these may
-   # interact in unexpected ways with afl-cc instrumentation.
-   CFLAGS= CXXFLAGS= make test


### PR DESCRIPTION
Patched a test-case timeout.  
https://github.com/AFLplusplus/AFLplusplus/issues/2145  
If upstream has no response in 2 days, please review this patch.  