### PR TITLE
addpatch: fuseiso 20070709-9

### DIFF
--- a/fuseiso/riscv64.patch
+++ b/fuseiso/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -21,6 +21,12 @@ sha256sums=('8b242e077d66cd20900c59c905ff90b4c934b0613dd5a20facb0b1260ac5fd88'
+             'def5dd8dc20ad44ec659c20472744db6329684fc1d53f451e28bae655c799a8f'
+             '520e01cd544d21e6400c5d63bcaf57e344fbb59406a6a61636dc0d4cb6447bd1')
+ 
++prepare() {
++  cd ${pkgname}-${pkgver}
++  cp /usr/share/autoconf/build-aux/config.guess config.guess
++  cp /usr/share/autoconf/build-aux/config.sub config.sub
++}
++
+ build() {
+   cd ${pkgname}-${pkgver}
+ 


### PR DESCRIPTION
Outdated `config.guess` issue was reported to upstream in https://sourceforge.net/p/fuseiso/patches/3/ .