### PR TITLE
addpatch: coin-or-data-sample 1.2.12-2

### DIFF
--- a/coin-or-data-sample/riscv64.patch
+++ b/coin-or-data-sample/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -13,6 +13,12 @@ groups=(coin-or)
+ source=(git+https://github.com/coin-or-tools/Data-Sample#tag=releases/$pkgver)
+ sha256sums=('d447105b1e7b08fd5d4bc872150215e954510666cbc616b3acdfd48435463e11')
+ 
++prepare() {
++  cd Data-Sample
++  cp /usr/share/autoconf/build-aux/config.guess config.guess
++  cp /usr/share/autoconf/build-aux/config.sub config.sub
++}
++
+ build() {
+   cd Data-Sample
+   ./configure --prefix=/usr


### PR DESCRIPTION
Outdated `config.guess` issue was reported to upstream in https://github.com/coin-or-tools/Data-Sample/issues/4 .