### PR TITLE
addpatch: hedgedoc 1.9.9-2

### DIFF
--- a/hedgedoc/riscv64.patch
+++ b/hedgedoc/riscv64.patch
@@ -1,0 +1,9 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -131,3 +131,6 @@ package() {
+   # Install systemd service file.
+   install -Dm0644 -t "${pkgdir}/usr/lib/systemd/system/" "${srcdir}"/hedgedoc.service
+ }
++
++depends=(${depends[@]/nodejs/nodejs-lts-iron})
++makedepends=(${makedepends[@]/nodejs/nodejs-lts-iron} 'python' 'python-setuptools')


### PR DESCRIPTION
- Switch to Node.js v20 because Hedgedoc uses Yarn v4.
- Add some makedepends for building native module