### PR TITLE
addpatch: freealut 1.1.0-9

### DIFF
--- a/freealut/riscv64.patch
+++ b/freealut/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,6 +12,11 @@ depends=(openal)
+ source=(https://pkgs.fedoraproject.org/repo/pkgs/freealut/freealut-1.1.0.tar.gz/e089b28a0267faabdb6c079ee173664a/freealut-1.1.0.tar.gz)
+ sha512sums=('270f74972548b4ac6b98c52c51787ed43c20cf79979063d073bbee7bd08ac4f34c2b579fbf15c09c4e606a5ed38dcd0252f5c46fb3cfe43b727b6b53cf747933')
+ 
++prepare() {
++  cd $pkgname-$pkgver
++  autoreconf -fi
++}
++
+ build() {
+   cd $pkgname-$pkgver
+   ./configure --prefix=/usr --disable-static


### PR DESCRIPTION
We can patch this before https://gitlab.archlinux.org/archlinux/packaging/packages/freealut/-/issues/1 .