### PR TITLE
upgpatch: rocm-opencl-runtime 6.2.4-1.1

### DIFF
--- a/rocm-opencl-runtime/riscv64.patch
+++ b/rocm-opencl-runtime/riscv64.patch
@@ -1,18 +1,21 @@
 diff --git PKGBUILD PKGBUILD
-index 9f649e8..64e2fa5 100644
+index 9f649e8..e44f0d0 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -40,3 +40,13 @@
+@@ -40,3 +40,16 @@
      echo '/opt/rocm/lib/libamdocl64.so' > 'amdocl64.icd'
      install -Dm644 'amdocl64.icd' "$pkgdir/etc/OpenCL/vendors/amdocl64.icd"
  }
 +
 +source+=("$pkgname-clr-riscv-hard-float.patch"
-+         "$pkgname-clr-riscv-fence.patch")
++         "$pkgname-clr-riscv-fence.patch"
++         "$pkgname-clr-riscv-currentStackPtr.patch::https://github.com/ROCm/clr/pull/117.diff")
 +sha256sums+=('b8d9643df110fd016796fe5e3ffda0b13bfe6ba430304322684a691bc35b84ff'
-+             '1ddd118ec6f2f285adca0bd2511d7c3cff8c9cbe66d84572228957f995e9525f')
++             '1ddd118ec6f2f285adca0bd2511d7c3cff8c9cbe66d84572228957f995e9525f'
++             'df7a04af6cc8fd9145f50d56e0d6b4c4eb78a569227af1f6106b61bc322ca4c7')
 +
 +prepare() {
 +  patch -Np1 -d "$srcdir/$_dirname" -i "$srcdir/$pkgname-clr-riscv-hard-float.patch"
 +  patch -Np1 -d "$srcdir/$_dirname" -i "$srcdir/$pkgname-clr-riscv-fence.patch"
++  patch -Np1 -d "$srcdir/$_dirname" -i "$srcdir/$pkgname-clr-riscv-currentStackPtr.patch"
 +}


### PR DESCRIPTION
Same as #4406

Fix `clinfo` runtime error:
```text
static void amd::Os::currentStackInfo(unsigned char**, size_t*): Assertion `Os::currentStackPtr() >= *base - *size && Os::currentStackPtr() < *base && "just checking"' failed.
```