### PR TITLE
updpatch: python-flask-principle 0.4.0-11

### DIFF
--- a/python-flask-principal/riscv64.patch
+++ b/python-flask-principal/riscv64.patch
@@ -1,25 +1,19 @@
-diff --git PKGBUILD PKGBUILD
-index ce8b4da..47e0c62 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -11,9 +11,17 @@ license=('MIT')
- depends=('python' 'python-flask')
- makedepends=('python-blinker' 'python-sphinx' 'python-setuptools')
- checkdepends=('python-nose')
--source=(${pkgname}-${pkgver}.tar.gz::https://github.com/mattupstate/flask-principal/archive/${pkgver}.tar.gz)
--sha256sums=('ed8c58943460d7d54c29463e2fe98ae4969d3818c0f59b36e9b2649128db96c9')
--sha512sums=('ed8cb28c4e8d936de96db0bf9f7cb45b253dc204c4b8f8dd8022ef1552592ff6324b4a33d3ee862794a6e20eb8c32a0365e7b9397d427da5022c5ded3dfa308a')
-+source=(${pkgname}-${pkgver}.tar.gz::https://github.com/mattupstate/flask-principal/archive/${pkgver}.tar.gz
-+        "fix_docs_conf_py_syntax.patch")
-+sha256sums=('ed8c58943460d7d54c29463e2fe98ae4969d3818c0f59b36e9b2649128db96c9'
-+            '658aa8f03fd8053d7a3ea86e9dde0d1fec41cefe937fce2c549ea9128423b697')
-+sha512sums=('ed8cb28c4e8d936de96db0bf9f7cb45b253dc204c4b8f8dd8022ef1552592ff6324b4a33d3ee862794a6e20eb8c32a0365e7b9397d427da5022c5ded3dfa308a'
-+            '5cd8003c12f1e976f07fcced840de3f357681e67af4520d6ebf8c2708cf540dc12ea3f83ec9a4849e5fd870228d2ed277a55b09c0ea5a19770f794d5ee6eb755')
-+
-+prepare() {
-+  cd "${srcdir}/${_pkgname}-${pkgver}"
-+  patch -Np1 -i "${srcdir}/fix_docs_conf_py_syntax.patch"
-+}
+@@ -16,6 +16,7 @@ sha512sums=('ed8cb28c4e8d936de96db0bf9f7cb45b253dc204c4b8f8dd8022ef1552592ff6324
  
- build() {
+ prepare() {
    cd ${_pkgname}-${pkgver}
++  patch -Np1 -i ../sphinx-8.x.patch
+   2to3 -w docs/conf.py
+ }
+ 
+@@ -40,4 +41,8 @@ package() {
+   install -Dm 644 docs/_build/man/flask-principal.1 "${pkgdir}/usr/share/man/man1/${pkgname}.1"
+ }
+ 
++source+=(sphinx-8.x.patch)
++sha256sums+=('0d43c686575fec10e4b5d043f5c70a32509b87b9f92b3c2321a614b9ef81f900')
++sha512sums+=('690735860ac48297a372c44f1ee6e70a27ae168ee4bbcfd15035f6e28d25b1e28ebc94f87c3ae366a65f8920b361e183123f2ac1b5b98aed5d3a75fa274798c6')
++
+ # vim: ts=2 sw=2 et:

--- a/python-flask-principal/sphinx-8.x.patch
+++ b/python-flask-principal/sphinx-8.x.patch
@@ -1,0 +1,13 @@
+diff --git a/docs/conf.py b/docs/conf.py
+index 41f5e50..b25948c 100644
+--- a/docs/conf.py
++++ b/docs/conf.py
+@@ -290,7 +290,7 @@ epub_copyright = u'2012, Matt Wright'
+ 
+ 
+ # Example configuration for intersphinx: refer to the Python standard library.
+-intersphinx_mapping = {'http://docs.python.org/': None}
++intersphinx_mapping = {'python': ('http://docs.python.org/', None)}
+ 
+ pygments_style = 'flask_theme_support.FlaskyStyle'
+ 


### PR DESCRIPTION
Remove previous patch, new Sphinx 8.x compatibility patch upstreamed to https://github.com/pallets-eco/flask-principal/pull/109.