### PR TITLE
addpatch: mongo-c-driver 1.29.0, qemu-user-blacklist: add mongo-c-driver

### DIFF
--- a/mongo-c-driver/riscv64.patch
+++ b/mongo-c-driver/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -48,6 +48,7 @@ build() {
+ 
+ check() {
+   cd $pkgname-$pkgver
++  CFLAGS+=' -mcmodel=medany'
+   cmake --build build --target check
+   export MONGOC_TEST_OFFLINE=ON
+   export MONGOC_TEST_SKIP_LIVE=ON

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -75,6 +75,7 @@ memcached
 menyoki
 mkvtoolnix
 mold
+mongo-c-driver
 neochat
 nextcloud-client
 ninja


### PR DESCRIPTION
The test timeout will only randomly occurs on qemu-user, for example, it once costs 51.17 sec on Intel Ultra 9 185H. On both SG2042 and LicheePi 4A, it finished in just several seconds.