### PR TITLE
addpatch: lbreakout2 2.6.5-4

### DIFF
--- a/lbreakout2/riscv64.patch
+++ b/lbreakout2/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -24,6 +24,7 @@ prepare() {
+   cd ${pkgname}-${pkgver/_/-}
+ 
+   patch -Np1 -i "${srcdir}"/sdl_fix_pauses.patch
++  autoreconf -fi
+ }
+ 
+ build() {


### PR DESCRIPTION
The outdated configure file issue was reported to https://sourceforge.net/p/lgames/bugs/110/ .