### PR TITLE
addpatch: emovix 0.9.0-9

### DIFF
--- a/emovix/riscv64.patch
+++ b/emovix/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,6 +14,12 @@ depends=(cdrkit
+ source=(https://downloads.sourceforge.net/sourceforge/movix/$pkgname-$pkgver.tar.gz)
+ sha256sums=('96b84843ed80d31df5c07f6ee972362f7a0629a9b181afeb4a99b2127c07ff57')
+ 
++prepare() {
++  cd $pkgname-$pkgver
++  cp /usr/share/autoconf/build-aux/config.guess config.guess
++  cp /usr/share/autoconf/build-aux/config.sub config.sub
++}
++
+ build() {
+   cd $pkgname-$pkgver
+   ./configure --prefix=/usr


### PR DESCRIPTION
Outdated `config.guess` issue was reported to upstream in https://sourceforge.net/p/movix/discussion/207428/thread/7c4f6c96a4/ .