### PR TITLE
addpatch: rocblas 6.0.2-1

### DIFF
--- a/rocblas/riscv64.patch
+++ b/rocblas/riscv64.patch
@@ -1,0 +1,26 @@
+diff --git PKGBUILD PKGBUILD
+index 9e10eba..1e03232 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,7 +17,7 @@
+         "find-msgpack-5.patch")
+ sha256sums=('d1bf31063a2d349797b88c994c91d05f94e681bafb5550ad9b53529703d89dbb'
+             '1d8a92422560c1e908fa25fd97a4aa07a96659528a543f77618408ffcfe1f307'
+-            '3f91bf087e4ea72eaef5acd500e16b61aa69c029cfcca14666799a7c42a0c5aa')
++            'ef6c1feef3177573e57f2502452264ad0a0fdd36616bf03f0094f41d9d779eb3')
+ options=(!lto)
+ _dirname="$(basename "$_rocblas")-$(basename "${source[0]}" ".tar.gz")"
+ _tensile_dir="$(basename "$_tensile")-$(basename "${source[1]}" ".tar.gz")"
+diff --git find-msgpack-5.patch find-msgpack-5.patch
+index 37b7f82..9f347e2 100644
+--- find-msgpack-5.patch
++++ find-msgpack-5.patch
+@@ -5,7 +5,7 @@
+  
+  if(TENSILE_USE_MSGPACK)
+ -    find_package(msgpack REQUIRED)
+-+    find_package(msgpackc-cxx REQUIRED)
+++    find_package(msgpack-cxx REQUIRED)
+      target_compile_definitions(TensileHost PUBLIC -DTENSILE_MSGPACK=1)
+  
+      if(TARGET msgpackc-cxx)


### PR DESCRIPTION
The `msgpack-cxx` library is renamed since 6.0.0

https://gitlab.archlinux.org/archlinux/packaging/packages/rocblas/-/merge_requests/1