### PR TITLE
addpatch: system76-scheduler 2.0.2-1

### DIFF
--- a/system76-scheduler/riscv64.patch
+++ b/system76-scheduler/riscv64.patch
@@ -1,0 +1,22 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -35,6 +35,11 @@ pkgver() {
+   git describe --tags
+ }
+ 
++prepare() {
++  cd system76-scheduler
++  patch -Np1 -i ../bump-generator.patch
++}
++
+ build() {
+   cd system76-scheduler
+   export CC=clang
+@@ -46,4 +51,7 @@ package() {
+   just rootdir="${pkgdir}" install
+ }
+ 
++source+=(bump-generator.patch::https://github.com/pop-os/system76-scheduler/pull/120.diff)
++b2sums+=('521c1f2949a92a64af6b54a9831a3aa02a18d27e0cbdf2c9850bd46b5bc19e8705e5c4f333df137e6c72bb6463b807169f6215b6c63af9260b257c8427770e36')
++
+ # vim: ts=2 sw=2 et:


### PR DESCRIPTION
Bump generator crate which supports riscv64 in 0.8.x. Upstreamed to https://github.com/pop-os/system76-scheduler/pull/120.