### PR TITLE
updpatch: libfabric 1.22.0-2

### DIFF
--- a/libfabric/riscv64.patch
+++ b/libfabric/riscv64.patch
@@ -1,17 +1,15 @@
-diff --git PKGBUILD PKGBUILD
-index 5d5df56..54ba691 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -9,11 +9,14 @@
- license=(GPL2)
- depends=(glibc gcc-libs numactl)
+@@ -10,11 +10,14 @@ url="https://ofiwg.github.io/libfabric/"
+ license=('BSD-2-Clause OR GPL-2.0-or-later')
+ depends=(glibc numactl)
  options=(!lto)
 -source=(https://github.com/ofiwg/libfabric/releases/download/v${pkgver}/libfabric-${pkgver}.tar.bz2)
 -sha512sums=('02fe0713ab96288addef8777b0912f3db200720b42bb6976c8c6796c08de8e1a54bfb7b44d98c334c5184e24ffcf35eab40323e43a605d699630e5eee53548f8')
 +source=(https://github.com/ofiwg/libfabric/releases/download/v${pkgver}/libfabric-${pkgver}.tar.bz2
 +        riscv-page_size.patch::https://github.com/ofiwg/libfabric/pull/10308.diff)
 +sha512sums=('02fe0713ab96288addef8777b0912f3db200720b42bb6976c8c6796c08de8e1a54bfb7b44d98c334c5184e24ffcf35eab40323e43a605d699630e5eee53548f8'
-+            '0bc881eb43be167db8afa3604375ea8f7def9c018de383afcf3be7e9b3eb07bae67c101d526e96ca38925bcbdb321db8922d629e7847485829f34f241e8b479a')
++            'fd5bac99c0125ea048019a1191ed7fad033b026ea34d008b6042f005d655f8a89d2e4b71b359eebf9e40ab9c9a2f15442a927fa966ae3ae5c1a62d42392c052f')
  
  prepare() {
    cd ${pkgname}-${pkgver}


### PR DESCRIPTION
Upstream PR's .diff checksum changes. Since next version (2.0.0, currently in beta) will include the PR, we fix the checksum (hopefully) one last time.