### PR TITLE
addpatch: colorhug-client 0.2.8

### DIFF
--- a/colorhug-client/riscv64.patch
+++ b/colorhug-client/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,6 +15,8 @@ sha256sums=('b7787aa58db2dde6a69a13295b98154040a100d8772aac656f3b5ed0bffc0991')
+ 
+ build() {
+   cd ${pkgname}-${pkgver}
++  cp /usr/share/autoconf/build-aux/config.guess .
++  cp /usr/share/autoconf/build-aux/config.sub .
+   ./configure --prefix=/usr --libexecdir=/usr/lib
+   make
+ }


### PR DESCRIPTION
The [upstream](https://github.com/hughski/colorhug-client) is archived, can not create issue on it.