### PR TITLE
addpatch: musl 1.2.5-2

### DIFF
--- a/musl/riscv64.patch
+++ b/musl/riscv64.patch
@@ -1,0 +1,22 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -3,8 +3,8 @@
+ # Contributor: TJ Vanderpoel <tj@rubyists>
+ 
+ pkgbase=musl
+-pkgname=(musl musl-aarch64 musl-riscv64)
+-_archs=("aarch64" "riscv64")
++pkgname=(musl musl-aarch64)
++_archs=("aarch64")
+ pkgver=1.2.5
+ pkgrel=2
+ pkgdesc='Lightweight implementation of C standard library'
+@@ -12,7 +12,7 @@ arch=('x86_64')
+ url='https://www.musl-libc.org/'
+ license=('MIT')
+ options=('staticlibs' '!buildflags')
+-makedepends=('aarch64-linux-gnu-gcc' 'riscv64-linux-gnu-gcc')
++makedepends=('aarch64-linux-gnu-gcc')
+ validpgpkeys=('836489290BB6B70F99FFDA0556BCDB593020450F')
+ source=(https://www.musl-libc.org/releases/musl-$pkgver.tar.gz{,.asc})
+ sha256sums=('a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4'


### PR DESCRIPTION
- Remove musl-riscv64 package as we are on native riscv64.
- There's no x86_64-linux-gnu-gcc package so musl-x86_64 is not built for now.