### PR TITLE
updpatch: nodejs 22.9.0-1

### DIFF
--- a/nodejs/riscv64.patch
+++ b/nodejs/riscv64.patch
@@ -1,22 +1,24 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -40,6 +40,11 @@ validpgpkeys=(
-   '890C08DB8579162FEE0DF9DB8BEAB4DFCF555EF4' # RafaelGSS <rafael.nunu@hotmail.com>
+@@ -41,6 +41,12 @@ validpgpkeys=(
+   'C82FA3AE1CBEDC6BE46B9360C43CEC45C17AB93C' # Richard Lau <rlau@redhat.com>
  )
  
 +prepare() {
 +  cd node
 +  patch -Np1 -i ../fix-trap-handler.patch
++  patch -Np1 -i ../v8-disable-trap-handler.patch
 +}
 +
  build() {
    cd node
  
-@@ -76,4 +81,7 @@ package() {
+@@ -77,4 +83,8 @@ package() {
    install -Dm644 LICENSE -t "$pkgdir"/usr/share/licenses/nodejs/
  }
  
-+source+=("fix-trap-handler.patch")
-+sha512sums+=('f2ff6da8cf5dcc994a7a20342e2928dc1821fbbf42891009a6234b6051277e0200d7e3fbba63b9a2773887591d0ad5ceb1bb3d25e5efeb557f6d00109a80253c')
-+
++source+=("fix-trap-handler.patch"
++         "v8-disable-trap-handler.patch")
++sha512sums+=('f2ff6da8cf5dcc994a7a20342e2928dc1821fbbf42891009a6234b6051277e0200d7e3fbba63b9a2773887591d0ad5ceb1bb3d25e5efeb557f6d00109a80253c'
++             'b6495aefd36915969ee848cca350a565317c74864cd33e6a69a310ed9cbc71dfbd91f31e8c6176667f6f72daa1762eb4d519700a024cdbe8b18049100a9e3c80')
  # vim:set ts=2 sw=2 et:

--- a/nodejs/v8-disable-trap-handler.patch
+++ b/nodejs/v8-disable-trap-handler.patch
@@ -1,0 +1,13 @@
+diff --git a/deps/v8/src/trap-handler/trap-handler.h b/deps/v8/src/trap-handler/trap-handler.h
+index 4bf95b8c22..2612c00a07 100644
+--- a/deps/v8/src/trap-handler/trap-handler.h
++++ b/deps/v8/src/trap-handler/trap-handler.h
+@@ -46,7 +46,7 @@ namespace trap_handler {
+ #define V8_TRAP_HANDLER_SUPPORTED true
+ // RISCV64 (non-simulator) on Linux.
+ #elif V8_TARGET_ARCH_RISCV64 && V8_HOST_ARCH_RISCV64 && V8_OS_LINUX
+-#define V8_TRAP_HANDLER_SUPPORTED true
++#define V8_TRAP_HANDLER_SUPPORTED false
+ // RISCV64 simulator on x64 on Linux
+ #elif V8_TARGET_ARCH_RISCV64 && V8_HOST_ARCH_X64 && V8_OS_LINUX
+ #define V8_TRAP_HANDLER_VIA_SIMULATOR


### PR DESCRIPTION
Disable v8's trap handler[^1] to workaround ENOMEM on sv39 systems[^2].

v8's OOB trap handler for wasm tries to allocate a 10 GB guard region[^3], but unfortunately on sv39 systems we only have 256GB virtual memory for userspace, which is usually already exhausted by the node process and leads to `WebAssembly.Instance(): Out of memory: Cannot allocate Wasm memory for new instance` errors

There is a second bug in [^2], which needs to be investigated separately and disabling trap handler won't fix it.

[^1]: https://chromium-review.googlesource.com/c/v8/v8/+/5227604
[^2]: https://github.com/riscv-forks/electron/issues/3#issuecomment-2391689815
[^3]: https://github.com/nodejs/node/blob/09a8440b45f69651ff52110cb1bc2dde9e14e2e8/deps/v8/src/objects/backing-store.cc#L38
