### PR TITLE
updpatch: glibc 2.40+r16+gaa533d58ff-2

### DIFF
--- a/glibc/riscv64.patch
+++ b/glibc/riscv64.patch
@@ -1,14 +1,6 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -7,19 +7,18 @@
- # NOTE: valgrind requires rebuilt with each major glibc version
- 
- pkgbase=glibc
--pkgname=(glibc lib32-glibc glibc-locales)
-+pkgname=(glibc glibc-locales)
- pkgver=2.40
- _commit=3d1aed874918c466a4477af1da35983ab036690e
- pkgrel=1
+@@ -14,12 +14,11 @@ pkgrel=2
  arch=(x86_64)
  url='https://www.gnu.org/software/libc'
  license=(GPL-2.0-or-later LGPL-2.1-or-later)
@@ -23,7 +15,7 @@
  )
  validpgpkeys=(7273542B39962DF7B299931416792B4EA25340F8 # Carlos O'Donell
 @@ -27,7 +26,6 @@ validpgpkeys=(7273542B39962DF7B299931416792B4EA25340F8 # Carlos O'Donell
- b2sums=('b68f571cdedb6c9cdb5cd041aa3575ad74b78e2fb4d4f8867c1d1c1a03cfd0bc641b5d446224d3448099fdfad3fc8a109c97b04d57bc4718a2e31ad6421b4b6d'
+ b2sums=('74c4f1e1231834579d19c96cc60fc370c9c4468e254fe069aad6102c8678d163ab6e58ebf0a11de680483105ba02d362842a817d698e134731f70c2d5b383eed'
          'c859bf2dfd361754c9e3bbd89f10de31f8e81fd95dc67b77d10cb44e23834b096ba3caa65fbc1bd655a8696c6450dfd5a096c476b3abf5c7e125123f97ae1a72'
          '04fbb3b0b28705f41ccc6c15ed5532faf0105370f22133a2b49867e790df0491f5a1255220ff6ebab91a462f088d0cf299491b3eb8ea53534cb8638a213e46e3'
 -        '7c265e6d36a5c0dff127093580827d15519b6c7205c2e1300e82f0fb5b9dd00b6accb40c56581f18179c4fbbc95bd2bf1b900ace867a83accde0969f7b609f8a'
@@ -118,3 +110,14 @@
  package_glibc-locales() {
    pkgdesc='Pregenerated locales for GNU C Library'
    depends=("glibc=$pkgver")
+@@ -224,3 +173,10 @@ package_glibc-locales() {
+   # deduplicate locale data
+   hardlink -c "${pkgdir}"/usr/lib/locale
+ }
++
++for i in "${!pkgname[@]}"; do
++  if [[ ${pkgname[i]} = "lib32-glibc" ]]; then
++    unset 'pkgname[i]'
++  fi
++done
++


### PR DESCRIPTION
Fix rotten and prevent it from rotting when Arch only updates pkgver.