### PR TITLE
addpatch: xdg-desktop-portal-cosmic 1.0.0.alpha.1-1

### DIFF
--- a/xdg-desktop-portal-cosmic/riscv64.patch
+++ b/xdg-desktop-portal-cosmic/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -42,7 +42,7 @@ pkgver() {
+ 
+ build() {
+   cd xdg-desktop-portal-cosmic
+-  RUSTFLAGS+=" -C link-arg=-fuse-ld=lld"
++  #RUSTFLAGS+=" -C link-arg=-fuse-ld=lld"
+   make ARGS+=" --frozen --release"
+ }
+ 


### PR DESCRIPTION
Use gnu ld to workaround lld linker failure (https://archriscv.felixc.at/.status/logs/xdg-desktop-portal-cosmic/xdg-desktop-portal-cosmic-1.0.0.alpha.1-1.log)

That looks like a bug in lld but I am unsure.