### PR TITLE
updpatch: eslint 9.15.0-1

### DIFF
--- a/eslint/riscv64.patch
+++ b/eslint/riscv64.patch
@@ -1,14 +1,6 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -16,6 +16,7 @@ makedepends=(
-   git
-   jq
-   npm
-+  python
- )
- options=('!emptydirs')
- source=("git+https://github.com/$pkgname/$pkgname.git#tag=v$pkgver")
-@@ -28,7 +29,7 @@ prepare() {
+@@ -29,7 +29,7 @@ prepare() {
  
  check() {
    cd $pkgname


### PR DESCRIPTION
Python is not needed now.