### PR TITLE
addpatch: uv 0.4.25-1

### DIFF
--- a/uv/riscv64.patch
+++ b/uv/riscv64.patch
@@ -1,0 +1,18 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -27,6 +27,7 @@
+ 
+ prepare() {
+   cd "$pkgbase"
++  patch -Np0 -i ../uv-platform-arch-riscv64.patch
+   local tripple="$(rustc -vV | sed -n 's/host: //p')"
+   cargo fetch --locked --target "$tripple"
+   mkdir completions
+@@ -82,4 +83,7 @@ package_python-uv() {
+   rm -rf "$pkgdir/usr/bin"
+ }
+ 
++source+=(uv-platform-arch-riscv64.patch)
++sha256sums+=('070e691ba1812c05bf8490bb344368693caf000205ff23dc36ad609e51b7d03a')
++
+ # vim: ts=2 sw=2 et:

--- a/uv/uv-platform-arch-riscv64.patch
+++ b/uv/uv-platform-arch-riscv64.patch
@@ -1,0 +1,38 @@
+--- crates/uv-platform-tags/src/platform.rs
++++ crates/uv-platform-tags/src/platform.rs
+@@ -86,6 +86,7 @@ pub enum Arch {
+     #[serde(alias = "amd64")]
+     X86_64,
+     S390X,
++    Riscv64,
+ }
+ 
+ impl fmt::Display for Arch {
+@@ -99,6 +100,7 @@ impl fmt::Display for Arch {
+             Self::X86 => write!(f, "i686"),
+             Self::X86_64 => write!(f, "x86_64"),
+             Self::S390X => write!(f, "s390x"),
++            Self::Riscv64 => write!(f, "riscv64"),
+         }
+     }
+ }
+@@ -116,6 +118,7 @@ impl Arch {
+             Self::X86 | Self::X86_64 => Some(5),
+             // unsupported
+             Self::Armv6L => None,
++            Self::Riscv64 => None,
+         }
+     }
+ }
+--- crates/uv-python/src/platform.rs
++++ crates/uv-python/src/platform.rs
+@@ -165,6 +165,9 @@ impl From<&uv_platform_tags::Arch> for Arch {
+                 target_lexicon::X86_32Architecture::I686,
+             )),
+             uv_platform_tags::Arch::X86_64 => Self(target_lexicon::Architecture::X86_64),
++            uv_platform_tags::Arch::Riscv64 => Self(target_lexicon::Architecture::Riscv64(
++                target_lexicon::Riscv64Architecture::Riscv64,
++            )),
+         }
+     }
+ }


### PR DESCRIPTION
Before:
```bash
> uv python list
> uv pip list
error: No virtual environment or system Python installation found; run `uv venv` to create an environment
```

After:
```bash
> uv python list
cpython-3.12.7-linux-riscv64-gnu    /usr/bin/python3.12
cpython-3.12.7-linux-riscv64-gnu    /usr/bin/python3 -> python3.12
cpython-3.12.7-linux-riscv64-gnu    /usr/bin/python -> python3
```
----
- May fix [check failure of `python-build`](https://archriscv.felixc.at/.status/log.htm?url=logs/python-build/python-build-1.2.2-1.log)
```
==> Starting check()...
...
process = <Popen: returncode: 2 args: ['/usr/bin/uv', 'pip', 'install', 'test-flit @ f...>
stdout = b'', stderr = b'error: No virtual environment found\n', retcode = 2
```