### PR TITLE
fixpatch: projectm 3.1.12

### DIFF
--- a/projectm/riscv64.patch
+++ b/projectm/riscv64.patch
@@ -1,13 +1,10 @@
-diff --git a/trunk/PKGBUILD b/trunk/PKGBUILD
-index 7bbee18..fc53a9d 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -18,6 +18,8 @@ sha256sums=('b6b99dde5c8f0822ae362606a0429628ee478f4ec943a156723841b742954707')
-
+@@ -18,6 +18,7 @@ sha256sums=('b6b99dde5c8f0822ae362606a0429628ee478f4ec943a156723841b742954707')
+ 
  build() {
      cd "projectM-$pkgver"
-+    autoreconf -fi
-+    autoupdate -f
++    cp /usr/share/autoconf/build-aux/config.{sub,guess} .
      ./configure --prefix=/usr --enable-gles --enable-sdl --enable-threading --enable-qt
      sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool # Fix overlinking
      make


### PR DESCRIPTION
This PR should fix `dpf-plugins` building fault: https://archriscv.felixc.at/.status/log.htm?url=logs/dpf-plugins/dpf-plugins-1.7-2.log , although `projectm` itself can be built successfully with current riscv64 patch.

The current patch uses `autoreconf` to update the outdated `config.{guess,sub}` , while also updating `libtool` at the same time, which breaking the behavior of  `sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool` in the original PKGBUILD, which causes projectm to be overlinked, more specifically linking `libprojectm.so` to `libqt5gui.so` and `libqt5opengl.so`, meanwhile `projectm`'s depends not containing `qt5-base`.

Although, the `dpf-plugins` doesn't depend on `qt5-base` but `projectm`, then, boom.

We believe in that just update the `config.{guess,sub}` is enough to build it.