### PR TITLE
addpatch: libgfshare 2.0.0-4

### DIFF
--- a/libgfshare/riscv64.patch
+++ b/libgfshare/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -13,6 +13,11 @@ provides=('libgfshare.so')
+ source=(https://www.digital-scurf.org/files/libgfshare/libgfshare-${pkgver}.tar.bz2)
+ sha512sums=('d6fd60a743825df85cb429b1dee583ab0a6d998fd5c79ee45b3da4c83a55970aee896337514c3686abfd3ff63099232e0f4af4203c32fa042500bfa8bc8d3495')
+ 
++prepare() {
++  cd ${pkgname}-${pkgver}
++  autoreconf -fi
++}
++
+ build() {
+   cd ${pkgname}-${pkgver}
+   ./configure --prefix=/usr


### PR DESCRIPTION
The outdated configure file issue couldn't be reported because their homepage was down.  