### PR TITLE
addpatch: libftdi-compat 0.20-9

### DIFF
--- a/libftdi-compat/riscv64.patch
+++ b/libftdi-compat/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,6 +14,11 @@ sha512sums=('540e5eb201a65936c3dbabff70c251deba1615874b11ff27c5ca16c39d71c150cf6
+             'SKIP')
+ validpgpkeys=('3CEA9B8868BC3852618EB5B4707F91A424F006F5')  # Intra2net open source
+ 
++prepare() {
++  cd libftdi-$pkgver
++  autoreconf -fi
++}
++
+ build() {
+   cd libftdi-$pkgver
+   ./configure --prefix=/usr --without-examples


### PR DESCRIPTION
The outdated configure file issue couldn't be reported because it was replaced by libftdi.  