### PR TITLE
addpatch: bfs 3.3.1

### DIFF
--- a/bfs/riscv64.patch
+++ b/bfs/riscv64.patch
@@ -1,0 +1,16 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -20,6 +20,13 @@ source=("$pkgname::git+https://github.com/tavianator/bfs#tag=$pkgver")
+ sha512sums=('acdf3ff2184f079a4d2357d4316b704354f45ad0cef7fa97532cf8b93a2ed91dc71d07262786757f64f542990c6192db1394ea319473482937edf8ecebfa6ee6')
+ b2sums=('ff6f313866a70c7cf9af52caaee0f8191223f9a2651f490bee0f439511f3252a8145b0ea3e54cbbfbd286df484164efb65ee5487e392aa22611b10e210df2c4d')
+ 
++prepare() {
++ cd "$pkgname"
++
++ # https://github.com/tavianator/bfs/commit/8c130ca0117fd225c24569be2ec16c7dc2150a13
++ git cherry-pick -n 8c130ca0117fd225c24569be2ec16c7dc2150a13
++}
++
+ build() {
+   cd "$pkgname"
+ 


### PR DESCRIPTION
Not all posix_spawn() implementations use errno to report execv() failures from the child process, such as qemu-user, OpenBSD and HPPA.

Link: https://github.com/tavianator/bfs/commit/8c130ca0117fd225c24569be2ec16c7dc2150a13