### PR TITLE
addpatch: libsmf 1.3-12

### DIFF
--- a/libsmf/riscv64.patch
+++ b/libsmf/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -16,6 +16,11 @@ provides=('libsmf.so')
+ source=("https://downloads.sourceforge.net/project/${pkgname}/${pkgname}/${pkgver}/${pkgname}-${pkgver}.tar.gz")
+ sha512sums=('3c383ec8f2fbe48ddab1008b3ecfe6941c38e33cfd963eabdf07f09c8c04c1b8758c8774b25672f70c29b570f2c250c795979d19b39c5027810b54b07035497d')
+ 
++prepare() {
++  cd "${pkgname}-${pkgver}"
++  autoreconf -fi
++}
++
+ build() {
+   cd "${pkgname}-${pkgver}"
+   ./configure --prefix=/usr \


### PR DESCRIPTION
Outdated `config.guess` issue was reported to upstream in https://github.com/stump/libsmf/issues/13 .