### PR TITLE
addpatch: libpagemaker 0.0.4-4

### DIFF
--- a/libpagemaker/riscv64.patch
+++ b/libpagemaker/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -18,6 +18,7 @@ prepare() {
+   cd ${pkgname}-${pkgver}
+   # fix build - https://bugs.archlinux.org/task/62165
+   patch -Np1 -i ../libpagemaker-0.0.4-const-ref-exception.patch
++  autoreconf -fi
+ }
+ 
+ build() {


### PR DESCRIPTION
Configure error `cannot guess build type; you must specify one` was reported to upstream in https://bugs.documentfoundation.org/show_bug.cgi?id=162311 .