### PR TITLE
addpatch: iml 1.0.5-4

### DIFF
--- a/iml/riscv64.patch
+++ b/iml/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,6 +14,11 @@ depends=(cblas
+ source=(https://www.cs.uwaterloo.ca/~astorjoh/$pkgname-$pkgver.tar.bz2)
+ sha256sums=('1dad666850895a5709b00b97422e2273f293cfadea7697a9f90b90953e847c2a')
+ 
++prepare() {
++  cd $pkgname-$pkgver
++  autoreconf -fi
++}
++
+ build() {
+   cd $pkgname-$pkgver
+   ./configure \


### PR DESCRIPTION
Outdated `config.guess` issue was reported to upstream via email.  
