### PR TITLE
addpatch: dgen-sdl 1.33-4

### DIFF
--- a/dgen-sdl/riscv64.patch
+++ b/dgen-sdl/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,6 +15,11 @@ depends=('sdl' 'libgl' 'libarchive')
+ source=(https://downloads.sourceforge.net/dgen/$pkgname-$pkgver.tar.gz)
+ sha512sums=('c98ab8cdced62a5d26fd677ad36b031e756620114c946ac067599e84ae6ebcfab731554dd4337b6314c3b5db4601c8a6cc67c285d2aad136e659b9973c01a749')
+ 
++prepare() {
++  cd $pkgname-$pkgver
++  autoreconf -fi
++}
++
+ build() {
+   cd $pkgname-$pkgver
+ 


### PR DESCRIPTION
Configure error `cannot guess build type; you must specify one` was reported to upstream in https://sourceforge.net/p/dgen/bugs/28/ .