### PR TITLE
updpatch: libgovirt 2:0.3.9-2

### DIFF
--- a/libgovirt/riscv64.patch
+++ b/libgovirt/riscv64.patch
@@ -1,15 +1,6 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -12,11 +12,14 @@ url='https://gitlab.gnome.org/GNOME/libgovirt'
- license=(LGPL)
- depends=(librest)
- makedepends=(gobject-introspection meson)
--source=("https://gitlab.gnome.org/GNOME/libgovirt/-/archive/v${pkgver}/libgovirt-v${pkgver}.tar.bz2")
--b2sums=('383660540bcde90e4406e086f8acc98af233b83cd8a8d7f3634fa1de4e6cc43ceeae2f476a16a65732c3cf5c302a2f108b9c5b1d67b39b9999d1de48af22da24')
-+source=("https://gitlab.gnome.org/GNOME/libgovirt/-/archive/v${pkgver}/libgovirt-v${pkgver}.tar.bz2"
-+        "${pkgname}-suppress-error-cast-align.patch::https://gitlab.gnome.org/GNOME/libgovirt/-/merge_requests/21.diff")
-+b2sums=('383660540bcde90e4406e086f8acc98af233b83cd8a8d7f3634fa1de4e6cc43ceeae2f476a16a65732c3cf5c302a2f108b9c5b1d67b39b9999d1de48af22da24'
-+        'c4cb09c44dd2a8410191e98a4054ddd27e9890d37166fa4c33c74c08dda025e57eed3f8140df3690fdcf8909398fa016b319e2da65058365d9af1154b74af060')
+@@ -17,6 +17,7 @@ b2sums=('383660540bcde90e4406e086f8acc98af233b83cd8a8d7f3634fa1de4e6cc43ceeae2f4
  
  prepare() {
    cd ${pkgname}-v${pkgver}
@@ -17,3 +8,10 @@
  }
    
  build() {
+@@ -31,3 +32,6 @@ check() {
+ package() {
+   meson install -C build --destdir "${pkgdir}"
+ }
++
++source+=("${pkgname}-suppress-error-cast-align.patch::https://gitlab.gnome.org/GNOME/libgovirt/-/merge_requests/21.diff")
++b2sums+=('SKIP')


### PR DESCRIPTION
Make patch rot less. Still waiting for new release.