### PR TITLE
addpatch: scx-scheds 1.0.6-5

### DIFF
--- a/scx-scheds/riscv64.patch
+++ b/scx-scheds/riscv64.patch
@@ -1,0 +1,20 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -31,8 +31,15 @@ makedepends=(
+   rust
+ )
+ options=(!lto)
+-source=("git+https://github.com/sched-ext/scx#tag=v${pkgver}")
+-sha256sums=('81ebebdef84d9e02fb56b766633545ecfa875c297381c4912448409592aa407a')
++source=("git+https://github.com/sched-ext/scx#tag=v${pkgver}"
++        fix-non-x86.patch::https://github.com/sched-ext/scx/pull/1005.diff)
++sha256sums=('81ebebdef84d9e02fb56b766633545ecfa875c297381c4912448409592aa407a'
++            '432689707149e9baf17c46dc4bd53d4b1393f15a423624a6f6202b113c3d61c6')
++
++prepare() {
++  cd $_gitname
++  patch -Np1 -i ../fix-non-x86.patch
++}
+ 
+ build() {
+   cd $_gitname


### PR DESCRIPTION
Fix non-x86 build, upstreamed to https://github.com/sched-ext/scx/pull/1005.