### PR TITLE
addpatch: libnova 0.15.0-4

### DIFF
--- a/libnova/riscv64.patch
+++ b/libnova/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,6 +12,11 @@ depends=('glibc')
+ source=(https://downloads.sourceforge.net/sourceforge/libnova/$pkgname-$pkgver.tar.gz)
+ sha512sums=('77ab0ccbfe462c03a21e88656cb4d6389994ea1da0ee8da997f19a83d24ad8fd9e505e70e1580b75332e826e5b7859b5f2af4417f65eb811440493ba586f2574')
+ 
++prepare() {
++	cd ${pkgname}-${pkgver}
++	autoreconf -fi
++}
++
+ build() {
+ 	cd ${pkgname}-${pkgver}
+ 	autoreconf -i


### PR DESCRIPTION
Outdated `config.guess` issue was reported to upstream in https://sourceforge.net/p/libnova/bugs/24/ .