### PR TITLE
addpatch: libgringotts 1.2.1-15

### DIFF
--- a/libgringotts/riscv64.patch
+++ b/libgringotts/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,6 +12,11 @@ changelog=$pkgname.changelog
+ source=(https://sourceforge.net/projects/gringotts.berlios/files/$pkgname-$pkgver.tar.bz2)
+ sha512sums=('504f3bc64fb95c489eb9bdbfe0ec97dde2ad04a1f9609f943444828dc5b2954a961bf42de8ce9ea1736230e1719d584903caac11e0c0f690a6c7fdb47c1b82f5')
+ 
++prepare() {
++  cd "${srcdir}"/$pkgname-$pkgver
++  autoreconf -fi
++}
++
+ build() {
+   cd "${srcdir}"/$pkgname-$pkgver
+ 


### PR DESCRIPTION
Configure error `cannot guess build type; you must specify one` was not reported to upstream because can't get contact.  