### PR TITLE
qemu-user-blacklist.txt: add abseil-cpp

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -1,3 +1,4 @@
+abseil-cpp
 arrow
 asio
 bat


### PR DESCRIPTION
absl_symbolize_test fails only in qemu-user

```
58/221 Testing: absl_symbolize_test
58/221 Test: absl_symbolize_test
Command: "/build/abseil-cpp/src/abseil-cpp-20240722.0/build/bin/absl_symbolize_test"
Directory: /build/abseil-cpp/src/abseil-cpp-20240722.0/build/absl/debugging
"absl_symbolize_test" start time: Aug 11 07:03 CEST
Output:
----------------------------------------------------------
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
F0000 00:00:1723352599.379092     988 symbolize_test.cc:170] Check failed: symbol != nullptr ((null) vs. (null)) TestWithReturnAddress failed
*** Check failure stack trace: ***
    @     0x7a440ac1f306  (unknown)
    @     0x7a440ac1fcbc  (unknown)
    @     0x555555562bd0  (unknown)
    @     0x55555555b4b4  (unknown)
    @     0x7a4409ca498e  (unknown)
    @     0x7a4409ca4a3a  (unknown)
    @     0x55555555b560  (unknown)
<end of output>
Test time =   0.07 sec
----------------------------------------------------------
Test Failed.
"absl_symbolize_test" end time: Aug 11 07:03 CEST
"absl_symbolize_test" time elapsed: 00:00:00
----------------------------------------------------------
```