### PR TITLE
updpatch: protobuf 27.2-1

### DIFF
--- a/protobuf/riscv64.patch
+++ b/protobuf/riscv64.patch
@@ -1,13 +1,32 @@
-diff --git PKGBUILD PKGBUILD
-index 6df1c59..d17877c 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -38,7 +38,7 @@ source=(https://github.com/protocolbuffers/protobuf/archive/v$pkgver/$pkgname-$p
-         soversion.patch
-         $pkgbase-21.12-pep517.patch)  # let's not call setup.py like a script and just build...
- sha512sums=('1f73e237c919082e5423ae9e2ea8813dccf672c059051d1531fe89ffaa45872d3cf3052b8c3af26f674296ec17d7dc861c67b8f0834ed80261ce4a6a14ed7115'
--            'f42d9bd702abe2c7fc4dcb07d050376287ac60b0b7e2fde0d7a9e9df24a620866bee5fd7de2e3b216095376de47e1fe7443cca74c9a9e85c1a0bc42e8973a280'
-+            '18bc71031bbcbc3810a9985fa670465040f06a6c104ab8079b56bdfc499bb6cec40805a0cefd455031142490a576dc60aa8000523877ac0353b93558e9beabbd'
-             'f0813a415cff5639e4709400f15b0c5565294e7907ae164e620b76258734c643115d8e5170bf0e4aee264c347fb7e01ac4be60d19be2a91c0ce9c561dad8c8e9'
-             'a297e74ee4f807b3fad7da7d0de6dd9647963521be66cd2a2370343f5bd191cbb38759157ac0cdb161a5893a30a10520a5098e88a292c800859af33db5cf7a41')
+@@ -22,7 +22,6 @@ depends=(
+   'abseil-cpp'
+ )
+ makedepends=(
+-  'bazel'
+   'cmake'
+   'gtest'
+   'python-build'
+@@ -60,8 +59,8 @@ build() {
+   cmake "${cmake_options[@]}"
+   cmake --build build --verbose
  
+-  cd "$pkgbase-$pkgver"
+-  bazel build //python/dist:binary_wheel
++  cd "$pkgbase-5.$pkgver"
++  python -m build --wheel --no-isolation
+ }
+ 
+ check() {
+@@ -89,6 +88,9 @@ package_python-protobuf() {
+     'python'
+   )
+ 
+-  python -m installer --destdir="$pkgdir" "$pkgbase-$pkgver"/bazel-bin/python/dist/*.whl
++  python -m installer --destdir="$pkgdir" "$pkgbase-5.$pkgver"/dist/*.whl
+   install -vDm 644 $pkgbase-$pkgver/LICENSE -t "$pkgdir/usr/share/licenses/$pkgname/"
+ }
++
++source+=("$pkgbase-$pkgver-python.tar.gz::https://files.pythonhosted.org/packages/source/${pkgbase::1}/${pkgbase//-/_}/${pkgbase//-/_}-5.$pkgver.tar.gz")
++sha512sums+=('b3afcf13e223d7e855ac0aa000cc395e3ea1301b2e3dfe3c0d5435d8031be3726e6aec1fb6228c572aa1685f75aba2d97d2c9dfdb6d9e058a2e88321d6ba9180')


### PR DESCRIPTION
Temporarily use PyPI's source package to build python-protobuf instead of using Bazel to prevent loop makedepends. Will be reverted once Bazel is built (see https://github.com/bazelbuild/bazel/issues/23018)