### PR TITLE
updpatch: emovix 0.9.0-9

### DIFF
--- a/emovix/riscv64.patch
+++ b/emovix/riscv64.patch
@@ -13,3 +13,11 @@
  build() {
    cd $pkgname-$pkgver
    ./configure --prefix=/usr
+@@ -22,6 +28,6 @@ build() {
+ 
+ package() {
+   cd $pkgname-$pkgver
+-  make DESTDIR="$pkgdir" install
++  make DESTDIR="$pkgdir" install -j1
+   find "$pkgdir"/usr/share/emovix -type d -exec chmod 755 {} \;
+ }


### PR DESCRIPTION
Two targets can race when make install. Limit make jobs to 1 to mitigate it.

Upstream bug report: https://sourceforge.net/p/movix/bugs/56/ (though it has been ten years after the last update on the upstream side: https://sourceforge.net/p/movix/activity/?page=0&limit=100 )