### PR TITLE
addpatch: stalwart-mail-server 0.9.2-1

### DIFF
--- a/stalwart-mail-server/riscv64.patch
+++ b/stalwart-mail-server/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -41,6 +41,8 @@ b2sums=('dbfce58ad418b0cae3ce063ca50286c3c9897a13dc868eb30a8b16c340748a8de576066
+ prepare() {
+   cd $_name-$pkgver
+   export RUSTUP_TOOLCHAIN=stable
++  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
++  cargo update -p ring@0.16.20
+   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+ }
+ 


### PR DESCRIPTION
Fix ring 0.16.20.

Two dependencies pull in ring 0.16.20, which has updated ring to 0.17 but no release is made yet:

- https://github.com/hickory-dns/hickory-dns/blob/main/Cargo.lock#L1663-L1668
- https://github.com/inejge/ldap3/blob/master/Cargo.toml#L33