### PR TITLE
addpatch: lxappearance-obconf 0.2.3-4

### DIFF
--- a/lxappearance-obconf/riscv64.patch
+++ b/lxappearance-obconf/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,6 +14,11 @@ makedepends=('intltool')
+ source=(https://downloads.sourceforge.net/lxde/$pkgname-$pkgver.tar.xz)
+ sha256sums=('3150b33b4b7beb71c1803aee2be21c94767d73b70dfc8d2bcaafe2650ea83149')
+ 
++prepare() {
++  cd $pkgname-$pkgver
++  autoreconf -fi
++}
++
+ build() {
+   cd $pkgname-$pkgver
+   ./configure --prefix=/usr


### PR DESCRIPTION
Old config.guess not reported due to outdated archlinux-packaging version.