### PR TITLE
addpatch: libfreehand 0.1.2-5

### DIFF
--- a/libfreehand/riscv64.patch
+++ b/libfreehand/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,6 +17,7 @@ sha256sums=('0e422d1564a6dbf22a9af598535425271e583514c0f7ba7d9091676420de34ac'
+ prepare() {
+ 	cd "$pkgname-$pkgver"
+ 	patch -p1 -i $srcdir/libfreehand-0.1.2-icu-fix.patch
++	autoreconf -fi
+ }
+ 
+ build() {


### PR DESCRIPTION
Fixed cannot guess build type issue, and reported to https://bugs.documentfoundation.org/show_bug.cgi?id=162393 .  