### PR TITLE
addpatch: azcopy 10.27.1-1

### DIFF
--- a/azcopy/riscv64.patch
+++ b/azcopy/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -20,6 +20,8 @@ sha256sums=('3ed3ef0ded8ebcc3f46dc77e24fe4c39141b1b278492289cec8cf2ddcc1a3dc0')
+ 
+ prepare() {
+   cd $_pkgname-$pkgver
++  go mod edit -replace github.com/wastore/keyctl=github.com/hack3ric/go-keyctl@2e7db08a
++  go mod tidy
+   GOFLAGS="-mod=readonly" go mod vendor -v
+ }
+ 


### PR DESCRIPTION
Fork https://github.com/wastore/keyctl to add riscv64 support.