### PR TITLE
updpatch: nix-busybox 1.35.0-2

### DIFF
--- a/nix-busybox/riscv64.patch
+++ b/nix-busybox/riscv64.patch
@@ -1,8 +1,6 @@
-Index: PKGBUILD
-===================================================================
---- PKGBUILD	(revision 1320766)
-+++ PKGBUILD	(working copy)
-@@ -13,11 +13,9 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -13,8 +13,6 @@ url='https://www.busybox.net'
  license=('GPL')
  makedepends=(
    'ncurses'
@@ -10,12 +8,21 @@ Index: PKGBUILD
 -  'kernel-headers-musl'
  )
  source=(
--  "$url/download/$_pkgname-$pkgver.tar.bz2"{,.sig}
-+  "$url/downloads/$_pkgname-$pkgver.tar.bz2"{,.sig}
-   'config'
- )
- b2sums=('c08656bc863cd3fa8f7269032e808a30832215c36414c12f8233ab00503636ed1979541b7df42df654f1dfdfdd46fc00c8fe790bf0bed629a915b4c806c643b9'
-@@ -32,7 +30,7 @@
+   "$url/downloads/$_pkgname-$pkgver.tar.bz2"{,.sig}
+@@ -25,6 +23,12 @@ b2sums=('c08656bc863cd3fa8f7269032e808a30832215c36414c12f8233ab00503636ed1979541
+         'd592c063dc3f19c00795ba1dfd5241dad365b08a30494126fb3a5ef3c6d9077d885c0a2e150e7b5d9f06f483adcdeeea8df660be208373318472af9fcc52c5c7')
+ validpgpkeys=('C9E9416F76E610DBD09D040F47B70C55ACC9965B') # Denis Vlasenko <vda.linux@googlemail.com>
+ 
++
++prepare() {
++  # https://bugs.busybox.net/show_bug.cgi?id=15931
++  patch -Np1 -d "$_pkgname-$pkgver" <  busybox-1.36.1-no-cbq.patch
++}
++
+ build() {
+   cd "$_pkgname-$pkgver"
+ 
+@@ -32,7 +36,7 @@ build() {
  
    # reproducible build
    export KCONFIG_NOTIMESTAMP=1
@@ -24,3 +31,10 @@ Index: PKGBUILD
  }
  
  package() {
+@@ -40,3 +44,6 @@ package() {
+ 
+   install -vDm755 -t "$pkgdir/usr/lib/nix" busybox
+ }
++
++source+=(https://git.openembedded.org/openembedded-core/plain/meta/recipes-core/busybox/busybox/busybox-1.36.1-no-cbq.patch)
++b2sums+=(d5db048a8444d13a6cce894998ce7b43c42f6f96f61318712901e9c49e88d89398c6be5642a55dee99fd5be43d0c6b6996886fa6c32510c8e8fc28da290fae23)


### PR DESCRIPTION
- Fix rotten patch
- Remove CBQ support because 6.8 kernel header removed it
   - https://bugs.busybox.net/show_bug.cgi?id=15931
   - Arch doesn't need this because they are still using 4.19 musl kernel headers