### PR TITLE
addpatch: librustls 0.14.0-1

### DIFF
--- a/librustls/riscv64.patch
+++ b/librustls/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,6 +15,8 @@ makedepends=(
+   cargo-c
+   nasm
+   rust
++  cmake
++  clang
+ )
+ provides=('librustls.so')
+ options=(!lto)


### PR DESCRIPTION
Pregenerated bindings for aws-lc-sys are not available for riscv64. Add make dependencies for binding generation.