### PR TITLE
addpatch: anari-sdk 0.11.1-1

### DIFF
--- a/anari-sdk/riscv64.patch
+++ b/anari-sdk/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,6 +17,7 @@ sha256sums=('68e0ec25b42c375acad782a67250962651deff4b0d0f00cebbfa8ec1d3d4f82d')
+ 
+ build() {
+   cmake -B build -S ANARI-SDK \
++    -DBUILD_HELIDE_DEVICE=OFF \
+     -DCMAKE_INSTALL_PREFIX=/usr
+   cmake --build build
+ }


### PR DESCRIPTION
Disable BUILD_HELIDE_DEVICE because it depends on embree which we haven't ported yet (and which seems to require ispc).

This package is an opt&make dependency for vtk