### PR TITLE
addpatch: python-plop 0.4.0-6

### DIFF
--- a/python-plop/relax-time-restrictions.patch
+++ b/python-plop/relax-time-restrictions.patch
@@ -1,0 +1,13 @@
+diff --git a/plop/test/collector_test.py b/plop/test/collector_test.py
+index 12270cb..d4b7158 100644
+--- a/plop/test/collector_test.py
++++ b/plop/test/collector_test.py
+@@ -74,7 +74,7 @@ class CollectorTest(unittest.TestCase):
+ 
+         # cost depends on stack depth; for this tiny test I see 40-80usec
+         time_per_sample = float(collector.sample_time) / collector.samples_taken
+-        self.assertTrue(time_per_sample < 0.000100, time_per_sample)
++        self.assertTrue(time_per_sample < 0.000300, time_per_sample)
+ 
+     # TODO: any way to make this test not flaky?
+     def disabled_test_collect_threads(self):

--- a/python-plop/riscv64.patch
+++ b/python-plop/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -27,3 +27,11 @@ package() {
+   python setup.py install --root="$pkgdir" --optimize=1
+   install -Dm644 LICENSE.txt -t "$pkgdir"/usr/share/licenses/$pkgname
+ }
++
++prepare() {
++  cd plop-$pkgver
++  patch -Np1 -i ../relax-time-restrictions.patch
++}
++
++source+=(relax-time-restrictions.patch)
++sha256sums+=('42a9eb6b6c684a752cdab9e3fc45c0a79c143c2df45e7c53ccf9affc354d58c3')


### PR DESCRIPTION
`test_collector`'s time restriction is a bit tight on riscv64, extend it.

```
FAIL: test_collector (plop.test.collector_test.CollectorTest.test_collector)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/build/python-plop/src/plop-0.4.0/plop/test/collector_test.py", line 77, in test_collector
    self.assertTrue(time_per_sample < 0.000100, time_per_sample)
AssertionError: False is not true : 0.00010132487816146658
```