### PR TITLE
addpatch: yubico-c-client 2.15-6

### DIFF
--- a/yubico-c-client/riscv64.patch
+++ b/yubico-c-client/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -23,6 +23,7 @@ prepare() {
+ 	cd "${_shortname}-${pkgver}"
+ 
+ 	patch -Np1 < ../0001-https-ify-urls-and-drop-v1-selftest.patch
++        autoreconf -fi
+ }
+ 
+ build() {


### PR DESCRIPTION
The package was replaced by tie new api of Yubico: https://developers.yubico.com/OTP/ .