### PR TITLE
addpatch: sdl_ttf 2.0.11-6

### DIFF
--- a/sdl_ttf/riscv64.patch
+++ b/sdl_ttf/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -27,7 +27,7 @@ prepare() {
+   patch -Np1 -i ../freetype-pkgconfig.patch
+ 
+   touch NEWS README AUTHORS ChangeLog
+-  autoreconf -vi
++  autoreconf -vfi
+ }
+ 
+ build() {


### PR DESCRIPTION
Configurate failed.  
Not reported, it was replaced by sdl2_ttf.  