### PR TITLE
addpatch: libinsane 1.0.10-2

### DIFF
--- a/libinsane/riscv64.patch
+++ b/libinsane/riscv64.patch
@@ -1,0 +1,8 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -43,3 +43,5 @@ package() {
+   mkdir -p "$pkgdir/usr/share/doc/$pkgname"
+   cp -r build/doc/html "$pkgdir/usr/share/doc/$pkgname/html"
+ }
++
++checkdepends=(${checkdepends[@]/valgrind})


### PR DESCRIPTION
Disable Valgrind tests due to lack of debuginfod.