### PR TITLE
addpatch: cosmic-settings 1.0.0.alpha.1-1

### DIFF
--- a/cosmic-settings/remove-generator-075.diff
+++ b/cosmic-settings/remove-generator-075.diff
@@ -1,0 +1,50 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 7506805..e145401 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -1538,7 +1538,6 @@ version = "0.1.0"
+ dependencies = [
+  "derive_setters",
+  "downcast-rs",
+- "generator 0.7.5",
+  "libcosmic",
+  "once_cell",
+  "regex",
+diff --git a/page/Cargo.toml b/page/Cargo.toml
+index e0446b4..31e7570 100644
+--- a/page/Cargo.toml
++++ b/page/Cargo.toml
+@@ -8,7 +8,6 @@ derive_setters = "0.1.6"
+ regex = "1.10.5"
+ slotmap = "1.0.7"
+ libcosmic = { workspace = true }
+-generator = "0.7.5"
+ downcast-rs = "1.2.1"
+ once_cell = "1.19.0"
+ tokio.workspace = true
+diff --git a/page/src/binder.rs b/page/src/binder.rs
+index f256d7e..235828c 100644
+--- a/page/src/binder.rs
++++ b/page/src/binder.rs
+@@ -204,16 +204,11 @@ impl<Message: 'static> Binder<Message> {
+         &'a self,
+         rule: &'a Regex,
+     ) -> impl Iterator<Item = (crate::Entity, section::Entity)> + 'a {
+-        generator::Gn::new_scoped_local(|mut s| {
+-            for (page, sections) in self.content.iter() {
+-                for id in sections {
+-                    if self.sections[*id].search_matches(rule) {
+-                        s.yield_((page, *id));
+-                    }
+-                }
+-            }
+-
+-            generator::done!();
++        self.content.iter().flat_map(move |(page, sections)| {
++            sections
++                .into_iter()
++                .filter(|&id| self.sections[*id].search_matches(rule))
++                .map(move |&id| (page, id))
+         })
+     }
+ 

--- a/cosmic-settings/riscv64.patch
+++ b/cosmic-settings/riscv64.patch
@@ -1,0 +1,19 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -33,11 +33,14 @@ makedepends=(
+ )
+ optdepends=('power-profiles-daemon: power profiles support')
+ _tag=648c4e24ab825444af4e84bf713dc37c6250dbee
+-source=(git+https://github.com/pop-os/cosmic-settings.git#tag=${_tag})
+-b2sums=('210c175a3282bee335434b88d466c053d5ba3fd56c5c2b0989c1afafe90f6465d99aac70915b7fe956e7c35e8b39d811b97e2cf28c8f43b292376638811b9f16')
++source=(git+https://github.com/pop-os/cosmic-settings.git#tag=${_tag}
++        remove-generator-075.diff)
++b2sums=('210c175a3282bee335434b88d466c053d5ba3fd56c5c2b0989c1afafe90f6465d99aac70915b7fe956e7c35e8b39d811b97e2cf28c8f43b292376638811b9f16'
++        'cd6dcc70767e5021a12690a8f44b13de62e24fd0ad31d35a42fccb97c28c5ac41701eda1af4e10af850236b212028cadf563a9a79fc518d5c173536241ba6a8f')
+ 
+ prepare() {
+   cd cosmic-settings
++  patch -Np1 -i ../remove-generator-075.diff
+   cargo fetch --locked
+ }
+ 


### PR DESCRIPTION
Backport part of https://github.com/pop-os/cosmic-settings/commit/3ec53d7f8a7fa8cdb0a6e51dc9d94fe513518991 to get rid of dependency generator 0.7.5, which doesn't support riscv64 until 0.8.0