### PR TITLE
addpkg: x86_64-linux-gnu-binutils 2.43-1

### DIFF
--- a/x86_64-linux-gnu-binutils/PKGBUILD
+++ b/x86_64-linux-gnu-binutils/PKGBUILD
@@ -1,0 +1,66 @@
+# Contributor: Levi Zim <rsworktech@outlook.com>
+# Contributor: Anatol Pomozov <anatol.pomozov@gmail.com>
+
+_target=x86_64-linux-gnu
+pkgname=$_target-binutils
+pkgver=2.43
+pkgrel=1
+pkgdesc='A set of programs to assemble and manipulate binary and object files for the x86_64 target'
+arch=(riscv64)
+url='https://www.gnu.org/software/binutils/'
+license=(GPL)
+depends=(zlib libelf)
+source=(https://ftp.gnu.org/gnu/binutils/binutils-$pkgver.tar.bz2{,.sig})
+sha1sums=('9b0b465bf52fdbb677bd67ba64424842e297ebcd'
+          'SKIP')
+sha256sums=('fed3c3077f0df7a4a1aa47b080b8c53277593ccbb4e5e78b73ffb4e3f265e750'
+            'SKIP')
+validpgpkeys=('3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F') # Nick Clifton (Chief Binutils Maintainer) <nickc@redhat.com>
+
+prepare() {
+  cd binutils-$pkgver
+  sed -i "/ac_cpp=/s/\$CPPFLAGS/\$CPPFLAGS -O2/" libiberty/configure
+}
+
+build() {
+  cd binutils-$pkgver
+
+  ./configure --target=$_target \
+              --with-sysroot=/usr/$_target \
+              --prefix=/usr \
+              --enable-multilib \
+              --with-gnu-as \
+              --with-gnu-ld \
+              --disable-nls \
+              --enable-ld=default \
+              --enable-gold \
+              --enable-plugins \
+              --enable-deterministic-archives
+
+  make
+}
+
+check() {
+  cd binutils-$pkgver
+
+  # unset LDFLAGS as testsuite makes assumptions about which ones are active
+  # do not abort on errors - manually check log files
+  make -k LDFLAGS="" check || true
+}
+
+package() {
+  cd binutils-$pkgver
+
+  make DESTDIR="$pkgdir" install
+
+  # Remove file conflicting with host binutils and manpages for MS Windows tools
+  rm "$pkgdir"/usr/share/man/man1/$_target-{dlltool,windres,windmc}*
+  rm "$pkgdir"/usr/lib/bfd-plugins/libdep.so
+  rm "$pkgdir"/usr/etc/gprofng.rc
+  rm "$pkgdir"/usr/lib/libgprofng.a
+  rm -r "$pkgdir"/usr/include
+  rm -r "$pkgdir"/usr/lib/gprofng/
+
+  # Remove info documents that conflict with host version
+  rm -r "$pkgdir"/usr/share/info
+}


### PR DESCRIPTION
Based on aarch64-linux-gnu-binutils.