### PR TITLE
updpatch: dpdk 24.07-1

### DIFF
--- a/dpdk/riscv64.patch
+++ b/dpdk/riscv64.patch
@@ -5,7 +5,7 @@
    )
    # shellcheck disable=SC2068
 -  meson test -C build --print-errorlogs ${tests[@]}
-+  meson test -C build --print-errorlogs ${tests[@]} --timeout-multiplier 0
++  meson test -C build --print-errorlogs ${tests[@]} --timeout-multiplier 6
  }
  
  package() {


### PR DESCRIPTION
RISC-V specific fast test timeout increase submitted in https://patches.dpdk.org/project/dpdk/patch/MW4PR11MB8289B816B08C6E19716B8F82D72C2@MW4PR11MB8289.namprd11.prod.outlook.com/.