### PR TITLE
addpatch: deepin-launchpad 0.5.0

### DIFF
--- a/deepin-launchpad/riscv64.patch
+++ b/deepin-launchpad/riscv64.patch
@@ -1,0 +1,16 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,6 +17,13 @@ replaces=('deepin-launcher')
+ source=("git+https://github.com/linuxdeepin/dde-launchpad.git#tag=$pkgver")
+ sha512sums=('8786d6b500a5c896633f61c488bc665500ae0aae05aa8c710e32abd08d1e1bc285e8ac62055bf1697f3f3c43e4e739d2dd62e28e0faaa08fb40f479d2c16c18e')
+ 
++prepare() {
++  cd dde-launchpad
++
++  # https://github.com/linuxdeepin/dde-launchpad/pull/193
++  git cherry-pick -n b7e0dd5c441d31927fe8fc9f26517703464103b6
++}
++
+ build() {
+   cd dde-launchpad
+   cmake . -GNinja -DCMAKE_INSTALL_PREFIX=/usr


### PR DESCRIPTION
> 由于 CMP0071，CMake 的 AUTOMOC 跳过了一些生成的 CPP 文件的处理，例如launcher-qml-windowed_org_deepin_launchpad_windowedPlugin.cpp。我们直接提高 CMake 最小版本来处理此问题。

Link: https://github.com/linuxdeepin/dde-launchpad/pull/193