### PR TITLE
addpatch: rocfft 6.0.2-1

### DIFF
--- a/rocfft/riscv64.patch
+++ b/rocfft/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index 426ca93..6a8b80b 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -30,6 +30,8 @@
+     -D CMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc
+     -D CMAKE_CXX_FLAGS="${CXXFLAGS} -fcf-protection=none"
+     -D CMAKE_INSTALL_PREFIX=/opt/rocm
++    -D CMAKE_EXE_LINKER_FLAGS=-fuse-ld=bfd
++    -D CMAKE_SHARED_LINKER_FLAGS=-fuse-ld=bfd
+   )
+   cmake "${cmake_args[@]}"
+   cmake --build build


### PR DESCRIPTION
Use `ld.bfd` to workaround `ld.lld: error: section size decrease is too large`