### PR TITLE
addpatch: fastjar 0.98-7

### DIFF
--- a/fastjar/riscv64.patch
+++ b/fastjar/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,6 +14,11 @@ source=(https://download.savannah.nongnu.org/releases/${pkgname}/${pkgname}-${pk
+ #validpgpkeys=('EEFF99F6ADE26B135C85141D663843B80213D86E') # Dalibor Topic
+ sha256sums=('f156abc5de8658f22ee8f08d7a72c88f9409ebd8c7933e9466b0842afeb2f145')
+ 
++prepare() {
++  cd ${pkgname}-${pkgver}
++  autoreconf -fi
++}
++
+ build() {
+   cd ${pkgname}-${pkgver}
+   ./configure --prefix=/usr


### PR DESCRIPTION
The outdated `config.guess` and `config.sub` file issue was reported in https://savannah.nongnu.org/bugs/index.php?65966 .