### PR TITLE
addpatch: chezmoi 2.57.0-1, qemu-user-blacklist: add chezmoi

### DIFF
--- a/chezmoi/riscv64.patch
+++ b/chezmoi/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -46,7 +46,7 @@ build() {
+ check() {
+   cd "$pkgname-$pkgver"
+ 
+-  go test -v ./...
++  go test -v ./... -timeout 1h
+ }
+ 
+ package() {

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -12,6 +12,7 @@ cargo-audit
 cargo-generate-rpm
 cargo-nextest
 cherrytree
+chezmoi
 cloud-init
 coreutils
 ctags


### PR DESCRIPTION
Disable the test timeout, it's passed by args instead of hard encoding in the source, so may not report upstream.

It costs ~800s on `centiskorch` to finish, on qemu-user it will costs more than 1 hour (1 hour is the timeout set on upstream action CI) and I'm not able to wait it to finish, each step costs several minutes. But I believe it finally could be before the universe death hh

 Just be patient, we are using RISC-V.