### PR TITLE
addpatch: termscp 0.13.0-2

### DIFF
--- a/termscp/bump-ring.patch
+++ b/termscp/bump-ring.patch
@@ -1,0 +1,123 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 0da61f77..f89c2085 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -403,9 +403,9 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+ 
+ [[package]]
+ name = "cc"
+-version = "1.0.79"
++version = "1.1.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
++checksum = "eaff6f8ce506b9773fa786672d63fc7a191ffea1be33f72bbd4aeacefca9ffc8"
+ 
+ [[package]]
+ name = "cfg-if"
+@@ -1522,9 +1522,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+ 
+ [[package]]
+ name = "libc"
+-version = "0.2.147"
++version = "0.2.155"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
++checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+ 
+ [[package]]
+ name = "libdbus-sys"
+@@ -2545,17 +2545,17 @@ dependencies = [
+ 
+ [[package]]
+ name = "ring"
+-version = "0.16.20"
++version = "0.17.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
++checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+ dependencies = [
+  "cc",
++ "cfg-if 1.0.0",
++ "getrandom",
+  "libc",
+- "once_cell",
+  "spin",
+  "untrusted",
+- "web-sys",
+- "winapi 0.3.9",
++ "windows-sys 0.52.0",
+ ]
+ 
+ [[package]]
+@@ -2641,9 +2641,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "rustls"
+-version = "0.21.3"
++version = "0.21.12"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "b19faa85ecb5197342b54f987b142fb3e30d0c90da40f80ef4fa9a726e6676ed"
++checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+ dependencies = [
+  "log",
+  "ring",
+@@ -2662,9 +2662,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "rustls-webpki"
+-version = "0.101.1"
++version = "0.101.7"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e"
++checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+ dependencies = [
+  "ring",
+  "untrusted",
+@@ -2717,9 +2717,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+ 
+ [[package]]
+ name = "sct"
+-version = "0.7.0"
++version = "0.7.1"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
++checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+ dependencies = [
+  "ring",
+  "untrusted",
+@@ -2992,9 +2992,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "spin"
+-version = "0.5.2"
++version = "0.9.8"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
++checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+ 
+ [[package]]
+ name = "ssh2"
+@@ -3542,9 +3542,9 @@ checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+ 
+ [[package]]
+ name = "untrusted"
+-version = "0.7.1"
++version = "0.9.0"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
++checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+ 
+ [[package]]
+ name = "url"
+@@ -3706,9 +3706,9 @@ dependencies = [
+ 
+ [[package]]
+ name = "webpki"
+-version = "0.22.0"
++version = "0.22.4"
+ source = "registry+https://github.com/rust-lang/crates.io-index"
+-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
++checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
+ dependencies = [
+  "ring",
+  "untrusted",

--- a/termscp/riscv64.patch
+++ b/termscp/riscv64.patch
@@ -1,0 +1,20 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,6 +17,9 @@ options=('!lto')
+ 
+ prepare() {
+   cd "$pkgname-$pkgver"
++  patch -Np1 -i ../bump-ring.patch
++  echo -e "[patch.crates-io]\npavao = { git = 'https://github.com/veeso/pavao', rev = 'e802cb48351375adfbd83991d3acf02b737499bb' }" >> Cargo.toml
++  cargo update -p pavao
+   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+ }
+ 
+@@ -40,4 +43,7 @@ package() {
+   install -Dm 644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+ }
+ 
++source+=(bump-ring.patch)
++sha512sums+=('7ebddee1ff13148717e0159e50f0654b224f8c3ae51e0cfc4b79600bfcfb37402ae248f32448c8c56879b8892e077d0a4f2bd63859ed29d40f159966e21ecd18')
++
+ # vim: ts=2 sw=2 et:


### PR DESCRIPTION
- Bump ring upstreamed to https://github.com/veeso/termscp/pull/265
- Bump pavao with riscv64 support, thanks moui0