### PR TITLE
addpatch: ext4magic 0.3.2-5

### DIFF
--- a/ext4magic/riscv64.patch
+++ b/ext4magic/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -28,6 +28,7 @@ prepare() {
+     fi
+   done
+   :
++  autoreconf -fi
+ }
+ 
+ build() {


### PR DESCRIPTION
Outdated `config.guess` issue was reported to upstream in https://sourceforge.net/p/ext4magic/tickets/16/ .