### PR TITLE
updpatch: qt6-webengine 6.7.2-2

### DIFF
--- a/qt6-webengine/riscv64.patch
+++ b/qt6-webengine/riscv64.patch
@@ -1,17 +1,20 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -83,6 +83,10 @@ prepare() {
- 
- # Fix build with ninja 1.12 - Gentoo patch
-   patch -Np1 -i ../qtwebengine-6.7.0-ninja1.12.patch
+@@ -87,6 +87,13 @@ prepare() {
+   patch -p1 -i ../qtwebengine-6.7.0-ninja1.12.patch
+ # Fix build with ffmpeg 7 - Chromium patches
+   patch -d src/3rdparty/chromium -p1 -i "$srcdir"/qtwebengine-ffmpeg-7.patch
 +  for _patch in angle libgav1 sandbox base dav1d; do
 +    patch -d src/3rdparty/chromium -Np1 < ../riscv-$_patch.patch
 +  done
++  patch -d src/3rdparty/chromium    -Np1 < ../unscaledcycleclock-remove-riscv-support.patch
 +  patch -d src/3rdparty/chromium/v8 -Np1 < ../riscv-v8.patch
++  patch -d src/3rdparty/chromium/v8 -Np1 < ../Skip-check-sv57-when-enable-pointer-compress.patch
++  patch -d src/3rdparty/chromium/v8 -Np1 < ../avoid-cpu-probing-in-li_ptr.patch	
  }
  
  build() {
-@@ -94,7 +98,10 @@ build() {
+@@ -98,7 +105,10 @@ build() {
      -DQT_FEATURE_webengine_system_libevent=ON \
      -DQT_FEATURE_webengine_proprietary_codecs=ON \
      -DQT_FEATURE_webengine_kerberos=ON \
@@ -23,16 +26,22 @@
    cmake --build build
  }
  
-@@ -103,3 +110,12 @@ package() {
+@@ -107,3 +117,18 @@ package() {
  
    install -Dm644 "$srcdir"/${_pkgfn}/src/3rdparty/chromium/LICENSE "$pkgdir"/usr/share/licenses/${pkgname}/LICENSE.chromium
  }
 +
-+makedepends=("${makedepends[@]/nodejs/nodejs-lts-iron}" clang)
-+source+=(riscv-{angle,libgav1,sandbox,base,dav1d,v8}.patch)
++makedepends+=(clang)
++source+=(riscv-{angle,libgav1,sandbox,base,dav1d,v8}.patch
++         "https://github.com/riscv-forks/electron/raw/1e16216b089b6aaed055d17608667e6582263cfd/patches/v8/avoid-cpu-probing-in-li_ptr.patch"
++         "https://github.com/riscv-forks/electron/raw/1e16216b089b6aaed055d17608667e6582263cfd/patches/v8/Skip-check-sv57-when-enable-pointer-compress.patch"
++         "https://github.com/riscv-forks/electron/raw/4eff53436a1a86ac548a107e21ca5078518833c0/patches/chromium/unscaledcycleclock-remove-riscv-support.patch")
 +sha256sums+=('d092ee05e50b4140e9b94038c3da76eceac2de498cec092ac35eb7f89273a04f'
 +             '4b2dcfdeb8ab32130d220d9827f49a930cf748bf4d6c7aef97a7b36a98316430'
 +             '8d52d4da703c8a86059418d1a4ed63d2d6bc1134e9dfe569695a830479a9afae'
 +             'aab631f5b6ea316b08bd290b52f60ed7715fceabd5c8de67535271fbbe2ae794'
 +             '5689e9422624c8725509b6fdc277e20c3e8862cf515656faef7507978489bc4e'
-+             '668e63bc4a388db24fc2ed519d29d6bf73c6f97e768d651adcd72378e93291f5')
++             '668e63bc4a388db24fc2ed519d29d6bf73c6f97e768d651adcd72378e93291f5'
++             'faaf1af670ab202f2e531b19c0af81e97b56afffdcd9f58afd33f0f65468f119'
++             '6a3ad2b09fe28be4bd3aa922d071b973cf52531c447b31a7415a02f467a795a0'
++             'bea6346ab4fc88061d3a657281e46eb14c1ce7fcfe108deda02b47bee50241aa')


### PR DESCRIPTION
Pick up some chromium/v8 patches to

- Fix v8 performance regression (https://github.com/riscv-forks/electron/issues/1)
- Fix rdcycle SIGILL on linux >= 6.6 (https://github.com/riscv-forks/electron/issues/2)

There's no riscv specific security patch needs backporting for this release.

Fix rotten and use nodejs in makedepends again because it seems nodejs no longer hangs when building this package in qemu.