### PR TITLE
addpatch: libmng 2.0.3-4

### DIFF
--- a/libmng/riscv64.patch
+++ b/libmng/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -16,6 +16,11 @@ sha256sums=('4a462fdd48d4bc82c1d7a21106c8a18b62f8cc0042454323058e6da0dbb57dd3'
+             'SKIP')
+ validpgpkeys=('8048643BA2C840F4F92A195FF54984BFA16C640F')
+ 
++prepare() {
++  cd $pkgname-$pkgver
++  autoreconf -fi
++}
++
+ build() {
+   cd $pkgname-$pkgver
+   ./configure \


### PR DESCRIPTION
Outdated `config.guess` issue couldn't be reported to upstream. Their GitHub repo is archived(https://github.com/LuaDist/libmng), SourceForge issue tracker is no longer available(http://sourceforge.net/tracker/?func=add&group_id=5635&atid=205635). and their website is empty.  