### PR TITLE
addpatch: libtiff4 3.9.7-6

### DIFF
--- a/libtiff4/riscv64.patch
+++ b/libtiff4/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -30,6 +30,8 @@ prepare() {
+   patch -Np1 -i ../libtiff4-soname.patch
+ 
+   ./autogen.sh
++
++  autoreconf -fi
+ }
+ 
+ build() {


### PR DESCRIPTION
No reported to upstream, it was replaced by `libtiff`.