### PR TITLE
fixpkg: x86_64-linux-gnu-gcc 14.2.0-2

### DIFF
--- a/x86_64-linux-gnu-gcc/PKGBUILD
+++ b/x86_64-linux-gnu-gcc/PKGBUILD
@@ -36,6 +36,9 @@ prepare() {
   # Do not run fixincludes
   sed -i 's@\./fixinc\.sh@-c true@' gcc/Makefile.in
 
+  # Arch Linux installs x86_64 libraries /lib
+  sed -i '/m64=/s/lib64/lib/' gcc/config/i386/t-linux64
+
   rm -rf "$srcdir"/gcc-build
   mkdir "$srcdir"/gcc-build
 }
@@ -72,7 +75,7 @@ build() {
       --enable-gnu-unique-object --enable-linker-build-id \
       --enable-lto --enable-plugin --enable-install-libiberty \
       --with-linker-hash-style=gnu --enable-gnu-indirect-function \
-      --enable-multilib --disable-werror \
+      --disable-multilib --disable-werror \
       --enable-checking=release
 
   make


### PR DESCRIPTION
- multilib shouldn't be enabled.
- Fix lib dir
- Some potentially unnecessary sources files get installed, reported here: https://gitlab.archlinux.org/archlinux/packaging/packages/aarch64-linux-gnu-gcc/-/issues/3