### PR TITLE
addpatch: hddtemp 0.3.beta15.53-4

### DIFF
--- a/hddtemp/riscv64.patch
+++ b/hddtemp/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -26,6 +26,7 @@ sha256sums=('618541584054093d53be8a2d9e81c97174f30f00af91cb8700a97e442d79ef5b'
+ prepare() {
+ 	cd "$_archive"
+ 	patch -p1 -i "../${pkgname}_$_patchver.diff"
++        autoreconf -fi
+ }
+ 
+ build() {


### PR DESCRIPTION
The upstream issue existed https://savannah.nongnu.org/bugs/index.php?65483 .