### PR TITLE
upgpatch: go 2:1.23.4-1

### DIFF
--- a/go/riscv64.patch
+++ b/go/riscv64.patch
@@ -1,18 +1,19 @@
 diff --git PKGBUILD PKGBUILD
-index 35ea9f9..2b57efd 100644
+index b175d00..bff3e5a 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -30,8 +30,7 @@
+@@ -30,8 +30,8 @@
              'SKIP')
  
  build() {
 -  export GOARCH=amd64
 -  export GOAMD64=v1 # make sure we're building for the right x86-64 version
 +  export GOARCH=riscv64
++  export GORISCV64=rva20u64 # make sure we're building for the right riscv64 version
    export GOROOT_FINAL=/usr/lib/go
    export GOROOT_BOOTSTRAP=/usr/lib/go
  
-@@ -50,7 +49,7 @@
+@@ -50,7 +50,7 @@
    cd "$pkgname"
  
    install -d "$pkgdir/usr/bin" "$pkgdir/usr/lib/go" "$pkgdir/usr/share/doc/go" \


### PR DESCRIPTION
Explicitly set `GORISCV64` which is supported since Go 1.23.