### PR TITLE
addpatch: cl-ppcre 2.1.2-1

### DIFF
--- a/bitwarden/cl-ppcre/riscv64.patch
+++ b/bitwarden/cl-ppcre/riscv64.patch
@@ -1,0 +1,24 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -7,7 +7,7 @@ pkgdesc='Perl-compatible portable regexp library for Common Lisp'
+ arch=('any')
+ url='https://edicl.github.io/cl-ppcre/'
+ license=('BSD-2-Clause')
+-depends=('common-lisp' 'cl-asdf' 'cl-unicode')
++depends=('common-lisp' 'cl-asdf')
+ makedepends=('git')
+ checkdepends=('sbcl' 'cl-flexi-streams' 'perl')
+ source=(
+@@ -19,12 +19,6 @@ sha512sums=('ba61c40d9d4052247f22241140f003e4dc23127800301514db03b686473b9a45045
+ b2sums=('991780ec87219c1884eb80f64923065fcb6f3849b9a4b73c89a285d65bbe1bdd6338131816d57f150958741c2c1002801b3bfbecb89862b961c053235cbf5ff5'
+         'cd4fc113c2f1b1e3180010a79621d84b44d79dd47f10aaef9615b56b41f94625584a034059164546456b472adcac19ca0c2db98c889c159ac3c323fc5163d469')
+ 
+-check() {
+-  cd "$pkgname"
+-
+-  sbcl --script ../run-tests.lisp
+-}
+-
+ package() {
+   cd "$pkgname"
+ 


### PR DESCRIPTION
Bootstrap cl-ppcre by building without cl-unicode. Tests are disabled because run-tests.lisp requires cl-unicode.