### PR TITLE
addpatch: electron32 32.0.1-1

### DIFF
--- a/electron32/Debian-fix-rust-linking.patch
+++ b/electron32/Debian-fix-rust-linking.patch
@@ -1,0 +1,47 @@
+--- build/toolchain/gcc_toolchain.gni.orig	2024-08-19 14:13:35.233954725 +0200
++++ build/toolchain/gcc_toolchain.gni	2024-08-22 00:56:01.438433033 +0200
+@@ -441,7 +441,13 @@
+         # -soname flag is not available on aix ld
+         soname_flag = "-Wl,-soname=\"$soname\""
+       }
+-      link_command = "$ld -shared $soname_flag {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" @\"$rspfile\" {{rlibs}}"
++      if (target_cpu == "riscv64") {
++        # Work around linker failures due to Rust libraries and the use of whole-archive
++        link_command = "$ld -shared $soname_flag -Wl,--start-group {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" @\"$rspfile\" {{rlibs}} -Wl,--end-group"
++      }
++      else {
++        link_command = "$ld -shared $soname_flag {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" @\"$rspfile\" {{rlibs}}"
++      }
+ 
+       # Generate a map file to be used for binary size analysis.
+       # Map file adds ~10% to the link time on a z620.
+@@ -553,7 +559,13 @@
+         whole_archive_flag = "-Wl,--whole-archive"
+         no_whole_archive_flag = "-Wl,--no-whole-archive"
+       }
+-      command = "$ld -shared {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" $soname_flag @\"$rspfile\""
++      if (target_cpu == "riscv64") {
++        # Work around linker failures due to Rust libraries and the use of whole-archive
++        command = "$ld -shared -Wl,--start-group {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" $soname_flag @\"$rspfile\" -Wl,--end-group"
++      }
++      else {
++        command = "$ld -shared {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" $soname_flag @\"$rspfile\""
++      }
+ 
+       if (defined(invoker.strip)) {
+         strip_command = "${invoker.strip} -o \"$sofile\" \"$unstripped_sofile\""
+@@ -617,8 +629,12 @@
+       # We need to specify link groups, at least, for single pass linkers. I.e.
+       # Rust libraries are alpha-sorted instead of by dependencies so they fail
+       # to link if not properly ordered or grouped.
+-      link_command = "$ld {{ldflags}}${extra_ldflags} -o \"$unstripped_outfile\" $start_group_flag @\"$rspfile\" $end_group_flag {{solibs}} {{libs}} $start_group_flag {{rlibs}} $end_group_flag"
+-
++      if (target_cpu == "riscv64") {
++        link_command = "$ld -Wl,--start-group {{ldflags}}${extra_ldflags} -o \"$unstripped_outfile\" @\"$rspfile\" {{solibs}} {{libs}} {{rlibs}} -Wl,--end-group"
++      }
++      else {
++        link_command = "$ld {{ldflags}}${extra_ldflags} -o \"$unstripped_outfile\" $start_group_flag @\"$rspfile\" $end_group_flag {{solibs}} {{libs}} $start_group_flag {{rlibs}} $end_group_flag"
++      }
+       # Generate a map file to be used for binary size analysis.
+       # Map file adds ~10% to the link time on a z620.
+       # With target_os="android", libchrome.so.map.gz is ~20MB.

--- a/electron32/riscv64.patch
+++ b/electron32/riscv64.patch
@@ -1,0 +1,132 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -29,6 +29,7 @@ depends=(c-ares
+ makedepends=(clang
+              git
+              gn
++             go
+              gperf
+              harfbuzz-icu
+              http-parser
+@@ -63,7 +64,7 @@ optdepends=('kde-cli-tools: file deletion support (kioclient5)'
+             'trash-cli: file deletion support (trash-put)'
+             'xdg-utils: open URLs with desktop’s default (xdg-email, xdg-open)')
+ options=('!lto') # Electron adds its own flags for ThinLTO
+-source=("git+https://github.com/electron/electron.git#tag=v$pkgver"
++source=("git+https://github.com/riscv-forks/electron.git#branch=v$pkgver-riscv"
+         https://gitlab.com/Matt.Jolly/chromium-patches/-/archive/$_gcc_patches/chromium-patches-$_gcc_patches.tar.bz2
+         # Chromium
+         allow-ANGLEImplementation-kVulkan.patch
+@@ -76,6 +77,7 @@ source=("git+https://github.com/electron/electron.git#tag=v$pkgver"
+         electron.desktop
+         jinja-python-3.10.patch
+         use-system-libraries-in-node.patch
++        Debian-fix-rust-linking.patch
+         makepkg-source-roller.py
+         # BEGIN managed sources
+         chromium-mirror::git+https://github.com/chromium/chromium.git#tag=128.0.6613.36
+@@ -243,7 +245,7 @@ source=("git+https://github.com/electron/electron.git#tag=v$pkgver"
+ sha256sums=('949031dea79ba4d5b90e447259836d50c735fb51f7b8d48aafafb37c2b78df64'
+             '3dfc43d901b96273201ba6d6d8b932b07c3661942d42a8bb0aae2c547757c73d'
+             '1a5bc75a90abad153c8eb6dbdce138132a5f11190b0a40c925958a72d706b2aa'
+-            'b3de01b7df227478687d7517f61a777450dca765756002c80c4915f271e2d961'
++            '8e128dec0d9416029ea8124e14963c9e0caf897bf60d347a070e393edebdff1c'
+             'd634d2ce1fc63da7ac41f432b1e84c59b7cceabf19d510848a7cff40c8025342'
+             'a4a822e135b253c93089a80c679842cc470c6936742767ae09d952646889abd6'
+             'dd2d248831dd4944d385ebf008426e66efe61d6fdf66f8932c963a12167947b4'
+@@ -251,6 +253,7 @@ sha256sums=('949031dea79ba4d5b90e447259836d50c735fb51f7b8d48aafafb37c2b78df64'
+             '4484200d90b76830b69eea3a471c103999a3ce86bb2c29e6c14c945bf4102bae'
+             '55dbe71dbc1f3ab60bf1fa79f7aea7ef1fe76436b1d7df48728a1f8227d2134e'
+             'ff588a8a4fd2f79eb8a4f11cf1aa151298ffb895be566c57cc355d47f161f53f'
++            '3eb5e621757be3f2984acb76d16cf3571bfe5bbbc71ad230b21aa983041ff5ea'
+             '2c8cd28cee0e1df1862e801794f210d2b7cac652f943cf94f43c2abe26f2a2f4'
+             '46e54ec3c2e98a80d42af2b0319ed5c75ee2a038a9abb31c07ef8e450a6a4ad8'
+             '0b7a546ee6913c49519c10c293ac530ff381641a8a465fa2e184d6dbe0fb784d'
+@@ -459,12 +462,22 @@ prepare() {
+   cp -r chromium-mirror_third_party_depot_tools depot_tools
+   export PATH+=":$PWD/depot_tools" DEPOT_TOOLS_UPDATE=0
+   #export VPYTHON_BYPASS='manually managed python not supported by chrome operations'
++  # Use a known commit that supports riscv64
++  git -C depot_tools checkout --detach 2a18f6d3245450d8c96c843a6584aaea561ef873
++  # Python 3.12 breaks gsutils
++  # Bundled wheels are not available for riscv64
++  sed -i '/wheel: </,$d' depot_tools/.vpython3
++  sed -i '/wheel: </,$d' depot_tools/gsutil.vpython3
++  # Manually install required wheels
++  vpython3 -m pip install httplib2==0.13.1 six==1.10.0 requests==2.31.0
+ 
+   echo "Putting together electron sources"
+   # Generate gclient gn args file and prepare-electron-source-tree.sh
+   python makepkg-source-roller.py generate electron/DEPS $pkgname
++  sed -i '/esbuild/d' prepare-electron-source-tree.sh
+   rbash prepare-electron-source-tree.sh "$CARCH"
+   mv electron src/electron
++  GOBIN=$(realpath src/third_party/devtools-frontend/src/third_party/esbuild/) go install "github.com/evanw/esbuild/cmd/esbuild@v0.14.13"
+ 
+   echo "Running hooks..."
+   # depot_tools/gclient.py runhooks
+@@ -505,6 +518,8 @@ prepare() {
+ 
+   patch -Np0 -i ../blink-fix-missing-stdlib-include.patch
+ 
++  patch -Np0 -i ../Debian-fix-rust-linking.patch
++
+   ## Upstream fixes
+   patch -Np1 -i ../allow-ANGLEImplementation-kVulkan.patch
+ 
+@@ -580,6 +595,7 @@ build() {
+     'enable_hangout_services_extension=true'
+     'enable_widevine=false'
+     'enable_nacl=false'
++    'is_clang=true'
+   )
+ 
+   if [[ -n ${_system_libs[icu]+set} ]]; then
+@@ -615,6 +631,10 @@ build() {
+   CFLAGS+='   -Wno-unknown-warning-option'
+   CXXFLAGS+=' -Wno-unknown-warning-option'
+ 
++  # Remove flags that are causing weird bugs on riscv64
++  CFLAGS=${CFLAGS/-Wp,-D_FORTIFY_SOURCE=2}
++  CXXFLAGS=${CXXFLAGS/-Wp,-D_FORTIFY_SOURCE=2}
++
+   # Let Chromium set its own symbol level
+   CFLAGS=${CFLAGS/-g }
+   CXXFLAGS=${CXXFLAGS/-g }
+@@ -662,3 +682,5 @@ package() {
+   install -Dm644 src/electron/default_app/icon.png \
+           "${pkgdir}/usr/share/pixmaps/${pkgname}.png"  # hicolor has no 1024x1024
+ }
++
++sha256sums[0]=SKIP
+diff --git compiler-rt-adjust-paths.patch compiler-rt-adjust-paths.patch
+index 0469220..8ee7f55 100644
+--- compiler-rt-adjust-paths.patch
++++ compiler-rt-adjust-paths.patch
+@@ -1,8 +1,6 @@
+-diff --git a/build/config/clang/BUILD.gn b/build/config/clang/BUILD.gn
+-index d4de2e0cca0..57359c32121 100644
+---- a/build/config/clang/BUILD.gn
+-+++ b/build/config/clang/BUILD.gn
+-@@ -130,12 +130,15 @@ template("clang_lib") {
++--- a/build/config/clang/BUILD.gn	2024-03-09 04:32:07.577338262 +0100
+++++ b/build/config/clang/BUILD.gn	2024-03-09 04:55:29.376410067 +0100
++@@ -124,14 +124,18 @@
+        } else if (is_linux || is_chromeos) {
+          if (current_cpu == "x64") {
+            _dir = "x86_64-unknown-linux-gnu"
+@@ -15,10 +13,13 @@ index d4de2e0cca0..57359c32121 100644
+          } else if (current_cpu == "arm64") {
+            _dir = "aarch64-unknown-linux-gnu"
+ +          _suffix = "-aarch64"
++         } else if (current_cpu == "riscv64") {
++           _dir = "riscv64-unknown-linux-gnu"
+++          _suffix = "-riscv64"
+          } else {
+            assert(false)  # Unhandled cpu type
+          }
+-@@ -166,6 +169,11 @@ template("clang_lib") {
++@@ -162,6 +166,11 @@
+          assert(false)  # Unhandled target platform
+        }
+  


### PR DESCRIPTION
PKGBUILD changes compared to electron31:

- Fix rotten
- Set GN flag "is_clang" to use lld and enable thin LTO to workaround that gnu ld failed to link v8 torque (relocation truncated to fit)

RISC-V fork changes: https://github.com/riscv-forks/electron/commit/3e5f893b85f77e051c50ee22a58d550ac6559dd1

- Fix rotten patches, remove merged patches
- Bump v8 to a known good revision for riscv64, as said in #4021
- Revert the removal of some deprecated API in v8 and fix electron's rotten v8 patches.