### PR TITLE
addpatch: vamp-plugin-sdk 2.10.0-3

### DIFF
--- a/vamp-plugin-sdk/riscv64.patch
+++ b/vamp-plugin-sdk/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -28,7 +28,7 @@ b2sums=('50ad1c69d497b17c03439d94be7b3f70071de0c34c02c597506290fbd0e0cd2632f0a54
+ build() {
+   cd $pkgname-$pkgver
+   ./configure --prefix=/usr
+-  make
++  make -j1
+ }
+ 
+ package() {


### PR DESCRIPTION
Ranlib might race with gcc. Limit make jobs to 1 to solve it.

Meanwhile I have opened an upstream PR to fix it: https://github.com/vamp-plugins/vamp-plugin-sdk/pull/16