### PR TITLE
updpatch: qt5-webengine 5.15.17-5

### DIFF
--- a/qt5-webengine/riscv-v8-security-backport.patch
+++ b/qt5-webengine/riscv-v8-security-backport.patch
@@ -1,0 +1,90 @@
+--- src/regexp/riscv64/regexp-macro-assembler-riscv64.cc.orig	2024-07-08 17:16:17.723123922 +0200
++++ src/regexp/riscv64/regexp-macro-assembler-riscv64.cc	2024-07-08 17:28:42.328290188 +0200
+@@ -661,19 +661,20 @@
+     __ li(a0, Operand(stack_limit));
+     __ Ld(a0, MemOperand(a0));
+     __ Sub64(a0, sp, a0);
++    Operand extra_space(num_registers_ * kPointerSize);
+     // Handle it if the stack pointer is already below the stack limit.
+     __ Branch(&stack_limit_hit, le, a0, Operand(zero_reg));
+     // Check if there is room for the variable number of registers above
+     // the stack limit.
+     __ Branch(&stack_ok, Ugreater_equal, a0,
+-              Operand(num_registers_ * kPointerSize));
++              extra_space);
+     // Exit with OutOfMemory exception. There is not enough space on the stack
+     // for our working registers.
+     __ li(a0, Operand(EXCEPTION));
+     __ jmp(&return_a0);
+ 
+     __ bind(&stack_limit_hit);
+-    CallCheckStackGuardState(a0);
++    CallCheckStackGuardState(a0, extra_space);
+     // If returned value is non-zero, we exit with the returned value as result.
+     __ Branch(&return_a0, ne, a0, Operand(zero_reg));
+ 
+@@ -857,7 +858,7 @@
+                                            current_character().bit() |
+                                            backtrack_stackpointer().bit();
+       __ MultiPush(regexp_registers_to_retain);
+-      CallCheckStackGuardState(a0);
++      CallCheckStackGuardState(a0, extra_space);
+       __ MultiPop(regexp_registers_to_retain);
+       // If returning non-zero, we should end execution with the given
+       // result as return value.
+@@ -1056,7 +1057,7 @@
+ 
+ // Private methods:
+ 
+-void RegExpMacroAssemblerRISCV::CallCheckStackGuardState(Register scratch) {
++void RegExpMacroAssemblerRISCV::CallCheckStackGuardState(Register scratch, Operand extra_space) {
+   DCHECK(!isolate()->IsGeneratingEmbeddedBuiltins());
+   DCHECK(!masm_->options().isolate_independent_code);
+ 
+@@ -1069,6 +1070,7 @@
+   __ And(sp, sp, Operand(-stack_alignment));
+   __ Sd(scratch, MemOperand(sp));
+ 
++  __ li(a3, extra_space);
+   __ mv(a2, frame_pointer());
+   // Code of self.
+   __ li(a1, Operand(masm_->CodeObject()), CONSTANT_SIZE);
+@@ -1129,7 +1131,8 @@
+ 
+ int64_t RegExpMacroAssemblerRISCV::CheckStackGuardState(Address* return_address,
+                                                         Address raw_code,
+-                                                        Address re_frame) {
++                                                        Address re_frame,
++                                                        uintptr_t extra_space) {
+   Code re_code = Code::cast(Object(raw_code));
+   return NativeRegExpMacroAssembler::CheckStackGuardState(
+       frame_entry<Isolate*>(re_frame, kIsolate),
+@@ -1139,7 +1142,7 @@
+       return_address, re_code,
+       frame_entry_address<Address>(re_frame, kInputString),
+       frame_entry_address<const byte*>(re_frame, kInputStart),
+-      frame_entry_address<const byte*>(re_frame, kInputEnd));
++      frame_entry_address<const byte*>(re_frame, kInputEnd), extra_space);
+ }
+ 
+ MemOperand RegExpMacroAssemblerRISCV::register_location(int register_index) {
+--- src/regexp/riscv64/regexp-macro-assembler-riscv64.h.orig	2024-07-08 17:10:55.261317262 +0200
++++ src/regexp/riscv64/regexp-macro-assembler-riscv64.h	2024-07-08 17:15:50.989364456 +0200
+@@ -82,7 +82,7 @@
+   // returning.
+   // {raw_code} is an Address because this is called via ExternalReference.
+   static int64_t CheckStackGuardState(Address* return_address, Address raw_code,
+-                                      Address re_frame);
++                                      Address re_frame, uintptr_t extra_space);
+ 
+   void print_regexp_frame_constants();
+ 
+@@ -133,7 +133,7 @@
+   void CheckStackLimit();
+ 
+   // Generate a call to CheckStackGuardState.
+-  void CallCheckStackGuardState(Register scratch);
++  void CallCheckStackGuardState(Register scratch, Operand extra_space = Operand(zero_reg));
+ 
+   // The ebp-relative location of a regexp register.
+   MemOperand register_location(int register_index);

--- a/qt5-webengine/riscv64.patch
+++ b/qt5-webengine/riscv64.patch
@@ -1,25 +1,25 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -32,6 +32,11 @@ sha256sums=('SKIP'
-             'bfae9e773edfd0ddbc617777fdd4c0609cba2b048be7afe40f97768e4eb6117e'
-             '547e092f6a20ebd15e486b31111145bc94b8709ec230da89c591963001378845')
- 
-+makedepends=("${makedepends[@]/nodejs/nodejs-lts-iron}")
-+source+=($pkgname-v8.patch $pkgname-riscv.patch)
-+sha256sums+=('f0394a75373d319fbe5826862a59c5b266a901887a8ef32e7d05fb8efa23992c'
-+             '1b04f07fe50a6312f829354c8f1efa9af6914d25d00898bd69d5196cb844b7ba')
-+
- prepare() {
-   mkdir -p build
- 
-@@ -41,6 +46,10 @@ prepare() {
+@@ -45,6 +45,10 @@ prepare() {
    git submodule set-branch --branch 87-based src/3rdparty
    git -c protocol.file.allow=always submodule update
  
 +  patch -Np1 -i "$srcdir"/$pkgname-v8.patch
 +  patch -Np1 -i "$srcdir"/$pkgname-riscv.patch
++  patch -Np0 -d src/3rdparty/chromium/v8 < "$srcdir"/riscv-v8-security-backport.patch
 +
+   patch -p1 -d src/3rdparty -i "$srcdir"/qt5-webengine-ffmpeg5.patch # Fix build with ffmpeg 5
+   patch -p1 -d src/3rdparty -i "$srcdir"/qt5-webengine-pipewire-0.3.patch # Port to pipewire 0.3
+   patch -p2 -d src/3rdparty/chromium -i "$srcdir"/qt5-webengine-icu-75.patch # Fix build with ICU 75
+@@ -91,3 +95,11 @@ package() {
+   # Fix cmake dependency versions
+   sed -e "s|$pkgver\ |$_basever |" -i "$pkgdir"/usr/lib/cmake/*/*Config.cmake
+ }
 +
-   patch -p1 -i "$srcdir"/qt5-webengine-python3.patch # Fix build with Python 3
-   patch -p1 -d src/3rdparty -i "$srcdir"/qt5-webengine-chromium-python3.patch
- 
++source+=($pkgname-v8.patch
++         $pkgname-riscv.patch
++         riscv-v8-security-backport.patch)
++sha256sums+=('f0394a75373d319fbe5826862a59c5b266a901887a8ef32e7d05fb8efa23992c'
++             '1b04f07fe50a6312f829354c8f1efa9af6914d25d00898bd69d5196cb844b7ba'
++             'd70a78f884171ae8131ffb4fcc074f3f56ce78627ac788e5b21b8963870a5294')
++options+=(!lto)


### PR DESCRIPTION
- Fix rotten
- Manually backport the following security fix(it also breaks compilation):
  - [regexp] Fix stack check in native code when interrupt was requested
    - QT Backport: https://codereview.qt-project.org/c/qt/qtwebengine-chromium/+/523701
    - V8: https://chromium-review.googlesource.com/c/v8/v8/+/4971832 
    - V8 RISC-V: https://chromium-review.googlesource.com/c/v8/v8/+/4975715
- Arch re-enabled LTO in https://gitlab.archlinux.org/archlinux/packaging/packages/qt5-webengine/-/commit/fad05d485fed0dba24b71b4987d33002cdfd356b , but LTO on riscv64 is causing an undefined reference linker error that I can't find where the undef sym is used. Thus LTO is disabled.