### PR TITLE
addpatch: python-into-dbus

### DIFF
--- a/python-into-dbus/relax-test-deadline.patch
+++ b/python-into-dbus/relax-test-deadline.patch
@@ -1,0 +1,22 @@
+diff --git a/tests/test_hypothesis.py b/tests/test_hypothesis.py
+index dc812db..d13aae0 100644
+--- a/tests/test_hypothesis.py
++++ b/tests/test_hypothesis.py
+@@ -213,7 +213,7 @@ class ParseTestCase(unittest.TestCase):
+             xform([struct[:-1]])
+ 
+     @given(dbus_signatures(blacklist="hbs", exclude_dicts=True))
+-    @settings(max_examples=100)
++    @settings(max_examples=100, deadline=1000)
+     @example(sig="v")
+     def test_exceptions(self, sig):
+         """
+@@ -235,7 +235,7 @@ class SignatureTestCase(unittest.TestCase):
+     """
+ 
+     @given(STRATEGY_GENERATOR.parseString("v", parseAll=True)[0])
+-    @settings(max_examples=50)
++    @settings(max_examples=50, deadline=1000)
+     def test_unpacking(self, value):
+         """
+         Test that signature unpacking works.

--- a/python-into-dbus/riscv64.patch
+++ b/python-into-dbus/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -31,4 +31,12 @@ package() {
+   python setup.py install --root="${pkgdir}" --optimize=1
+ }
+ 
++prepare() {
++  cd "${_srcname}-${pkgver}"
++  patch -Np1 -i ../relax-test-deadline.patch
++}
++
++source+=(relax-test-deadline.patch)
++sha256sums+=('599107ec1a023c3e040917162d051fa521bef4c41bfc2035c1eccf4e60f73a92')
++
+ # vim: ts=2 sw=2 et:


### PR DESCRIPTION
Test `test_unpacking` and `test_exceptions` are flaky:

```
Unreliable test timings! On an initial run, this test took 274.95ms, which exceeded the deadline of 200.00ms, but on a subsequent run it took 165.32 ms, which did not. If you expect this sort of variability in your test timings, consider turning deadlines off for this test by setting deadline=None.
```

Extend their deadline from the default 200ms to 1000ms.