### PR TITLE
addpatch: cudd 3.0.0

### DIFF
--- a/cudd/riscv64.patch
+++ b/cudd/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -11,6 +11,12 @@ depends=("gcc-libs")
+ source=("https://github.com/ivmai/cudd/archive/cudd-3.0.0.tar.gz")
+ sha512sums=('a26728fedc3033ae2a842000f43f215b4abc914cd00fe0097fd483e59dc630568bfa6a115baa93af94b2f70f3d538761a12143fdb757167e90395c9fd244318c')
+ 
++prepare() {
++  cd cudd-cudd-$pkgver
++  cp /usr/share/autoconf/build-aux/config.guess build-aux
++  cp /usr/share/autoconf/build-aux/config.sub build-aux
++}
++
+ build() {
+   cd cudd-cudd-$pkgver
+   ./configure --prefix=/usr --enable-shared --enable-dddmp --enable-obj


### PR DESCRIPTION
[Upstream](https://github.com/ivmai/cudd) is actually an unofficial and inactive mirror, I would like to know whether should I still report it.