### PR TITLE
addpatch: flite 2.2-2

### DIFF
--- a/flite/riscv64.patch
+++ b/flite/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -19,6 +19,7 @@ prepare() {
+   cd $pkgname
+   sed '/^#VOXES.*$/d; s/+//g; s/cmu_indic_lex/&\nVOXES = cmu_us_kal16 cmu_us_slt/' config/android.lv >config/archlinux.lv
+   sed -i '/$(INSTALL) -m 755 $(BINDIR)\/flite_time $(DESTDIR)$(INSTALLBINDIR)/d' main/Makefile
++  autoreconf -fi
+ }
+ 
+ build() {


### PR DESCRIPTION
Outdated `config.guess` was reported in https://github.com/festvox/flite/issues/113.