### PR TITLE
addpatch: sugar-toolkit-gtk3 0.120-2

### DIFF
--- a/sugar-toolkit-gtk3/riscv64.patch
+++ b/sugar-toolkit-gtk3/riscv64.patch
@@ -1,0 +1,17 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,6 +17,7 @@ sha256sums=('15476d1cc0bac2367ede4c855625cee88741c4d774908a7e633c264bb68b6928')
+ prepare() {
+   cd $pkgname-$pkgver
+   autoreconf -vif
++  patch -Np1 -i ../include-gdk-x11.patch
+ }
+ 
+ build() {
+@@ -36,3 +37,6 @@ package() {
+   make DESTDIR="$pkgdir" install
+   rm "$pkgdir/usr/bin/sugar-activity"
+ }
++
++source+=(include-gdk-x11.patch::https://github.com/sugarlabs/sugar-toolkit-gtk3/commit/282ec05f655356bd53c2d812ed1b520696a8d4c8.diff)
++sha256sums+=('08c76bf511447e91570ab5dcfda3c22a090bbfa13057ab1d826644879ac3e7b5')


### PR DESCRIPTION
Backport upstream fix https://github.com/sugarlabs/sugar-toolkit-gtk3/commit/282ec05f655356bd53c2d812ed1b520696a8d4c8; flagged as outdated in Arch.