### PR TITLE
addpatch: rlog 1.4-10

### DIFF
--- a/rlog/riscv64.patch
+++ b/rlog/riscv64.patch
@@ -1,0 +1,13 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -20,6 +20,10 @@ validpgpkeys=('C08708603F2AA745ECA0D3665A9DB4032EAF4D80') # Valient Gough <vgoug
+ 
+ build() {
+ 	cd "${srcdir}/${pkgname}-${pkgver}"
++	
++	cp /usr/share/autoconf/build-aux/config.guess ./config/
++	cp /usr/share/autoconf/build-aux/config.sub ./config/
++
+ 	patch -Np1 -i "${srcdir}/${pkgname}-section.patch"
+ 	./configure --prefix=/usr
+ 	make


### PR DESCRIPTION
[Upstream](https://code.google.com/archive/p/rlog/issues) has been inactive for a long time, and couldn't create issue.