### PR TITLE
addpatch: libdaemon 0.14-6.

### DIFF
--- a/libdaemon/riscv64.patch
+++ b/libdaemon/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,6 +15,11 @@ makedepends=('git')
+ source=(http://0pointer.de/lennart/projects/libdaemon/libdaemon-${pkgver}.tar.gz)
+ sha512sums=('a96b25c09bd63cc192c1c5f8b5bf34cc6ad0c32d42ac14b520add611423b6ad3d64091a47e0c7ab9a94476a5e645529abccea3ed6b23596567163fba88131ff2')
+ 
++prepare() {
++	cd "${srcdir}/${pkgname}-${pkgver}"
++	autoreconf -fi
++}
++
+ build() {
+ 	cd "${srcdir}/${pkgname}-${pkgver}"
+ 	./bootstrap.sh


### PR DESCRIPTION
Outdated `config.guess` issue was reported to upstream via email.  