### PR TITLE
addpatch: niri 0.1.10.1-1

### DIFF
--- a/niri/riscv64.patch
+++ b/niri/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -48,6 +48,8 @@ b2sums=('394cce3c11d19ef65d450a0e402e3c97affdff798340bb37aba90ea9b49c4cb5e741787
+ prepare() {
+   cd $pkgname-$pkgver
+   export RUSTUP_TOOLCHAIN=stable
++  echo -e "\n[patch.crates-io]\nrustix = { git = 'https://github.com/hack3ric/rustix', branch = 'riscv-0.38.41' }" >> Cargo.toml
++  cargo update -p rustix@0.38
+   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+ }
+ 


### PR DESCRIPTION
Fix rustix vDSO RISC-V getcpu not correctly named. Upstreamed to https://github.com/bytecodealliance/rustix/pull/1239.