### PR TITLE
addpatch: tiny 0.12.0-3

### DIFF
--- a/tiny/riscv64.patch
+++ b/tiny/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -27,7 +27,9 @@ prepare() {
+   cd $pkgname
+ 
+   export RUSTUP_TOOLCHAIN=stable
++  sed -i 's/tokio-rustls = { version = "0.23",/tokio-rustls = { version = "0.24",/' crates/libtiny_client/Cargo.toml
+   cargo update --workspace
++  cargo update -p sct --precise 0.7.1
+   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+ }
+ 


### PR DESCRIPTION
Upgrade ring to 0.17, upstreamed to https://github.com/osa1/tiny/pull/433.