### PR TITLE
addpatch: ruby 3.3.5-2

### DIFF
--- a/ruby/riscv64.patch
+++ b/ruby/riscv64.patch
@@ -1,0 +1,33 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index f0d4d66..45d2636 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -42,9 +42,15 @@ checkdepends=(
+   procps-ng
+ )
+ options=('!emptydirs')
+-source=("https://cache.ruby-lang.org/pub/ruby/${pkgver:0:3}/ruby-${pkgver}.tar.xz")
+-sha512sums=('dd5c6a7f74854e143e0ca46b9d7c0d1983fc4886f5f733cd108345dbf4b21f61ad978ad6806e05a57b7af28fd9216dd38d7145808188bbb3695a7f3a4eda3883')
+-b2sums=('4fa242ceeaf0dbf0d048b3f116f149f299c1a0ccca500a47929344da523cd3c49365381777e56546fe94003ee90ccc1f2cc957697eb82cd8beb7311b0b00287c')
++source=("https://cache.ruby-lang.org/pub/ruby/${pkgver:0:3}/ruby-${pkgver}.tar.xz"
++        "test_https.patch"
++        "test_x509req.patch")
++sha512sums=('dd5c6a7f74854e143e0ca46b9d7c0d1983fc4886f5f733cd108345dbf4b21f61ad978ad6806e05a57b7af28fd9216dd38d7145808188bbb3695a7f3a4eda3883'
++            '77aafecb9d3ae3417ad1fd69ad30fc453e88a2c14768983f6411ea9d8c52c204'
++            '177d920a02965c4628824f3c94951de779cdf2127f6d85c21b456edaa215d9ba')
++b2sums=('4fa242ceeaf0dbf0d048b3f116f149f299c1a0ccca500a47929344da523cd3c49365381777e56546fe94003ee90ccc1f2cc957697eb82cd8beb7311b0b00287c'
++        '74cc6c6c65dd56847da195347371007ca03b7b233b87a74fa2393c08781c4ba9272f94d94d039ed3956761e643eb183bdd4bcbf2791f372114c51375a793a21b'
++        '778d518d7c51036f237ac7dd0dd1112e2ba75f1010683dae276f72be4ea600bf10746582868ad70661bf03e823006c08b91559a7a141eaba0ea46ead23807b10')
+ 
+ _bootstrap=0
+ _rubyver="${pkgver:0:3}.0"
+@@ -182,6 +188,9 @@ build() {
+ check() {
+   cd "ruby-${pkgver}"
+ 
++  patch -Np1 -i "../test_x509req.patch"
++  patch -Np1 -i "../test_https.patch"
++
+   # this uses malloc_usable_size, which is incompatible with fortification level 3
+   export CFLAGS="${CFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
+   export CXXFLAGS="${CXXFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"

--- a/ruby/riscv64.patch
+++ b/ruby/riscv64.patch
@@ -1,0 +1,33 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index f0d4d66..45d2636 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -42,9 +42,15 @@ checkdepends=(
+   procps-ng
+ )
+ options=('!emptydirs')
+-source=("https://cache.ruby-lang.org/pub/ruby/${pkgver:0:3}/ruby-${pkgver}.tar.xz")
+-sha512sums=('dd5c6a7f74854e143e0ca46b9d7c0d1983fc4886f5f733cd108345dbf4b21f61ad978ad6806e05a57b7af28fd9216dd38d7145808188bbb3695a7f3a4eda3883')
+-b2sums=('4fa242ceeaf0dbf0d048b3f116f149f299c1a0ccca500a47929344da523cd3c49365381777e56546fe94003ee90ccc1f2cc957697eb82cd8beb7311b0b00287c')
++source=("https://cache.ruby-lang.org/pub/ruby/${pkgver:0:3}/ruby-${pkgver}.tar.xz"
++        "test_https.patch"
++        "test_x509req.patch")
++sha512sums=('dd5c6a7f74854e143e0ca46b9d7c0d1983fc4886f5f733cd108345dbf4b21f61ad978ad6806e05a57b7af28fd9216dd38d7145808188bbb3695a7f3a4eda3883'
++            '13a8674393abeb10b86aa27e9d3daa681ecdc461ea06f4ddb7c814758958f971377d09a08761f697ea72ef975810d130347d8e67c59dac95165f9a91bcabc068'
++            '3a037eedd4571545f383ec4fb0d75945c56d793d8ee8e87b1d70b2801891ffa14ad971d0a4f4a478932d159d933e04fc17757807f294755136081a0ac47effa9')
++b2sums=('4fa242ceeaf0dbf0d048b3f116f149f299c1a0ccca500a47929344da523cd3c49365381777e56546fe94003ee90ccc1f2cc957697eb82cd8beb7311b0b00287c'
++        'dbce88d84645e823143ecf528e8bd709036b6bc86e8b4e9882cb278fbb13bd9a1c8efecdb366a8ac11a1ece4f9a43356d03bb56de0f1d54a9f66ee0bf0ca85ce'
++        'e86d1a13458a594b050bbb7b313b2bb3e08be9010cb8973df1c05edc3cb7436e26cce5e7852a20795f1e20fec49629060e176fc3ee6a23b8402e6263a2755520')
+ 
+ _bootstrap=0
+ _rubyver="${pkgver:0:3}.0"
+@@ -182,6 +188,9 @@ build() {
+ check() {
+   cd "ruby-${pkgver}"
+ 
++  patch -Np1 -i "../test_x509req.patch"
++  patch -Np1 -i "../test_https.patch"
++
+   # this uses malloc_usable_size, which is incompatible with fortification level 3
+   export CFLAGS="${CFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
+   export CXXFLAGS="${CXXFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"

--- a/ruby/test_https.patch
+++ b/ruby/test_https.patch
@@ -1,0 +1,10 @@
+--- a/test/net/http/test_https.rb	2024-11-24 21:17:41.800000000 +0000
++++ b/test/net/http/test_https.rb	2024-11-24 21:16:57.370000000 +0000
+@@ -169,6 +169,7 @@
+     omit if OpenSSL::OPENSSL_LIBRARY_VERSION.include?('OpenSSL 1.1.0h')
+     omit if OpenSSL::OPENSSL_LIBRARY_VERSION.include?('OpenSSL 3.2.')
+     omit if OpenSSL::OPENSSL_LIBRARY_VERSION.include?('OpenSSL 3.3.')
++    omit if OpenSSL::OPENSSL_LIBRARY_VERSION.include?('OpenSSL 3.4.')
+ 
+     http = Net::HTTP.new(HOST, config("port"))
+     http.use_ssl = true

--- a/ruby/test_https.patch
+++ b/ruby/test_https.patch
@@ -1,0 +1,10 @@
+--- test/net/http/test_https.rb.old	2024-11-24 21:17:41.800000000 +0000
++++ test/net/http/test_https.rb	2024-11-24 21:16:57.370000000 +0000
+@@ -169,6 +169,7 @@
+     omit if OpenSSL::OPENSSL_LIBRARY_VERSION.include?('OpenSSL 1.1.0h')
+     omit if OpenSSL::OPENSSL_LIBRARY_VERSION.include?('OpenSSL 3.2.')
+     omit if OpenSSL::OPENSSL_LIBRARY_VERSION.include?('OpenSSL 3.3.')
++    omit if OpenSSL::OPENSSL_LIBRARY_VERSION.include?('OpenSSL 3.4.')
+ 
+     http = Net::HTTP.new(HOST, config("port"))
+     http.use_ssl = true

--- a/ruby/test_x509req.patch
+++ b/ruby/test_x509req.patch
@@ -1,0 +1,23 @@
+--- a/test/openssl/test_x509req.rb	2024-11-24 21:21:54.410000000 +0000
++++ b/test/openssl/test_x509req.rb	2024-11-24 21:16:26.670000000 +0000
+@@ -39,11 +39,6 @@
+     assert_equal(0, req.version)
+     req = OpenSSL::X509::Request.new(req.to_der)
+     assert_equal(0, req.version)
+-
+-    req = issue_csr(1, @dn, @rsa1024, OpenSSL::Digest.new('SHA256'))
+-    assert_equal(1, req.version)
+-    req = OpenSSL::X509::Request.new(req.to_der)
+-    assert_equal(1, req.version)
+   end
+ 
+   def test_subject
+@@ -106,7 +106,7 @@
+     assert_equal(false, req.verify(@rsa2048))
+     assert_equal(false, request_error_returns_false { req.verify(@dsa256) })
+     assert_equal(false, request_error_returns_false { req.verify(@dsa512) })
+-    req.version = 1
++    req.subject = OpenSSL::X509::Name.parse("/C=JP/CN=FooBarFooBar")
+     assert_equal(false, req.verify(@rsa1024))
+   rescue OpenSSL::X509::RequestError # RHEL 9 disables SHA1
+   end

--- a/ruby/test_x509req.patch
+++ b/ruby/test_x509req.patch
@@ -1,0 +1,23 @@
+--- test/openssl/test_x509req.rb.old	2024-11-24 21:21:54.410000000 +0000
++++ test/openssl/test_x509req.rb	2024-11-24 21:16:26.670000000 +0000
+@@ -39,11 +39,6 @@
+     assert_equal(0, req.version)
+     req = OpenSSL::X509::Request.new(req.to_der)
+     assert_equal(0, req.version)
+-
+-    req = issue_csr(1, @dn, @rsa1024, OpenSSL::Digest.new('SHA256'))
+-    assert_equal(1, req.version)
+-    req = OpenSSL::X509::Request.new(req.to_der)
+-    assert_equal(1, req.version)
+   end
+ 
+   def test_subject
+@@ -106,7 +106,7 @@
+     assert_equal(false, req.verify(@rsa2048))
+     assert_equal(false, request_error_returns_false { req.verify(@dsa256) })
+     assert_equal(false, request_error_returns_false { req.verify(@dsa512) })
+-    req.version = 1
++    req.subject = OpenSSL::X509::Name.parse("/C=JP/CN=FooBarFooBar")
+     assert_equal(false, req.verify(@rsa1024))
+   rescue OpenSSL::X509::RequestError # RHEL 9 disables SHA1
+   end


### PR DESCRIPTION
- test_x509req.rb needs adjustment for OpenSSL 3.3+ [https://github.com/ruby/openssl/pull/747/commits/c06fdeb0912221d9a2888369bbf9c10704af021e]
- test_https.rb needs to skip the test for OpenSSL 3.4 alike to OpenSSL 3.3