### PR TITLE
updpatch: electron{28,29,30,31,32}

### DIFF
--- a/electron28/riscv64.patch
+++ b/electron28/riscv64.patch
@@ -84,7 +84,16 @@
    patch -Np1 -i ../chromium-patches-*/chromium-119-clang16.patch
  
    # Link to system tools required by the build
-@@ -590,6 +606,10 @@ build() {
+@@ -556,6 +572,8 @@ build() {
+     'enable_hangout_services_extension=true'
+     'enable_widevine=false'
+     'enable_nacl=false'
++    'is_clang=true'
++    "override_electron_version\"$pkgver\""
+   )
+ 
+   if [[ -n ${_system_libs[icu]+set} ]]; then
+@@ -590,6 +608,10 @@ build() {
    CFLAGS+='   -Wno-unknown-warning-option'
    CXXFLAGS+=' -Wno-unknown-warning-option'
  
@@ -95,7 +104,7 @@
    # Let Chromium set its own symbol level
    CFLAGS=${CFLAGS/-g }
    CXXFLAGS=${CXXFLAGS/-g }
-@@ -637,3 +657,4 @@ package() {
+@@ -637,3 +659,4 @@ package() {
    install -Dm644 src/electron/default_app/icon.png \
            "${pkgdir}/usr/share/pixmaps/${pkgname}.png"  # hicolor has no 1024x1024
  }

--- a/electron29/riscv64.patch
+++ b/electron29/riscv64.patch
@@ -1,6 +1,6 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -52,6 +52,7 @@ makedepends=(clang
+@@ -53,6 +53,7 @@ makedepends=(clang
               python-setuptools
               python-six
               rust
@@ -8,7 +8,7 @@
               qt5-base
               wget
               yarn)
-@@ -62,12 +63,13 @@ optdepends=('kde-cli-tools: file deletion support (kioclient5)'
+@@ -63,12 +64,13 @@ optdepends=('kde-cli-tools: file deletion support (kioclient5)'
              'trash-cli: file deletion support (trash-put)'
              'xdg-utils: open URLs with desktop’s default (xdg-email, xdg-open)')
  options=('!lto') # Electron adds its own flags for ThinLTO
@@ -23,7 +23,7 @@
          # Electron
          default_app-icon.patch
          electron-launcher.sh
-@@ -234,7 +236,8 @@ sha256sums=('3fa549d267e3f02d321b800a4700f4192d12f85b0b10dbbec3de30074864713e'
+@@ -235,7 +237,8 @@ sha256sums=('122f8b14fed91703729ec84b10e7871657e16e5620549b7cd94e0770d77c9375'
              '7916b80d801bcc5c23cb9dd1ae820d939af3ef640dbcb2a3c8d6780dcf6ba7a3'
              '8c256b2a9498a63706a6e7a55eadbeb8cc814be66a75e49aec3716c6be450c6c'
              '3bd35dab1ded5d9e1befa10d5c6c4555fe0a76d909fb724ac57d0bf10cb666c1'
@@ -33,7 +33,7 @@
              'dd2d248831dd4944d385ebf008426e66efe61d6fdf66f8932c963a12167947b4'
              '13fcf26193f4417fd5dfbc82a3f24e5c7a1cce82f729f6a73f1b1d3a7b580b34'
              '4484200d90b76830b69eea3a471c103999a3ce86bb2c29e6c14c945bf4102bae'
-@@ -439,12 +442,23 @@ prepare() {
+@@ -440,12 +443,23 @@ prepare() {
  
    cp -r chromium-mirror_third_party_depot_tools depot_tools
    export PATH+=":$PWD/depot_tools" DEPOT_TOOLS_UPDATE=0
@@ -57,7 +57,7 @@
  
    echo "Running hooks..."
    # depot_tools/gclient.py runhooks
-@@ -475,6 +489,8 @@ prepare() {
+@@ -476,6 +490,8 @@ prepare() {
  
    echo "Applying local patches..."
  
@@ -66,7 +66,16 @@
    ## Upstream fixes
  
    # https://crbug.com/893950
-@@ -589,6 +605,10 @@ build() {
+@@ -556,6 +572,8 @@ build() {
+     'enable_hangout_services_extension=true'
+     'enable_widevine=false'
+     'enable_nacl=false'
++    'is_clang=true'
++    "override_electron_version\"$pkgver\""
+   )
+ 
+   if [[ -n ${_system_libs[icu]+set} ]]; then
+@@ -590,6 +608,10 @@ build() {
    CFLAGS+='   -Wno-unknown-warning-option'
    CXXFLAGS+=' -Wno-unknown-warning-option'
  
@@ -77,7 +86,7 @@
    # Let Chromium set its own symbol level
    CFLAGS=${CFLAGS/-g }
    CXXFLAGS=${CXXFLAGS/-g }
-@@ -636,3 +656,5 @@ package() {
+@@ -637,3 +659,5 @@ package() {
    install -Dm644 src/electron/default_app/icon.png \
            "${pkgdir}/usr/share/pixmaps/${pkgname}.png"  # hicolor has no 1024x1024
  }

--- a/electron30/riscv64.patch
+++ b/electron30/riscv64.patch
@@ -24,9 +24,9 @@
 +        Debian-fix-rust-linking.patch
          makepkg-source-roller.py
          # BEGIN managed sources
-         chromium-mirror::git+https://github.com/chromium/chromium.git#tag=124.0.6367.233
+         chromium-mirror::git+https://github.com/chromium/chromium.git#tag=124.0.6367.243
 @@ -235,12 +237,13 @@ source=("git+https://github.com/electron/electron.git#tag=v$pkgver"
- sha256sums=('b76443c063c26069651e3e4968ffd9802b40df80febe4aaac5a95649175d4666'
+ sha256sums=('aaf19eb1c3baa169df8e3b9b891daac734c6e3158e5e5cc2d7dae49cdd30f775'
              'c2bc4e65ed2a4e23528dd10d5c15bf99f880b7bbb789cc720d451b78098a7e12'
              '3bd35dab1ded5d9e1befa10d5c6c4555fe0a76d909fb724ac57d0bf10cb666c1'
 -            'b3de01b7df227478687d7517f61a777450dca765756002c80c4915f271e2d961'
@@ -38,7 +38,7 @@
              'ff588a8a4fd2f79eb8a4f11cf1aa151298ffb895be566c57cc355d47f161f53f'
 +            '98b0fbe1318897954cb8891cafed65e985613c69192e65984ba6785579b29f80'
              '3ae82375ba212c31fd4ba6f1fa4e2445eeca8eb8c952176131ad57c0258db224'
-             '5b726fabb7b6a7364eb4e712947596989c411b0735d745084c8609579f3f6b5b'
+             'f1674e6550645996c9e4fdb3de00f1f53978c2d4a72daec127d9e2973cc33ecb'
              '0b7a546ee6913c49519c10c293ac530ff381641a8a465fa2e184d6dbe0fb784d'
 @@ -445,12 +448,22 @@ prepare() {
    cp -r chromium-mirror_third_party_depot_tools depot_tools
@@ -72,7 +72,16 @@
    ## Upstream fixes
  
    # https://crbug.com/893950
-@@ -592,6 +607,10 @@ build() {
+@@ -558,6 +573,8 @@ build() {
+     'enable_hangout_services_extension=true'
+     'enable_widevine=false'
+     'enable_nacl=false'
++    'is_clang=true'
++    "override_electron_version\"$pkgver\""
+   )
+ 
+   if [[ -n ${_system_libs[icu]+set} ]]; then
+@@ -592,6 +609,10 @@ build() {
    CFLAGS+='   -Wno-unknown-warning-option'
    CXXFLAGS+=' -Wno-unknown-warning-option'
  
@@ -83,7 +92,7 @@
    # Let Chromium set its own symbol level
    CFLAGS=${CFLAGS/-g }
    CXXFLAGS=${CXXFLAGS/-g }
-@@ -639,3 +658,5 @@ package() {
+@@ -639,3 +660,5 @@ package() {
    install -Dm644 src/electron/default_app/icon.png \
            "${pkgdir}/usr/share/pixmaps/${pkgname}.png"  # hicolor has no 1024x1024
  }

--- a/electron31/riscv64.patch
+++ b/electron31/riscv64.patch
@@ -24,9 +24,9 @@
 +        Debian-fix-rust-linking.patch
          makepkg-source-roller.py
          # BEGIN managed sources
-         chromium-mirror::git+https://github.com/chromium/chromium.git#tag=126.0.6478.36
+         chromium-mirror::git+https://github.com/chromium/chromium.git#tag=126.0.6478.234
 @@ -241,7 +243,7 @@ source=("git+https://github.com/electron/electron.git#tag=v$pkgver"
- sha256sums=('dd052fd7062f56783f99ec52e42223b340b1910114130235b1e2fe83ab411951'
+ sha256sums=('20a43f399b4755064efa5cfccaeccfe6074c6c0f505b328ba01e0191597a3d90'
              'daf0df74d2601c35fd66a746942d9ca3fc521ede92312f85af51d94c399fd6e0'
              '8f81059d79040ec598b5fb077808ec69d26d6c9cbebf9c4f4ea48b388a2596c5'
 -            'b3de01b7df227478687d7517f61a777450dca765756002c80c4915f271e2d961'
@@ -34,13 +34,13 @@
              '2654f5924e01c2b4cac1046d973b71614fb9d16fda659ddddd028d0b579174b4'
              'a4a822e135b253c93089a80c679842cc470c6936742767ae09d952646889abd6'
              'dd2d248831dd4944d385ebf008426e66efe61d6fdf66f8932c963a12167947b4'
-@@ -249,6 +251,7 @@ sha256sums=('dd052fd7062f56783f99ec52e42223b340b1910114130235b1e2fe83ab411951'
+@@ -249,6 +251,7 @@ sha256sums=('20a43f399b4755064efa5cfccaeccfe6074c6c0f505b328ba01e0191597a3d90'
              '4484200d90b76830b69eea3a471c103999a3ce86bb2c29e6c14c945bf4102bae'
              '55dbe71dbc1f3ab60bf1fa79f7aea7ef1fe76436b1d7df48728a1f8227d2134e'
              'ff588a8a4fd2f79eb8a4f11cf1aa151298ffb895be566c57cc355d47f161f53f'
 +            '98b0fbe1318897954cb8891cafed65e985613c69192e65984ba6785579b29f80'
              '2c8cd28cee0e1df1862e801794f210d2b7cac652f943cf94f43c2abe26f2a2f4'
-             'ff45dec4eb10be28cb411a0769c41f1536af7c6452ced295941512824b8f5951'
+             '917390cf253828e9a67abb2df83c8f8d9276b973c09b19baf2dc59111ba8ece9'
              '0b7a546ee6913c49519c10c293ac530ff381641a8a465fa2e184d6dbe0fb784d'
 @@ -457,12 +460,22 @@ prepare() {
    cp -r chromium-mirror_third_party_depot_tools depot_tools
@@ -74,7 +74,16 @@
    ## Upstream fixes
    patch -Np1 -i ../allow-ANGLEImplementation-kVulkan.patch
  
-@@ -607,6 +622,10 @@ build() {
+@@ -573,6 +588,8 @@ build() {
+     'enable_hangout_services_extension=true'
+     'enable_widevine=false'
+     'enable_nacl=false'
++    'is_clang=true'
++    "override_electron_version\"$pkgver\""
+   )
+ 
+   if [[ -n ${_system_libs[icu]+set} ]]; then
+@@ -607,6 +624,10 @@ build() {
    CFLAGS+='   -Wno-unknown-warning-option'
    CXXFLAGS+=' -Wno-unknown-warning-option'
  
@@ -85,7 +94,7 @@
    # Let Chromium set its own symbol level
    CFLAGS=${CFLAGS/-g }
    CXXFLAGS=${CXXFLAGS/-g }
-@@ -654,3 +673,5 @@ package() {
+@@ -654,3 +675,5 @@ package() {
    install -Dm644 src/electron/default_app/icon.png \
            "${pkgdir}/usr/share/pixmaps/${pkgname}.png"  # hicolor has no 1024x1024
  }

--- a/electron32/riscv64.patch
+++ b/electron32/riscv64.patch
@@ -24,9 +24,9 @@
 +        Debian-fix-rust-linking.patch
          makepkg-source-roller.py
          # BEGIN managed sources
-         chromium-mirror::git+https://github.com/chromium/chromium.git#tag=128.0.6613.36
+         chromium-mirror::git+https://github.com/chromium/chromium.git#tag=128.0.6613.162
 @@ -243,7 +245,7 @@ source=("git+https://github.com/electron/electron.git#tag=v$pkgver"
- sha256sums=('949031dea79ba4d5b90e447259836d50c735fb51f7b8d48aafafb37c2b78df64'
+ sha256sums=('9e4a3516e2a99c8e0fd512c78d4b9a3e7ab2178a5bcfe8d45f0710ab089380db'
              '3dfc43d901b96273201ba6d6d8b932b07c3661942d42a8bb0aae2c547757c73d'
              '1a5bc75a90abad153c8eb6dbdce138132a5f11190b0a40c925958a72d706b2aa'
 -            'b3de01b7df227478687d7517f61a777450dca765756002c80c4915f271e2d961'
@@ -34,13 +34,13 @@
              'd634d2ce1fc63da7ac41f432b1e84c59b7cceabf19d510848a7cff40c8025342'
              'a4a822e135b253c93089a80c679842cc470c6936742767ae09d952646889abd6'
              'dd2d248831dd4944d385ebf008426e66efe61d6fdf66f8932c963a12167947b4'
-@@ -251,6 +253,7 @@ sha256sums=('949031dea79ba4d5b90e447259836d50c735fb51f7b8d48aafafb37c2b78df64'
+@@ -251,6 +253,7 @@ sha256sums=('9e4a3516e2a99c8e0fd512c78d4b9a3e7ab2178a5bcfe8d45f0710ab089380db'
              '4484200d90b76830b69eea3a471c103999a3ce86bb2c29e6c14c945bf4102bae'
              '55dbe71dbc1f3ab60bf1fa79f7aea7ef1fe76436b1d7df48728a1f8227d2134e'
              'ff588a8a4fd2f79eb8a4f11cf1aa151298ffb895be566c57cc355d47f161f53f'
 +            '3eb5e621757be3f2984acb76d16cf3571bfe5bbbc71ad230b21aa983041ff5ea'
              '2c8cd28cee0e1df1862e801794f210d2b7cac652f943cf94f43c2abe26f2a2f4'
-             '46e54ec3c2e98a80d42af2b0319ed5c75ee2a038a9abb31c07ef8e450a6a4ad8'
+             '7ad936abf5f51382ff1cb5bfc6f7f9614733a0a200435c495779c89663e103d3'
              '0b7a546ee6913c49519c10c293ac530ff381641a8a465fa2e184d6dbe0fb784d'
 @@ -459,12 +462,22 @@ prepare() {
    cp -r chromium-mirror_third_party_depot_tools depot_tools
@@ -74,15 +74,16 @@
    ## Upstream fixes
    patch -Np1 -i ../allow-ANGLEImplementation-kVulkan.patch
  
-@@ -580,6 +595,7 @@ build() {
+@@ -580,6 +595,8 @@ build() {
      'enable_hangout_services_extension=true'
      'enable_widevine=false'
      'enable_nacl=false'
 +    'is_clang=true'
++    "override_electron_version\"$pkgver\""
    )
  
    if [[ -n ${_system_libs[icu]+set} ]]; then
-@@ -615,6 +631,10 @@ build() {
+@@ -615,6 +632,10 @@ build() {
    CFLAGS+='   -Wno-unknown-warning-option'
    CXXFLAGS+=' -Wno-unknown-warning-option'
  
@@ -93,7 +94,7 @@
    # Let Chromium set its own symbol level
    CFLAGS=${CFLAGS/-g }
    CXXFLAGS=${CXXFLAGS/-g }
-@@ -662,3 +682,5 @@ package() {
+@@ -662,3 +683,5 @@ package() {
    install -Dm644 src/electron/default_app/icon.png \
            "${pkgdir}/usr/share/pixmaps/${pkgname}.png"  # hicolor has no 1024x1024
  }


### PR DESCRIPTION
- Sync 'is_clang=true' to old electrons, to work around (possibly a regression in gnu ld) relocation truncated to fit.
- Force override electron version with pkgver to fix https://github.com/riscv-forks/electron-riscv-releases/issues/4
  - This is because electron determines its version by finding the nearest git tag. But in riscv fork, the upstream tags are not synced back.