### PR TITLE
addpatch: nominatim-ui 3.5.3-1

### DIFF
--- a/nominatim-ui/longer-timeout.patch
+++ b/nominatim-ui/longer-timeout.patch
@@ -1,0 +1,25 @@
+diff --git .mocharc.json .mocharc.json
+index 49e0f0e..8c1a379 100644
+--- .mocharc.json
++++ .mocharc.json
+@@ -2,5 +2,5 @@
+ {
+   "ignore": ["test/_bootstrap.js"],
+   "require": ["test/_bootstrap.js"],
+-  "timeout": "5s"
++  "timeout": "10s"
+ }
+\ No newline at end of file
+diff --git test/_bootstrap.js test/_bootstrap.js
+index 746d15d..e608d2b 100644
+--- test/_bootstrap.js
++++ test/_bootstrap.js
+@@ -62,7 +62,7 @@ Nominatim_Config.Reverse_Only = ${reverse_only};
+   // 3. Create browser instance
+   global.browser = await puppeteer.launch({
+     defaultViewport: { width: 1024, height: 768 },
+-    timeout: 10000,
++    timeout: 20000,
+     // latency: 1000,
+     headless: 'new',
+     args: [

--- a/nominatim-ui/riscv64.patch
+++ b/nominatim-ui/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,9 +14,10 @@ backup=('etc/webapps/nominatim-ui/config.theme.js')
+ install=nominatim-ui.install
+ source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/tags/v${pkgver}.tar.gz"
+         'nginx.conf'
+-)
++	'longer-timeout.patch')
+ sha256sums=('31f793bafda4a3259e9b1a4be0cb4dd1a70d856c2fd96db760cbbf64462f8cd6'
+-            '045dda10d978acedba43b071271731b2b63a8ad2743cdd6eda7dab2fd98a52ae')
++            '045dda10d978acedba43b071271731b2b63a8ad2743cdd6eda7dab2fd98a52ae'
++            '914520cf86ec3c212b798a4be3b3619ed1ae12f6ae8746b617069709bb83ceee')
+ 
+ prepare() {
+   cd "${pkgname}-tags-v${pkgver}"

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -77,6 +77,7 @@ neochat
 nextcloud-client
 ninja
 nodejs-lts-hydrogen
+nominatim-ui
 notepadqq
 nushell
 ob-xd


### PR DESCRIPTION
Fix the check of nominatim-ui.  
The test code needs to launch a chromium which cannot run on qemu-user.  
The timeout is too short for RISC-V devices with extremely low performance, it might be discussed at https://github.com/osm-search/nominatim-ui/issues/253 .  