### PR TITLE
updpatch: ldc 3:1.39.0-1

### DIFF
--- a/ldc/riscv64.patch
+++ b/ldc/riscv64.patch
@@ -3,9 +3,9 @@
 @@ -14,7 +14,7 @@ pkgdesc="A D Compiler based on the LLVM Compiler Infrastructure including D runt
  arch=('x86_64')
  url="https://github.com/ldc-developers/ldc"
- license=('BSD')
+ license=('BSD-3-Clause AND BSL-1.0 AND Apache-2.0 WITH LLVM-exception')
 -makedepends=('git' 'cmake' 'llvm' 'lld' 'ldc' 'ninja')
-+makedepends=('git' 'cmake' 'llvm' 'ldc' 'ninja')
++makedepends=('git' 'cmake' 'llvm' 'lld' 'ldc' 'ninja' 'llvm17-libs')
  # Disable lto as linking the ldc2 binary fails
  options=(!lto)
  
@@ -23,7 +23,7 @@
      -DBUILD_LTO_LIBS=ON \
      -DLDC_WITH_LLD=OFF \
 -    -DD_COMPILER_FLAGS="-link-defaultlib-shared=false -linker=lld --flto=thin" \
-+    -DD_COMPILER_FLAGS="-link-defaultlib-shared=false" \
++    -DD_COMPILER_FLAGS="-link-defaultlib-shared=false -linker=lld" \
 +    -DLD_FLAGS="-Wl,--no-as-needed -latomic -Wl,--as-needed" \
      -DADDITIONAL_DEFAULT_LDC_SWITCHES="\"-link-defaultlib-shared\"," \
      ..
@@ -33,5 +33,5 @@
      install -D -m644 "$srcdir/ldc/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
  }
 +
-+source+=(disable-static-NaN-tests.patch)
++source+=("disable-static-NaN-tests.patch")
 +sha256sums+=('22b9132b58dde320d6da3c22d2eeabbc0c4d6a079348e9e0fbe5172ef4b86aba')


### PR DESCRIPTION
LLVM 18 rebuild; also built successfully using lld so re-enable it as well.