### PR TITLE
updpatch: oha 1.4.7-1

### DIFF
--- a/oha/riscv64.patch
+++ b/oha/riscv64.patch
@@ -1,12 +1,9 @@
-diff --git PKGBUILD PKGBUILD
-index cabc846..e48ced8 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -14,7 +14,7 @@ sha512sums=('9d2b8306c5663daca2c3b55a2c0e313bb72a42044ef5ef56ab91dac44027e12b380
-
- build() {
-   cd "$srcdir/$pkgname-$pkgver"
--
-+  printf '\n[profile.release]\nopt-level = 1' >> Cargo.toml
-   cargo build --release --locked
+@@ -31,4 +31,6 @@ package() {
+   install -Dm644 LICENSE "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
  }
+ 
++makedepends+=('cmake' 'clang')
++
+ # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
Add cmake and clang for aws-lc-sys crate to build from source.