### PR TITLE
sg2042-blacklist: add gnutls and fix filename

### DIFF
--- a/sg2042-blacklist.txt
+++ b/sg2042-blacklist.txt
@@ -8,6 +8,7 @@ electron30
 electron31
 electron32
 electron33
+gnutls
 qt5-webengine
 qt6-webengine
 typescript


### PR DESCRIPTION
gnutls' test-pthread-rwlock time outs on sg2042. Not sure if increasing timeout here is feasible since it's exponentially slower as more cores are used.

![image](https://github.com/user-attachments/assets/dde06e77-064f-4495-8860-7f260d30d855)
