### PR TITLE
updpatch: onnxruntime 1.19.2-2

### DIFF
--- a/onnxruntime/riscv64.patch
+++ b/onnxruntime/riscv64.patch
@@ -1,5 +1,5 @@
 diff --git PKGBUILD PKGBUILD
-index 9329cdd..6a0deed 100644
+index 000f5fc..a7f8c50 100644
 --- PKGBUILD
 +++ PKGBUILD
 @@ -3,23 +3,21 @@
@@ -11,9 +11,9 @@ index 9329cdd..6a0deed 100644
 -         "python-${pkgbase}-rocm" "python-${pkgbase}-opt-rocm")
 +pkgname=("${pkgbase}" "${pkgbase}-opt"
 +         "python-${pkgbase}" "python-${pkgbase}-opt")
- pkgver=1.18.0
+ pkgver=1.19.2
  _pkgdesc='Cross-platform, high performance scoring engine for ML models'
- pkgrel=3
+ pkgrel=2
  arch=('x86_64')
  url='https://github.com/microsoft/onnxruntime'
  license=('MIT')
@@ -23,14 +23,23 @@ index 9329cdd..6a0deed 100644
  _pydepends=('python-onnx' 'python-numpy' 'python-coloredlogs' 'python-psutil'
              'python-py-cpuinfo' 'python-sympy' 'python-scipy' 'python-pillow'
              'python-flatbuffers' 'python-protobuf' 'python-packaging')
- makedepends=('git' 'cmake' 'ninja' 'pybind11' 'nlohmann-json' 'chrono-date' 'eigen' 'cxxopts' 'openmpi'
+ makedepends=('git' 'cmake' 'ninja' 'pybind11' 'nlohmann-json' 'chrono-date' 'cxxopts' 'openmpi'
 -             'python-setuptools' 'python-installer' 'python-wheel' 'python-build' 'gcc13'
 -             'cuda' 'cudnn' 'nccl' 'rocm-hip-sdk' 'hipify-clang' 'rocm-smi-lib' 'roctracer')
 +             'python-setuptools' 'python-installer' 'python-wheel' 'python-build' 'gcc13')
  makedepends+=("${_pydepends[@]}")
  #TODO: Add migraphx for ROCm and tensorrt for CUDA.
  optdepends=('openmpi: Distributed memory parallelization')
-@@ -148,28 +146,30 @@ build() {
+@@ -106,7 +104,7 @@ build() {
+     -DBUILD_TESTING=OFF
+     -Donnxruntime_ENABLE_TRAINING=ON
+     -Donnxruntime_ENABLE_LAZY_TENSOR=OFF
+-    -Donnxruntime_USE_MPI=ON
++    -Donnxruntime_USE_MPI=OFF
+     -Donnxruntime_USE_DNNL=ON
+     # Stable release of eigen is too old for onnxruntime.
+     -Donnxruntime_USE_PREINSTALLED_EIGEN=OFF
+@@ -145,28 +143,30 @@ build() {
    export CXX="$NVCC_CCBIN"
    export CC="${NVCC_CCBIN/g++/gcc}"
  
@@ -67,7 +76,7 @@ index 9329cdd..6a0deed 100644
    echo "Build onnxruntime with ROCm without optimization"
    cd "${srcdir}/${pkgbase}-rocm"
    cmake "${_cmake_rocm_args[@]}"
-@@ -195,9 +195,6 @@ build() {
+@@ -192,9 +192,6 @@ build() {
  
  package_onnxruntime() {
    pkgdesc="$_pkgdesc"
@@ -77,7 +86,7 @@ index 9329cdd..6a0deed 100644
  
    cd "${pkgbase}-cuda"
    DESTDIR="${pkgdir}" cmake --install build
-@@ -206,10 +203,7 @@ package_onnxruntime() {
+@@ -203,10 +200,7 @@ package_onnxruntime() {
  }
  
  package_onnxruntime-opt() {
@@ -89,7 +98,7 @@ index 9329cdd..6a0deed 100644
    provides=("${pkgbase}=${pkgver}")
    conflicts=("${pkgbase}")
  
-@@ -247,9 +241,6 @@ package_onnxruntime-opt-rocm() {
+@@ -244,9 +238,6 @@ package_onnxruntime-opt-rocm() {
  package_python-onnxruntime() {
    pkgdesc="$_pkgdesc"
    depends+=("${pkgbase}" "${_pydepends[@]}")
@@ -99,7 +108,7 @@ index 9329cdd..6a0deed 100644
  
    cd "${pkgbase}-cuda/build"
    python -m installer --destdir="${pkgdir}" dist/*.whl
-@@ -258,13 +249,10 @@ package_python-onnxruntime() {
+@@ -255,13 +246,10 @@ package_python-onnxruntime() {
  }
  
  package_python-onnxruntime-opt() {


### PR DESCRIPTION
onnxruntime_USE_MPI was guarded with onnxruntime_USE_NCCL before, which is no longer the case now. The MPI path depends on AVX instrinsics for fp16, so we have to disable it for now.