### PR TITLE
addpatch: libwnck 2.31.0-4

### DIFF
--- a/libwnck/riscv64.patch
+++ b/libwnck/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -31,6 +31,8 @@ sha512sums=('54262a08882021f08f3ba7f2ddfa33fc1f02e391a0f61cf999a50a089e0d277dfe1
+ prepare() {
+   cd $pkgname-$pkgver
+   patch -Np1 -i ../WindowActionMenu-unset-window-and-stop-async-events-on-dispose.patch
++  cp /usr/share/autoconf/build-aux/config.guess config.guess
++  cp /usr/share/autoconf/build-aux/config.sub config.sub
+ }
+ build() {
+     cd "${srcdir}/${pkgname}-${pkgver}"


### PR DESCRIPTION
Configure error `cannot guess build type; you must specify one` was not reported to upstream because it was replaced by libwnck3.  