### PR TITLE
addpatch: libabw 0.1.3-4

### DIFF
--- a/libabw/riscv64.patch
+++ b/libabw/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,6 +12,11 @@ makedepends=('doxygen' 'gperf' 'boost')
+ source=(https://dev-www.libreoffice.org/src/$pkgname/$pkgname-$pkgver.tar.xz)
+ sha256sums=('e763a9dc21c3d2667402d66e202e3f8ef4db51b34b79ef41f56cacb86dcd6eed')
+ 
++prepare() {
++  cd $pkgname-$pkgver
++  autoreconf -fi
++}
++
+ build() {
+   cd $pkgname-$pkgver
+   ./configure --prefix=/usr


### PR DESCRIPTION
Configure error `cannot guess build type; you must specify one` was reported in https://bugs.documentfoundation.org/show_bug.cgi?id=162204 .