### PR TITLE
addpatch: ext3grep 0.10.2-7

### DIFF
--- a/ext3grep/riscv64.patch
+++ b/ext3grep/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -23,6 +23,9 @@ prepare() {
+   patch -Np1 -i "${srcdir}"/${pkgname}-build.patch
+ 
+   patch -p1 -i ../ext3grep-e2fsprogs-1.44.1.patch # Fix build with e2fsprogs 1.44.1
++
++  cp /usr/share/autoconf/build-aux/config.guess config.guess
++  cp /usr/share/autoconf/build-aux/config.sub config.sub
+ }
+ 
+ build() {


### PR DESCRIPTION
Fixed cannot guess build type issue.  
The upstream code was hosted on Google Code which was archived in 2016, so it was unable to report to upstream.