### PR TITLE
addpatch: llvm 18.1.8-4

### DIFF
--- a/llvm/JITLink-Always-unmap-standard-segments-in-InProcessM.patch
+++ b/llvm/JITLink-Always-unmap-standard-segments-in-InProcessM.patch
@@ -1,0 +1,35 @@
+From 3d67cf681a728e4cf0ab9947c0dd07539dda8b74 Mon Sep 17 00:00:00 2001
+From: Min-Yih Hsu <min.hsu@sifive.com>
+Date: Fri, 16 Feb 2024 16:19:56 -0800
+Subject: [PATCH] [JITLink] Always unmap standard segments in
+ InProcessMemoryManager::deallocate (#81943)
+
+Right now InProcessMemoryManager only releases a standard segment (via
+sys::Memory::releaseMappedMemory) in `deallocate` when there is a
+DeallocAction associated, leaving residual memory pages in the process
+until termination.
+Despite being a de facto memory leak, it won't cause a major issue if
+users only create a single LLJIT instance per process, which is the most
+common use cases. It will, however, drain virtual memory pages if we
+create thousands of ephemeral LLJIT instances in the same process.
+
+This patch fixes this issue by releasing every standard segments
+regardless of the attached DeallocAction.
+---
+ llvm/lib/ExecutionEngine/JITLink/JITLinkMemoryManager.cpp | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/llvm/lib/ExecutionEngine/JITLink/JITLinkMemoryManager.cpp b/llvm/lib/ExecutionEngine/JITLink/JITLinkMemoryManager.cpp
+index 474a0b5160bcb0..dacf0e6c8aa4f2 100644
+--- a/llvm/lib/ExecutionEngine/JITLink/JITLinkMemoryManager.cpp
++++ b/llvm/lib/ExecutionEngine/JITLink/JITLinkMemoryManager.cpp
+@@ -449,8 +449,7 @@ void InProcessMemoryManager::deallocate(std::vector<FinalizedAlloc> Allocs,
+     for (auto &Alloc : Allocs) {
+       auto *FA = Alloc.release().toPtr<FinalizedAllocInfo *>();
+       StandardSegmentsList.push_back(std::move(FA->StandardSegments));
+-      if (!FA->DeallocActions.empty())
+-        DeallocActionsList.push_back(std::move(FA->DeallocActions));
++      DeallocActionsList.push_back(std::move(FA->DeallocActions));
+       FA->~FinalizedAllocInfo();
+       FinalizedAllocInfos.Deallocate(FA);
+     }

--- a/llvm/JITLink-RISCV-Use-hashmap-to-find-PCREL_HI20-edge-78.patch
+++ b/llvm/JITLink-RISCV-Use-hashmap-to-find-PCREL_HI20-edge-78.patch
@@ -1,0 +1,104 @@
+From 78f39dc70c1feaea5130b90ea3fb7b3ddd62446b Mon Sep 17 00:00:00 2001
+From: Jonas Hahnfeld <hahnjo@hahnjo.de>
+Date: Mon, 12 Feb 2024 19:45:52 +0100
+Subject: [PATCH] [JITLink][RISCV] Use hashmap to find PCREL_HI20 edge (#78849)
+
+As noted in issues #68594 and #73935, `JITLink/RISCV/ELF_ehframe.s`
+fails with libstdc++'s expensive checks because `getRISCVPCRelHi20`
+calls `std::equal_range` on the edges which may not be ordered by their
+offset. Instead let `ELFJITLinker_riscv` build a hashmap of all edges
+with type `R_RISCV_PCREL_HI20` that can be looked up in constant time.
+
+Closes #73935
+---
+ .../lib/ExecutionEngine/JITLink/ELF_riscv.cpp | 68 ++++++++++---------
+ 1 file changed, 35 insertions(+), 33 deletions(-)
+
+diff --git a/llvm/lib/ExecutionEngine/JITLink/ELF_riscv.cpp b/llvm/lib/ExecutionEngine/JITLink/ELF_riscv.cpp
+index 2fcdfcf9c0669e..0cf548ede93890 100644
+--- a/llvm/lib/ExecutionEngine/JITLink/ELF_riscv.cpp
++++ b/llvm/lib/ExecutionEngine/JITLink/ELF_riscv.cpp
+@@ -133,38 +133,6 @@ const uint8_t
+ namespace llvm {
+ namespace jitlink {
+ 
+-static Expected<const Edge &> getRISCVPCRelHi20(const Edge &E) {
+-  using namespace riscv;
+-  assert((E.getKind() == R_RISCV_PCREL_LO12_I ||
+-          E.getKind() == R_RISCV_PCREL_LO12_S) &&
+-         "Can only have high relocation for R_RISCV_PCREL_LO12_I or "
+-         "R_RISCV_PCREL_LO12_S");
+-
+-  const Symbol &Sym = E.getTarget();
+-  const Block &B = Sym.getBlock();
+-  orc::ExecutorAddrDiff Offset = Sym.getOffset();
+-
+-  struct Comp {
+-    bool operator()(const Edge &Lhs, orc::ExecutorAddrDiff Offset) {
+-      return Lhs.getOffset() < Offset;
+-    }
+-    bool operator()(orc::ExecutorAddrDiff Offset, const Edge &Rhs) {
+-      return Offset < Rhs.getOffset();
+-    }
+-  };
+-
+-  auto Bound =
+-      std::equal_range(B.edges().begin(), B.edges().end(), Offset, Comp{});
+-
+-  for (auto It = Bound.first; It != Bound.second; ++It) {
+-    if (It->getKind() == R_RISCV_PCREL_HI20)
+-      return *It;
+-  }
+-
+-  return make_error<JITLinkError>(
+-      "No HI20 PCREL relocation type be found for LO12 PCREL relocation type");
+-}
+-
+ static uint32_t extractBits(uint32_t Num, unsigned Low, unsigned Size) {
+   return (Num & (((1ULL << Size) - 1) << Low)) >> Low;
+ }
+@@ -184,9 +152,43 @@ class ELFJITLinker_riscv : public JITLinker<ELFJITLinker_riscv> {
+ public:
+   ELFJITLinker_riscv(std::unique_ptr<JITLinkContext> Ctx,
+                      std::unique_ptr<LinkGraph> G, PassConfiguration PassConfig)
+-      : JITLinker(std::move(Ctx), std::move(G), std::move(PassConfig)) {}
++      : JITLinker(std::move(Ctx), std::move(G), std::move(PassConfig)) {
++    JITLinkerBase::getPassConfig().PostAllocationPasses.push_back(
++        [this](LinkGraph &G) { return gatherRISCVPCRelHi20(G); });
++  }
+ 
+ private:
++  DenseMap<std::pair<const Block *, orc::ExecutorAddrDiff>, const Edge *>
++      RelHi20;
++
++  Error gatherRISCVPCRelHi20(LinkGraph &G) {
++    for (Block *B : G.blocks())
++      for (Edge &E : B->edges())
++        if (E.getKind() == R_RISCV_PCREL_HI20)
++          RelHi20[{B, E.getOffset()}] = &E;
++
++    return Error::success();
++  }
++
++  Expected<const Edge &> getRISCVPCRelHi20(const Edge &E) const {
++    using namespace riscv;
++    assert((E.getKind() == R_RISCV_PCREL_LO12_I ||
++            E.getKind() == R_RISCV_PCREL_LO12_S) &&
++           "Can only have high relocation for R_RISCV_PCREL_LO12_I or "
++           "R_RISCV_PCREL_LO12_S");
++
++    const Symbol &Sym = E.getTarget();
++    const Block &B = Sym.getBlock();
++    orc::ExecutorAddrDiff Offset = Sym.getOffset();
++
++    auto It = RelHi20.find({&B, Offset});
++    if (It != RelHi20.end())
++      return *It->second;
++
++    return make_error<JITLinkError>("No HI20 PCREL relocation type be found "
++                                    "for LO12 PCREL relocation type");
++  }
++
+   Error applyFixup(LinkGraph &G, Block &B, const Edge &E) const {
+     using namespace riscv;
+     using namespace llvm::support;

--- a/llvm/riscv64.patch
+++ b/llvm/riscv64.patch
@@ -1,0 +1,31 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -22,7 +22,7 @@ sha256sums=('f68cf90f369bc7d0158ba70d860b0cb34dbc163d6ff0ebc6cfa5e515b9b2e28d'
+             'SKIP'
+             'b76b810f3d3dc5d08e83c4236cb6e395aa9bd5e3ea861e8c319b216d093db074'
+             'SKIP'
+-            '62cc0a323ebe6a61a1302605d42a28ce812dbeae186e23515b333211e3de008a')
++            '9b53e584f8b8a44648a2a066da1860155b61118c8cdebed3632161db0b680462')
+ validpgpkeys=('474E22316ABF4785A88C6E8EA2C794A986419D8A') # Tom Stellard <tstellar@redhat.com>
+ 
+ # Utilizing LLVM_DISTRIBUTION_COMPONENTS to avoid
+@@ -67,6 +67,9 @@ prepare() {
+   # https://github.com/llvm/llvm-project/issues/82431
+   sed '/^diff.*inline-asm-memop.ll/,$d' ../$pkgname-SelectionDAG.patch | patch -Np2
+ 
++  patch -Np2 -i ../JITLink-RISCV-Use-hashmap-to-find-PCREL_HI20-edge-78.patch
++  patch -Np2 -i ../JITLink-Always-unmap-standard-segments-in-InProcessM.patch
++
+   # Remove CMake find module for zstd; breaks if out of sync with upstream zstd
+   rm cmake/modules/Findzstd.cmake
+ }
+@@ -158,4 +161,9 @@ package_llvm-libs() {
+     "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+ }
+ 
++source+=(JITLink-RISCV-Use-hashmap-to-find-PCREL_HI20-edge-78.patch
++         JITLink-Always-unmap-standard-segments-in-InProcessM.patch)
++sha256sums+=('dd0d5904bdd69aea6e4937cc11336dc7a9d9c64584575c183da306a9baf93199'
++             '3fccc34270fa1cc0645fe8e6eac74c410ec108c63d653beca26434bd93dfd159')
++
+ # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
- Backport 2 patches for fixing LLVMPipe ORCJIT; see https://github.com/AOSC-Dev/aosc-os-abbs/commit/a9a7ce6a740a4471e1562a1a50ae54cc3fbabec6
- Temporary checksum fix; upstreamed to https://gitlab.archlinux.org/archlinux/packaging/packages/llvm/-/merge_requests/2