### PR TITLE
updpatch: mkinitcpio-busybox 1.36.1-1

### DIFF
--- a/mkinitcpio-busybox/riscv64.patch
+++ b/mkinitcpio-busybox/riscv64.patch
@@ -1,15 +1,6 @@
-diff --git PKGBUILD PKGBUILD
-index cb174a1..9adb771 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -16,13 +16,13 @@ source=(https://busybox.net/downloads/busybox-$pkgver.tar.bz2{,.sig}
-         config)
- sha256sums=('b8cc24c9574d809e7279c3be349795c5d5ceb6fdf19ca709f80cde50e47de314'
-             'SKIP'
--            'f1a67ecda5b73a50e49953efaaa0be582e4b707cf5a6270519e28ee022098518')
-+            'dff8f6049f4c2ad9c02d289a5a84384aa9c1889caa84fe6fc0fc70d77f2e4518')
- validpgpkeys=('C9E9416F76E610DBD09D040F47B70C55ACC9965B') # Denis Vlasenko <vda.linux@googlemail.com>
- 
+@@ -22,7 +22,7 @@ validpgpkeys=('C9E9416F76E610DBD09D040F47B70C55ACC9965B') # Denis Vlasenko <vda.
  prepare() {
    cd "busybox-$pkgver"
    
@@ -18,16 +9,3 @@ index cb174a1..9adb771 100644
  
    # use make oldconfig for updating the config file
    sed 's|^\(CONFIG_EXTRA_CFLAGS\)=.*|\1="'"$safeflags"'"|' "$srcdir/config" > .config
-diff --git config config
-index 9054660..edcdda8 100644
---- config
-+++ config
-@@ -49,7 +49,7 @@ CONFIG_PIE=y
- # CONFIG_FEATURE_SHARED_BUSYBOX is not set
- CONFIG_CROSS_COMPILER_PREFIX=""
- CONFIG_SYSROOT=""
--CONFIG_EXTRA_CFLAGS="-march=x86-64 -mtune=generic -Os -pipe -fno-strict-aliasing"
-+CONFIG_EXTRA_CFLAGS="-march=rv64gc -mabi=lp64d -Os -pipe -fno-strict-aliasing"
- CONFIG_EXTRA_LDFLAGS=""
- CONFIG_EXTRA_LDLIBS=""
- # CONFIG_USE_PORTABLE_CODE is not set


### PR DESCRIPTION
config file for busybox don't need patching. PKGBUILD update the CONFIG_EXTRA_CFLAGS with the safeflags.