### PR TITLE
addpatch: coin-or-asl 2.1.0-1

### DIFF
--- a/coin-or-asl/riscv64.patch
+++ b/coin-or-asl/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -22,6 +22,7 @@ prepare() {
+ 
+ build() {
+   cd ThirdParty-ASL
++  export CFLAGS="$CFLAGS -DNO_fpu_control"
+   ./configure --prefix=/usr --srcdir="$PWD"
+   make
+ }


### PR DESCRIPTION
Disable FPU control, as fedisableexcept will always fail (even when _GNU_SOURCE is defined): https://github.com/riscv-collab/riscv-gnu-toolchain/issues/417#issuecomment-475128185