### PR TITLE
addpatch: presenterm 0.8.0-2

### DIFF
--- a/presenterm/riscv64.patch
+++ b/presenterm/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index 107b963..98fe7ab 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -7,7 +7,7 @@
+ arch=('x86_64')
+ url="https://github.com/mfontanini/presenterm"
+ license=('BSD-2-Clause')
+-depends=('gcc-libs')
++depends=('gcc-libs' 'libsixel')
+ makedepends=('cargo')
+ source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
+ sha512sums=('65a4ab5b1a04d5833c40248c718c6779f49b1a766509f51a0f6f49909015566ae1af5d8ae918ae89e6f7961d14cf1a295b9a96216f814086a8067b0c80243fb6')


### PR DESCRIPTION
Without a prebuilt sixel cargo package on riscv, building needs a libsixel. 