### PR TITLE
addpatch: laszip2 2.2.0-2

### DIFF
--- a/laszip2/riscv64.patch
+++ b/laszip2/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,6 +14,11 @@ depends=(gcc-libs)
+ source=(https://download.osgeo.org/laszip/${pkgname%2}-src-${pkgver}.tar.bz2)
+ sha512sums=('da523243b93296e308eff9121adf9c2a917fc934b21a92a64d192aaa5a1dfbfededc347f5d5ce7b51ea7a5eb5972dc0a5724d50bef26406b359a85c578c60ef8')
+ 
++prepare() {
++  cd ${pkgname%2}-src-${pkgver}
++  autoreconf -fi
++}
++
+ build() {
+   cd ${pkgname%2}-src-${pkgver}
+   ./configure --prefix=/usr --libdir=/usr/lib/${pkgname} --includedir=/usr/include/${pkgname}


### PR DESCRIPTION
The outdated configure file issue was not reported because the upstream won't maintain outdated 2.2.0, the active version is 3.4.3.