### PR TITLE
addpatch: libidl2 0.8.14-7

### DIFF
--- a/libidl2/riscv64.patch
+++ b/libidl2/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,6 +14,11 @@ source=(https://download.gnome.org/sources/libIDL/0.8/libIDL-${pkgver}.tar.bz2)
+ url="http://www.gnome.org"
+ sha256sums=('c5d24d8c096546353fbc7cedf208392d5a02afe9d56ebcc1cccb258d7c4d2220')
+ 
++prepare() {
++  cd "${srcdir}/libIDL-${pkgver}"
++  autoreconf -fi
++}
++
+ build() {
+   cd "${srcdir}/libIDL-${pkgver}"
+   ./configure --prefix=/usr


### PR DESCRIPTION
Outdated `config.guess` issue can't be reported to upstream, gnome. This project is no longer available on their GitLab.  