### PR TITLE
qemu-user-blacklist: add dtk6core

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -21,6 +21,7 @@ diffutils
 digikam
 dovecot
 dqlite
+dtk6core
 element
 elfutils
 ell


### PR DESCRIPTION
Test segfaults under qemu-user:

```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==43==ERROR: AddressSanitizer: SEGV on unknown address 0x0feec1210150 (pc 0x7f0b5d68794c bp 0x7f0b5e600a90 sp 0x7f0b5e600230 T-1)
==43==The signal is caused by a READ memory access.
AddressSanitizer: CHECK failed: asan_suppressions.cpp:47 "((suppression_ctx)) != (0)" (0x0, 0x0) (tid=43)
AddressSanitizer: CHECK failed: asan_suppressions.cpp:47 "((suppression_ctx)) != (0)" (0x0, 0x0) (tid=43)
Trace/breakpoint trap (core dumped)
```