### PR TITLE
addpatch: scponly 4.8-12

### DIFF
--- a/scponly/riscv64.patch
+++ b/scponly/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -16,6 +16,12 @@ source=(https://downloads.sourceforge.net/sourceforge/scponly/scponly-$pkgver.tg
+ sha256sums=('1693dd678355749c5d9e48ecdd4628dbfe71d82955afde950ee8d88b5adc01cf'
+             'c194a70d992cf265f35b70808edb6ffeac7ef321dbd6bf12038e9a55f3f6799d')
+ 
++prepare() {
++  cd "$srcdir"/$pkgname-$pkgver
++  cp /usr/share/autoconf/build-aux/config.guess config.guess
++  cp /usr/share/autoconf/build-aux/config.sub config.sub
++}
++
+ build() {
+   cd "$srcdir"/$pkgname-$pkgver
+   [ $NOEXTRACT -eq 1 ] || ./configure --prefix=/usr --sysconfdir=/etc \


### PR DESCRIPTION
Configure failed.  
Reported in https://sourceforge.net/p/scponly/bugs/6/ .