### PR TITLE
updpatch: java-rxtx 2.2pre2-10

### DIFF
--- a/java-rxtx/riscv64.patch
+++ b/java-rxtx/riscv64.patch
@@ -1,36 +1,6 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -22,7 +22,8 @@ source=(http://rxtx.qbang.org/pub/$_pkgname/$_pkgname-$pkgver.zip
-         ttyACM_port.patch
-         java10.patch
-         java11.patch
--        rxtx-2.2-undefined_symbol.patch)
-+        rxtx-2.2-undefined_symbol.patch
-+        fix-riscv64-build.patch)
- md5sums=('7eedb18e3f33a427e2b0e9be8ce3f94c'
-          '2f21ec5eb108f871815242698b6150f1'
-          '1f7c43d582bfe9daea22d7f7057436da'
-@@ -31,7 +32,8 @@ md5sums=('7eedb18e3f33a427e2b0e9be8ce3f94c'
-          '903a3fe0067d0682dd5f64483c741df6'
-          '683dd95e6e419b2b63851c08ede7ca86'
-          '1db5c64e239c80294d00c932237889dd'
--         '4695fe9bb28a7c9b21447f998fb46b02')
-+         '4695fe9bb28a7c9b21447f998fb46b02'
-+         'a99178f7f50e2cfdb99d2eb3ed167421')
- sha256sums=('3c30373e760f444def3650c76c5a00ae12fb1d860ec008750d084f4880495b03'
-             '307ddf4bdcd5ba8d71a10d54253d9b6c3b531f5c6e2619b6895701d2cb81325a'
-             '93d76b9747e3cf9a7d2e8767a4e3e977afa0ff83277e17d85727a423f68faa18'
-@@ -40,7 +42,8 @@ sha256sums=('3c30373e760f444def3650c76c5a00ae12fb1d860ec008750d084f4880495b03'
-             'f67db773131805d5344972e32f79cc9272b4dde6a44733ba4edb298107d36c55'
-             '21108e0dd258b4b7d4d0abf22207a3bf34e9df8d78bd9909d1810df00ea5a359'
-             '3d9729cbdb2de9e41869bb355b2e6d6f7b4f32386219ef1a8694c72dc856cbf0'
--            'bb289c83b66cc314a3b3c9ddc20c342577d76accdd49d2e2b24921a02689725d')
-+            'bb289c83b66cc314a3b3c9ddc20c342577d76accdd49d2e2b24921a02689725d'
-+            'b111b2b7395d74d5560839d73c67843f5422c44cf9c50fa3d35d4345e18c612b')
- 
- prepare() {
-   cd $_pkgname-$pkgver
-@@ -69,6 +72,9 @@ prepare() {
+@@ -69,12 +69,16 @@ prepare() {
    # Fix format-security errors
    patch -p1 -i ../rxtx-2.2-format-security.patch
  
@@ -40,3 +10,18 @@
    rm *.m4
    autoreconf -fi
  }
+ 
+ build() {
+   cd $_pkgname-$pkgver
++  export CFLAGS="$CFLAGS -Wno-error=implicit-function-declaration"
+   ./configure --prefix=/usr --sysconfdir=/etc --localstatedir=/var
+   make -j1
+ }
+@@ -88,3 +92,7 @@ package() {
+   install -dm755 "$pkgdir"/usr/lib/tmpfiles.d
+   echo 'd /run/lock/lockdev 0775 root lock -' > "$pkgdir/usr/lib/tmpfiles.d/$pkgname.conf"
+ }
++
++source+=(fix-riscv64-build.patch)
++md5sums+=('a99178f7f50e2cfdb99d2eb3ed167421')
++sha256sums+=('b111b2b7395d74d5560839d73c67843f5422c44cf9c50fa3d35d4345e18c612b')


### PR DESCRIPTION
Even though fix-riscv64-build.patch is applied and sys/io.h is not included, src/RawImp.c still calls its functions but left unused. So we simply allow implicit function declaration to let linker ignore it.