### PR TITLE
updpatch: highway 1.2.0-1

### DIFF
--- a/highway/riscv64.patch
+++ b/highway/riscv64.patch
@@ -1,8 +1,24 @@
-diff --git PKGBUILD PKGBUILD
-index d59be29..9c383f2 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -19,6 +19,7 @@ build() {
+@@ -9,8 +9,15 @@ url='https://github.com/google/highway/'
+ license=('Apache-2.0' 'BSD-3-Clause')
+ depends=('gcc-libs')
+ makedepends=('cmake' 'gtest')
+-source=("https://github.com/google/highway/archive/${pkgver}/${pkgname}-${pkgver}.tar.gz")
+-sha256sums=('7e0be78b8318e8bdbf6fa545d2ecb4c90f947df03f7aadc42c1967f019e63343')
++source=("https://github.com/google/highway/archive/${pkgver}/${pkgname}-${pkgver}.tar.gz"
++        "highway-disable-RVV-runtime-dispatch.patch::https://github.com/google/highway/commit/c95cc0237d2f7a0f5ca5dc3fb4b5961b2b1dcdfc.patch")
++sha256sums=('7e0be78b8318e8bdbf6fa545d2ecb4c90f947df03f7aadc42c1967f019e63343'
++            '81d2248de29b07fce1a949f7c251d8279687ee38fe8646e131ca7d1ea8a72d6a')
++
++prepare() {
++    cd "${pkgname}-${pkgver}"
++    patch -p1 -i "${srcdir}/highway-disable-RVV-runtime-dispatch.patch"
++}
+ 
+ build() {
+     cmake -B build -S "${pkgname}-${pkgver}" \
+@@ -19,6 +26,7 @@ build() {
          -DCMAKE_INSTALL_PREFIX:PATH='/usr' \
          -DBUILD_SHARED_LIBS:BOOL='ON' \
          -DHWY_SYSTEM_GTEST:BOOL='ON' \


### PR DESCRIPTION
Backport https://github.com/google/highway/commit/c95cc0237d2f7a0f5ca5dc3fb4b5961b2b1dcdfc into 1.2.0 to build.  