### PR TITLE
addpatch: gtkmm 2.24.5-5

### DIFF
--- a/gtkmm/riscv64.patch
+++ b/gtkmm/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,6 +14,12 @@ depends=(gtk2 pangomm atkmm)
+ source=(https://ftp.gnome.org/pub/GNOME/sources/$pkgbase/2.24/$pkgbase-$pkgver.tar.xz)
+ sha256sums=('0680a53b7bf90b4e4bf444d1d89e6df41c777e0bacc96e9c09fc4dd2f5fe6b72')
+ 
++prepare() {
++  cd $pkgbase-$pkgver
++  cp /usr/share/autoconf/build-aux/config.guess build/config.guess
++  cp /usr/share/autoconf/build-aux/config.sub build/config.sub
++}
++
+ build() {
+   cd $pkgbase-$pkgver
+ 


### PR DESCRIPTION
Configure error `cannot guess build type; you must specify one` was not reported to upstream because it was replaced by gtkmm4.  