### PR TITLE
addpatch: cargo-deny

### DIFF
--- a/cargo-deny/riscv64.patch
+++ b/cargo-deny/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -21,6 +21,9 @@ sha256sums=('1ed227a49263bd34d65efb0a0dbacd1fc6e550da297e54573b0857af0d6a000e'
+ 
+ prepare() {
+   cd "$pkgname-$pkgver"
++  # increase test timeout
++  sed -i 's/const TIMEOUT:.*= std::time::Duration::from_secs(30)/const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(160)/' src/test_utils.rs
++
+   git submodule init
+   git config submodule."tests/advisory-db/github.com-2f857891b7f43c59".url "${srcdir}/${pkgname}-advisory-db"
+   git config submodule."tests/advisory-db/github.com-c373669cccc50ac0".url "${srcdir}/${pkgname}-test-advisory-db"


### PR DESCRIPTION
Increase test timeout to make build pass.

I have opened a PR upstream to add an environment variable to control the test timeout and asked if they can increase the timeout: https://github.com/EmbarkStudios/cargo-deny/pull/683. But it need some time for them to respond and make a new release. So I think it would be helpful to make a patch here and then we can estimate the appropriate timeout.

The 160s timeout is just an arbitrary large enough number I choose.