### PR TITLE
addpatch: gnujump 1.0.8-7

### DIFF
--- a/gnujump/riscv64.patch
+++ b/gnujump/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -18,6 +18,11 @@ sha256sums=('13c3fe5f430eb0c010560c7e438123a573ca61a55c6708aa750cfbf56bf25e17'
+             '74db0c3e9921d7d1374e116ea045bd1c63b30b501dd656d84bce67767d0d7f2c'
+             'd29d273a015fea06ea5b811e88aa572423e0c3418225a52cf04f2c01d6a2b3ed')
+ 
++prepare() {
++  cd $pkgname-$pkgver
++  autoreconf -fi
++}
++
+ build() {
+   cd $pkgname-$pkgver
+ 


### PR DESCRIPTION
Configure error `cannot guess build type; you must specify one` was reported in https://savannah.gnu.org/bugs/index.php?66028 .