### PR TITLE
addpatch: libofa 0.9.3-10

### DIFF
--- a/libofa/riscv64.patch
+++ b/libofa/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -29,6 +29,7 @@ prepare() {
+   patch -p1 -i "${srcdir}/libofa-gcc4.5.patch"
+   patch -p1 -i "${srcdir}/libofa-0.9.3-gcc-4.7.patch"
+   patch -p1 -i "${srcdir}/libofa-0.9.3-curl-7.21.patch"
++  autoreconf -fi
+ }
+ 
+ build() {


### PR DESCRIPTION
Outdated `config.guess` issue was reported to upstream in https://github.com/tanob/libofa/issues/3 .