### PR TITLE
addpatch: zed 0.155.2-3

### DIFF
--- a/zed/riscv64.patch
+++ b/zed/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -48,6 +48,8 @@ _appid=dev.zed.Zed
+ 
+ prepare() {
+ 	cd "$_archive"
++	echo -e "[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
++	cargo update -p ring@0.16.20
+ 	cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+ 	export DO_STARTUP_NOTIFY="true"
+ 	export APP_ICON="zed"


### PR DESCRIPTION
Use forked ring 0.16 since the dependencies are complicated and hard to upgrade to ring 0.17.