### PR TITLE
addpatch: apcupsd 3.14.14-8

### DIFF
--- a/apcupsd/riscv64.patch
+++ b/apcupsd/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -39,6 +39,9 @@ validpgpkeys=(635B9D943945DCA05BE9AB0A24E84804A57B2D90)
+ prepare() {
+ 	cd "$srcdir/$pkgname-$pkgver"
+ 	patch -p1 -i "$srcdir/apcupsd-3.14.4-shutdown.patch"
++	cd "autoconf"
++	cp /usr/share/autoconf/build-aux/config.guess config.guess
++	cp /usr/share/autoconf/build-aux/config.sub config.sub
+ }
+ 
+ build() {


### PR DESCRIPTION
Configure error `cannot guess build type; you must specify one` was not reported due to the inability to contact upstream.  