### PR TITLE
updpatch: nzbget 24.5-1

### DIFF
--- a/nzbget/riscv64.patch
+++ b/nzbget/riscv64.patch
@@ -1,14 +1,8 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -22,6 +22,11 @@ prepare() {
-   cd $pkgname-$pkgver
-   # https://github.com/nzbget/nzbget/pull/793
-   patch -Np1 -i ../nzbget_21.1_openssl3_update.patch
-+  # https://github.com/nzbget/nzbget/issues/755
-+  # https://github.com/nzbget/nzbget/pull/765
-+  _sharedir=/usr/share/autoconf/build-aux
-+  cp ${_sharedir}/config.guess posix
-+  cp ${_sharedir}/config.sub posix
+@@ -63,3 +63,5 @@ package() {
+   DESTDIR="$pkgdir" cmake --install build
+   install -vDm644 -t "$pkgdir/usr/share/doc/$pkgname" ./*.md
  }
- 
- build() {
++
++options=(!lto)


### PR DESCRIPTION
fix: `lto1: fatal error: target specific builtin not available`