### PR TITLE
addpatch: abseil-cpp

### DIFF
--- a/abseil-cpp/riscv64.patch
+++ b/abseil-cpp/riscv64.patch
@@ -1,0 +1,24 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,13 +12,19 @@ license=('Apache-2.0')
+ depends=('gcc-libs' 'glibc' 'gtest')
+ makedepends=('cmake')
+ source=("https://github.com/abseil/abseil-cpp/archive/$pkgver/$pkgname-$pkgver.tar.gz"
+-         scoped-mock-log.patch)
++         scoped-mock-log.patch
++        "no-rdcycle.patch::https://github.com/abseil/abseil-cpp/commit/7335a36d0b5c1c597566f9aa3f458a5b6817c3b4.patch"
++        "fix-neg-nan.patch::https://github.com/abseil/abseil-cpp/commit/96cdf6cc87e7a21d92f9f96a72263a93d3929ec7.patch")
+ sha256sums=('733726b8c3a6d39a4120d7e45ea8b41a434cdacde401cba500f14236c49b39dc'
+-            'a6cbc612a2b96fcbd52d081e03e8581107ceb4827edb19d96510a31c568e1396')
++            'a6cbc612a2b96fcbd52d081e03e8581107ceb4827edb19d96510a31c568e1396'
++            'e904ac3d961670334d33658d29bf29fb5019a1f7423d5bc6af918a7fa6a7103a'
++            'a3ecbaa47c124fcbaff0f850fc584548e6562de22a56b3a3954dd7ff262d7be1')
+ 
+ prepare() {
+   cd "$srcdir/$pkgname-$pkgver"
+   patch -p1 -i ../scoped-mock-log.patch # Install target needed by protobuf
++  patch -p1 -i ../fix-neg-nan.patch
++  patch -p1 -i ../no-rdcycle.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
- Backport two commits:
  1. remove usage of rdcycle, which has become a privileged instruction since linux 6.6
  2. Fix a test failure involving negative NaN
- Test AbslDeathTest/FailureSignalHandlerDeathTest.*/SIGBUS is flaky. The sigbus hander sometimes segfaults, which can't be easily reproduced under gdb. It appears that this test is no longer flaky if I disable all Arch specific compiler flags.