### PR TITLE
addpatch: python-proton-vpn-local-agent 1.2.0-4

### DIFF
--- a/python-proton-vpn-local-agent/riscv64.patch
+++ b/python-proton-vpn-local-agent/riscv64.patch
@@ -1,0 +1,22 @@
+diff --git PKGBUILD PKGBUILD
+index cd28d94..8732031 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -20,6 +20,8 @@
+ makedepends=(
+   git
+   cargo
++  cmake
++  clang
+ )
+ source=("git+https://github.com/ProtonVPN/local-agent-rs.git#tag=${pkgver}")
+ sha256sums=('7f4f04942328d1512c710d28fa172a868b71f82bf7bd13f9e6433244afc41190')
+@@ -31,6 +33,8 @@
+ 
+ build() {
+     cd "${srcdir}"/local-agent-rs/python-proton-vpn-local-agent
++    export CFLAGS=${CFLAGS/-Wp,-D_FORTIFY_SOURCE=3/}
++    export CXXFLAGS=${CXXFLAGS/-Wp,-D_FORTIFY_SOURCE=3/}
+     cargo build --frozen --release --all-features
+ }
+ 


### PR DESCRIPTION
`aws-lc-sys` crate needs `cmake` and `clang` without pregenerated bindgen.

The package force `-O0` which is incompatible with `_FORTIFY_SOURCE`.