### PR TITLE
updpatch: linux-tools 6.12-8

### DIFF
--- a/linux-tools/riscv64.patch
+++ b/linux-tools/riscv64.patch
@@ -1,6 +1,6 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -5,13 +5,10 @@ pkgname=(
+@@ -5,14 +5,10 @@ pkgname=(
    'bootconfig'
    'bpf'
    'cpupower'
@@ -11,10 +11,30 @@
 -  'turbostat'
    'usbip'
 -  'x86_energy_perf_policy'
+-  'intel-speed-select'
  )
- pkgver=6.10
- pkgrel=2
-@@ -100,11 +97,6 @@ build() {
+ pkgver=6.12
+ pkgrel=8
+@@ -66,6 +62,8 @@ sha256sums=('267bab84f30e3ce4a88b6441aeee777b114fd58041b43cabfe50fdf0c0a97321'
+ prepare() {
+   cd linux
+ 
++  git cherry-pick -n 710fbca820c721cdd60fa8c5bbe9deb4c0788aae
++
+   # apply patch from the source array (should be a pacman feature)
+   local src
+   for src in "${source[@]}"; do
+@@ -97,7 +95,8 @@ build() {
+     NO_LIBLLVM=1 \
+     PYTHON_CONFIG=python-config \
+     LIBPFM4=1 \
+-    DESTDIR="$pkgdir"
++    DESTDIR="$pkgdir" \
++    SRCARCH=riscv
+   popd
+ 
+   echo ':: cpupower'
+@@ -105,11 +104,6 @@ build() {
    make VERSION=$pkgver-$pkgrel
    popd
  
@@ -26,7 +46,7 @@
    echo ':: usbip'
    pushd linux/tools/usb/usbip
    # Fix gcc compilation
-@@ -119,16 +111,6 @@ build() {
+@@ -124,21 +118,11 @@ build() {
    make
    popd
  
@@ -43,7 +63,25 @@
    echo ':: bpf'
    pushd linux/tools/bpf
    # doesn't compile when we don't first compile bpftool in its own directory and
-@@ -151,12 +133,9 @@ package_linux-tools-meta() {
+   # man pages require to be also launch from the subdirectory
+-  make -C bpftool all doc
++  make -C bpftool all doc SRCARCH=riscv
+   # runqslower, require kernel binary path to build, skip it
+   make -W runqslower
+   popd
+@@ -147,11 +131,6 @@ build() {
+   pushd linux/tools/bootconfig
+   make
+   popd
+-
+-  echo ':: intel-speed-select'
+-  pushd linux/tools/power/x86/intel-speed-select
+-  make
+-  popd
+ }
+ 
+ package_linux-tools-meta() {
+@@ -161,13 +140,9 @@ package_linux-tools-meta() {
      'bootconfig'
      'bpf'
      'cpupower'
@@ -53,6 +91,7 @@
 -    'turbostat'
      'usbip'
 -    'x86_energy_perf_policy'
+-    'intel-speed-select'
    )
    conflicts=(
      'acpidump'


### PR DESCRIPTION
- Remove intel-speed-select
- Fix `<asm/fence.h> not found` issue by cherry-picking https://github.com/torvalds/linux/commit/710fbca820c721cdd60fa8c5bbe9deb4c0788aae and set SRCARCH explicitly