### PR TITLE
qemu-user-blacklist.txt: add breezy

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -4,6 +4,7 @@ asio
 bat
 bear
 bmake
+breezy
 buildbot
 caps
 cargo-audit


### PR DESCRIPTION
qemu-user does not handle prlimit64 with second argument set to RLIMIT_AS
correctly, failling `breezy/tests/blackbox/test_big_file.py`.

Reference: https://gitlab.com/qemu-project/qemu/-/blob/v9.1.0/linux-user/syscall.c?ref_type=tags#L13322-13351