### PR TITLE
addpatch: virt-what 1.25-2

### DIFF
--- a/virt-what/riscv64.patch
+++ b/virt-what/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,6 +15,11 @@ source=("https://people.redhat.com/~rjones/virt-what/files/${pkgname}-${pkgver}.
+ sha512sums=('0147b4b44ae0ee685977aa34dfa9bf30ae8e0eb31b7a6d5c0097d16f830fa6fb6afd7156964fc79f3fd5e82b2f68d921fd5306245cc63a2140f6dddc7fdd0e98'
+             'SKIP')
+ 
++prepare() {
++  cd "${srcdir}/${pkgname}-${pkgver}"
++  autoreconf -fi
++}
++
+ build() {
+   cd "${srcdir}/${pkgname}-${pkgver}"
+ 


### PR DESCRIPTION
Unable to report because this package is abandoned.  