### PR TITLE
addpatch: libstaroffice 0.0.7-3

### DIFF
--- a/libstaroffice/riscv64.patch
+++ b/libstaroffice/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -13,6 +13,11 @@ makedepends=('doxygen')
+ source=(https://github.com/fosnola/$pkgname/releases/download/$pkgver/libstaroffice-$pkgver.tar.xz)
+ sha256sums=('f94fb0ad8216f97127bedef163a45886b43c62deac5e5b0f5e628e234220c8db')
+ 
++prepare() {
++  cd "${pkgname}-${pkgver}"
++  autoreconf -fi
++}
++
+ build() {
+   cd "${pkgname}-${pkgver}"
+   ./configure --prefix=/usr


### PR DESCRIPTION
Configure error `cannot guess build type; you must specify one` was reported to upstream in https://github.com/fosnola/libstaroffice/issues/10 .