### PR TITLE
addpatch: arti 1.2.7-1, qemu-user-blacklist.txt: add arti

### DIFF
--- a/arti/riscv64.patch
+++ b/arti/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -25,6 +25,8 @@ b2sums=('32a9818e13607ed81d0132935617e6b29d6b44ff34e07e37e31f56e41b7b116ad933947
+ prepare() {
+   mv "$pkgname-$pkgname-v$pkgver" "$pkgname-$pkgver"
+   cd "$pkgname-$pkgver"
++  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
++  cargo update -p ring@0.16.20
+   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+ }
+ 

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -1,5 +1,6 @@
 abseil-cpp
 arrow
+arti
 asio
 bat
 bear


### PR DESCRIPTION
check phase failed dut to

```log
test channel::test::check_match ... ok
test circuit::sendme::test::recvwindow ... ok
test circuit::sendme::test::sendwindow_bad_put ... ok
test circuit::halfstream::test::halfstream_sendme ... ok
test circuit::halfstream::test::halfstream_other ... ok
test circuit::sendme::test::sendwindow_basic ... ok
test circuit::halfstream::test::halfstream_connected ... ok
test circuit::halfstream::test::halfstream_data ... ok
test circuit::sendme::test::sendwindow_erroring ... ok
test channel::circmap::test::circmap_basics ... ok
test circuit::sendme::test::what_counts ... ok
test circuit::streammap::test::test_wrapping_next_stream_id ... ok
test circuit::streammap::test::streammap_basics ... ok
qemu-riscv64-static: QEMU internal SIGSEGV {code=MAPERR, addr=0x20}
error: test failed, to rerun pass `-p tor-proto --lib`

Caused by:
  process didn't exit successfully: `/build/arti/src/arti-1.2.7/target/debug/deps/tor_proto-ee32d38c8b63bcfd` (signal: 11, SIGSEGV: invalid memory reference)
```