### PR TITLE
addpatch: mp3unicode 1.2.1-6

### DIFF
--- a/mp3unicode/riscv64.patch
+++ b/mp3unicode/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -16,6 +16,9 @@ sha256sums=('375b432ce784407e74fceb055d115bf83b1bd04a83b95256171e1a36e00cfe07'
+ 
+ prepare() {
+   patch -d $pkgname-$pkgver -p1 < taglib-2.patch
++
++  cd $pkgname-$pkgver
++  autoreconf -fi
+ }
+ 
+ build() {


### PR DESCRIPTION
The outdated configure file issue was reported to https://github.com/alonbl/mp3unicode/issues/4 .