### PR TITLE
updpatch: grafana 11.2.0-2

### DIFF
--- a/grafana/riscv64.patch
+++ b/grafana/riscv64.patch
@@ -1,5 +1,3 @@
-diff --git PKGBUILD PKGBUILD
-index 64dd0bb..d1fad77 100644
 --- PKGBUILD
 +++ PKGBUILD
 @@ -69,9 +69,9 @@ package() {
@@ -15,3 +13,11 @@ index 64dd0bb..d1fad77 100644
    install -Dm640 -o207 -g207 conf/sample.ini "$pkgdir/etc/$pkgname.ini"
    install -Dm644 conf/defaults.ini "$pkgdir/usr/share/$pkgname/conf/defaults.ini"
    install -dm755 "$pkgdir/usr/share/grafana/"
+@@ -83,4 +83,7 @@ package() {
+   rm -r "$pkgdir/usr/share/grafana/public/test"
+ }
+ 
++source+=('upgrade-nx.patch')
++sha512sums+=('f67d4f2a49ba9758161ae20952fb73d7fdd505d8cd8a9b7d9bdaf808f4bd3c32d9c86af121b2d43ff2cf7056bf98b000b9974123fe9ef5041d8263d6d858a725')
++
+ # vim:set ts=2 sw=2 et:

--- a/grafana/upgrade-nx.patch
+++ b/grafana/upgrade-nx.patch
@@ -1,0 +1,356 @@
+diff --git a/package.json b/package.json
+index 236a8313..9c18136a 100644
+--- a/package.json
++++ b/package.json
+@@ -204,7 +204,7 @@
+     "mutationobserver-shim": "0.3.7",
+     "ngtemplate-loader": "2.1.0",
+     "node-notifier": "10.0.1",
+-    "nx": "19.2.0",
++    "nx": "^19.6.4",
+     "postcss": "8.4.41",
+     "postcss-loader": "8.1.1",
+     "postcss-reporter": "7.1.0",
+@@ -420,7 +420,8 @@
+     "history@^4.9.0": "patch:history@npm%3A4.10.1#./.yarn/patches/history-npm-4.10.1-ee217563ae.patch",
+     "redux": "^5.0.0",
+     "@storybook/blocks@npm:8.1.6": "patch:@storybook/blocks@npm%3A8.1.6#~/.yarn/patches/@storybook-blocks-npm-8.1.6-892f57a6d7.patch",
+-    "react-grid-layout": "patch:react-grid-layout@npm%3A1.4.4#~/.yarn/patches/react-grid-layout-npm-1.4.4-4024c5395b.patch"
++    "react-grid-layout": "patch:react-grid-layout@npm%3A1.4.4#~/.yarn/patches/react-grid-layout-npm-1.4.4-4024c5395b.patch",
++    "nx": "19.6.4"
+   },
+   "workspaces": {
+     "packages": [
+diff --git a/yarn.lock b/yarn.lock
+index 5f122101..c355f256 100644
+--- a/yarn.lock
++++ b/yarn.lock
+@@ -1948,6 +1948,34 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@emnapi/core@npm:^1.1.0":
++  version: 1.2.0
++  resolution: "@emnapi/core@npm:1.2.0"
++  dependencies:
++    "@emnapi/wasi-threads": "npm:1.0.1"
++    tslib: "npm:^2.4.0"
++  checksum: 10/b0b32b7702ae501be76c72ee77778e0356696b49a72f56c3c04774db23baa3a6054acf839a3d8a49fee415386946685edb904eaa3ac95b5c73cedd2f2766853c
++  languageName: node
++  linkType: hard
++
++"@emnapi/runtime@npm:^1.1.0":
++  version: 1.2.0
++  resolution: "@emnapi/runtime@npm:1.2.0"
++  dependencies:
++    tslib: "npm:^2.4.0"
++  checksum: 10/c954b36493b713e451c74e9f1a48124b5491196700ec458c5d4a94eac3351e14803b4fd48ae6f72c77956d75792093d377f96412a6f59766099cb142e5c5b8f4
++  languageName: node
++  linkType: hard
++
++"@emnapi/wasi-threads@npm:1.0.1":
++  version: 1.0.1
++  resolution: "@emnapi/wasi-threads@npm:1.0.1"
++  dependencies:
++    tslib: "npm:^2.4.0"
++  checksum: 10/949f8bdcb11153d530652516b11d4b11d8c6ed48a692b4a59cbaa4305327aed59a61f0d87c366085c20ad0b0336c3b50eaddbddeeb3e8c55e7e82b583b9d98fb
++  languageName: node
++  linkType: hard
++
+ "@emotion/babel-plugin@npm:^11.11.0":
+   version: 11.11.0
+   resolution: "@emotion/babel-plugin@npm:11.11.0"
+@@ -4896,6 +4924,17 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@napi-rs/wasm-runtime@npm:0.2.4":
++  version: 0.2.4
++  resolution: "@napi-rs/wasm-runtime@npm:0.2.4"
++  dependencies:
++    "@emnapi/core": "npm:^1.1.0"
++    "@emnapi/runtime": "npm:^1.1.0"
++    "@tybys/wasm-util": "npm:^0.9.0"
++  checksum: 10/af335867eca9696b0dbb1b8439878e0408a853c42419cd71d2c5dcf9f7c9f6a8549ea88b3a31b9544bb3a9376e5742f3268e58ee066925d3726bd76a121eb8a6
++  languageName: node
++  linkType: hard
++
+ "@ndelangen/get-tarball@npm:^3.0.7":
+   version: 3.0.7
+   resolution: "@ndelangen/get-tarball@npm:3.0.7"
+@@ -5151,15 +5190,15 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"@nrwl/tao@npm:19.2.0":
+-  version: 19.2.0
+-  resolution: "@nrwl/tao@npm:19.2.0"
++"@nrwl/tao@npm:19.6.4":
++  version: 19.6.4
++  resolution: "@nrwl/tao@npm:19.6.4"
+   dependencies:
+-    nx: "npm:19.2.0"
++    nx: "npm:19.6.4"
+     tslib: "npm:^2.3.0"
+   bin:
+     tao: index.js
+-  checksum: 10/d578ebcaeb7b4e0d6cd09cf53e21d08bf1517f6e5af6a67c554758fea2d2569ea9a11db94c11f9ecc72fe5553ad277433ef1ebc4623256e486df395f92830a31
++  checksum: 10/26b3d619c978d5d913a3947c28d7c096689237524d493ba9bd5b3d4dd748c2f7ab3d2639096a540109e96ee3114d97d2110c295d3bbd66b484bdcd255b6bd69d
+   languageName: node
+   linkType: hard
+ 
+@@ -5182,72 +5221,72 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"@nx/nx-darwin-arm64@npm:19.2.0":
+-  version: 19.2.0
+-  resolution: "@nx/nx-darwin-arm64@npm:19.2.0"
++"@nx/nx-darwin-arm64@npm:19.6.4":
++  version: 19.6.4
++  resolution: "@nx/nx-darwin-arm64@npm:19.6.4"
+   conditions: os=darwin & cpu=arm64
+   languageName: node
+   linkType: hard
+ 
+-"@nx/nx-darwin-x64@npm:19.2.0":
+-  version: 19.2.0
+-  resolution: "@nx/nx-darwin-x64@npm:19.2.0"
++"@nx/nx-darwin-x64@npm:19.6.4":
++  version: 19.6.4
++  resolution: "@nx/nx-darwin-x64@npm:19.6.4"
+   conditions: os=darwin & cpu=x64
+   languageName: node
+   linkType: hard
+ 
+-"@nx/nx-freebsd-x64@npm:19.2.0":
+-  version: 19.2.0
+-  resolution: "@nx/nx-freebsd-x64@npm:19.2.0"
++"@nx/nx-freebsd-x64@npm:19.6.4":
++  version: 19.6.4
++  resolution: "@nx/nx-freebsd-x64@npm:19.6.4"
+   conditions: os=freebsd & cpu=x64
+   languageName: node
+   linkType: hard
+ 
+-"@nx/nx-linux-arm-gnueabihf@npm:19.2.0":
+-  version: 19.2.0
+-  resolution: "@nx/nx-linux-arm-gnueabihf@npm:19.2.0"
++"@nx/nx-linux-arm-gnueabihf@npm:19.6.4":
++  version: 19.6.4
++  resolution: "@nx/nx-linux-arm-gnueabihf@npm:19.6.4"
+   conditions: os=linux & cpu=arm
+   languageName: node
+   linkType: hard
+ 
+-"@nx/nx-linux-arm64-gnu@npm:19.2.0":
+-  version: 19.2.0
+-  resolution: "@nx/nx-linux-arm64-gnu@npm:19.2.0"
++"@nx/nx-linux-arm64-gnu@npm:19.6.4":
++  version: 19.6.4
++  resolution: "@nx/nx-linux-arm64-gnu@npm:19.6.4"
+   conditions: os=linux & cpu=arm64 & libc=glibc
+   languageName: node
+   linkType: hard
+ 
+-"@nx/nx-linux-arm64-musl@npm:19.2.0":
+-  version: 19.2.0
+-  resolution: "@nx/nx-linux-arm64-musl@npm:19.2.0"
++"@nx/nx-linux-arm64-musl@npm:19.6.4":
++  version: 19.6.4
++  resolution: "@nx/nx-linux-arm64-musl@npm:19.6.4"
+   conditions: os=linux & cpu=arm64 & libc=musl
+   languageName: node
+   linkType: hard
+ 
+-"@nx/nx-linux-x64-gnu@npm:19.2.0":
+-  version: 19.2.0
+-  resolution: "@nx/nx-linux-x64-gnu@npm:19.2.0"
++"@nx/nx-linux-x64-gnu@npm:19.6.4":
++  version: 19.6.4
++  resolution: "@nx/nx-linux-x64-gnu@npm:19.6.4"
+   conditions: os=linux & cpu=x64 & libc=glibc
+   languageName: node
+   linkType: hard
+ 
+-"@nx/nx-linux-x64-musl@npm:19.2.0":
+-  version: 19.2.0
+-  resolution: "@nx/nx-linux-x64-musl@npm:19.2.0"
++"@nx/nx-linux-x64-musl@npm:19.6.4":
++  version: 19.6.4
++  resolution: "@nx/nx-linux-x64-musl@npm:19.6.4"
+   conditions: os=linux & cpu=x64 & libc=musl
+   languageName: node
+   linkType: hard
+ 
+-"@nx/nx-win32-arm64-msvc@npm:19.2.0":
+-  version: 19.2.0
+-  resolution: "@nx/nx-win32-arm64-msvc@npm:19.2.0"
++"@nx/nx-win32-arm64-msvc@npm:19.6.4":
++  version: 19.6.4
++  resolution: "@nx/nx-win32-arm64-msvc@npm:19.6.4"
+   conditions: os=win32 & cpu=arm64
+   languageName: node
+   linkType: hard
+ 
+-"@nx/nx-win32-x64-msvc@npm:19.2.0":
+-  version: 19.2.0
+-  resolution: "@nx/nx-win32-x64-msvc@npm:19.2.0"
++"@nx/nx-win32-x64-msvc@npm:19.6.4":
++  version: 19.6.4
++  resolution: "@nx/nx-win32-x64-msvc@npm:19.6.4"
+   conditions: os=win32 & cpu=x64
+   languageName: node
+   linkType: hard
+@@ -8300,6 +8339,15 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
++"@tybys/wasm-util@npm:^0.9.0":
++  version: 0.9.0
++  resolution: "@tybys/wasm-util@npm:0.9.0"
++  dependencies:
++    tslib: "npm:^2.4.0"
++  checksum: 10/aa58e64753a420ad1eefaf7bacef3dda61d74f9336925943d9244132d5b48d9242f734f1e707fd5ccfa6dd1d8ec8e6debc234b4dedb3a5b0d8486d1f373350b2
++  languageName: node
++  linkType: hard
++
+ "@types/angular-route@npm:1.7.6":
+   version: 1.7.6
+   resolution: "@types/angular-route@npm:1.7.6"
+@@ -11352,14 +11400,14 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"axios@npm:^1.6.0":
+-  version: 1.6.7
+-  resolution: "axios@npm:1.6.7"
++"axios@npm:^1.7.4":
++  version: 1.7.6
++  resolution: "axios@npm:1.7.6"
+   dependencies:
+-    follow-redirects: "npm:^1.15.4"
++    follow-redirects: "npm:^1.15.6"
+     form-data: "npm:^4.0.0"
+     proxy-from-env: "npm:^1.1.0"
+-  checksum: 10/a1932b089ece759cd261f175d9ebf4d41c8994cf0c0767cda86055c7a19bcfdade8ae3464bf4cec4c8b142f4a657dc664fb77a41855e8376cf38b86d7a86518f
++  checksum: 10/c9a488da1e5bae690b4832d270bf0bc99c4246407f65783446c94216a6d63d228bccbacff4bde1891d6612c4a89369356101a1cbbd66efeac1776950750a561b
+   languageName: node
+   linkType: hard
+ 
+@@ -14787,20 +14835,36 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"dotenv-expand@npm:^10.0.0, dotenv-expand@npm:~10.0.0":
++"dotenv-expand@npm:^10.0.0":
+   version: 10.0.0
+   resolution: "dotenv-expand@npm:10.0.0"
+   checksum: 10/b41eb278bc96b92cbf3037ca5f3d21e8845bf165dc06b6f9a0a03d278c2bd5a01c0cfbb3528ae3a60301ba1a8a9cace30e748c54b460753bc00d4c014b675597
+   languageName: node
+   linkType: hard
+ 
+-"dotenv@npm:^16.0.0, dotenv@npm:~16.3.1":
++"dotenv-expand@npm:~11.0.6":
++  version: 11.0.6
++  resolution: "dotenv-expand@npm:11.0.6"
++  dependencies:
++    dotenv: "npm:^16.4.4"
++  checksum: 10/8912aba44c024982449c14a701455f84a65af8db38c58977d9952b73d1741952a1ef950e72e5fb9201cc3ab231b593dc9d5c5293c9154794dbaa33c900faceb4
++  languageName: node
++  linkType: hard
++
++"dotenv@npm:^16.0.0":
+   version: 16.3.1
+   resolution: "dotenv@npm:16.3.1"
+   checksum: 10/dbb778237ef8750e9e3cd1473d3c8eaa9cc3600e33a75c0e36415d0fa0848197f56c3800f77924c70e7828f0b03896818cd52f785b07b9ad4d88dba73fbba83f
+   languageName: node
+   linkType: hard
+ 
++"dotenv@npm:^16.4.4, dotenv@npm:~16.4.5":
++  version: 16.4.5
++  resolution: "dotenv@npm:16.4.5"
++  checksum: 10/55a3134601115194ae0f924e54473459ed0d9fc340ae610b676e248cca45aa7c680d86365318ea964e6da4e2ea80c4514c1adab5adb43d6867fb57ff068f95c8
++  languageName: node
++  linkType: hard
++
+ "dotparser@npm:^1.1.1":
+   version: 1.1.1
+   resolution: "dotparser@npm:1.1.1"
+@@ -16642,7 +16706,7 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.4":
++"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.6":
+   version: 1.15.6
+   resolution: "follow-redirects@npm:1.15.6"
+   peerDependenciesMeta:
+@@ -17712,7 +17776,7 @@ __metadata:
+     ngtemplate-loader: "npm:2.1.0"
+     node-forge: "npm:^1.3.1"
+     node-notifier: "npm:10.0.1"
+-    nx: "npm:19.2.0"
++    nx: "npm:^19.6.4"
+     ol: "npm:7.4.0"
+     ol-ext: "npm:4.0.21"
+     pluralize: "npm:^8.0.0"
+@@ -23119,31 +23183,32 @@ __metadata:
+   languageName: node
+   linkType: hard
+ 
+-"nx@npm:19.2.0, nx@npm:>=17.1.2 < 20":
+-  version: 19.2.0
+-  resolution: "nx@npm:19.2.0"
++"nx@npm:19.6.4":
++  version: 19.6.4
++  resolution: "nx@npm:19.6.4"
+   dependencies:
+-    "@nrwl/tao": "npm:19.2.0"
+-    "@nx/nx-darwin-arm64": "npm:19.2.0"
+-    "@nx/nx-darwin-x64": "npm:19.2.0"
+-    "@nx/nx-freebsd-x64": "npm:19.2.0"
+-    "@nx/nx-linux-arm-gnueabihf": "npm:19.2.0"
+-    "@nx/nx-linux-arm64-gnu": "npm:19.2.0"
+-    "@nx/nx-linux-arm64-musl": "npm:19.2.0"
+-    "@nx/nx-linux-x64-gnu": "npm:19.2.0"
+-    "@nx/nx-linux-x64-musl": "npm:19.2.0"
+-    "@nx/nx-win32-arm64-msvc": "npm:19.2.0"
+-    "@nx/nx-win32-x64-msvc": "npm:19.2.0"
++    "@napi-rs/wasm-runtime": "npm:0.2.4"
++    "@nrwl/tao": "npm:19.6.4"
++    "@nx/nx-darwin-arm64": "npm:19.6.4"
++    "@nx/nx-darwin-x64": "npm:19.6.4"
++    "@nx/nx-freebsd-x64": "npm:19.6.4"
++    "@nx/nx-linux-arm-gnueabihf": "npm:19.6.4"
++    "@nx/nx-linux-arm64-gnu": "npm:19.6.4"
++    "@nx/nx-linux-arm64-musl": "npm:19.6.4"
++    "@nx/nx-linux-x64-gnu": "npm:19.6.4"
++    "@nx/nx-linux-x64-musl": "npm:19.6.4"
++    "@nx/nx-win32-arm64-msvc": "npm:19.6.4"
++    "@nx/nx-win32-x64-msvc": "npm:19.6.4"
+     "@yarnpkg/lockfile": "npm:^1.1.0"
+     "@yarnpkg/parsers": "npm:3.0.0-rc.46"
+     "@zkochan/js-yaml": "npm:0.0.7"
+-    axios: "npm:^1.6.0"
++    axios: "npm:^1.7.4"
+     chalk: "npm:^4.1.0"
+     cli-cursor: "npm:3.1.0"
+     cli-spinners: "npm:2.6.1"
+     cliui: "npm:^8.0.1"
+-    dotenv: "npm:~16.3.1"
+-    dotenv-expand: "npm:~10.0.0"
++    dotenv: "npm:~16.4.5"
++    dotenv-expand: "npm:~11.0.6"
+     enquirer: "npm:~2.3.6"
+     figures: "npm:3.2.0"
+     flat: "npm:^5.0.2"
+@@ -23199,7 +23264,7 @@ __metadata:
+   bin:
+     nx: bin/nx.js
+     nx-cloud: bin/nx-cloud.js
+-  checksum: 10/7a8858d21e9201f1f0d800f7893bf85c6a8f943eaa8802980f5e1488c5f7345820e41f256535010bf5ac5eb85a107f73a87274fbce592f0be1f54b22dc3ce946
++  checksum: 10/9826bb23b87803f1f28f3c4ab878992ca1d3aed7c5a3b9e0d3d5ae0b10884db6b1f929156e9053796e8e781ba2c4316899aacb782e92bdddeae43d6e6288141b
+   languageName: node
+   linkType: hard
+ 


### PR DESCRIPTION
Bump nx to 19.6.4 where riscv64 prebuilt is available.