### PR TITLE
addpatch: liblqr 0.4.2-4

### DIFF
--- a/liblqr/riscv64.patch
+++ b/liblqr/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -13,6 +13,12 @@ source=(https://liblqr.wikidot.com/local--files/en:download-page/$pkgname-1-$pkg
+ sha256sums=('173a822efd207d72cda7d7f4e951c5000f31b10209366ff7f0f5972f7f9ff137')
+ options=(!emptydirs)
+ 
++prepare() {
++  cd $pkgname-1-$pkgver
++  cp /usr/share/autoconf/build-aux/config.guess config.guess
++  cp /usr/share/autoconf/build-aux/config.sub config.sub
++}
++
+ build() {
+   cd $pkgname-1-$pkgver
+   ./configure \


### PR DESCRIPTION
Outdated `config.guess` issue was reported to upstream in http://liblqr.wikidot.com/forum/t-16886430/outdated-config-guess-and-config-sub-file-in-the-source-of-l .