### PR TITLE
addpatch: colorhug-client 0.2.8-4

### DIFF
--- a/colorhug-client/riscv64.patch
+++ b/colorhug-client/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -13,6 +13,12 @@ makedepends=(intltool itstool gobject-introspection libgusb gtk3
+ source=(https://people.freedesktop.org/~hughsient/releases/${pkgname}-${pkgver}.tar.xz)
+ sha256sums=('b7787aa58db2dde6a69a13295b98154040a100d8772aac656f3b5ed0bffc0991')
+ 
++prepare() {
++  cd ${pkgname}-${pkgver}
++  cp /usr/share/autoconf/build-aux/config.guess config.guess
++  cp /usr/share/autoconf/build-aux/config.sub config.sub
++}
++
+ build() {
+   cd ${pkgname}-${pkgver}
+   ./configure --prefix=/usr --libexecdir=/usr/lib


### PR DESCRIPTION
The upstream repo was archived in 2020. https://github.com/hughski/colorhug-client