### PR TITLE
upgpatch: rocm-llvm 6.2.4-1

### DIFF
--- a/rocm-llvm/riscv64.patch
+++ b/rocm-llvm/riscv64.patch
@@ -1,8 +1,8 @@
 diff --git PKGBUILD PKGBUILD
-index 0f3d538..11296e0 100644
+index 3523ba3..d55d562 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -30,7 +30,7 @@ build() {
+@@ -30,7 +30,7 @@
          -DLLVM_ENABLE_RUNTIMES='libcxx;libcxxabi;libunwind'
          -DLIBCXX_ENABLE_STATIC=ON
          -DLIBCXXABI_ENABLE_STATIC=ON
@@ -11,3 +11,14 @@ index 0f3d538..11296e0 100644
          -DCLANG_DEFAULT_LINKER=lld
          -DLLVM_INSTALL_UTILS=ON
          -DLLVM_ENABLE_BINDINGS=OFF
+@@ -119,3 +119,10 @@
+     cd "$pkgbase/amd/comgr"
+     install -Dm644 LICENSE.txt "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+ }
++
++source+=("$pkgbase-fix-llvm-mc-abi.patch")
++sha256sums+=('f87358fa2cf2528f75a37a9c1dcef6572cb631fda40a971c1efc565e47c0a533')
++
++prepare() {
++    patch -d $pkgbase -Np1 -i ../$pkgbase-fix-llvm-mc-abi.patch
++}

--- a/rocm-llvm/rocm-llvm-fix-llvm-mc-abi.patch
+++ b/rocm-llvm/rocm-llvm-fix-llvm-mc-abi.patch
@@ -1,0 +1,14 @@
+diff --git a/clang/lib/Driver/ToolChains/HIPUtility.cpp b/clang/lib/Driver/ToolChains/HIPUtility.cpp
+index 82f56277bf..da1709c97e 100644
+--- a/clang/lib/Driver/ToolChains/HIPUtility.cpp
++++ b/clang/lib/Driver/ToolChains/HIPUtility.cpp
+@@ -465,6 +465,9 @@ void HIP::constructGenerateObjFileFromHIPFatBinary(
+   Objf << ObjBuffer;
+ 
+   ArgStringList McArgs{"-triple", Args.MakeArgString(HostTriple.normalize()),
++#if defined(__riscv) && __riscv_xlen == 64
++                       "-target-abi=lp64d","-mattr=+d",
++#endif
+                        "-o",      Output.getFilename(),
+                        McinFile,  "--filetype=obj"};
+   const char *Mc = Args.MakeArgString(TC.GetProgramPath("llvm-mc"));


### PR DESCRIPTION
Fix `rccl` build error about float abi.