### PR TITLE
addpatch: zigbee2mqtt 1.42.0-1

### DIFF
--- a/zigbee2mqtt/riscv64.patch
+++ b/zigbee2mqtt/riscv64.patch
@@ -1,0 +1,27 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -69,8 +69,8 @@ package() {
+   install -Dm644 "${srcdir}/${pkgname}.sysusers" "${pkgdir}/usr/lib/sysusers.d/${pkgname}.conf"
+   install -Dm644 "${srcdir}/${pkgname}.tmpfiles" "${pkgdir}/usr/lib/tmpfiles.d/${pkgname}.conf"
+ 
+-  # Cleanups x86_64 specific
+-  if [ "${CARCH}" = "x86_64" ]; then
++  # Cleanups riscv64 specific
++  if [ "${CARCH}" = "riscv64" ]; then
+     local find_dirs=(
+     -iwholename '*.github' -o
+     -iwholename '*.idea' -o
+@@ -85,6 +85,7 @@ package() {
+     -iwholename '*/linux-armvy' -o
+     -iwholename '*/linux-armv7' -o
+     -iwholename '*/linux-arm' -o
++    -iwholename '*/linux-x64' -o
+     -iwholename '*/win32-ia32' -o
+     -iwholename '*/win32-x64' -o
+     -iwholename '*/darwin-x64'
+@@ -94,3 +95,5 @@ package() {
+   fi
+ 
+ }
++
++makedepends+=('python')


### PR DESCRIPTION
- Add Python for building native Node modules
- Remove prebuilt binaries of other architectures