### PR TITLE
addpkg: openpgl 0.7.0-1

### DIFF
--- a/openpgl/riscv64.patch
+++ b/openpgl/riscv64.patch
@@ -1,0 +1,22 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -9,9 +9,16 @@ arch=('x86_64')
+ url="https://github.com/openpathguidinglibrary/openpgl"
+ license=('Apache')
+ depends=('onetbb')
+-makedepends=('cmake' 'make' 'gcc' 'ninja')
+-source=("$pkgname-$pkgver.tar.gz::https://github.com/OpenPathGuidingLibrary/openpgl/archive/refs/tags/v${pkgver}.tar.gz")
+-sha512sums=('f5482ddf13217f81936098101c9bc16e63c36f79500aef25d15f7725deb5578ace7cf82764fbdbf4b09262bdef69ed0bcf42e9886cae7129605b31fee0f918ff')
++makedepends=('cmake' 'make' 'gcc' 'ninja' 'simde')
++source=("$pkgname-$pkgver.tar.gz::https://github.com/OpenPathGuidingLibrary/openpgl/archive/refs/tags/v${pkgver}.tar.gz"
++        "use-simde.patch::https://github.com/Cryolitia-Forks/openpgl/commit/77074e2ff062a16ad20f071189dac56e6d075d52.patch")
++sha512sums=('f5482ddf13217f81936098101c9bc16e63c36f79500aef25d15f7725deb5578ace7cf82764fbdbf4b09262bdef69ed0bcf42e9886cae7129605b31fee0f918ff'
++            '4ba2fdd16104e3da16458bf25253085b42df4e305af1887e5c24f41ef0acdac23204f7c7a7ebd50a010dc17bf8bd3d8bd8cd572e47e9abad98ba923bca8221b2')
++
++prepare() {
++  cd openpgl-$pkgver
++  patch -Np1 -i ../use-simde.patch
++}
+ 
+ build() {
+   cd openpgl-$pkgver


### PR DESCRIPTION
using simde, fetched from my own repo: https://github.com/Cryolitia-Forks/openpgl/commit/77074e2ff062a16ad20f071189dac56e6d075d52

Upstreamed: https://github.com/RenderKit/openpgl/issues/20

Still need to waiting openpgl upstream for their insights about porting it to riscv64

Actually the biggest challenge is its dependency embree. And openpgl just copy a part of embree's source code to itself's repo without any dependency management. I can not determine how to modify these part of codes on upstream though.

Plus, there is also a still-open PR on embree that port it to RISC-V V extension. Also keep an eye on it.
Link: https://github.com/RenderKit/embree/pull/503