### PR TITLE
addpatch: wireguard-vanity-address 0.4.0-3

### DIFF
--- a/wireguard-vanity-address/riscv64.patch
+++ b/wireguard-vanity-address/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -22,6 +22,7 @@ b2sums=('8bc6fedd3a17b40b4d0018ad8f1fb8c067345480794d16c980cb354b733e130af930fa1
+ 
+ prepare() {
+   cd "${pkgname}-${pkgver}"
++  cargo update -p libc --precise 0.2.155
+   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+ }
+ 


### PR DESCRIPTION
Upgrade outdated libc, reported to https://github.com/warner/wireguard-vanity-address/issues/30.