### PR TITLE
updpatch: zettlr 3.4.1-1

### DIFF
--- a/zettlr/electron-packager-riscv64.patch
+++ b/zettlr/electron-packager-riscv64.patch
@@ -1,18 +1,33 @@
-diff --git a/src/targets.js b/src/targets.js
-index 39b50dd7e34dca393b083b488485eaed30e2e7f6..1a7b229bce4dba5c4e533b357dae53a8c0cff1df 100644
---- a/src/targets.js
-+++ b/src/targets.js
-@@ -4,11 +4,11 @@ const common = require('./common')
- const { getHostArch } = require('@electron/get')
- const semver = require('semver')
- 
--const officialArchs = ['ia32', 'x64', 'armv7l', 'arm64', 'mips64el', 'universal']
-+const officialArchs = ['ia32', 'x64', 'armv7l', 'arm64', 'mips64el', 'universal', 'riscv64']
- const officialPlatforms = ['darwin', 'linux', 'mas', 'win32']
- const officialPlatformArchCombos = {
-   darwin: ['x64', 'arm64', 'universal'],
--  linux: ['ia32', 'x64', 'armv7l', 'arm64', 'mips64el'],
-+  linux: ['ia32', 'x64', 'armv7l', 'arm64', 'mips64el', 'riscv64'],
-   mas: ['x64', 'arm64', 'universal'],
-   win32: ['ia32', 'x64', 'arm64']
+diff --git a/dist/targets.js b/dist/targets.js
+index 54faae8..ae9248c 100644
+--- a/dist/targets.js
++++ b/dist/targets.js
+@@ -7,11 +7,11 @@ exports.validateListFromOptions = exports.allOfficialArchsForPlatformAndVersion
+ const common_1 = require("./common");
+ const get_1 = require("@electron/get");
+ const semver_1 = __importDefault(require("semver"));
+-exports.officialArchs = ['ia32', 'x64', 'armv7l', 'arm64', 'mips64el', 'universal'];
++exports.officialArchs = ['ia32', 'x64', 'armv7l', 'arm64', 'mips64el', 'universal', 'riscv64'];
+ exports.officialPlatforms = ['darwin', 'linux', 'mas', 'win32'];
+ exports.officialPlatformArchCombos = {
+     darwin: ['x64', 'arm64', 'universal'],
+-    linux: ['ia32', 'x64', 'armv7l', 'arm64', 'mips64el'],
++    linux: ['ia32', 'x64', 'armv7l', 'arm64', 'mips64el', 'riscv64'],
+     mas: ['x64', 'arm64', 'universal'],
+     win32: ['ia32', 'x64', 'arm64'],
+ };
+@@ -24,6 +24,7 @@ const buildVersions = {
+         arm64: '>= 1.8.0',
+         ia32: '<19.0.0-beta.1',
+         mips64el: '^1.8.2-beta.5',
++        riscv64: '>= 22'
+     },
+     mas: {
+         arm64: '>= 11.0.0-beta.1',
+@@ -136,4 +137,4 @@ function validateListFromOptions(opts, name) {
+     return list;
  }
+ exports.validateListFromOptions = validateListFromOptions;
+-//# sourceMappingURL=targets.js.map
+\ No newline at end of file
++//# sourceMappingURL=targets.js.map

--- a/zettlr/riscv64.patch
+++ b/zettlr/riscv64.patch
@@ -1,50 +1,37 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -36,8 +36,19 @@ sha256sums=('96ad5f6871bb15a9a02e23cc576bc0d6fd62a8d705a3714b641dbcd5ca774a24'
- 
- #_yarnargs="--cache-folder '$srcdir/cache' --link-folder '$srcdir/link'"
- 
-+makedepends+=(zip)
-+source+=("liblzma-fix.patch::https://github.com/addaleax/lzma-native/pull/135.patch"
-+         "electron-packager-riscv64.patch")
-+sha256sums+=('066f050457349873ff36375b547dd7de482ecce182ed9d9ad2514db8fc81c75b'
-+             '52b8f1250740402821c62d717aaf60b84acddfae456e3eeea99649c1b7c062c8')
-+
- prepare() {
--	local _electronVersion=$($_electron --version | sed -e 's/^v//')
-+	local _electronVersion=$( <"/usr/lib/$_electron/version")
-+	local _hash=$(echo -n "https://github.com/electron/electron/releases/download/v$_electronVersion" | sha256sum | cut -d ' ' -f 1)
-+	local _electron_zip="electron-v$_electronVersion-linux-riscv64.zip"
-+	cd "/usr/lib/$_electron" && zip -r "/tmp/$_electron_zip" ./ && cd -
-+	local _cache_dir="$HOME/.cache/electron/$_hash"
-+	mkdir -p "$_cache_dir" && mv "/tmp/$_electron_zip" "$_cache_dir"
- 	gendesk -q -f -n \
- 		--pkgname "$pkgname" \
- 		--pkgdesc "$pkgdesc" \
-@@ -51,14 +62,19 @@ prepare() {
- 	sed -i "s/\([\^ :]\)${_oldElectron[0]}/\1$_electronVersion/"  package.json yarn.lock
+@@ -50,14 +50,27 @@ prepare() {
+ 	sed -i "s/\([\^ :]\)${_oldElectron[0]}/\1$_electronVersion/" package.json yarn.lock
  	echo -ne '#!/usr/bin/env bash\n\nexit 0' > scripts/get-pandoc.sh
  	sed -e "s/@ELECTRON@/$_electron/" "../${source[1]}" > $pkgname.sh
--	yarn $_yarnargs install --immutable # postinstall script installs electron-builder deps
+-	yarn install --immutable # postinstall script installs electron-builder deps
 -	ln -sf /usr/bin/pandoc resources/pandoc-linux-x64
-+	jq ".resolutions.\"lzma-native\" = \"patch:lzma-native@npm%3A8.0.6#${srcdir}/liblzma-fix.patch\"
-+	  | .resolutions.\"electron-packager\" = \"patch:electron-packager@npm%3A17.1.1#${srcdir}/electron-packager-riscv64.patch\"
-+	   " package.json > package.json.new
++	local _hash=$(echo -n "https://github.com/electron/electron/releases/download/v$_electronVersion" | sha256sum | cut -d ' ' -f 1)
++	local _electron_zip="electron-v$_electronVersion-linux-$CARCH.zip"
++	cd "/usr/lib/$_electron" && zip -r "/tmp/$_electron_zip" ./ && cd -
++	local _sha256="$(sha256sum "/tmp/$_electron_zip" | cut -d ' ' -f 1)"
++	local _cache_dir="$HOME/.cache/electron/$_hash"
++	mkdir -p "$_cache_dir" && mv "/tmp/$_electron_zip" "$_cache_dir"
++	echo "$_sha256 *$_electron_zip" > "$_cache_dir/SHASUMS256.txt"
++ 	jq ".resolutions.\"lzma-native\" = \"patch:lzma-native@npm%3A8.0.6#${srcdir}/liblzma-fix.patch\"
++	| .resolutions.\"@electron/packager\" = \"patch:@electron/packager@npm%3A18.3.5#${srcdir}/electron-packager-riscv64.patch\"
++	" package.json > package.json.new
 +	mv package.json.new package.json
-+	ELECTRON_SKIP_BINARY_DOWNLOAD=1 yarn $_yarnargs install # postinstall script installs electron-builder deps
++	export ELECTRON_SKIP_BINARY_DOWNLOAD=1
++	yarn install # postinstall script installs electron-builder deps
 +	ln -sf /usr/bin/pandoc resources/pandoc-linux-riscv64
  }
  
  build() {
  	cd "$_archive"
  	local NODE_ENV=''
--	yarn $_yarnargs package:linux-x64
+-	yarn package:linux-x64
 +	export PATH+=":$(realpath node_modules/.bin)"
 +	cross-env NODE_ENV=production npm_config_arch=riscv64 electron-forge package --platform=linux --arch=riscv64
  }
  
  package() {
-@@ -67,8 +83,8 @@ package() {
+@@ -66,11 +79,17 @@ package() {
  	install -Dm0755 "$pkgname.sh" "$pkgdir/usr/bin/$pkgname"
  	local _destdir="usr/lib/$pkgname"
  	install -Dm0644 -t "$pkgdir/$_destdir/" \
@@ -55,3 +42,12 @@
  	for px in 16 24 32 48 64 96 128 256 512 1024; do
  		install -Dm0644 "resources/icons/png/${px}x${px}.png" \
  			"$pkgdir/usr/share/icons/hicolor/${px}x${px}/apps/$pkgname.png"
+ 	done
+ 	install -Dm0644 -t "$pkgdir/usr/share/mime/packages/" "../${source[2]}"
+ }
++
++makedepends+=(zip)
++source+=("liblzma-fix.patch::https://github.com/addaleax/lzma-native/pull/135.patch"
++         "electron-packager-riscv64.patch")
++sha256sums+=('066f050457349873ff36375b547dd7de482ecce182ed9d9ad2514db8fc81c75b'
++             '8f5cfa5f3005c7bff8267f958ebed1309c792c7bddf8f888e6cab6c6b000b19d')


### PR DESCRIPTION
- Fix rotten patches
- Write a SHASUMS256 file for locally generated electron zip as electron-forge now checks that.
- Tested on centiskorch. It sometimes crashes on start.

![image](https://github.com/user-attachments/assets/59604fc1-bf1d-475b-ab83-d427088cd816)

when crashing:

```
Received signal 4 <unknown> 00004fa90ce0
#0 0x002abfa88f8e (/usr/lib/electron33/electron+0x16b6f8d)
#1 0x002ac219f6b6 (/usr/lib/electron33/electron+0x3dcd6b5)
#2 0x003f89405800 ([vdso]+0x7ff)
#3 0x003f63317274 <unknown>
#4 0x002ac06f0770 (/usr/lib/electron33/electron+0x231e76f)
#5 0x002ac06f0770 (/usr/lib/electron33/electron+0x231e76f)
#6 0x002ac06f0770 (/usr/lib/electron33/electron+0x231e76f)
#7 0x002ac06f0770 (/usr/lib/electron33/electron+0x231e76f)
#8 0x002ac07534e0 (/usr/lib/electron33/electron+0x23814df)
#9 0x002ac0887bec (/usr/lib/electron33/electron+0x24b5beb)
#10 0x002ac073d690 (/usr/lib/electron33/electron+0x236b68f)
#11 0x002ac06ed98c (/usr/lib/electron33/electron+0x231b98b)
#12 0x408f400000000000 <unknown>
#13 0x002ac8069384 (/usr/lib/electron33/electron+0x9c97383)
#14 0x000c001f03f0 ([anon:partition_alloc]+0xc001f03ef)
#15 0x000c006a58b0 ([anon:partition_alloc]+0xc006a58af)
[end of stack trace]
Illegal instruction (core dumped)
```

I will debug it later.