### PR TITLE
addpatch: gmtk 1.0.9-7

### DIFF
--- a/gmtk/riscv64.patch
+++ b/gmtk/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -13,6 +13,12 @@ makedepends=('intltool')
+ source=("https://github.com/kdekorte/$pkgname/archive/v$pkgver/$pkgname-$pkgver.tar.gz")
+ sha256sums=('fc23c853deb35ee35db06dd3da5069ce3dc64faf3a0053324616fadf81a415db')
+ 
++prepare() {
++  cd $pkgname-$pkgver
++  cp /usr/share/autoconf/build-aux/config.guess config.guess
++  cp /usr/share/autoconf/build-aux/config.sub config.sub
++}
++
+ build() {
+   cd $pkgname-$pkgver
+   ./configure --prefix=/usr


### PR DESCRIPTION
Fixed cannot guess build type issue.  
The upstream code was hosted on Google Code which was archived in 2016, so it was unable to report to upstream.  