### PR TITLE
updpatch: linux-tools 6.10-2

### DIFF
--- a/linux-tools/riscv64.patch
+++ b/linux-tools/riscv64.patch
@@ -1,18 +1,20 @@
-diff --git PKGBUILD PKGBUILD
-index 2389983d..28d092e7 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -11,9 +11,7 @@ pkgname=(
+@@ -5,13 +5,10 @@ pkgname=(
+   'bootconfig'
+   'bpf'
+   'cpupower'
+-  'hyperv'
+   'linux-tools-meta'
    'perf'
- #  'python-perf'
    'tmon'
 -  'turbostat'
    'usbip'
 -  'x86_energy_perf_policy'
  )
- pkgver=6.0
+ pkgver=6.10
  pkgrel=2
-@@ -97,11 +95,6 @@ build() {
+@@ -100,11 +97,6 @@ build() {
    make VERSION=$pkgver-$pkgrel
    popd
  
@@ -24,7 +26,7 @@ index 2389983d..28d092e7 100644
    echo ':: usbip'
    pushd linux/tools/usb/usbip
    # Fix gcc compilation
-@@ -121,11 +114,6 @@ build() {
+@@ -119,16 +111,6 @@ build() {
    make
    popd
  
@@ -33,12 +35,20 @@ index 2389983d..28d092e7 100644
 -  make
 -  popd
 -
-   echo ':: hv'
-   pushd linux/tools/hv
-   CFLAGS+=' -DKVP_SCRIPTS_PATH=\"/usr/lib/hyperv/kvp_scripts/\"' make
-@@ -158,9 +146,7 @@ package_linux-tools-meta() {
+-  echo ':: hv'
+-  pushd linux/tools/hv
+-  CFLAGS+=' -DKVP_SCRIPTS_PATH=\"/usr/lib/hypervkvpd/\"' make
+-  popd
+-
+   echo ':: bpf'
+   pushd linux/tools/bpf
+   # doesn't compile when we don't first compile bpftool in its own directory and
+@@ -151,12 +133,9 @@ package_linux-tools-meta() {
+     'bootconfig'
+     'bpf'
+     'cpupower'
+-    'hyperv'
      'perf'
- #    'python-perf'
      'tmon'
 -    'turbostat'
      'usbip'


### PR DESCRIPTION
Disable hyperv package as it is not relevant until windows supports riscv64.
It FTBFS BTW: https://archriscv.felixc.at/.status/log.htm?url=logs/linux-tools/linux-tools-6.10-2.log