### PR TITLE
addpkg: dart-bootstrap 3.4.4-1

### DIFF
--- a/dart-bootstrap/DEPS.patch
+++ b/dart-bootstrap/DEPS.patch
@@ -1,0 +1,131 @@
+diff --git a/DEPS b/DEPS
+index 627823962f8..2a66a2d7e12 100644
+--- a/DEPS
++++ b/DEPS
+@@ -64,9 +64,8 @@ vars = {
+   # Checkout the flute benchmark only when benchmarking.
+   "checkout_flute": False,
+ 
+-  # Checkout Android dependencies only on Mac and Linux.
+-  "download_android_deps":
+-    "host_os == mac or (host_os == linux and host_cpu == x64)",
++  # Do not checkout Android dependencies.
++  "download_android_deps": False,
+ 
+   # Checkout extra javascript engines for testing or benchmarking.
+   # d8, the V8 shell, is always checked out.
+@@ -81,7 +80,7 @@ vars = {
+   "gn_version": "git_revision:e4702d7409069c4f12d45ea7b7f0890717ca3f4b",
+ 
+   "reclient_version": "git_revision:c7349324c93c6e0d85bc1e00b5d7526771006ea0",
+-  "download_reclient": True,
++  "download_reclient": False,
+ 
+   # Update from https://chrome-infra-packages.appspot.com/p/fuchsia/sdk/core
+   "fuchsia_sdk_version": "version:16.20231105.3.1",
+@@ -503,37 +502,7 @@ Var("dart_root") + "/third_party/pkg/tar":
+   Var("dart_root") + "/third_party/pkg/yaml":
+       Var("dart_git") + "yaml.git" + "@" + Var("yaml_rev"),
+ 
+-  Var("dart_root") + "/buildtools/sysroot/linux": {
+-      "packages": [
+-          {
+-              "package": "fuchsia/third_party/sysroot/linux",
+-              "version": "git_revision:fa7a5a9710540f30ff98ae48b62f2cdf72ed2acd",
+-          },
+-      ],
+-      "condition": "host_os == linux",
+-      "dep_type": "cipd",
+-  },
+-  Var("dart_root") + "/buildtools/sysroot/focal": {
+-      "packages": [
+-          {
+-              "package": "fuchsia/third_party/sysroot/focal",
+-              "version": "git_revision:fa7a5a9710540f30ff98ae48b62f2cdf72ed2acd",
+-          },
+-      ],
+-      "condition": "host_os == linux",
+-      "dep_type": "cipd",
+-  },
+-
+   # Keep consistent with pkg/test_runner/lib/src/options.dart.
+-  Var("dart_root") + "/buildtools/linux-x64/clang": {
+-      "packages": [
+-          {
+-              "package": "fuchsia/third_party/clang/linux-amd64",
+-              "version": Var("clang_version"),
+-          },
+-      ],
+-      "dep_type": "cipd",
+-  },
+   Var("dart_root") + "/buildtools/mac-x64/clang": {
+       "packages": [
+           {
+@@ -600,16 +569,6 @@ Var("dart_root") + "/third_party/pkg/tar":
+     "dep_type": "cipd",
+   },
+ 
+-  Var("dart_root") + "/buildtools": {
+-      "packages": [
+-          {
+-              "package": "gn/gn/${{platform}}",
+-              "version": Var("gn_version"),
+-          },
+-      ],
+-      "condition": "host_os != 'win'",
+-      "dep_type": "cipd",
+-  },
+   Var("dart_root") + "/buildtools/win": {
+       "packages": [
+           {
+@@ -621,14 +580,6 @@ Var("dart_root") + "/third_party/pkg/tar":
+       "dep_type": "cipd",
+   },
+ 
+-  Var("dart_root") + "/buildtools/ninja": {
+-      "packages": [{
+-          "package": "infra/3pp/tools/ninja/${{platform}}",
+-          "version": Var("ninja_tag"),
+-      }],
+-      "dep_type": "cipd",
+-  },
+-
+   Var("dart_root") + "/third_party/android_tools/ndk": {
+       "packages": [
+           {
+@@ -693,35 +644,6 @@ Var("dart_root") + "/third_party/pkg/tar":
+     "dep_type": "cipd",
+   },
+ 
+-  # TODO(37531): Remove these cipd packages and build with sdk instead when
+-  # benchmark runner gets support for that.
+-  Var("dart_root") + "/benchmarks/FfiBoringssl/native/out/": {
+-      "packages": [
+-          {
+-              "package": "dart/benchmarks/ffiboringssl",
+-              "version": "commit:a86c69888b9a416f5249aacb4690a765be064969",
+-          },
+-      ],
+-      "dep_type": "cipd",
+-  },
+-  Var("dart_root") + "/benchmarks/FfiCall/native/out/": {
+-      "packages": [
+-          {
+-              "package": "dart/benchmarks/fficall",
+-              "version": "ebF5aRXKDananlaN4Y8b0bbCNHT1MnkGbWqfpCpiND4C",
+-          },
+-      ],
+-          "dep_type": "cipd",
+-  },
+-  Var("dart_root") + "/benchmarks/NativeCall/native/out/": {
+-      "packages": [
+-          {
+-              "package": "dart/benchmarks/nativecall",
+-              "version": "w1JKzCIHSfDNIjqnioMUPq0moCXKwX67aUfhyrvw4E0C",
+-          },
+-      ],
+-          "dep_type": "cipd",
+-  },
+   Var("dart_root") + "/third_party/browsers/chrome": {
+       "packages": [
+           {

--- a/dart-bootstrap/PKGBUILD
+++ b/dart-bootstrap/PKGBUILD
@@ -1,0 +1,117 @@
+# Maintainer: Alexander Rødseth <rodseth@gmail.com>
+# Maintainer: Felix Yan <felixonmars@archlinux.org>
+# Maintainer: Orhun Parmaksız <orhun@archlinux.org>
+# Contributor: Daniele Basso <d dot bass05 at proton dot me>
+# Contributor: T. Jameson Little <t.jameson.little at gmail dot com>
+# Contributor: Usagi Ito <usagi@WonderRabbitProject.net>
+# Contributor: siasia <http://pastebin.com/qsBEmNCw>
+# Contributor: Julien Nicoulaud <julien.nicoulaud@gmail.com>
+# Contributor: The one with the braid <info@braid.business>
+
+_pkgname=dart
+pkgname=dart-bootstrap
+pkgver=3.4.4
+pkgrel=1
+pkgdesc='The dart programming language SDK'
+arch=('riscv64')
+url='https://dart.dev/'
+depends=('glibc')
+license=('BSD')
+provides=('dart')
+makedepends=(
+  'git'
+  'gn'
+  'ninja'
+  'python'
+  'python-httplib2'
+  'python-six'
+)
+source=(
+  "git+https://github.com/dart-lang/sdk.git#tag=$pkgver"
+  "git+https://chromium.googlesource.com/chromium/tools/depot_tools.git"
+  "DEPS.patch"
+  "package_config.json"
+  "dart-riscv-no-cross.patch"
+)
+sha256sums=('aba863b230001773aa8cbbedb2824de154f778377c4048dbcc12460fdcd969f5'
+            'SKIP'
+            'db6576a70c6719e26795b9824546058b79fefa64158c1002d36546d826084403'
+            'c91bb6c87b1d8af3417c12b4eb5283475f3cf1ddb4910784fb542f29dbc0f21f'
+            '9b69b12208faa1a4b98be5e5e73385526e2571f0f3527aadd0496eadb4b7aab6')
+
+prepare() {
+cat >.gclient <<EOF
+solutions = [
+  {
+    "name": "sdk",
+    "url": "file://${srcdir}/sdk",
+    "deps_file": "DEPS",
+    "managed": False,
+    "custom_deps": {},
+    "custom_vars": {},
+  },
+]
+EOF
+
+  export PATH+=":$PWD/depot_tools" DEPOT_TOOLS_UPDATE=0
+
+  cd sdk
+
+  patch -Np 1 --input=$srcdir/DEPS.patch
+  patch -Np 1 --input=$srcdir/dart-riscv-no-cross.patch
+
+  python ../depot_tools/gclient.py sync -D \
+      --nohooks \
+      --no-history \
+      --shallow \
+      -r ${srcdir}/sdk@${_commit}
+
+  cp ../package_config.json .dart_tool/
+  python tools/generate_sdk_version_file.py
+
+  #ln -s /usr/bin/gn buildtools/gn
+  #mkdir -p buildtools/ninja
+  #ln -s /usr/bin/ninja buildtools/ninja/ninja
+  sed -i 's|prefix = rebased_clang_dir|prefix= ""|g' build/toolchain/linux/BUILD.gn # use system clang
+  sed -i 's|}/|}|g' build/toolchain/linux/BUILD.gn # use system clang
+  sed -i 's|rebase|#|g' build/toolchain/linux/BUILD.gn
+}
+
+build() {
+  cd sdk
+
+  # gn args --list out
+
+  /usr/bin/gn gen -qv out --args='
+                        target_cpu = "riscv64"
+                        is_debug = false
+                        is_release = true
+                        is_clang = false
+                        dart_platform_sdk = false
+                        verify_sdk_hash = false'
+  ninja create_sdk -v -C out
+}
+
+package() {
+  # cd to directory
+  cd sdk/out/
+
+  # Create directories
+  install -d "$pkgdir"{"/opt/$_pkgname-sdk",/usr/{bin,"share/doc/$_pkgname"}}
+
+  # Package the files
+  cp -a "$_pkgname-sdk/"* "$pkgdir/opt/$_pkgname-sdk/"
+
+  # Set up symbolic links for the executables
+  for f in dart dartaotruntime; do
+    ln -s "/opt/$_pkgname-sdk/bin/$f" "$pkgdir/usr/bin/$f"
+  done
+
+  # Package documentation
+  install -Dm644 "$pkgdir/opt/$_pkgname-sdk/README" -t "$pkgdir/usr/share/doc/$_pkgname"
+
+  # BSD License
+  install -Dm644 ../LICENSE "$pkgdir/usr/share/licenses/$_pkgname/LICENSE"
+}
+
+# vim:set ts=2 sw=2 et:

--- a/dart-bootstrap/dart-riscv-no-cross.patch
+++ b/dart-bootstrap/dart-riscv-no-cross.patch
@@ -1,0 +1,17 @@
+diff --git a/build/toolchain/linux/BUILD.gn b/build/toolchain/linux/BUILD.gn
+index ec670afe15b..7abf9df6e8b 100644
+--- a/build/toolchain/linux/BUILD.gn
++++ b/build/toolchain/linux/BUILD.gn
+@@ -275,10 +275,8 @@ gcc_toolchain("clang_riscv32") {
+ }
+ 
+ gcc_toolchain("riscv64") {
+-  prefix = "riscv64-linux-gnu-"
+-  if (riscv64_toolchain_prefix != "") {
+-    prefix = riscv64_toolchain_prefix
+-  }
++  # Not cross-compiling
++  prefix = ""
+ 
+   cc = "${gcc_compiler_prefix}${prefix}gcc"
+   cxx = "${gcc_compiler_prefix}${prefix}g++"

--- a/dart-bootstrap/package_config.json
+++ b/dart-bootstrap/package_config.json
@@ -1,0 +1,1235 @@
+{
+  "copyright": [
+    "Copyright (c) 2020, the Dart project authors. Please see the AUTHORS ",
+    "file for details. All rights reserved. Use of this source code is ",
+    "governed by a BSD-style license that can be found in the LICENSE file."
+  ],
+  "comment": [
+    "Package configuration for all packages in pkg/ and third_party/pkg/"
+  ],
+  "configVersion": 2,
+  "generator": "tools/generate_package_config.dart",
+  "packages": [
+    {
+      "name": "_experiment_sound",
+      "rootUri": "../third_party/pkg/webdev/fixtures/_experimentSound",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "_fe_analyzer_shared",
+      "rootUri": "../pkg/_fe_analyzer_shared",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "_fe_analyzer_shared_assigned_variables",
+      "rootUri": "../pkg/_fe_analyzer_shared/test/flow_analysis/assigned_variables",
+      "packageUri": ".nonexisting/"
+    },
+    {
+      "name": "_fe_analyzer_shared_data",
+      "rootUri": "../pkg/_fe_analyzer_shared/test/exhaustiveness/data",
+      "packageUri": ".nonexisting/"
+    },
+    {
+      "name": "_fe_analyzer_shared_definite_assignment",
+      "rootUri": "../pkg/_fe_analyzer_shared/test/flow_analysis/definite_assignment",
+      "packageUri": ".nonexisting/"
+    },
+    {
+      "name": "_fe_analyzer_shared_definite_unassignment",
+      "rootUri": "../pkg/_fe_analyzer_shared/test/flow_analysis/definite_unassignment",
+      "packageUri": ".nonexisting/"
+    },
+    {
+      "name": "_fe_analyzer_shared_inheritance",
+      "rootUri": "../pkg/_fe_analyzer_shared/test/inheritance",
+      "packageUri": ".nonexisting/"
+    },
+    {
+      "name": "_fe_analyzer_shared_nullability",
+      "rootUri": "../pkg/_fe_analyzer_shared/test/flow_analysis/nullability",
+      "packageUri": ".nonexisting/"
+    },
+    {
+      "name": "_fe_analyzer_shared_reachability",
+      "rootUri": "../pkg/_fe_analyzer_shared/test/flow_analysis/reachability",
+      "packageUri": ".nonexisting/"
+    },
+    {
+      "name": "_fe_analyzer_shared_type_promotion",
+      "rootUri": "../pkg/_fe_analyzer_shared/test/flow_analysis/type_promotion",
+      "packageUri": ".nonexisting/"
+    },
+    {
+      "name": "_fe_analyzer_shared_why_not_promoted",
+      "rootUri": "../pkg/_fe_analyzer_shared/test/flow_analysis/why_not_promoted",
+      "packageUri": ".nonexisting/"
+    },
+    {
+      "name": "_js_interop_checks",
+      "rootUri": "../pkg/_js_interop_checks",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "_macros",
+      "rootUri": "../pkg/_macros",
+      "packageUri": "lib/",
+      "languageVersion": "3.4"
+    },
+    {
+      "name": "_test",
+      "rootUri": "../third_party/pkg/webdev/fixtures/_test",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "_test_circular1",
+      "rootUri": "../third_party/pkg/webdev/fixtures/_testCircular1",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "_test_circular1_sound",
+      "rootUri": "../third_party/pkg/webdev/fixtures/_testCircular1Sound",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "_test_circular2",
+      "rootUri": "../third_party/pkg/webdev/fixtures/_testCircular2",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "_test_circular2_sound",
+      "rootUri": "../third_party/pkg/webdev/fixtures/_testCircular2Sound",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "_test_hot_restart1",
+      "rootUri": "../third_party/pkg/webdev/fixtures/_testHotRestart1Sound",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "_test_hot_restart2",
+      "rootUri": "../third_party/pkg/webdev/fixtures/_testHotRestart2Sound",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "_test_package",
+      "rootUri": "../third_party/pkg/webdev/fixtures/_testPackage",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "_test_package_sound",
+      "rootUri": "../third_party/pkg/webdev/fixtures/_testPackageSound",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "_test_sound",
+      "rootUri": "../third_party/pkg/webdev/fixtures/_testSound",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "_webdev_smoke",
+      "rootUri": "../third_party/pkg/webdev/fixtures/_webdevSmoke",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "_webdev_sound_smoke",
+      "rootUri": "../third_party/pkg/webdev/fixtures/_webdevSoundSmoke",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "analysis_server",
+      "rootUri": "../pkg/analysis_server",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "analysis_server_client",
+      "rootUri": "../pkg/analysis_server_client",
+      "packageUri": "lib/",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "analyzer",
+      "rootUri": "../pkg/analyzer",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "analyzer_cli",
+      "rootUri": "../pkg/analyzer_cli",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "analyzer_plugin",
+      "rootUri": "../pkg/analyzer_plugin",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "analyzer_utilities",
+      "rootUri": "../pkg/analyzer_utilities",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "api_benchmark",
+      "rootUri": "../third_party/pkg/protobuf/api_benchmark",
+      "packageUri": "lib/",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "args",
+      "rootUri": "../third_party/pkg/args",
+      "packageUri": "lib/",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "async",
+      "rootUri": "../third_party/pkg/async",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "async_helper",
+      "rootUri": "../pkg/async_helper",
+      "packageUri": "lib/",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "autosnapshotting_example",
+      "rootUri": "../third_party/pkg/leak_tracker/examples/autosnapshotting",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "bazel_worker",
+      "rootUri": "../third_party/pkg/bazel_worker",
+      "packageUri": "lib/",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "benchmark_harness",
+      "rootUri": "../third_party/pkg/benchmark_harness",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "bisect_dart",
+      "rootUri": "../pkg/bisect_dart",
+      "packageUri": "lib/",
+      "languageVersion": "3.1"
+    },
+    {
+      "name": "blast_repo",
+      "rootUri": "../third_party/pkg/ecosystem/pkgs/blast_repo",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "boolean_selector",
+      "rootUri": "../third_party/pkg/boolean_selector",
+      "packageUri": "lib/",
+      "languageVersion": "3.1"
+    },
+    {
+      "name": "browser_launcher",
+      "rootUri": "../third_party/pkg/browser_launcher",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "build_integration",
+      "rootUri": "../pkg/build_integration",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "checks",
+      "rootUri": "../third_party/pkg/test/pkgs/checks",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "cli_config",
+      "rootUri": "../third_party/pkg/tools/pkgs/cli_config",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "cli_util",
+      "rootUri": "../third_party/pkg/cli_util",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "clock",
+      "rootUri": "../third_party/pkg/clock",
+      "packageUri": "lib/",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "collection",
+      "rootUri": "../third_party/pkg/collection",
+      "packageUri": "lib/",
+      "languageVersion": "3.1"
+    },
+    {
+      "name": "compiler",
+      "rootUri": "../pkg/compiler",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "convert",
+      "rootUri": "../third_party/pkg/convert",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "corpus",
+      "rootUri": "../third_party/pkg/ecosystem/pkgs/corpus",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "cronet_http",
+      "rootUri": "../third_party/pkg/http/pkgs/cronet_http",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "crypto",
+      "rootUri": "../third_party/pkg/crypto",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "csslib",
+      "rootUri": "../third_party/pkg/csslib",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "cupertino_http",
+      "rootUri": "../third_party/pkg/http/pkgs/cupertino_http",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "dap",
+      "rootUri": "../third_party/pkg/dap",
+      "packageUri": "lib/",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "dart2js_info",
+      "rootUri": "../pkg/dart2js_info",
+      "packageUri": "lib/",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "dart2js_runtime_metrics",
+      "rootUri": "../pkg/dart2js_runtime_metrics",
+      "packageUri": "lib/",
+      "languageVersion": "2.14"
+    },
+    {
+      "name": "dart2js_tools",
+      "rootUri": "../pkg/dart2js_tools",
+      "packageUri": "lib/",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "dart2native",
+      "rootUri": "../pkg/dart2native",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "dart2wasm",
+      "rootUri": "../pkg/dart2wasm",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "dart_flutter_team_lints",
+      "rootUri": "../third_party/pkg/ecosystem/pkgs/dart_flutter_team_lints",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "dart_internal",
+      "rootUri": "../pkg/dart_internal",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "dart_service_protocol_shared",
+      "rootUri": "../pkg/dart_service_protocol_shared",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "dart_style",
+      "rootUri": "../third_party/pkg/dart_style",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "dartdev",
+      "rootUri": "../pkg/dartdev",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "dartdoc",
+      "rootUri": "../third_party/pkg/dartdoc",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "dds",
+      "rootUri": "../pkg/dds",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "dds_service_extensions",
+      "rootUri": "../pkg/dds_service_extensions",
+      "packageUri": "lib/",
+      "languageVersion": "2.15"
+    },
+    {
+      "name": "dev_compiler",
+      "rootUri": "../pkg/dev_compiler",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "devtools_shared",
+      "rootUri": "../third_party/devtools/devtools_shared",
+      "packageUri": "lib/",
+      "languageVersion": "3.4"
+    },
+    {
+      "name": "dtd",
+      "rootUri": "../pkg/dtd",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "dtd_impl",
+      "rootUri": "../pkg/dtd_impl",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "dwds",
+      "rootUri": "../third_party/pkg/webdev/dwds",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "expect",
+      "rootUri": "../pkg/expect",
+      "packageUri": "lib/",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "extension_discovery",
+      "rootUri": "../third_party/pkg/tools/pkgs/extension_discovery",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "ffi",
+      "rootUri": "../third_party/pkg/native/pkgs/ffi",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "ffigen",
+      "rootUri": "../third_party/pkg/native/pkgs/ffigen",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "file",
+      "rootUri": "../third_party/pkg/file/packages/file",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "file_testing",
+      "rootUri": "../third_party/pkg/file/packages/file_testing",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "firehose",
+      "rootUri": "../third_party/pkg/ecosystem/pkgs/firehose",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "fixnum",
+      "rootUri": "../third_party/pkg/fixnum",
+      "packageUri": "lib/",
+      "languageVersion": "3.1"
+    },
+    {
+      "name": "flutter_http_example",
+      "rootUri": "../third_party/pkg/http/pkgs/flutter_http_example",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "front_end",
+      "rootUri": "../pkg/front_end",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "front_end_testcases",
+      "rootUri": "../pkg/front_end/testcases",
+      "packageUri": ".nonexisting/"
+    },
+    {
+      "name": "frontend_server",
+      "rootUri": "../pkg/frontend_server",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "frontend_server_client",
+      "rootUri": "../third_party/pkg/webdev/frontend_server_client",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "frontend_server_common",
+      "rootUri": "../third_party/pkg/webdev/frontend_server_common",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "frontend_server_fixtures",
+      "rootUri": "../pkg/frontend_server/test/fixtures",
+      "packageUri": ".nonexisting/"
+    },
+    {
+      "name": "glob",
+      "rootUri": "../third_party/pkg/glob",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "graphs",
+      "rootUri": "../third_party/pkg/tools/pkgs/graphs",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "heap_snapshot",
+      "rootUri": "../pkg/heap_snapshot",
+      "packageUri": "lib/",
+      "languageVersion": "2.17"
+    },
+    {
+      "name": "heapsnapshot",
+      "rootUri": "../runtime/tools/heapsnapshot",
+      "packageUri": "lib/",
+      "languageVersion": "2.17"
+    },
+    {
+      "name": "html",
+      "rootUri": "../third_party/pkg/html",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "http",
+      "rootUri": "../third_party/pkg/http/pkgs/http",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "http_client_conformance_tests",
+      "rootUri": "../third_party/pkg/http/pkgs/http_client_conformance_tests",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "http_multi_server",
+      "rootUri": "../third_party/pkg/http_multi_server",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "http_parser",
+      "rootUri": "../third_party/pkg/http_parser",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "http_profile",
+      "rootUri": "../third_party/pkg/http/pkgs/http_profile",
+      "packageUri": "lib/",
+      "languageVersion": "3.4"
+    },
+    {
+      "name": "http_sample",
+      "rootUri": "../samples/ffi/http",
+      "packageUri": "lib/",
+      "languageVersion": "3.1"
+    },
+    {
+      "name": "intl",
+      "rootUri": "../third_party/pkg/intl",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "java_http",
+      "rootUri": "../third_party/pkg/http/pkgs/java_http",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "jni",
+      "rootUri": "../third_party/pkg/native/pkgs/jni",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "jnigen",
+      "rootUri": "../third_party/pkg/native/pkgs/jnigen",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "js",
+      "rootUri": "../pkg/js",
+      "packageUri": "lib/",
+      "languageVersion": "3.1"
+    },
+    {
+      "name": "js_ast",
+      "rootUri": "../pkg/js_ast",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "js_runtime",
+      "rootUri": "../pkg/js_runtime",
+      "packageUri": "lib/",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "js_shared",
+      "rootUri": "../pkg/js_shared",
+      "packageUri": "lib/",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "json_rpc_2",
+      "rootUri": "../third_party/pkg/json_rpc_2",
+      "packageUri": "lib/",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "kernel",
+      "rootUri": "../pkg/kernel",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "language_server_protocol",
+      "rootUri": "../third_party/pkg/language_server_protocol",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "language_versioning_2_12_test",
+      "rootUri": "../pkg/language_versioning_2_12_test",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "leak_tracker",
+      "rootUri": "../third_party/pkg/leak_tracker/pkgs/leak_tracker",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "leak_tracker_flutter_testing",
+      "rootUri": "../third_party/pkg/leak_tracker/pkgs/leak_tracker_flutter_testing",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "leak_tracker_minimal_flutter_example",
+      "rootUri": "../third_party/pkg/leak_tracker/examples/leak_tracking",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "leak_tracker_testing",
+      "rootUri": "../third_party/pkg/leak_tracker/pkgs/leak_tracker_testing",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "linter",
+      "rootUri": "../pkg/linter",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "lints",
+      "rootUri": "../third_party/pkg/lints",
+      "packageUri": "lib/",
+      "languageVersion": "3.1"
+    },
+    {
+      "name": "logging",
+      "rootUri": "../third_party/pkg/logging",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "macros",
+      "rootUri": "../pkg/macros",
+      "packageUri": "lib/",
+      "languageVersion": "3.4"
+    },
+    {
+      "name": "markdown",
+      "rootUri": "../third_party/pkg/markdown",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "matcher",
+      "rootUri": "../third_party/pkg/matcher",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "memory_usage",
+      "rootUri": "../third_party/pkg/leak_tracker/pkgs/memory_usage",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "meta",
+      "rootUri": "../pkg/meta",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "mime",
+      "rootUri": "../third_party/pkg/mime",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "mmap",
+      "rootUri": "../pkg/mmap",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "mockito",
+      "rootUri": "../third_party/pkg/mockito",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "modular_test",
+      "rootUri": "../pkg/modular_test",
+      "packageUri": "lib/",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "native_assets_builder",
+      "rootUri": "../third_party/pkg/native/pkgs/native_assets_builder",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "native_assets_cli",
+      "rootUri": "../third_party/pkg/native/pkgs/native_assets_cli",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "native_stack_traces",
+      "rootUri": "../pkg/native_stack_traces",
+      "packageUri": "lib/",
+      "languageVersion": "2.17"
+    },
+    {
+      "name": "native_toolchain_c",
+      "rootUri": "../third_party/pkg/native/pkgs/native_toolchain_c",
+      "packageUri": "lib/",
+      "languageVersion": "3.1"
+    },
+    {
+      "name": "observatory",
+      "rootUri": "../runtime/observatory",
+      "packageUri": "lib/",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "observatory_test_package",
+      "rootUri": "../runtime/observatory/tests/service/observatory_test_package",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "package_config",
+      "rootUri": "../third_party/pkg/package_config",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "package_deps",
+      "rootUri": "../tools/package_deps",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "path",
+      "rootUri": "../third_party/pkg/path",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "pkg_vm_testcases",
+      "rootUri": "../pkg/vm/testcases",
+      "packageUri": ".nonexisting/"
+    },
+    {
+      "name": "pool",
+      "rootUri": "../third_party/pkg/pool",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "protobuf",
+      "rootUri": "../third_party/pkg/protobuf/protobuf",
+      "packageUri": "lib/",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "protobuf_benchmarks",
+      "rootUri": "../third_party/pkg/protobuf/benchmarks",
+      "packageUri": "lib/",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "protoc_plugin",
+      "rootUri": "../third_party/pkg/protobuf/protoc_plugin",
+      "packageUri": "lib/",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "pub",
+      "rootUri": "../third_party/pkg/pub",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "pub_semver",
+      "rootUri": "../third_party/pkg/pub_semver",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "regression_tests",
+      "rootUri": "../third_party/pkg/test/integration_tests/regression",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "reload_test",
+      "rootUri": "../pkg/reload_test",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "repo_manage",
+      "rootUri": "../third_party/pkg/ecosystem/pkgs/repo_manage",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "scrape",
+      "rootUri": "../pkg/scrape",
+      "packageUri": "lib/",
+      "languageVersion": "3.1"
+    },
+    {
+      "name": "sdk_library_metadata",
+      "rootUri": "../sdk/lib/_internal/sdk_library_metadata",
+      "packageUri": "lib/",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "server_plugin",
+      "rootUri": "../pkg/server_plugin",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "shelf",
+      "rootUri": "../third_party/pkg/shelf/pkgs/shelf",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "shelf_packages_handler",
+      "rootUri": "../third_party/pkg/shelf/pkgs/shelf_packages_handler",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "shelf_proxy",
+      "rootUri": "../third_party/pkg/shelf/pkgs/shelf_proxy",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "shelf_router",
+      "rootUri": "../third_party/pkg/shelf/pkgs/shelf_router",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "shelf_router_generator",
+      "rootUri": "../third_party/pkg/shelf/pkgs/shelf_router_generator",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "shelf_static",
+      "rootUri": "../third_party/pkg/shelf/pkgs/shelf_static",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "shelf_test_handler",
+      "rootUri": "../third_party/pkg/shelf/pkgs/shelf_test_handler",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "shelf_web_socket",
+      "rootUri": "../third_party/pkg/shelf/pkgs/shelf_web_socket",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "smith",
+      "rootUri": "../pkg/smith",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "source_map_stack_trace",
+      "rootUri": "../third_party/pkg/source_map_stack_trace",
+      "packageUri": "lib/",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "source_maps",
+      "rootUri": "../third_party/pkg/source_maps",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "source_span",
+      "rootUri": "../third_party/pkg/source_span",
+      "packageUri": "lib/",
+      "languageVersion": "3.1"
+    },
+    {
+      "name": "sourcemap_testing",
+      "rootUri": "../pkg/sourcemap_testing",
+      "packageUri": "lib/",
+      "languageVersion": "2.16"
+    },
+    {
+      "name": "spawn_hybrid",
+      "rootUri": "../third_party/pkg/test/integration_tests/spawn_hybrid",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "sqlite3",
+      "rootUri": "../samples/ffi/sqlite",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "sse",
+      "rootUri": "../third_party/pkg/sse",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "stack_trace",
+      "rootUri": "../third_party/pkg/stack_trace",
+      "packageUri": "lib/",
+      "languageVersion": "3.1"
+    },
+    {
+      "name": "status_file",
+      "rootUri": "../pkg/status_file",
+      "packageUri": "lib/",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "stream_channel",
+      "rootUri": "../third_party/pkg/stream_channel",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "string_scanner",
+      "rootUri": "../third_party/pkg/string_scanner",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "sync_http",
+      "rootUri": "../third_party/pkg/sync_http",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "tar",
+      "rootUri": "../third_party/pkg/tar",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "telemetry",
+      "rootUri": "../pkg/telemetry",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "term_glyph",
+      "rootUri": "../third_party/pkg/term_glyph",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "test",
+      "rootUri": "../third_party/pkg/test/pkgs/test",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "test_api",
+      "rootUri": "../third_party/pkg/test/pkgs/test_api",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "test_common",
+      "rootUri": "../third_party/pkg/webdev/test_common",
+      "packageUri": "lib/",
+      "languageVersion": "3.1"
+    },
+    {
+      "name": "test_core",
+      "rootUri": "../third_party/pkg/test/pkgs/test_core",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "test_descriptor",
+      "rootUri": "../third_party/pkg/test_descriptor",
+      "packageUri": "lib/",
+      "languageVersion": "3.1"
+    },
+    {
+      "name": "test_package",
+      "rootUri": "../pkg/vm_service/test/test_package",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "test_process",
+      "rootUri": "../third_party/pkg/test_process",
+      "packageUri": "lib/",
+      "languageVersion": "3.1"
+    },
+    {
+      "name": "test_reflective_loader",
+      "rootUri": "../third_party/pkg/test_reflective_loader",
+      "packageUri": "lib/",
+      "languageVersion": "3.1"
+    },
+    {
+      "name": "test_runner",
+      "rootUri": "../pkg/test_runner",
+      "packageUri": "lib/",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "testing",
+      "rootUri": "../pkg/testing",
+      "packageUri": "lib/",
+      "languageVersion": "2.12"
+    },
+    {
+      "name": "tool",
+      "rootUri": "../third_party/pkg/webdev/tool",
+      "languageVersion": "3.1"
+    },
+    {
+      "name": "typed_data",
+      "rootUri": "../third_party/pkg/typed_data",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "unified_analytics",
+      "rootUri": "../third_party/pkg/tools/pkgs/unified_analytics",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "usage",
+      "rootUri": "../third_party/pkg/usage",
+      "packageUri": "lib/",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "vector_math",
+      "rootUri": "../third_party/pkg/vector_math",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "vm",
+      "rootUri": "../pkg/vm",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "vm_service",
+      "rootUri": "../pkg/vm_service",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "vm_service_interface",
+      "rootUri": "../pkg/vm_service_interface",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "vm_service_protos",
+      "rootUri": "../pkg/vm_service_protos",
+      "packageUri": "lib/",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "vm_snapshot_analysis",
+      "rootUri": "../pkg/vm_snapshot_analysis",
+      "packageUri": "lib/",
+      "languageVersion": "2.14"
+    },
+    {
+      "name": "wasm_builder",
+      "rootUri": "../pkg/wasm_builder",
+      "packageUri": "lib/",
+      "languageVersion": "2.19"
+    },
+    {
+      "name": "wasm_tests",
+      "rootUri": "../third_party/pkg/test/integration_tests/wasm",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "watcher",
+      "rootUri": "../third_party/pkg/watcher",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "web",
+      "rootUri": "../third_party/pkg/web",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "web_socket",
+      "rootUri": "../third_party/pkg/http/pkgs/web_socket",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "web_socket_channel",
+      "rootUri": "../third_party/pkg/web_socket_channel",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "web_socket_conformance_tests",
+      "rootUri": "../third_party/pkg/http/pkgs/web_socket_conformance_tests",
+      "packageUri": "lib/",
+      "languageVersion": "3.3"
+    },
+    {
+      "name": "webdev",
+      "rootUri": "../third_party/pkg/webdev/webdev",
+      "packageUri": "lib/",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "webdev_example_app",
+      "rootUri": "../third_party/pkg/webdev/example",
+      "languageVersion": "3.2"
+    },
+    {
+      "name": "webdriver",
+      "rootUri": "../third_party/pkg/webdriver",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "webkit_inspection_protocol",
+      "rootUri": "../third_party/pkg/webkit_inspection_protocol",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "yaml",
+      "rootUri": "../third_party/pkg/yaml",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    },
+    {
+      "name": "yaml_edit",
+      "rootUri": "../third_party/pkg/yaml_edit",
+      "packageUri": "lib/",
+      "languageVersion": "3.0"
+    }
+  ]
+}


### PR DESCRIPTION
For bootstrapping dart, which makedepends on itself.

The only part that requires dart is generating package_config.json. Thus package_config.json is generated on x86_64, added to source.

dart-riscv-no-croos.patch is needed because gcc package doesn't provide riscv64-linux-gnu-ar but riscv64-linux-gnu-gcc-ar.