### PR TITLE
addpatch: maxima 5.47.0-14

### DIFF
--- a/maxima/riscv64.patch
+++ b/maxima/riscv64.patch
@@ -1,0 +1,37 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -3,7 +3,7 @@
+ # Contributor: Damir Perisa <damir@archlinux.org>
+ 
+ pkgbase=maxima
+-pkgname=($pkgbase{,-sbcl,-ecl,-fas})
++pkgname=($pkgbase{,-ecl,-fas})
+ pkgver=5.47.0
+ _sbclver=2.4.7
+ _eclver=23.9.9
+@@ -13,7 +13,7 @@ arch=(x86_64)
+ license=(GPL)
+ url='http://maxima.sourceforge.net'
+ depends=(texinfo shared-mime-info)
+-makedepends=(python emacs ecl sbcl)
++makedepends=(python emacs ecl)
+ # needs rebuild when bash changes version
+ # needs a rebuild when ecl or sbcl changes version
+ options=(!zipman) # don't zip info pages or they won't work inside maxima
+@@ -35,14 +35,14 @@ prepare() {
+ 
+ build() {
+   cd $pkgbase-$pkgver
++  autoreconf -fiv
+   ./configure \
+     --prefix=/usr \
+     --mandir=/usr/share/man \
+     --infodir=/usr/share/info \
+     --libexecdir=/usr/lib \
+-    --enable-sbcl \
+     --enable-ecl \
+-    --with-default-lisp=sbcl
++    --with-default-lisp=ecl
+ 
+   # help avoid (re)running makeinfo/tex
+   touch doc/info/maxima.info


### PR DESCRIPTION
Fix outdated config.{guess,sub}, reported here: https://sourceforge.net/p/maxima/bugs/4382/

Disable sbcl backend. There are problems when building with sbcl backend enabled, like:
- Interactive questions
- A REPL pops up several times

I suspect this is sbcl bug on riscv64.

![image](https://github.com/user-attachments/assets/c1c82f55-c2d1-4073-81a5-746a5aa1b4a8)
