### PR TITLE
addpatch: trurl 0.13-1

### DIFF
--- a/trurl/riscv64.patch
+++ b/trurl/riscv64.patch
@@ -1,0 +1,19 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -10,7 +10,7 @@ arch=(x86_64)
+ url="https://github.com/curl/trurl"
+ license=(custom)
+ depends=(curl glibc)
+-checkdepends=(python valgrind)
++checkdepends=(python)
+ source=("https://github.com/curl/$pkgname/archive/refs/tags/$pkgname-$pkgver.tar.gz")
+ sha256sums=('8ceeb09d0e08dc677897f26651aa625d9ad18021f881f9d5f31e5a95bb3cc047')
+ 
+@@ -22,7 +22,6 @@ build() {
+ check() {
+ 	cd "$pkgname-$pkgname-$pkgver"
+ 	make test
+-	make test-memory
+ }
+ 
+ package() {


### PR DESCRIPTION
Tests with Valgrind cannot be run due to lack of debug symbols, either from debuginfod (which we don't have now) or -debug packages (which is not enabled during build).