### PR TITLE
addpatch: guichan 0.8.2-8

### DIFF
--- a/guichan/riscv64.patch
+++ b/guichan/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,6 +15,11 @@ options=('!strip')
+ source=(https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/$pkgname/$pkgname-$pkgver.tar.gz)
+ sha256sums=('eedf206eae5201eaae027b133226d0793ab9a287bfd74c5f82c7681e3684eeab')
+ 
++prepare() {
++  cd "${srcdir}"/$pkgname-$pkgver
++  autoreconf -fi
++}
++
+ build() {
+   cd "${srcdir}"/$pkgname-$pkgver
+ 


### PR DESCRIPTION
Configure error `cannot guess build type; you must specify one` was reported to upstream in https://github.com/darkbitsorg/guichan/issues/3 .