### PR TITLE
addpatch: liboggz 1.1.1-8

### DIFF
--- a/liboggz/riscv64.patch
+++ b/liboggz/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,6 +17,12 @@ provides=('liboggz.so')
+ source=("https://downloads.xiph.org/releases/${pkgname}/${pkgname}-${pkgver}.tar.gz")
+ sha512sums=('8f5fc8ca49cb6f7a1160a9c1932876b771d55985d59ddc1f48497dfc08641414a58244d7a7e52bfcecdb69f52913d0123efd8f92513f8b9064e4abe1442f2cba')
+ 
++prepare() {
++  cd "${pkgname}-${pkgver}"
++  cp /usr/share/autoconf/build-aux/config.guess config.guess
++  cp /usr/share/autoconf/build-aux/config.sub config.sub
++}
++
+ build() {
+   cd "${pkgname}-${pkgver}"
+   ./configure --prefix=/usr \


### PR DESCRIPTION
Configure error `cannot guess build type; you must specify one` was reported to upstream via email.  