### PR TITLE
addpatch: hiprt 2.3.bd75b7c.rc7-2

### DIFF
--- a/hiprt/riscv64.patch
+++ b/hiprt/riscv64.patch
@@ -1,0 +1,12 @@
+diff --git PKGBUILD PKGBUILD
+index bd9054c..0283af0 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -22,6 +22,7 @@
+ }
+ 
+ build() {
++	g++ $CXXFLAGS $LDFLAGS $LTOFLAGS contrib/easy-encryption/cl.cpp -o contrib/easy-encryption/bin/linux/ee64
+ 	local cmake_args=(
+ 		-Wno-dev
+ 		-S "$pkgname-$pkgver"


### PR DESCRIPTION
Overwrite x86_64 `easy-encryption` prebuilt.