### PR TITLE
addpatch: sdl_net 1.2.8-6

### DIFF
--- a/sdl_net/riscv64.patch
+++ b/sdl_net/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -13,6 +13,12 @@ depends=(sdl)
+ source=(https://www.libsdl.org/projects/SDL_net/release/SDL_net-$pkgver.tar.gz)
+ sha256sums=('5f4a7a8bb884f793c278ac3f3713be41980c5eedccecff0260411347714facb4')
+ 
++prepare() {
++  cd SDL_net-$pkgver
++  cp /usr/share/autoconf/build-aux/config.guess config.guess
++  cp /usr/share/autoconf/build-aux/config.sub config.sub
++}
++
+ build() {
+   cd SDL_net-$pkgver
+   ./configure --prefix=/usr --disable-static


### PR DESCRIPTION
Configuration failed.  
Not reported, it was replaced by sdl2_net.  