### PR TITLE
addpatch: yubico-c 1.13-7

### DIFF
--- a/yubico-c/riscv64.patch
+++ b/yubico-c/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,6 +17,11 @@ source=("https://developers.yubico.com/${pkgname}/Releases/${_shortname}-${pkgve
+ sha256sums=('04edd0eb09cb665a05d808c58e1985f25bb7c5254d2849f36a0658ffc51c3401'
+             'SKIP')
+ 
++prepare() {
++        cd "${_shortname}-${pkgver}"
++        autoreconf -fi
++}
++
+ build() {
+ 	cd "${_shortname}-${pkgver}"
+ 


### PR DESCRIPTION
Yubico-c has no newer release, arch linux still use the latest release in 2015, according to their [document](https://developers.yubico.com/yubico-c/), developers should pull from the latest commit, I have tried to [ask for a newer release](https://github.com/Yubico/yubico-c/issues/28), but no response. So we may have a vendor patch for that.  