### PR TITLE
blacklist: Blacklist NDIS Wrapper

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -35,6 +35,8 @@ intel-ucode
 intel-undervolt
 libmfx
 libva-intel-driver
+ndiswrapper
+ndiswrapper-dkms
 throttled
 tp_smapi
 tp_smapi-lts


### PR DESCRIPTION
NDISwrapper is a Windows network driver wrapper.

It doesn't support anything beyond XP, and XP drivers are x86 which riscv64 can't use.