### PR TITLE
addpatch: termusic 0.9.1-1

### DIFF
--- a/termusic/riscv64.patch
+++ b/termusic/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index d14c363..eb65758 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -8,7 +8,7 @@
+ arch=('x86_64')
+ url="https://github.com/tramhao/termusic"
+ license=('MIT' 'GPL3')
+-depends=('gstreamer' 'gst-plugins-base' 'gst-plugins-good' 'gst-plugins-bad' 'gst-plugins-ugly' 'gst-libav' 'dbus' 'ueberzug' 'protobuf')
++depends=('gstreamer' 'gst-plugins-base' 'gst-plugins-good' 'gst-plugins-bad' 'gst-plugins-ugly' 'gst-libav' 'dbus' 'ueberzug' 'protobuf' 'libsixel')
+ optdepends=('yt-dlp: download mp3'
+   'ffmpeg: download mp3'
+   'emoji-font: for displaying emojis')


### PR DESCRIPTION
Without a prebuilt sixel cargo package on riscv, building needs a libsixel.