### PR TITLE
addpatch: lbzip2-2.5-6

### DIFF
--- a/lbzip2/riscv64.patch
+++ b/lbzip2/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -19,6 +19,9 @@ sha256sums=('eec4ff08376090494fa3710649b73e5412c3687b4b9b758c93f73aa7be27555b'
+ prepare() {
+   cd "${srcdir}"/$pkgname-$pkgver
+ 
++  cp /usr/share/autoconf/build-aux/config.guess ./build-aux/
++  cp /usr/share/autoconf/build-aux/config.sub ./build-aux/
++
+   patch -Np1 -i "${srcdir}"/lbzip2-gnulib-build-fix.patch
+ }
+ 


### PR DESCRIPTION
Arch Linux takes this package's source from [Debian](https://gitlab.archlinux.org/archlinux/packaging/packages/lbzip2/-/blob/main/PKGBUILD?ref_type=heads#L14)

Upstream is here: https://github.com/kjn/lbzip2/tree/master/build-aux , but it doesn't contains config.{guess, sub} at all.

I wonder where should I report it.