### PR TITLE
addpatch: vue-language-tools 2.1.10-1

### DIFF
--- a/vue-language-tools/riscv64.patch
+++ b/vue-language-tools/riscv64.patch
@@ -1,0 +1,13 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -23,7 +23,9 @@ b2sums=('875a1b5a34cfffb70b753b0903a953dc5632815a6b38d85105327a1152efb5599a031ec
+ 
+ prepare() {
+   cd $pkgbase
+-  pnpm install --frozen-lockfile
++  sed -i 's/testTimeout: .*,/testTimeout: 120_000,/' vitest.config.ts
++  sed -i '/@vscode\/vsce/d' extensions/vscode/package.json
++  pnpm install --no-frozen-lockfile
+ }
+ 
+ build() {


### PR DESCRIPTION
- Remove @vscode/vsce from project dependencies to avoid installing @vscode/vsce-sign(which is proprietary and doesn't support riscv)
- Double the test timeout.