### PR TITLE
updpatch: sh4d0wup 0.10.0

### DIFF
--- a/sh4d0wup/riscv64.patch
+++ b/sh4d0wup/riscv64.patch
@@ -1,13 +1,27 @@
-diff --git PKGBUILD PKGBUILD
-index 561d8b8..e37ea14 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -33,6 +33,8 @@ b2sums=('cd594be73fcf632544195d09518901b1055ae86dcf463a5d446a83beba66073c70a9dfb
+@@ -23,6 +23,7 @@ checkdepends=('sequoia-sq')
+ makedepends=(
+   'cargo'
+   'clang'
++  'cmake'
+ )
+ options=(!lto)
+ source=(https://github.com/kpcyrd/${pkgname}/archive/v${pkgver}/${pkgname}-${pkgver}.tar.gz)
+@@ -31,6 +32,8 @@ b2sums=('7109e4523a61478a7f51e28f1a850071c3c9b966e47a5ef4e59c9e62b5267ae255b1d6b
  
  prepare() {
    cd "${pkgname}-${pkgver}"
 +  echo -e "\n[patch.crates-io]\nring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" >> Cargo.toml
 +  cargo update -p ring@0.16.20
    cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+ }
+ 
+@@ -41,6 +44,7 @@ build() {
+ 
+ check() {
+   cd ${pkgname}-${pkgver}
++  CFLAGS=${CFLAGS/-Wp,-D_FORTIFY_SOURCE=3/}
+   cargo test --frozen
  }
  


### PR DESCRIPTION
cmake is needed to generate bindgen for non pre-generated platforms.

1. https://github.com/aws/aws-lc-rs/blob/96484642d4f4b4c3572870629c6c830364f66483/aws-lc-sys/README.md#pregenerated-bindings-availability