### PR TITLE
updpatch: mongo-c-driver 1.29.0-1

### DIFF
--- a/mongo-c-driver/riscv64.patch
+++ b/mongo-c-driver/riscv64.patch
@@ -1,6 +1,24 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -48,6 +48,7 @@ build() {
+@@ -30,8 +30,15 @@ replaces=(
+   libbson
+   libmongoc
+ )
+-source=("https://github.com/mongodb/mongo-c-driver/archive/$pkgver/$pkgname-$pkgver.tar.gz")
+-sha256sums=('507414795dfb24ddf1a418b155b57459d8cea1191c7f0fcd8b826acf5400343c')
++source=("https://github.com/mongodb/mongo-c-driver/archive/$pkgver/$pkgname-$pkgver.tar.gz"
++        "fix-test.patch::https://github.com/mongodb/mongo-c-driver/pull/1808/commits/0d05c741b6efd668726a4a78008fb76690a982e5.patch")
++sha256sums=('507414795dfb24ddf1a418b155b57459d8cea1191c7f0fcd8b826acf5400343c'
++            '9e0145918865ec778693a07690af4970f51872ac776956d015a52ac50357ae53')
++
++prepare() {
++  cd $pkgname-$pkgver
++  patch -Np1 -i ../fix-test.patch
++}
+ 
+ build() {
+   cd $pkgname-$pkgver
+@@ -48,6 +55,7 @@ build() {
  
  check() {
    cd $pkgname-$pkgver


### PR DESCRIPTION
The sleep time to wait for spawn is not enough on TH1520

The upstream repo disables issue.