### PR TITLE
updpatch: gd 2.3.3-8

### DIFF
--- a/gd/riscv64.patch
+++ b/gd/riscv64.patch
@@ -1,8 +1,8 @@
-Index: PKGBUILD
-===================================================================
---- PKGBUILD	(revision 448169)
-+++ PKGBUILD	(working copy)
-@@ -11,9 +11,11 @@
+diff --git PKGBUILD PKGBUILD
+index 7241fa8..ef9b5e3 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -11,9 +11,11 @@ depends=('fontconfig' 'libxpm' 'libwebp' 'libavif' 'libheif')
  optdepends=('perl: bdftogd script')
  checkdepends=('ttf-liberation')
  source=("https://github.com/libgd/libgd/archive/${pkgname}-${pkgver}.tar.gz"
@@ -16,10 +16,10 @@ Index: PKGBUILD
  
  prepare() {
    cd libgd-${pkgname}-${pkgver}
-@@ -21,6 +23,10 @@
-   # Re-add macros that are used in PHP
-   # See https://github.com/php/php-src/pull/7490
-   patch -p1 -R -i "$srcdir/bdc281eadb1d58d5c0c7bbc1125ee4674256df08.patch"
+@@ -26,6 +28,10 @@ prepare() {
+   for f in tests/tiff/{tiff_read_bw,tiff_im2im,tiff_dpi}.c; do
+     echo 'int main() { return 0; }' > $f
+   done
 +
 +  # 2 tests fail on aarch64 (and riscv64): https://github.com/libgd/libgd/issues/745
 +  # upstream disabled them only for aarch64: https://github.com/libgd/libgd/commit/4ff557bc31fc12fba0a57554bf5f596e7fb3f15b


### PR DESCRIPTION
Tests still fail at the moment, but x86_64 fails the same way: https://gitlab.archlinux.org/archlinux/packaging/packages/gd/-/issues/1