### PR TITLE
updpatch: chromium 132.0.6834.83-1

### DIFF
--- a/chromium/riscv-ffmpeg.patch
+++ b/chromium/riscv-ffmpeg.patch
@@ -1,19 +1,12 @@
-From 9af1bc01fafc8f39668fd416d8fc4999c196c81c Mon Sep 17 00:00:00 2001
+From 10ff221077e33a6f1970c4e55a73609771296039 Mon Sep 17 00:00:00 2001
 From: kxxt <rsworktech@outlook.com>
-Date: Wed, 13 Nov 2024 13:26:53 +0100
+Date: Sat, 11 Jan 2025 00:53:23 +0100
 Subject: [PATCH] ffmpeg: generate riscv64 changes
 
 ---
- CREDITS.chromium                              |  145 ++
- chromium/config/Chrome/ios/arm64/config.h     |   21 +-
- .../Chrome/ios/arm64/config_components.h      |   13 +
- .../Chrome/ios/arm64/libavutil/ffversion.h    |    2 +-
- chromium/config/Chrome/ios/x64/config.asm     |   17 +-
- chromium/config/Chrome/ios/x64/config.h       |   21 +-
- .../config/Chrome/ios/x64/config_components.h |   13 +
- .../Chrome/ios/x64/libavutil/ffversion.h      |    2 +-
- chromium/config/Chrome/linux/riscv64/config.h |  787 ++++++
- .../Chrome/linux/riscv64/config_components.h  | 2231 +++++++++++++++++
+ CREDITS.chromium                              |  175 ++
+ chromium/config/Chrome/linux/riscv64/config.h |  793 ++++++
+ .../Chrome/linux/riscv64/config_components.h  | 2234 +++++++++++++++++
  .../linux/riscv64/libavcodec/bsf_list.c       |    2 +
  .../linux/riscv64/libavcodec/codec_list.c     |   17 +
  .../linux/riscv64/libavcodec/parser_list.c    |    9 +
@@ -25,15 +18,29 @@ Subject: [PATCH] ffmpeg: generate riscv64 changes
  chromium/config/Chrome/linux/x64/config.asm   |    4 +-
  chromium/config/Chrome/linux/x64/config.h     |    8 +-
  .../Chrome/linux/x64/libavutil/ffversion.h    |    2 +-
- chromium/config/Chromium/ios/arm64/config.h   |   21 +-
- .../Chromium/ios/arm64/config_components.h    |   13 +
- .../Chromium/ios/arm64/libavutil/ffversion.h  |    2 +-
- chromium/config/Chromium/ios/x64/config.asm   |   17 +-
- chromium/config/Chromium/ios/x64/config.h     |   21 +-
- .../Chromium/ios/x64/config_components.h      |   13 +
- .../Chromium/ios/x64/libavutil/ffversion.h    |    2 +-
- .../config/Chromium/linux/riscv64/config.h    |  787 ++++++
- .../linux/riscv64/config_components.h         | 2231 +++++++++++++++++
+ .../config/ChromeOS/linux/riscv64/config.h    |  751 ++++++
+ .../linux/riscv64/config_components.h         | 2164 ++++++++++++++++
+ .../linux/riscv64/libavcodec/bsf_list.c       |    2 +
+ .../linux/riscv64/libavcodec/codec_list.c     |   22 +
+ .../linux/riscv64/libavcodec/parser_list.c    |   13 +
+ .../linux/riscv64/libavformat/demuxer_list.c  |   10 +
+ .../linux/riscv64/libavformat/muxer_list.c    |    2 +
+ .../linux/riscv64/libavformat/protocol_list.c |    2 +
+ .../linux/riscv64/libavutil/avconfig.h        |    6 +
+ .../linux/riscv64/libavutil/ffversion.h       |    5 +
+ chromium/config/ChromeOS/linux/x64/config.asm |  734 ++++++
+ chromium/config/ChromeOS/linux/x64/config.h   |  751 ++++++
+ .../ChromeOS/linux/x64/config_components.h    | 2164 ++++++++++++++++
+ .../ChromeOS/linux/x64/libavcodec/bsf_list.c  |    2 +
+ .../linux/x64/libavcodec/codec_list.c         |   22 +
+ .../linux/x64/libavcodec/parser_list.c        |   13 +
+ .../linux/x64/libavformat/demuxer_list.c      |   10 +
+ .../linux/x64/libavformat/muxer_list.c        |    2 +
+ .../linux/x64/libavformat/protocol_list.c     |    2 +
+ .../ChromeOS/linux/x64/libavutil/avconfig.h   |    6 +
+ .../ChromeOS/linux/x64/libavutil/ffversion.h  |    5 +
+ .../config/Chromium/linux/riscv64/config.h    |  793 ++++++
+ .../linux/riscv64/config_components.h         | 2234 +++++++++++++++++
  .../linux/riscv64/libavcodec/bsf_list.c       |    2 +
  .../linux/riscv64/libavcodec/codec_list.c     |   15 +
  .../linux/riscv64/libavcodec/parser_list.c    |    7 +
@@ -59,7 +66,7 @@ Subject: [PATCH] ffmpeg: generate riscv64 changes
  .../autorename_libavcodec_x86_sbrdsp_init.c   |    2 +
  .../autorename_libavcodec_x86_videodsp.asm    |    2 +-
  .../autorename_libavcodec_x86_videodsp_init.c |    2 +
- ...autorename_libavcodec_x86_vorbisdsp_init.c |    2 +-
+ ...autorename_libavcodec_x86_vorbisdsp_init.c |    2 +
  libavformat/autorename_libavformat_aacdec.c   |    2 +-
  libavformat/autorename_libavformat_flacdec.c  |    2 +-
  libavformat/autorename_libavformat_options.c  |    2 +-
@@ -67,6 +74,7 @@ Subject: [PATCH] ffmpeg: generate riscv64 changes
  libavformat/autorename_libavformat_utils.c    |    2 +-
  libavformat/autorename_libavformat_version.c  |    2 +-
  libavutil/autorename_libavutil_cpu.c          |    2 +-
+ libavutil/autorename_libavutil_executor.c     |    2 +-
  libavutil/autorename_libavutil_fixed_dsp.c    |    2 +-
  libavutil/autorename_libavutil_float_dsp.c    |    2 +-
  libavutil/autorename_libavutil_imgutils.c     |    2 +-
@@ -75,9 +83,9 @@ Subject: [PATCH] ffmpeg: generate riscv64 changes
  libavutil/autorename_libavutil_version.c      |    2 +-
  libavutil/x86/autorename_libavutil_x86_cpu.c  |    2 +-
  .../autorename_libavutil_x86_fixed_dsp_init.c |    2 +
- .../autorename_libavutil_x86_float_dsp_init.c |    2 +-
+ .../autorename_libavutil_x86_float_dsp_init.c |    2 +
  .../x86/autorename_libavutil_x86_lls_init.c   |    2 +
- 73 files changed, 6534 insertions(+), 272 deletions(-)
+ 81 files changed, 13142 insertions(+), 224 deletions(-)
  create mode 100644 chromium/config/Chrome/linux/riscv64/config.h
  create mode 100644 chromium/config/Chrome/linux/riscv64/config_components.h
  create mode 100644 chromium/config/Chrome/linux/riscv64/libavcodec/bsf_list.c
@@ -88,6 +96,27 @@ Subject: [PATCH] ffmpeg: generate riscv64 changes
  create mode 100644 chromium/config/Chrome/linux/riscv64/libavformat/protocol_list.c
  create mode 100644 chromium/config/Chrome/linux/riscv64/libavutil/avconfig.h
  create mode 100644 chromium/config/Chrome/linux/riscv64/libavutil/ffversion.h
+ create mode 100644 chromium/config/ChromeOS/linux/riscv64/config.h
+ create mode 100644 chromium/config/ChromeOS/linux/riscv64/config_components.h
+ create mode 100644 chromium/config/ChromeOS/linux/riscv64/libavcodec/bsf_list.c
+ create mode 100644 chromium/config/ChromeOS/linux/riscv64/libavcodec/codec_list.c
+ create mode 100644 chromium/config/ChromeOS/linux/riscv64/libavcodec/parser_list.c
+ create mode 100644 chromium/config/ChromeOS/linux/riscv64/libavformat/demuxer_list.c
+ create mode 100644 chromium/config/ChromeOS/linux/riscv64/libavformat/muxer_list.c
+ create mode 100644 chromium/config/ChromeOS/linux/riscv64/libavformat/protocol_list.c
+ create mode 100644 chromium/config/ChromeOS/linux/riscv64/libavutil/avconfig.h
+ create mode 100644 chromium/config/ChromeOS/linux/riscv64/libavutil/ffversion.h
+ create mode 100644 chromium/config/ChromeOS/linux/x64/config.asm
+ create mode 100644 chromium/config/ChromeOS/linux/x64/config.h
+ create mode 100644 chromium/config/ChromeOS/linux/x64/config_components.h
+ create mode 100644 chromium/config/ChromeOS/linux/x64/libavcodec/bsf_list.c
+ create mode 100644 chromium/config/ChromeOS/linux/x64/libavcodec/codec_list.c
+ create mode 100644 chromium/config/ChromeOS/linux/x64/libavcodec/parser_list.c
+ create mode 100644 chromium/config/ChromeOS/linux/x64/libavformat/demuxer_list.c
+ create mode 100644 chromium/config/ChromeOS/linux/x64/libavformat/muxer_list.c
+ create mode 100644 chromium/config/ChromeOS/linux/x64/libavformat/protocol_list.c
+ create mode 100644 chromium/config/ChromeOS/linux/x64/libavutil/avconfig.h
+ create mode 100644 chromium/config/ChromeOS/linux/x64/libavutil/ffversion.h
  create mode 100644 chromium/config/Chromium/linux/riscv64/config.h
  create mode 100644 chromium/config/Chromium/linux/riscv64/config_components.h
  create mode 100644 chromium/config/Chromium/linux/riscv64/libavcodec/bsf_list.c
@@ -103,14 +132,16 @@ Subject: [PATCH] ffmpeg: generate riscv64 changes
  create mode 100644 libavcodec/x86/autorename_libavcodec_x86_h264dsp_init.c
  create mode 100644 libavcodec/x86/autorename_libavcodec_x86_sbrdsp_init.c
  create mode 100644 libavcodec/x86/autorename_libavcodec_x86_videodsp_init.c
+ create mode 100644 libavcodec/x86/autorename_libavcodec_x86_vorbisdsp_init.c
  create mode 100644 libavutil/x86/autorename_libavutil_x86_fixed_dsp_init.c
+ create mode 100644 libavutil/x86/autorename_libavutil_x86_float_dsp_init.c
  create mode 100644 libavutil/x86/autorename_libavutil_x86_lls_init.c
 
 diff --git a/CREDITS.chromium b/CREDITS.chromium
-index ccd7f4afa5d..ff969ba527b 100644
+index ccd7f4afa5..88e0abeb84 100644
 --- a/CREDITS.chromium
 +++ b/CREDITS.chromium
-@@ -129,6 +129,151 @@ incompatible with the GPLv2 and v3. To the best of our knowledge, they are
+@@ -129,6 +129,181 @@ incompatible with the GPLv2 and v3. To the best of our knowledge, they are
  compatible with the LGPL.
  
  
@@ -205,6 +236,36 @@ index ccd7f4afa5d..ff969ba527b 100644
 +
 +********************************************************************************
 +
++libavcodec/riscv/h264qpel_rvv.S
++
++SPDX-License-Identifier: BSD-2-Clause
++
++Copyright (c) 2024 Niklas Haas
++
++Redistribution and use in source and binary forms, with or without
++modification, are permitted provided that the following conditions are met:
++
++1. Redistributions of source code must retain the above copyright notice,
++this list of conditions and the following disclaimer.
++
++2. Redistributions in binary form must reproduce the above copyright notice,
++this list of conditions and the following disclaimer in the documentation
++and/or other materials provided with the distribution.
++
++THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
++LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
++CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
++SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
++INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
++CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
++ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
++POSSIBILITY OF SUCH DAMAGE.
++
++********************************************************************************
++
 +libavcodec/riscv/startcode_rvb.S
 +
 +Copyright © 2024 Rémi Denis-Courmont.
@@ -262,586 +323,21 @@ index ccd7f4afa5d..ff969ba527b 100644
  ********************************************************************************
  
  libavformat/oggparsetheora.c
-diff --git a/chromium/config/Chrome/ios/arm64/config.h b/chromium/config/Chrome/ios/arm64/config.h
-index 44bab03499c..e1f121acdc1 100644
---- a/chromium/config/Chrome/ios/arm64/config.h
-+++ b/chromium/config/Chrome/ios/arm64/config.h
-@@ -1,12 +1,12 @@
- /* Automatically generated by configure - do not modify! */
- #ifndef FFMPEG_CONFIG_H
- #define FFMPEG_CONFIG_H
--/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-iamf --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/usr/local/google/home/dalecurtis/code/chrome/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\"-O2\"' --enable-pic --cc=clang --cxx=clang++ --ld=clang --enable-cross-compile --cc=clang --ld=ld64.lld --nm=llvm-nm --ar=llvm-ar --target-os=darwin --extra-cflags='--target=arm64-apple-macosx' --extra-cflags=-F/usr/local/google/home/dalecurtis/code/chrome/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks --extra-cflags='-mmacosx-version-min=10.10' --extra-cflags=-fblocks --extra-cflags=-nostdinc --extra-cflags=-isystem/usr/local/google/home/dalecurtis/code/chrome/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include --extra-cflags=-isystem/usr/local/google/home/dalecurtis/code/chrome/src/third_party/llvm-build/Release+Asserts/lib/clang/19/include --extra-ldflags=-syslibroot --extra-ldflags=/usr/local/google/home/dalecurtis/code/chrome/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk --extra-ldflags=-L/usr/local/google/home/dalecurtis/code/chrome/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib --extra-ldflags=-lSystem --extra-ldflags=-macosx_version_min --extra-ldflags=10.10 --extra-ldflags=-sdk_version --extra-ldflags=10.10 --extra-ldflags=-platform_version --extra-ldflags=macos --extra-ldflags=10.10 --extra-ldflags=10.10 --arch=arm64 --extra-cflags='-arch arm64' --extra-ldflags='-arch arm64' --enable-decoder='aac,h264' --enable-demuxer=aac --enable-parser='aac,h264'" -- elide long configuration string from binary */
-+/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-iamf --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/usr/local/google/home/sandersd/src/chromium/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\"-O2\"' --enable-pic --cc=clang --cxx=clang++ --ld=clang --enable-cross-compile --cc=clang --ld=ld64.lld --nm=llvm-nm --ar=llvm-ar --target-os=darwin --extra-cflags='--target=arm64-apple-macosx' --extra-cflags=-F/usr/local/google/home/sandersd/src/chromium/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks --extra-cflags='-mmacosx-version-min=10.10' --extra-cflags=-fblocks --extra-cflags=-nostdinc --extra-cflags=-isystem/usr/local/google/home/sandersd/src/chromium/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include --extra-cflags=-isystem/usr/local/google/home/sandersd/src/chromium/src/third_party/llvm-build/Release+Asserts/lib/clang/20/include --extra-ldflags=-syslibroot --extra-ldflags=/usr/local/google/home/sandersd/src/chromium/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk --extra-ldflags=-L/usr/local/google/home/sandersd/src/chromium/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib --extra-ldflags=-lSystem --extra-ldflags=-macosx_version_min --extra-ldflags=10.10 --extra-ldflags=-sdk_version --extra-ldflags=10.10 --extra-ldflags=-platform_version --extra-ldflags=macos --extra-ldflags=10.10 --extra-ldflags=10.10 --arch=arm64 --extra-cflags='-arch arm64' --extra-ldflags='-arch arm64' --enable-decoder='aac,h264' --enable-demuxer=aac --enable-parser='aac,h264'" -- elide long configuration string from binary */
- #define FFMPEG_LICENSE "LGPL version 2.1 or later"
- #define CONFIG_THIS_YEAR 2024
- #define FFMPEG_DATADIR "/usr/local/share/ffmpeg"
- #define AVCONV_DATADIR "/usr/local/share/ffmpeg"
--#define CC_IDENT "clang version 19.0.0git (https://chromium.googlesource.com/a/external/github.com/llvm/llvm-project ecea8371ff03c15fb3dc27ee4108b98335fd2d63)"
-+#define CC_IDENT "clang version 20.0.0git (https://chromium.googlesource.com/a/external/github.com/llvm/llvm-project 6ee7e90a5d21cc0173dc5a0a344d230a80a46fd0)"
- #define OS_NAME darwin
- #define EXTERN_PREFIX "_"
- #define EXTERN_ASM _
-@@ -15,12 +15,7 @@
- #define SWS_MAX_FILTER_SIZE 256
- #define AS_ARCH_LEVEL armv8.6-a+crc
- #define ARCH_AARCH64 1
--#define ARCH_ALPHA 0
- #define ARCH_ARM 0
--#define ARCH_AVR32 0
--#define ARCH_AVR32_AP 0
--#define ARCH_AVR32_UC 0
--#define ARCH_BFIN 0
- #define ARCH_IA64 0
- #define ARCH_LOONGARCH 0
- #define ARCH_LOONGARCH32 0
-@@ -33,7 +28,6 @@
- #define ARCH_PPC64 0
- #define ARCH_RISCV 0
- #define ARCH_S390 0
--#define ARCH_SH4 0
- #define ARCH_SPARC 0
- #define ARCH_SPARC64 0
- #define ARCH_TILEGX 0
-@@ -59,6 +53,7 @@
- #define HAVE_VSX 0
- #define HAVE_RV 0
- #define HAVE_RVV 0
-+#define HAVE_RV_ZICBOP 1
- #define HAVE_RV_ZVBB 0
- #define HAVE_AESNI 0
- #define HAVE_AMD3DNOW 0
-@@ -111,6 +106,7 @@
- #define HAVE_VSX_EXTERNAL 0
- #define HAVE_RV_EXTERNAL 0
- #define HAVE_RVV_EXTERNAL 0
-+#define HAVE_RV_ZICBOP_EXTERNAL 0
- #define HAVE_RV_ZVBB_EXTERNAL 0
- #define HAVE_AESNI_EXTERNAL 0
- #define HAVE_AMD3DNOW_EXTERNAL 0
-@@ -163,6 +159,7 @@
- #define HAVE_VSX_INLINE 0
- #define HAVE_RV_INLINE 0
- #define HAVE_RVV_INLINE 0
-+#define HAVE_RV_ZICBOP_INLINE 0
- #define HAVE_RV_ZVBB_INLINE 0
- #define HAVE_AESNI_INLINE 0
- #define HAVE_AMD3DNOW_INLINE 0
-@@ -261,6 +258,7 @@
- #define HAVE_WINDOWS_H 0
- #define HAVE_WINSOCK2_H 0
- #define HAVE_INTRINSICS_NEON 1
-+#define HAVE_INTRINSICS_SSE2 0
- #define HAVE_ATANF 1
- #define HAVE_ATAN2F 1
- #define HAVE_CBRT 1
-@@ -303,6 +301,7 @@
- #define HAVE_CLOCK_GETTIME 0
- #define HAVE_CLOSESOCKET 0
- #define HAVE_COMMANDLINETOARGVW 0
-+#define HAVE_ELF_AUX_INFO 0
- #define HAVE_FCNTL 1
- #define HAVE_GETADDRINFO 0
- #define HAVE_GETAUXVAL 0
-@@ -351,6 +350,7 @@
- #define HAVE_SYSCONF 1
- #define HAVE_SYSCTL 1
- #define HAVE_SYSCTLBYNAME 1
-+#define HAVE_TEMPNAM 1
- #define HAVE_USLEEP 1
- #define HAVE_UTGETOSTYPEFROMSTRING 0
- #define HAVE_VIRTUALALLOC 0
-@@ -434,6 +434,7 @@
- #define HAVE_OPENCL_VIDEOTOOLBOX 0
- #define HAVE_PERL 1
- #define HAVE_POD2MAN 1
-+#define HAVE_POSIX_IOCTL 0
- #define HAVE_TEXI2HTML 0
- #define HAVE_XMLLINT 1
- #define HAVE_ZLIB_GZIP 0
-@@ -523,6 +524,7 @@
- #define CONFIG_LIBKLVANC 0
- #define CONFIG_LIBKVAZAAR 0
- #define CONFIG_LIBLC3 0
-+#define CONFIG_LIBLCEVC_DEC 0
- #define CONFIG_LIBMODPLUG 0
- #define CONFIG_LIBMP3LAME 0
- #define CONFIG_LIBMYSOFA 0
-@@ -560,6 +562,7 @@
- #define CONFIG_LIBVMAF 0
- #define CONFIG_LIBVORBIS 0
- #define CONFIG_LIBVPX 0
-+#define CONFIG_LIBVVENC 0
- #define CONFIG_LIBWEBP 0
- #define CONFIG_LIBXEVD 0
- #define CONFIG_LIBXEVE 0
-@@ -692,6 +695,7 @@
- #define CONFIG_CBS_MPEG2 0
- #define CONFIG_CBS_VP8 0
- #define CONFIG_CBS_VP9 0
-+#define CONFIG_D3D12VA_ENCODE 0
- #define CONFIG_DEFLATE_WRAPPER 0
- #define CONFIG_DIRAC_PARSE 1
- #define CONFIG_DNN 0
-@@ -778,6 +782,7 @@
- #define CONFIG_VP3DSP 0
- #define CONFIG_VP56DSP 0
- #define CONFIG_VP8DSP 0
-+#define CONFIG_VULKAN_ENCODE 0
- #define CONFIG_WMA_FREQS 0
- #define CONFIG_WMV2DSP 0
- #endif /* FFMPEG_CONFIG_H */
-diff --git a/chromium/config/Chrome/ios/arm64/config_components.h b/chromium/config/Chrome/ios/arm64/config_components.h
-index 8ebce4c9b52..aaba26ad222 100644
---- a/chromium/config/Chrome/ios/arm64/config_components.h
-+++ b/chromium/config/Chrome/ios/arm64/config_components.h
-@@ -8,6 +8,7 @@
- #define CONFIG_CHOMP_BSF 0
- #define CONFIG_DUMP_EXTRADATA_BSF 0
- #define CONFIG_DCA_CORE_BSF 0
-+#define CONFIG_DOVI_RPU_BSF 0
- #define CONFIG_DTS2PTS_BSF 0
- #define CONFIG_DV_ERROR_MARKER_BSF 0
- #define CONFIG_EAC3_CORE_BSF 0
-@@ -599,6 +600,9 @@
- #define CONFIG_BINTEXT_DECODER 0
- #define CONFIG_XBIN_DECODER 0
- #define CONFIG_IDF_DECODER 0
-+#define CONFIG_AAC_MEDIACODEC_DECODER 0
-+#define CONFIG_AMRNB_MEDIACODEC_DECODER 0
-+#define CONFIG_AMRWB_MEDIACODEC_DECODER 0
- #define CONFIG_LIBAOM_AV1_DECODER 0
- #define CONFIG_AV1_DECODER 0
- #define CONFIG_AV1_CUVID_DECODER 0
-@@ -610,6 +614,7 @@
- #define CONFIG_HEVC_MEDIACODEC_DECODER 0
- #define CONFIG_MJPEG_CUVID_DECODER 0
- #define CONFIG_MJPEG_QSV_DECODER 0
-+#define CONFIG_MP3_MEDIACODEC_DECODER 0
- #define CONFIG_MPEG1_CUVID_DECODER 0
- #define CONFIG_MPEG2_CUVID_DECODER 0
- #define CONFIG_MPEG4_CUVID_DECODER 0
-@@ -621,6 +626,7 @@
- #define CONFIG_VP9_CUVID_DECODER 0
- #define CONFIG_VP9_MEDIACODEC_DECODER 0
- #define CONFIG_VP9_QSV_DECODER 0
-+#define CONFIG_VVC_QSV_DECODER 0
- #define CONFIG_VNULL_DECODER 0
- #define CONFIG_ANULL_DECODER 0
- #define CONFIG_A64MULTI_ENCODER 0
-@@ -828,6 +834,7 @@
- #define CONFIG_LIBVORBIS_ENCODER 0
- #define CONFIG_LIBVPX_VP8_ENCODER 0
- #define CONFIG_LIBVPX_VP9_ENCODER 0
-+#define CONFIG_LIBVVENC_ENCODER 0
- #define CONFIG_LIBWEBP_ANIM_ENCODER 0
- #define CONFIG_LIBWEBP_ENCODER 0
- #define CONFIG_LIBX262_ENCODER 0
-@@ -855,7 +862,9 @@
- #define CONFIG_H264_V4L2M2M_ENCODER 0
- #define CONFIG_H264_VAAPI_ENCODER 0
- #define CONFIG_H264_VIDEOTOOLBOX_ENCODER 0
-+#define CONFIG_H264_VULKAN_ENCODER 0
- #define CONFIG_HEVC_AMF_ENCODER 0
-+#define CONFIG_HEVC_D3D12VA_ENCODER 0
- #define CONFIG_HEVC_MEDIACODEC_ENCODER 0
- #define CONFIG_HEVC_MF_ENCODER 0
- #define CONFIG_HEVC_NVENC_ENCODER 0
-@@ -863,6 +872,7 @@
- #define CONFIG_HEVC_V4L2M2M_ENCODER 0
- #define CONFIG_HEVC_VAAPI_ENCODER 0
- #define CONFIG_HEVC_VIDEOTOOLBOX_ENCODER 0
-+#define CONFIG_HEVC_VULKAN_ENCODER 0
- #define CONFIG_LIBKVAZAAR_ENCODER 0
- #define CONFIG_MJPEG_QSV_ENCODER 0
- #define CONFIG_MJPEG_VAAPI_ENCODER 0
-@@ -1357,6 +1367,7 @@
- #define CONFIG_KIRSCH_FILTER 0
- #define CONFIG_LAGFUN_FILTER 0
- #define CONFIG_LATENCY_FILTER 0
-+#define CONFIG_LCEVC_FILTER 0
- #define CONFIG_LENSCORRECTION_FILTER 0
- #define CONFIG_LENSFUN_FILTER 0
- #define CONFIG_LIBPLACEBO_FILTER 0
-@@ -1552,6 +1563,7 @@
- #define CONFIG_XFADE_OPENCL_FILTER 0
- #define CONFIG_XFADE_VULKAN_FILTER 0
- #define CONFIG_XMEDIAN_FILTER 0
-+#define CONFIG_XPSNR_FILTER 0
- #define CONFIG_XSTACK_FILTER 0
- #define CONFIG_YADIF_FILTER 0
- #define CONFIG_YADIF_CUDA_FILTER 0
-@@ -1588,6 +1600,7 @@
- #define CONFIG_QRENCODESRC_FILTER 0
- #define CONFIG_PAL75BARS_FILTER 0
- #define CONFIG_PAL100BARS_FILTER 0
-+#define CONFIG_PERLIN_FILTER 0
- #define CONFIG_RGBTESTSRC_FILTER 0
- #define CONFIG_SIERPINSKI_FILTER 0
- #define CONFIG_SMPTEBARS_FILTER 0
-diff --git a/chromium/config/Chrome/ios/arm64/libavutil/ffversion.h b/chromium/config/Chrome/ios/arm64/libavutil/ffversion.h
-index 9b26d87ca8b..71bdf19217c 100644
---- a/chromium/config/Chrome/ios/arm64/libavutil/ffversion.h
-+++ b/chromium/config/Chrome/ios/arm64/libavutil/ffversion.h
-@@ -1,5 +1,5 @@
- /* Automatically generated by version.sh, do not manually edit! */
- #ifndef AVUTIL_FFVERSION_H
- #define AVUTIL_FFVERSION_H
--#define FFMPEG_VERSION "N-116575-gd941d9677b"
-+#define FFMPEG_VERSION "N-118356-gdd11b92cac"
- #endif /* AVUTIL_FFVERSION_H */
-diff --git a/chromium/config/Chrome/ios/x64/config.asm b/chromium/config/Chrome/ios/x64/config.asm
-index 61fe976c144..643baf94023 100644
---- a/chromium/config/Chrome/ios/x64/config.asm
-+++ b/chromium/config/Chrome/ios/x64/config.asm
-@@ -1,11 +1,6 @@
- ; Automatically generated by configure - do not modify!
- %define ARCH_AARCH64 0
--%define ARCH_ALPHA 0
- %define ARCH_ARM 0
--%define ARCH_AVR32 0
--%define ARCH_AVR32_AP 0
--%define ARCH_AVR32_UC 0
--%define ARCH_BFIN 0
- %define ARCH_IA64 0
- %define ARCH_LOONGARCH 0
- %define ARCH_LOONGARCH32 0
-@@ -18,7 +13,6 @@
- %define ARCH_PPC64 0
- %define ARCH_RISCV 0
- %define ARCH_S390 0
--%define ARCH_SH4 0
- %define ARCH_SPARC 0
- %define ARCH_SPARC64 0
- %define ARCH_TILEGX 0
-@@ -44,6 +38,7 @@
- %define HAVE_VSX 0
- %define HAVE_RV 0
- %define HAVE_RVV 0
-+%define HAVE_RV_ZICBOP 1
- %define HAVE_RV_ZVBB 0
- %define HAVE_AESNI 1
- %define HAVE_AMD3DNOW 1
-@@ -96,6 +91,7 @@
- %define HAVE_VSX_EXTERNAL 0
- %define HAVE_RV_EXTERNAL 0
- %define HAVE_RVV_EXTERNAL 0
-+%define HAVE_RV_ZICBOP_EXTERNAL 0
- %define HAVE_RV_ZVBB_EXTERNAL 0
- %define HAVE_AESNI_EXTERNAL 1
- %define HAVE_AMD3DNOW_EXTERNAL 1
-@@ -148,6 +144,7 @@
- %define HAVE_VSX_INLINE 0
- %define HAVE_RV_INLINE 0
- %define HAVE_RVV_INLINE 0
-+%define HAVE_RV_ZICBOP_INLINE 0
- %define HAVE_RV_ZVBB_INLINE 0
- %define HAVE_AESNI_INLINE 1
- %define HAVE_AMD3DNOW_INLINE 1
-@@ -246,6 +243,7 @@
- %define HAVE_WINDOWS_H 0
- %define HAVE_WINSOCK2_H 0
- %define HAVE_INTRINSICS_NEON 0
-+%define HAVE_INTRINSICS_SSE2 1
- %define HAVE_ATANF 1
- %define HAVE_ATAN2F 1
- %define HAVE_CBRT 1
-@@ -288,6 +286,7 @@
- %define HAVE_CLOCK_GETTIME 0
- %define HAVE_CLOSESOCKET 0
- %define HAVE_COMMANDLINETOARGVW 0
-+%define HAVE_ELF_AUX_INFO 0
- %define HAVE_FCNTL 1
- %define HAVE_GETADDRINFO 0
- %define HAVE_GETAUXVAL 0
-@@ -336,6 +335,7 @@
- %define HAVE_SYSCONF 1
- %define HAVE_SYSCTL 1
- %define HAVE_SYSCTLBYNAME 1
-+%define HAVE_TEMPNAM 1
- %define HAVE_USLEEP 1
- %define HAVE_UTGETOSTYPEFROMSTRING 0
- %define HAVE_VIRTUALALLOC 0
-@@ -419,6 +419,7 @@
- %define HAVE_OPENCL_VIDEOTOOLBOX 0
- %define HAVE_PERL 1
- %define HAVE_POD2MAN 1
-+%define HAVE_POSIX_IOCTL 0
- %define HAVE_TEXI2HTML 0
- %define HAVE_XMLLINT 1
- %define HAVE_ZLIB_GZIP 0
-@@ -508,6 +509,7 @@
- %define CONFIG_LIBKLVANC 0
- %define CONFIG_LIBKVAZAAR 0
- %define CONFIG_LIBLC3 0
-+%define CONFIG_LIBLCEVC_DEC 0
- %define CONFIG_LIBMODPLUG 0
- %define CONFIG_LIBMP3LAME 0
- %define CONFIG_LIBMYSOFA 0
-@@ -545,6 +547,7 @@
- %define CONFIG_LIBVMAF 0
- %define CONFIG_LIBVORBIS 0
- %define CONFIG_LIBVPX 0
-+%define CONFIG_LIBVVENC 0
- %define CONFIG_LIBWEBP 0
- %define CONFIG_LIBXEVD 0
- %define CONFIG_LIBXEVE 0
-@@ -677,6 +680,7 @@
- %define CONFIG_CBS_MPEG2 0
- %define CONFIG_CBS_VP8 0
- %define CONFIG_CBS_VP9 0
-+%define CONFIG_D3D12VA_ENCODE 0
- %define CONFIG_DEFLATE_WRAPPER 0
- %define CONFIG_DIRAC_PARSE 1
- %define CONFIG_DNN 0
-@@ -763,5 +767,6 @@
- %define CONFIG_VP3DSP 0
- %define CONFIG_VP56DSP 0
- %define CONFIG_VP8DSP 0
-+%define CONFIG_VULKAN_ENCODE 0
- %define CONFIG_WMA_FREQS 0
- %define CONFIG_WMV2DSP 0
-diff --git a/chromium/config/Chrome/ios/x64/config.h b/chromium/config/Chrome/ios/x64/config.h
-index 382b19fc1d5..b04ab04e366 100644
---- a/chromium/config/Chrome/ios/x64/config.h
-+++ b/chromium/config/Chrome/ios/x64/config.h
-@@ -1,12 +1,12 @@
- /* Automatically generated by configure - do not modify! */
- #ifndef FFMPEG_CONFIG_H
- #define FFMPEG_CONFIG_H
--/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-iamf --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/usr/local/google/home/dalecurtis/code/chrome/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\"-O2\"' --enable-pic --cc=clang --cxx=clang++ --ld=clang --enable-cross-compile --cc=clang --ld=ld64.lld --nm=llvm-nm --ar=llvm-ar --target-os=darwin --extra-cflags='--target=x86_64-apple-macosx' --extra-cflags=-F/usr/local/google/home/dalecurtis/code/chrome/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks --extra-cflags='-mmacosx-version-min=10.10' --extra-cflags=-fblocks --extra-cflags=-nostdinc --extra-cflags=-isystem/usr/local/google/home/dalecurtis/code/chrome/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include --extra-cflags=-isystem/usr/local/google/home/dalecurtis/code/chrome/src/third_party/llvm-build/Release+Asserts/lib/clang/19/include --extra-ldflags=-syslibroot --extra-ldflags=/usr/local/google/home/dalecurtis/code/chrome/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk --extra-ldflags=-L/usr/local/google/home/dalecurtis/code/chrome/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib --extra-ldflags=-lSystem --extra-ldflags=-macosx_version_min --extra-ldflags=10.10 --extra-ldflags=-sdk_version --extra-ldflags=10.10 --extra-ldflags=-platform_version --extra-ldflags=macos --extra-ldflags=10.10 --extra-ldflags=10.10 --arch=x86_64 --extra-cflags=-m64 --extra-ldflags='-arch x86_64' --enable-decoder='aac,h264' --enable-demuxer=aac --enable-parser='aac,h264'" -- elide long configuration string from binary */
-+/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-iamf --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/usr/local/google/home/sandersd/src/chromium/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\"-O2\"' --enable-pic --cc=clang --cxx=clang++ --ld=clang --enable-cross-compile --cc=clang --ld=ld64.lld --nm=llvm-nm --ar=llvm-ar --target-os=darwin --extra-cflags='--target=x86_64-apple-macosx' --extra-cflags=-F/usr/local/google/home/sandersd/src/chromium/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks --extra-cflags='-mmacosx-version-min=10.10' --extra-cflags=-fblocks --extra-cflags=-nostdinc --extra-cflags=-isystem/usr/local/google/home/sandersd/src/chromium/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include --extra-cflags=-isystem/usr/local/google/home/sandersd/src/chromium/src/third_party/llvm-build/Release+Asserts/lib/clang/20/include --extra-ldflags=-syslibroot --extra-ldflags=/usr/local/google/home/sandersd/src/chromium/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk --extra-ldflags=-L/usr/local/google/home/sandersd/src/chromium/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib --extra-ldflags=-lSystem --extra-ldflags=-macosx_version_min --extra-ldflags=10.10 --extra-ldflags=-sdk_version --extra-ldflags=10.10 --extra-ldflags=-platform_version --extra-ldflags=macos --extra-ldflags=10.10 --extra-ldflags=10.10 --arch=x86_64 --extra-cflags=-m64 --extra-ldflags='-arch x86_64' --enable-decoder='aac,h264' --enable-demuxer=aac --enable-parser='aac,h264'" -- elide long configuration string from binary */
- #define FFMPEG_LICENSE "LGPL version 2.1 or later"
- #define CONFIG_THIS_YEAR 2024
- #define FFMPEG_DATADIR "/usr/local/share/ffmpeg"
- #define AVCONV_DATADIR "/usr/local/share/ffmpeg"
--#define CC_IDENT "clang version 19.0.0git (https://chromium.googlesource.com/a/external/github.com/llvm/llvm-project ecea8371ff03c15fb3dc27ee4108b98335fd2d63)"
-+#define CC_IDENT "clang version 20.0.0git (https://chromium.googlesource.com/a/external/github.com/llvm/llvm-project 6ee7e90a5d21cc0173dc5a0a344d230a80a46fd0)"
- #define OS_NAME darwin
- #define EXTERN_PREFIX "_"
- #define EXTERN_ASM _
-@@ -14,12 +14,7 @@
- #define SLIBSUF ".dylib"
- #define SWS_MAX_FILTER_SIZE 256
- #define ARCH_AARCH64 0
--#define ARCH_ALPHA 0
- #define ARCH_ARM 0
--#define ARCH_AVR32 0
--#define ARCH_AVR32_AP 0
--#define ARCH_AVR32_UC 0
--#define ARCH_BFIN 0
- #define ARCH_IA64 0
- #define ARCH_LOONGARCH 0
- #define ARCH_LOONGARCH32 0
-@@ -32,7 +27,6 @@
- #define ARCH_PPC64 0
- #define ARCH_RISCV 0
- #define ARCH_S390 0
--#define ARCH_SH4 0
- #define ARCH_SPARC 0
- #define ARCH_SPARC64 0
- #define ARCH_TILEGX 0
-@@ -58,6 +52,7 @@
- #define HAVE_VSX 0
- #define HAVE_RV 0
- #define HAVE_RVV 0
-+#define HAVE_RV_ZICBOP 1
- #define HAVE_RV_ZVBB 0
- #define HAVE_AESNI 1
- #define HAVE_AMD3DNOW 1
-@@ -110,6 +105,7 @@
- #define HAVE_VSX_EXTERNAL 0
- #define HAVE_RV_EXTERNAL 0
- #define HAVE_RVV_EXTERNAL 0
-+#define HAVE_RV_ZICBOP_EXTERNAL 0
- #define HAVE_RV_ZVBB_EXTERNAL 0
- #define HAVE_AESNI_EXTERNAL 1
- #define HAVE_AMD3DNOW_EXTERNAL 1
-@@ -162,6 +158,7 @@
- #define HAVE_VSX_INLINE 0
- #define HAVE_RV_INLINE 0
- #define HAVE_RVV_INLINE 0
-+#define HAVE_RV_ZICBOP_INLINE 0
- #define HAVE_RV_ZVBB_INLINE 0
- #define HAVE_AESNI_INLINE 1
- #define HAVE_AMD3DNOW_INLINE 1
-@@ -260,6 +257,7 @@
- #define HAVE_WINDOWS_H 0
- #define HAVE_WINSOCK2_H 0
- #define HAVE_INTRINSICS_NEON 0
-+#define HAVE_INTRINSICS_SSE2 1
- #define HAVE_ATANF 1
- #define HAVE_ATAN2F 1
- #define HAVE_CBRT 1
-@@ -302,6 +300,7 @@
- #define HAVE_CLOCK_GETTIME 0
- #define HAVE_CLOSESOCKET 0
- #define HAVE_COMMANDLINETOARGVW 0
-+#define HAVE_ELF_AUX_INFO 0
- #define HAVE_FCNTL 1
- #define HAVE_GETADDRINFO 0
- #define HAVE_GETAUXVAL 0
-@@ -350,6 +349,7 @@
- #define HAVE_SYSCONF 1
- #define HAVE_SYSCTL 1
- #define HAVE_SYSCTLBYNAME 1
-+#define HAVE_TEMPNAM 1
- #define HAVE_USLEEP 1
- #define HAVE_UTGETOSTYPEFROMSTRING 0
- #define HAVE_VIRTUALALLOC 0
-@@ -433,6 +433,7 @@
- #define HAVE_OPENCL_VIDEOTOOLBOX 0
- #define HAVE_PERL 1
- #define HAVE_POD2MAN 1
-+#define HAVE_POSIX_IOCTL 0
- #define HAVE_TEXI2HTML 0
- #define HAVE_XMLLINT 1
- #define HAVE_ZLIB_GZIP 0
-@@ -522,6 +523,7 @@
- #define CONFIG_LIBKLVANC 0
- #define CONFIG_LIBKVAZAAR 0
- #define CONFIG_LIBLC3 0
-+#define CONFIG_LIBLCEVC_DEC 0
- #define CONFIG_LIBMODPLUG 0
- #define CONFIG_LIBMP3LAME 0
- #define CONFIG_LIBMYSOFA 0
-@@ -559,6 +561,7 @@
- #define CONFIG_LIBVMAF 0
- #define CONFIG_LIBVORBIS 0
- #define CONFIG_LIBVPX 0
-+#define CONFIG_LIBVVENC 0
- #define CONFIG_LIBWEBP 0
- #define CONFIG_LIBXEVD 0
- #define CONFIG_LIBXEVE 0
-@@ -691,6 +694,7 @@
- #define CONFIG_CBS_MPEG2 0
- #define CONFIG_CBS_VP8 0
- #define CONFIG_CBS_VP9 0
-+#define CONFIG_D3D12VA_ENCODE 0
- #define CONFIG_DEFLATE_WRAPPER 0
- #define CONFIG_DIRAC_PARSE 1
- #define CONFIG_DNN 0
-@@ -777,6 +781,7 @@
- #define CONFIG_VP3DSP 0
- #define CONFIG_VP56DSP 0
- #define CONFIG_VP8DSP 0
-+#define CONFIG_VULKAN_ENCODE 0
- #define CONFIG_WMA_FREQS 0
- #define CONFIG_WMV2DSP 0
- #endif /* FFMPEG_CONFIG_H */
-diff --git a/chromium/config/Chrome/ios/x64/config_components.h b/chromium/config/Chrome/ios/x64/config_components.h
-index 8ebce4c9b52..aaba26ad222 100644
---- a/chromium/config/Chrome/ios/x64/config_components.h
-+++ b/chromium/config/Chrome/ios/x64/config_components.h
-@@ -8,6 +8,7 @@
- #define CONFIG_CHOMP_BSF 0
- #define CONFIG_DUMP_EXTRADATA_BSF 0
- #define CONFIG_DCA_CORE_BSF 0
-+#define CONFIG_DOVI_RPU_BSF 0
- #define CONFIG_DTS2PTS_BSF 0
- #define CONFIG_DV_ERROR_MARKER_BSF 0
- #define CONFIG_EAC3_CORE_BSF 0
-@@ -599,6 +600,9 @@
- #define CONFIG_BINTEXT_DECODER 0
- #define CONFIG_XBIN_DECODER 0
- #define CONFIG_IDF_DECODER 0
-+#define CONFIG_AAC_MEDIACODEC_DECODER 0
-+#define CONFIG_AMRNB_MEDIACODEC_DECODER 0
-+#define CONFIG_AMRWB_MEDIACODEC_DECODER 0
- #define CONFIG_LIBAOM_AV1_DECODER 0
- #define CONFIG_AV1_DECODER 0
- #define CONFIG_AV1_CUVID_DECODER 0
-@@ -610,6 +614,7 @@
- #define CONFIG_HEVC_MEDIACODEC_DECODER 0
- #define CONFIG_MJPEG_CUVID_DECODER 0
- #define CONFIG_MJPEG_QSV_DECODER 0
-+#define CONFIG_MP3_MEDIACODEC_DECODER 0
- #define CONFIG_MPEG1_CUVID_DECODER 0
- #define CONFIG_MPEG2_CUVID_DECODER 0
- #define CONFIG_MPEG4_CUVID_DECODER 0
-@@ -621,6 +626,7 @@
- #define CONFIG_VP9_CUVID_DECODER 0
- #define CONFIG_VP9_MEDIACODEC_DECODER 0
- #define CONFIG_VP9_QSV_DECODER 0
-+#define CONFIG_VVC_QSV_DECODER 0
- #define CONFIG_VNULL_DECODER 0
- #define CONFIG_ANULL_DECODER 0
- #define CONFIG_A64MULTI_ENCODER 0
-@@ -828,6 +834,7 @@
- #define CONFIG_LIBVORBIS_ENCODER 0
- #define CONFIG_LIBVPX_VP8_ENCODER 0
- #define CONFIG_LIBVPX_VP9_ENCODER 0
-+#define CONFIG_LIBVVENC_ENCODER 0
- #define CONFIG_LIBWEBP_ANIM_ENCODER 0
- #define CONFIG_LIBWEBP_ENCODER 0
- #define CONFIG_LIBX262_ENCODER 0
-@@ -855,7 +862,9 @@
- #define CONFIG_H264_V4L2M2M_ENCODER 0
- #define CONFIG_H264_VAAPI_ENCODER 0
- #define CONFIG_H264_VIDEOTOOLBOX_ENCODER 0
-+#define CONFIG_H264_VULKAN_ENCODER 0
- #define CONFIG_HEVC_AMF_ENCODER 0
-+#define CONFIG_HEVC_D3D12VA_ENCODER 0
- #define CONFIG_HEVC_MEDIACODEC_ENCODER 0
- #define CONFIG_HEVC_MF_ENCODER 0
- #define CONFIG_HEVC_NVENC_ENCODER 0
-@@ -863,6 +872,7 @@
- #define CONFIG_HEVC_V4L2M2M_ENCODER 0
- #define CONFIG_HEVC_VAAPI_ENCODER 0
- #define CONFIG_HEVC_VIDEOTOOLBOX_ENCODER 0
-+#define CONFIG_HEVC_VULKAN_ENCODER 0
- #define CONFIG_LIBKVAZAAR_ENCODER 0
- #define CONFIG_MJPEG_QSV_ENCODER 0
- #define CONFIG_MJPEG_VAAPI_ENCODER 0
-@@ -1357,6 +1367,7 @@
- #define CONFIG_KIRSCH_FILTER 0
- #define CONFIG_LAGFUN_FILTER 0
- #define CONFIG_LATENCY_FILTER 0
-+#define CONFIG_LCEVC_FILTER 0
- #define CONFIG_LENSCORRECTION_FILTER 0
- #define CONFIG_LENSFUN_FILTER 0
- #define CONFIG_LIBPLACEBO_FILTER 0
-@@ -1552,6 +1563,7 @@
- #define CONFIG_XFADE_OPENCL_FILTER 0
- #define CONFIG_XFADE_VULKAN_FILTER 0
- #define CONFIG_XMEDIAN_FILTER 0
-+#define CONFIG_XPSNR_FILTER 0
- #define CONFIG_XSTACK_FILTER 0
- #define CONFIG_YADIF_FILTER 0
- #define CONFIG_YADIF_CUDA_FILTER 0
-@@ -1588,6 +1600,7 @@
- #define CONFIG_QRENCODESRC_FILTER 0
- #define CONFIG_PAL75BARS_FILTER 0
- #define CONFIG_PAL100BARS_FILTER 0
-+#define CONFIG_PERLIN_FILTER 0
- #define CONFIG_RGBTESTSRC_FILTER 0
- #define CONFIG_SIERPINSKI_FILTER 0
- #define CONFIG_SMPTEBARS_FILTER 0
-diff --git a/chromium/config/Chrome/ios/x64/libavutil/ffversion.h b/chromium/config/Chrome/ios/x64/libavutil/ffversion.h
-index 9b26d87ca8b..71bdf19217c 100644
---- a/chromium/config/Chrome/ios/x64/libavutil/ffversion.h
-+++ b/chromium/config/Chrome/ios/x64/libavutil/ffversion.h
-@@ -1,5 +1,5 @@
- /* Automatically generated by version.sh, do not manually edit! */
- #ifndef AVUTIL_FFVERSION_H
- #define AVUTIL_FFVERSION_H
--#define FFMPEG_VERSION "N-116575-gd941d9677b"
-+#define FFMPEG_VERSION "N-118356-gdd11b92cac"
- #endif /* AVUTIL_FFVERSION_H */
 diff --git a/chromium/config/Chrome/linux/riscv64/config.h b/chromium/config/Chrome/linux/riscv64/config.h
 new file mode 100644
-index 00000000000..9054542d07f
+index 0000000000..6d6b8f9854
 --- /dev/null
 +++ b/chromium/config/Chrome/linux/riscv64/config.h
-@@ -0,0 +1,787 @@
+@@ -0,0 +1,793 @@
 +/* Automatically generated by configure - do not modify! */
 +#ifndef FFMPEG_CONFIG_H
 +#define FFMPEG_CONFIG_H
-+/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-iamf --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/home/kxxt/Workspaces/chromium/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\"-O2\"' --arch=riscv64 --extra-cflags='-march=rv64gc' --enable-cross-compile --target-os=linux --sysroot=/home/kxxt/Workspaces/chromium/src/build/linux/debian_sid_riscv64-sysroot --extra-cflags='--target=riscv64-linux-gnu' --extra-ldflags='--target=riscv64-linux-gnu' --enable-pic --cc=clang --cxx=clang++ --ld=clang --extra-ldflags='-fuse-ld=lld' --enable-decoder='aac,h264' --enable-demuxer=aac --enable-parser='aac,h264'" -- elide long configuration string from binary */
++/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-iamf --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/home/kxxt/electron-ci/sources/electron/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\"-O2\"' --arch=riscv64 --extra-cflags='-march=rv64gc' --enable-cross-compile --target-os=linux --sysroot=/home/kxxt/electron-ci/sources/electron/src/build/linux/debian_sid_riscv64-sysroot --extra-cflags='--target=riscv64-linux-gnu' --extra-ldflags='--target=riscv64-linux-gnu' --enable-pic --cc=clang --cxx=clang++ --ld=clang --extra-ldflags='-fuse-ld=lld' --enable-decoder='aac,h264' --enable-demuxer=aac --enable-parser='aac,h264'" -- elide long configuration string from binary */
 +#define FFMPEG_LICENSE "LGPL version 2.1 or later"
 +#define CONFIG_THIS_YEAR 2024
 +#define FFMPEG_DATADIR "/usr/local/share/ffmpeg"
 +#define AVCONV_DATADIR "/usr/local/share/ffmpeg"
-+#define CC_IDENT "clang version 20.0.0git (https://chromium.googlesource.com/a/external/github.com/llvm/llvm-project 3dbd929ea6af134650dd1d91baeb61a4fc1b0eb8)"
++#define CC_IDENT "clang version 20.0.0git (https://chromium.googlesource.com/external/github.com/llvm/llvm-project b81d8e90339a788cc6cb148831612c6b39b93ad5)"
 +#define OS_NAME linux
 +#define EXTERN_PREFIX ""
 +#define EXTERN_ASM 
@@ -879,6 +375,8 @@ index 00000000000..9054542d07f
 +#define HAVE_VFP 0
 +#define HAVE_VFPV3 0
 +#define HAVE_SETEND 0
++#define HAVE_SVE 0
++#define HAVE_SVE2 0
 +#define HAVE_ALTIVEC 0
 +#define HAVE_DCBZL 0
 +#define HAVE_LDBRX 0
@@ -932,6 +430,8 @@ index 00000000000..9054542d07f
 +#define HAVE_VFP_EXTERNAL 0
 +#define HAVE_VFPV3_EXTERNAL 0
 +#define HAVE_SETEND_EXTERNAL 0
++#define HAVE_SVE_EXTERNAL 0
++#define HAVE_SVE2_EXTERNAL 0
 +#define HAVE_ALTIVEC_EXTERNAL 0
 +#define HAVE_DCBZL_EXTERNAL 0
 +#define HAVE_LDBRX_EXTERNAL 0
@@ -985,6 +485,8 @@ index 00000000000..9054542d07f
 +#define HAVE_VFP_INLINE 0
 +#define HAVE_VFPV3_INLINE 0
 +#define HAVE_SETEND_INLINE 0
++#define HAVE_SVE_INLINE 0
++#define HAVE_SVE2_INLINE 0
 +#define HAVE_ALTIVEC_INLINE 0
 +#define HAVE_DCBZL_INLINE 0
 +#define HAVE_LDBRX_INLINE 0
@@ -1037,13 +539,10 @@ index 00000000000..9054542d07f
 +#define HAVE_SIMD_ALIGN_16 0
 +#define HAVE_SIMD_ALIGN_32 0
 +#define HAVE_SIMD_ALIGN_64 0
-+#define HAVE_ATOMIC_CAS_PTR 0
-+#define HAVE_MACHINE_RW_BARRIER 0
 +#define HAVE_MEMORYBARRIER 0
 +#define HAVE_MM_EMPTY 0
 +#define HAVE_RDTSC 0
 +#define HAVE_SEM_TIMEDWAIT 1
-+#define HAVE_SYNC_VAL_COMPARE_AND_SWAP 1
 +#define HAVE_INLINE_ASM 1
 +#define HAVE_SYMVER 0
 +#define HAVE_X86ASM 0
@@ -1200,6 +699,8 @@ index 00000000000..9054542d07f
 +#define HAVE_AS_ARCH_DIRECTIVE 0
 +#define HAVE_AS_ARCHEXT_DOTPROD_DIRECTIVE 0
 +#define HAVE_AS_ARCHEXT_I8MM_DIRECTIVE 0
++#define HAVE_AS_ARCHEXT_SVE_DIRECTIVE 0
++#define HAVE_AS_ARCHEXT_SVE2_DIRECTIVE 0
 +#define HAVE_AS_DN_DIRECTIVE 0
 +#define HAVE_AS_FPU_DIRECTIVE 0
 +#define HAVE_AS_FUNC 0
@@ -1226,6 +727,7 @@ index 00000000000..9054542d07f
 +#define HAVE_KCMVIDEOCODECTYPE_HEVC 0
 +#define HAVE_KCMVIDEOCODECTYPE_HEVCWITHALPHA 0
 +#define HAVE_KCMVIDEOCODECTYPE_VP9 0
++#define HAVE_KCMVIDEOCODECTYPE_AV1 0
 +#define HAVE_KCVPIXELFORMATTYPE_420YPCBCR10BIPLANARVIDEORANGE 0
 +#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR8BIPLANARVIDEORANGE 0
 +#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR10BIPLANARVIDEORANGE 0
@@ -1622,10 +1124,10 @@ index 00000000000..9054542d07f
 +#endif /* FFMPEG_CONFIG_H */
 diff --git a/chromium/config/Chrome/linux/riscv64/config_components.h b/chromium/config/Chrome/linux/riscv64/config_components.h
 new file mode 100644
-index 00000000000..aaba26ad222
+index 0000000000..9c54631806
 --- /dev/null
 +++ b/chromium/config/Chrome/linux/riscv64/config_components.h
-@@ -0,0 +1,2231 @@
+@@ -0,0 +1,2234 @@
 +/* Automatically generated by configure - do not modify! */
 +#ifndef FFMPEG_CONFIG_COMPONENTS_H
 +#define FFMPEG_CONFIG_COMPONENTS_H
@@ -2480,6 +1982,7 @@ index 00000000000..aaba26ad222
 +#define CONFIG_AV1_NVENC_ENCODER 0
 +#define CONFIG_AV1_QSV_ENCODER 0
 +#define CONFIG_AV1_AMF_ENCODER 0
++#define CONFIG_AV1_MF_ENCODER 0
 +#define CONFIG_AV1_VAAPI_ENCODER 0
 +#define CONFIG_LIBOPENH264_ENCODER 0
 +#define CONFIG_H264_AMF_ENCODER 0
@@ -2526,6 +2029,7 @@ index 00000000000..aaba26ad222
 +#define CONFIG_AV1_NVDEC_HWACCEL 0
 +#define CONFIG_AV1_VAAPI_HWACCEL 0
 +#define CONFIG_AV1_VDPAU_HWACCEL 0
++#define CONFIG_AV1_VIDEOTOOLBOX_HWACCEL 0
 +#define CONFIG_AV1_VULKAN_HWACCEL 0
 +#define CONFIG_H263_VAAPI_HWACCEL 0
 +#define CONFIG_H263_VIDEOTOOLBOX_HWACCEL 0
@@ -2604,6 +2108,7 @@ index 00000000000..aaba26ad222
 +#define CONFIG_DCA_PARSER 0
 +#define CONFIG_DIRAC_PARSER 0
 +#define CONFIG_DNXHD_PARSER 0
++#define CONFIG_DNXUC_PARSER 0
 +#define CONFIG_DOLBY_E_PARSER 0
 +#define CONFIG_DPX_PARSER 0
 +#define CONFIG_DVAUDIO_PARSER 0
@@ -3859,7 +3364,7 @@ index 00000000000..aaba26ad222
 +#endif /* FFMPEG_CONFIG_COMPONENTS_H */
 diff --git a/chromium/config/Chrome/linux/riscv64/libavcodec/bsf_list.c b/chromium/config/Chrome/linux/riscv64/libavcodec/bsf_list.c
 new file mode 100644
-index 00000000000..7ff70c6e2d6
+index 0000000000..7ff70c6e2d
 --- /dev/null
 +++ b/chromium/config/Chrome/linux/riscv64/libavcodec/bsf_list.c
 @@ -0,0 +1,2 @@
@@ -3867,7 +3372,7 @@ index 00000000000..7ff70c6e2d6
 +    NULL };
 diff --git a/chromium/config/Chrome/linux/riscv64/libavcodec/codec_list.c b/chromium/config/Chrome/linux/riscv64/libavcodec/codec_list.c
 new file mode 100644
-index 00000000000..fe5adb0d923
+index 0000000000..fe5adb0d92
 --- /dev/null
 +++ b/chromium/config/Chrome/linux/riscv64/libavcodec/codec_list.c
 @@ -0,0 +1,17 @@
@@ -3890,7 +3395,7 @@ index 00000000000..fe5adb0d923
 +    NULL };
 diff --git a/chromium/config/Chrome/linux/riscv64/libavcodec/parser_list.c b/chromium/config/Chrome/linux/riscv64/libavcodec/parser_list.c
 new file mode 100644
-index 00000000000..3e4fa9c320e
+index 0000000000..3e4fa9c320
 --- /dev/null
 +++ b/chromium/config/Chrome/linux/riscv64/libavcodec/parser_list.c
 @@ -0,0 +1,9 @@
@@ -3905,7 +3410,7 @@ index 00000000000..3e4fa9c320e
 +    NULL };
 diff --git a/chromium/config/Chrome/linux/riscv64/libavformat/demuxer_list.c b/chromium/config/Chrome/linux/riscv64/libavformat/demuxer_list.c
 new file mode 100644
-index 00000000000..29f1f593818
+index 0000000000..29f1f59381
 --- /dev/null
 +++ b/chromium/config/Chrome/linux/riscv64/libavformat/demuxer_list.c
 @@ -0,0 +1,9 @@
@@ -3920,7 +3425,7 @@ index 00000000000..29f1f593818
 +    NULL };
 diff --git a/chromium/config/Chrome/linux/riscv64/libavformat/muxer_list.c b/chromium/config/Chrome/linux/riscv64/libavformat/muxer_list.c
 new file mode 100644
-index 00000000000..ae54c39f23d
+index 0000000000..ae54c39f23
 --- /dev/null
 +++ b/chromium/config/Chrome/linux/riscv64/libavformat/muxer_list.c
 @@ -0,0 +1,2 @@
@@ -3928,7 +3433,7 @@ index 00000000000..ae54c39f23d
 +    NULL };
 diff --git a/chromium/config/Chrome/linux/riscv64/libavformat/protocol_list.c b/chromium/config/Chrome/linux/riscv64/libavformat/protocol_list.c
 new file mode 100644
-index 00000000000..247e1e4c3a2
+index 0000000000..247e1e4c3a
 --- /dev/null
 +++ b/chromium/config/Chrome/linux/riscv64/libavformat/protocol_list.c
 @@ -0,0 +1,2 @@
@@ -3936,7 +3441,7 @@ index 00000000000..247e1e4c3a2
 +    NULL };
 diff --git a/chromium/config/Chrome/linux/riscv64/libavutil/avconfig.h b/chromium/config/Chrome/linux/riscv64/libavutil/avconfig.h
 new file mode 100644
-index 00000000000..8558b35027f
+index 0000000000..8558b35027
 --- /dev/null
 +++ b/chromium/config/Chrome/linux/riscv64/libavutil/avconfig.h
 @@ -0,0 +1,6 @@
@@ -3948,20 +3453,20 @@ index 00000000000..8558b35027f
 +#endif /* AVUTIL_AVCONFIG_H */
 diff --git a/chromium/config/Chrome/linux/riscv64/libavutil/ffversion.h b/chromium/config/Chrome/linux/riscv64/libavutil/ffversion.h
 new file mode 100644
-index 00000000000..4303e401160
+index 0000000000..677ca92389
 --- /dev/null
 +++ b/chromium/config/Chrome/linux/riscv64/libavutil/ffversion.h
 @@ -0,0 +1,5 @@
 +/* Automatically generated by version.sh, do not manually edit! */
 +#ifndef AVUTIL_FFVERSION_H
 +#define AVUTIL_FFVERSION_H
-+#define FFMPEG_VERSION "git-2024-10-01-686d6944501"
++#define FFMPEG_VERSION "git-2025-01-10-3d2a884996"
 +#endif /* AVUTIL_FFVERSION_H */
 diff --git a/chromium/config/Chrome/linux/x64/config.asm b/chromium/config/Chrome/linux/x64/config.asm
-index d91b9980223..92801546e19 100644
+index 9717a6eeb9..9d71f9d8bf 100644
 --- a/chromium/config/Chrome/linux/x64/config.asm
 +++ b/chromium/config/Chrome/linux/x64/config.asm
-@@ -366,7 +366,7 @@
+@@ -371,7 +371,7 @@
  %define HAVE_INLINE_ASM_LABELS 1
  %define HAVE_INLINE_ASM_NONLOCAL_LABELS 1
  %define HAVE_PRAGMA_DEPRECATED 1
@@ -3970,7 +3475,7 @@ index d91b9980223..92801546e19 100644
  %define HAVE_SYMVER_ASM_LABEL 1
  %define HAVE_SYMVER_GNU_ASM 1
  %define HAVE_VFP_ARGS 0
-@@ -421,7 +421,7 @@
+@@ -427,7 +427,7 @@
  %define HAVE_POD2MAN 1
  %define HAVE_POSIX_IOCTL 0
  %define HAVE_TEXI2HTML 0
@@ -3980,25 +3485,25 @@ index d91b9980223..92801546e19 100644
  %define HAVE_OPENVINO2 0
  %define CONFIG_DOC 0
 diff --git a/chromium/config/Chrome/linux/x64/config.h b/chromium/config/Chrome/linux/x64/config.h
-index 18bc0fd46a8..e7a7b276589 100644
+index bed4c1cc74..89e6585720 100644
 --- a/chromium/config/Chrome/linux/x64/config.h
 +++ b/chromium/config/Chrome/linux/x64/config.h
 @@ -1,12 +1,12 @@
  /* Automatically generated by configure - do not modify! */
  #ifndef FFMPEG_CONFIG_H
  #define FFMPEG_CONFIG_H
--/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-iamf --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/usr/local/google/home/sandersd/src/chromium/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\"-O2\"' --enable-lto --arch=x86_64 --target-os=linux --enable-pic --cc=clang --cxx=clang++ --ld=clang --extra-ldflags='-fuse-ld=lld' --enable-decoder='aac,h264' --enable-demuxer=aac --enable-parser='aac,h264'" -- elide long configuration string from binary */
-+/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-iamf --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/home/kxxt/Workspaces/chromium/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\"-O2\"' --enable-lto --arch=x86_64 --target-os=linux --enable-pic --cc=clang --cxx=clang++ --ld=clang --extra-ldflags='-fuse-ld=lld' --enable-decoder='aac,h264' --enable-demuxer=aac --enable-parser='aac,h264'" -- elide long configuration string from binary */
+-/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-iamf --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/usr/local/google/home/ezemtsov/projects/chromium/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\"-O2\"' --enable-lto --arch=x86_64 --target-os=linux --enable-pic --cc=clang --cxx=clang++ --ld=clang --extra-ldflags='-fuse-ld=lld' --enable-decoder='aac,h264' --enable-demuxer=aac --enable-parser='aac,h264'" -- elide long configuration string from binary */
++/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-iamf --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/home/kxxt/electron-ci/sources/electron/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\"-O2\"' --enable-lto --arch=x86_64 --target-os=linux --enable-pic --cc=clang --cxx=clang++ --ld=clang --extra-ldflags='-fuse-ld=lld' --enable-decoder='aac,h264' --enable-demuxer=aac --enable-parser='aac,h264'" -- elide long configuration string from binary */
  #define FFMPEG_LICENSE "LGPL version 2.1 or later"
  #define CONFIG_THIS_YEAR 2024
  #define FFMPEG_DATADIR "/usr/local/share/ffmpeg"
  #define AVCONV_DATADIR "/usr/local/share/ffmpeg"
--#define CC_IDENT "clang version 20.0.0git (https://chromium.googlesource.com/a/external/github.com/llvm/llvm-project 6ee7e90a5d21cc0173dc5a0a344d230a80a46fd0)"
-+#define CC_IDENT "clang version 20.0.0git (https://chromium.googlesource.com/a/external/github.com/llvm/llvm-project 3dbd929ea6af134650dd1d91baeb61a4fc1b0eb8)"
+-#define CC_IDENT "clang version 20.0.0git (https://chromium.googlesource.com/a/external/github.com/llvm/llvm-project 923566a67de39a00eb6fc5cabbad307a72aa338e)"
++#define CC_IDENT "clang version 20.0.0git (https://chromium.googlesource.com/external/github.com/llvm/llvm-project b81d8e90339a788cc6cb148831612c6b39b93ad5)"
  #define OS_NAME linux
  #define EXTERN_PREFIX ""
  #define EXTERN_ASM 
-@@ -380,7 +380,7 @@
+@@ -385,7 +385,7 @@
  #define HAVE_INLINE_ASM_LABELS 1
  #define HAVE_INLINE_ASM_NONLOCAL_LABELS 1
  #define HAVE_PRAGMA_DEPRECATED 1
@@ -4007,7 +3512,7 @@ index 18bc0fd46a8..e7a7b276589 100644
  #define HAVE_SYMVER_ASM_LABEL 1
  #define HAVE_SYMVER_GNU_ASM 1
  #define HAVE_VFP_ARGS 0
-@@ -435,7 +435,7 @@
+@@ -441,7 +441,7 @@
  #define HAVE_POD2MAN 1
  #define HAVE_POSIX_IOCTL 0
  #define HAVE_TEXI2HTML 0
@@ -4017,596 +3522,6845 @@ index 18bc0fd46a8..e7a7b276589 100644
  #define HAVE_OPENVINO2 0
  #define CONFIG_DOC 0
 diff --git a/chromium/config/Chrome/linux/x64/libavutil/ffversion.h b/chromium/config/Chrome/linux/x64/libavutil/ffversion.h
-index 71bdf19217c..4303e401160 100644
+index 54c2598a44..677ca92389 100644
 --- a/chromium/config/Chrome/linux/x64/libavutil/ffversion.h
 +++ b/chromium/config/Chrome/linux/x64/libavutil/ffversion.h
 @@ -1,5 +1,5 @@
  /* Automatically generated by version.sh, do not manually edit! */
  #ifndef AVUTIL_FFVERSION_H
  #define AVUTIL_FFVERSION_H
--#define FFMPEG_VERSION "N-118356-gdd11b92cac"
-+#define FFMPEG_VERSION "git-2024-10-01-686d6944501"
+-#define FFMPEG_VERSION "N-118887-g99f17d50d3"
++#define FFMPEG_VERSION "git-2025-01-10-3d2a884996"
  #endif /* AVUTIL_FFVERSION_H */
-diff --git a/chromium/config/Chromium/ios/arm64/config.h b/chromium/config/Chromium/ios/arm64/config.h
-index 6e3f4a26526..8a6bd88681b 100644
---- a/chromium/config/Chromium/ios/arm64/config.h
-+++ b/chromium/config/Chromium/ios/arm64/config.h
-@@ -1,12 +1,12 @@
- /* Automatically generated by configure - do not modify! */
- #ifndef FFMPEG_CONFIG_H
- #define FFMPEG_CONFIG_H
--/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-iamf --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/usr/local/google/home/dalecurtis/code/chrome/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\"-O2\"' --enable-pic --cc=clang --cxx=clang++ --ld=clang --enable-cross-compile --cc=clang --ld=ld64.lld --nm=llvm-nm --ar=llvm-ar --target-os=darwin --extra-cflags='--target=arm64-apple-macosx' --extra-cflags=-F/usr/local/google/home/dalecurtis/code/chrome/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks --extra-cflags='-mmacosx-version-min=10.10' --extra-cflags=-fblocks --extra-cflags=-nostdinc --extra-cflags=-isystem/usr/local/google/home/dalecurtis/code/chrome/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include --extra-cflags=-isystem/usr/local/google/home/dalecurtis/code/chrome/src/third_party/llvm-build/Release+Asserts/lib/clang/19/include --extra-ldflags=-syslibroot --extra-ldflags=/usr/local/google/home/dalecurtis/code/chrome/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk --extra-ldflags=-L/usr/local/google/home/dalecurtis/code/chrome/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib --extra-ldflags=-lSystem --extra-ldflags=-macosx_version_min --extra-ldflags=10.10 --extra-ldflags=-sdk_version --extra-ldflags=10.10 --extra-ldflags=-platform_version --extra-ldflags=macos --extra-ldflags=10.10 --extra-ldflags=10.10 --arch=arm64 --extra-cflags='-arch arm64' --extra-ldflags='-arch arm64'" -- elide long configuration string from binary */
-+/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-iamf --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/usr/local/google/home/sandersd/src/chromium/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\"-O2\"' --enable-pic --cc=clang --cxx=clang++ --ld=clang --enable-cross-compile --cc=clang --ld=ld64.lld --nm=llvm-nm --ar=llvm-ar --target-os=darwin --extra-cflags='--target=arm64-apple-macosx' --extra-cflags=-F/usr/local/google/home/sandersd/src/chromium/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks --extra-cflags='-mmacosx-version-min=10.10' --extra-cflags=-fblocks --extra-cflags=-nostdinc --extra-cflags=-isystem/usr/local/google/home/sandersd/src/chromium/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include --extra-cflags=-isystem/usr/local/google/home/sandersd/src/chromium/src/third_party/llvm-build/Release+Asserts/lib/clang/20/include --extra-ldflags=-syslibroot --extra-ldflags=/usr/local/google/home/sandersd/src/chromium/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk --extra-ldflags=-L/usr/local/google/home/sandersd/src/chromium/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib --extra-ldflags=-lSystem --extra-ldflags=-macosx_version_min --extra-ldflags=10.10 --extra-ldflags=-sdk_version --extra-ldflags=10.10 --extra-ldflags=-platform_version --extra-ldflags=macos --extra-ldflags=10.10 --extra-ldflags=10.10 --arch=arm64 --extra-cflags='-arch arm64' --extra-ldflags='-arch arm64'" -- elide long configuration string from binary */
- #define FFMPEG_LICENSE "LGPL version 2.1 or later"
- #define CONFIG_THIS_YEAR 2024
- #define FFMPEG_DATADIR "/usr/local/share/ffmpeg"
- #define AVCONV_DATADIR "/usr/local/share/ffmpeg"
--#define CC_IDENT "clang version 19.0.0git (https://chromium.googlesource.com/a/external/github.com/llvm/llvm-project ecea8371ff03c15fb3dc27ee4108b98335fd2d63)"
-+#define CC_IDENT "clang version 20.0.0git (https://chromium.googlesource.com/a/external/github.com/llvm/llvm-project 6ee7e90a5d21cc0173dc5a0a344d230a80a46fd0)"
- #define OS_NAME darwin
- #define EXTERN_PREFIX "_"
- #define EXTERN_ASM _
-@@ -15,12 +15,7 @@
- #define SWS_MAX_FILTER_SIZE 256
- #define AS_ARCH_LEVEL armv8.6-a+crc
- #define ARCH_AARCH64 1
--#define ARCH_ALPHA 0
- #define ARCH_ARM 0
--#define ARCH_AVR32 0
--#define ARCH_AVR32_AP 0
--#define ARCH_AVR32_UC 0
--#define ARCH_BFIN 0
- #define ARCH_IA64 0
- #define ARCH_LOONGARCH 0
- #define ARCH_LOONGARCH32 0
-@@ -33,7 +28,6 @@
- #define ARCH_PPC64 0
- #define ARCH_RISCV 0
- #define ARCH_S390 0
--#define ARCH_SH4 0
- #define ARCH_SPARC 0
- #define ARCH_SPARC64 0
- #define ARCH_TILEGX 0
-@@ -59,6 +53,7 @@
- #define HAVE_VSX 0
- #define HAVE_RV 0
- #define HAVE_RVV 0
-+#define HAVE_RV_ZICBOP 1
- #define HAVE_RV_ZVBB 0
- #define HAVE_AESNI 0
- #define HAVE_AMD3DNOW 0
-@@ -111,6 +106,7 @@
- #define HAVE_VSX_EXTERNAL 0
- #define HAVE_RV_EXTERNAL 0
- #define HAVE_RVV_EXTERNAL 0
-+#define HAVE_RV_ZICBOP_EXTERNAL 0
- #define HAVE_RV_ZVBB_EXTERNAL 0
- #define HAVE_AESNI_EXTERNAL 0
- #define HAVE_AMD3DNOW_EXTERNAL 0
-@@ -163,6 +159,7 @@
- #define HAVE_VSX_INLINE 0
- #define HAVE_RV_INLINE 0
- #define HAVE_RVV_INLINE 0
-+#define HAVE_RV_ZICBOP_INLINE 0
- #define HAVE_RV_ZVBB_INLINE 0
- #define HAVE_AESNI_INLINE 0
- #define HAVE_AMD3DNOW_INLINE 0
-@@ -261,6 +258,7 @@
- #define HAVE_WINDOWS_H 0
- #define HAVE_WINSOCK2_H 0
- #define HAVE_INTRINSICS_NEON 1
-+#define HAVE_INTRINSICS_SSE2 0
- #define HAVE_ATANF 1
- #define HAVE_ATAN2F 1
- #define HAVE_CBRT 1
-@@ -303,6 +301,7 @@
- #define HAVE_CLOCK_GETTIME 0
- #define HAVE_CLOSESOCKET 0
- #define HAVE_COMMANDLINETOARGVW 0
-+#define HAVE_ELF_AUX_INFO 0
- #define HAVE_FCNTL 1
- #define HAVE_GETADDRINFO 0
- #define HAVE_GETAUXVAL 0
-@@ -351,6 +350,7 @@
- #define HAVE_SYSCONF 1
- #define HAVE_SYSCTL 1
- #define HAVE_SYSCTLBYNAME 1
-+#define HAVE_TEMPNAM 1
- #define HAVE_USLEEP 1
- #define HAVE_UTGETOSTYPEFROMSTRING 0
- #define HAVE_VIRTUALALLOC 0
-@@ -434,6 +434,7 @@
- #define HAVE_OPENCL_VIDEOTOOLBOX 0
- #define HAVE_PERL 1
- #define HAVE_POD2MAN 1
-+#define HAVE_POSIX_IOCTL 0
- #define HAVE_TEXI2HTML 0
- #define HAVE_XMLLINT 1
- #define HAVE_ZLIB_GZIP 0
-@@ -523,6 +524,7 @@
- #define CONFIG_LIBKLVANC 0
- #define CONFIG_LIBKVAZAAR 0
- #define CONFIG_LIBLC3 0
-+#define CONFIG_LIBLCEVC_DEC 0
- #define CONFIG_LIBMODPLUG 0
- #define CONFIG_LIBMP3LAME 0
- #define CONFIG_LIBMYSOFA 0
-@@ -560,6 +562,7 @@
- #define CONFIG_LIBVMAF 0
- #define CONFIG_LIBVORBIS 0
- #define CONFIG_LIBVPX 0
-+#define CONFIG_LIBVVENC 0
- #define CONFIG_LIBWEBP 0
- #define CONFIG_LIBXEVD 0
- #define CONFIG_LIBXEVE 0
-@@ -692,6 +695,7 @@
- #define CONFIG_CBS_MPEG2 0
- #define CONFIG_CBS_VP8 0
- #define CONFIG_CBS_VP9 0
-+#define CONFIG_D3D12VA_ENCODE 0
- #define CONFIG_DEFLATE_WRAPPER 0
- #define CONFIG_DIRAC_PARSE 1
- #define CONFIG_DNN 0
-@@ -778,6 +782,7 @@
- #define CONFIG_VP3DSP 0
- #define CONFIG_VP56DSP 0
- #define CONFIG_VP8DSP 0
-+#define CONFIG_VULKAN_ENCODE 0
- #define CONFIG_WMA_FREQS 0
- #define CONFIG_WMV2DSP 0
- #endif /* FFMPEG_CONFIG_H */
-diff --git a/chromium/config/Chromium/ios/arm64/config_components.h b/chromium/config/Chromium/ios/arm64/config_components.h
-index 9b4b898861d..fe3b62f8200 100644
---- a/chromium/config/Chromium/ios/arm64/config_components.h
-+++ b/chromium/config/Chromium/ios/arm64/config_components.h
-@@ -8,6 +8,7 @@
- #define CONFIG_CHOMP_BSF 0
- #define CONFIG_DUMP_EXTRADATA_BSF 0
- #define CONFIG_DCA_CORE_BSF 0
-+#define CONFIG_DOVI_RPU_BSF 0
- #define CONFIG_DTS2PTS_BSF 0
- #define CONFIG_DV_ERROR_MARKER_BSF 0
- #define CONFIG_EAC3_CORE_BSF 0
-@@ -599,6 +600,9 @@
- #define CONFIG_BINTEXT_DECODER 0
- #define CONFIG_XBIN_DECODER 0
- #define CONFIG_IDF_DECODER 0
-+#define CONFIG_AAC_MEDIACODEC_DECODER 0
-+#define CONFIG_AMRNB_MEDIACODEC_DECODER 0
-+#define CONFIG_AMRWB_MEDIACODEC_DECODER 0
- #define CONFIG_LIBAOM_AV1_DECODER 0
- #define CONFIG_AV1_DECODER 0
- #define CONFIG_AV1_CUVID_DECODER 0
-@@ -610,6 +614,7 @@
- #define CONFIG_HEVC_MEDIACODEC_DECODER 0
- #define CONFIG_MJPEG_CUVID_DECODER 0
- #define CONFIG_MJPEG_QSV_DECODER 0
-+#define CONFIG_MP3_MEDIACODEC_DECODER 0
- #define CONFIG_MPEG1_CUVID_DECODER 0
- #define CONFIG_MPEG2_CUVID_DECODER 0
- #define CONFIG_MPEG4_CUVID_DECODER 0
-@@ -621,6 +626,7 @@
- #define CONFIG_VP9_CUVID_DECODER 0
- #define CONFIG_VP9_MEDIACODEC_DECODER 0
- #define CONFIG_VP9_QSV_DECODER 0
-+#define CONFIG_VVC_QSV_DECODER 0
- #define CONFIG_VNULL_DECODER 0
- #define CONFIG_ANULL_DECODER 0
- #define CONFIG_A64MULTI_ENCODER 0
-@@ -828,6 +834,7 @@
- #define CONFIG_LIBVORBIS_ENCODER 0
- #define CONFIG_LIBVPX_VP8_ENCODER 0
- #define CONFIG_LIBVPX_VP9_ENCODER 0
-+#define CONFIG_LIBVVENC_ENCODER 0
- #define CONFIG_LIBWEBP_ANIM_ENCODER 0
- #define CONFIG_LIBWEBP_ENCODER 0
- #define CONFIG_LIBX262_ENCODER 0
-@@ -855,7 +862,9 @@
- #define CONFIG_H264_V4L2M2M_ENCODER 0
- #define CONFIG_H264_VAAPI_ENCODER 0
- #define CONFIG_H264_VIDEOTOOLBOX_ENCODER 0
-+#define CONFIG_H264_VULKAN_ENCODER 0
- #define CONFIG_HEVC_AMF_ENCODER 0
-+#define CONFIG_HEVC_D3D12VA_ENCODER 0
- #define CONFIG_HEVC_MEDIACODEC_ENCODER 0
- #define CONFIG_HEVC_MF_ENCODER 0
- #define CONFIG_HEVC_NVENC_ENCODER 0
-@@ -863,6 +872,7 @@
- #define CONFIG_HEVC_V4L2M2M_ENCODER 0
- #define CONFIG_HEVC_VAAPI_ENCODER 0
- #define CONFIG_HEVC_VIDEOTOOLBOX_ENCODER 0
-+#define CONFIG_HEVC_VULKAN_ENCODER 0
- #define CONFIG_LIBKVAZAAR_ENCODER 0
- #define CONFIG_MJPEG_QSV_ENCODER 0
- #define CONFIG_MJPEG_VAAPI_ENCODER 0
-@@ -1357,6 +1367,7 @@
- #define CONFIG_KIRSCH_FILTER 0
- #define CONFIG_LAGFUN_FILTER 0
- #define CONFIG_LATENCY_FILTER 0
-+#define CONFIG_LCEVC_FILTER 0
- #define CONFIG_LENSCORRECTION_FILTER 0
- #define CONFIG_LENSFUN_FILTER 0
- #define CONFIG_LIBPLACEBO_FILTER 0
-@@ -1552,6 +1563,7 @@
- #define CONFIG_XFADE_OPENCL_FILTER 0
- #define CONFIG_XFADE_VULKAN_FILTER 0
- #define CONFIG_XMEDIAN_FILTER 0
-+#define CONFIG_XPSNR_FILTER 0
- #define CONFIG_XSTACK_FILTER 0
- #define CONFIG_YADIF_FILTER 0
- #define CONFIG_YADIF_CUDA_FILTER 0
-@@ -1588,6 +1600,7 @@
- #define CONFIG_QRENCODESRC_FILTER 0
- #define CONFIG_PAL75BARS_FILTER 0
- #define CONFIG_PAL100BARS_FILTER 0
-+#define CONFIG_PERLIN_FILTER 0
- #define CONFIG_RGBTESTSRC_FILTER 0
- #define CONFIG_SIERPINSKI_FILTER 0
- #define CONFIG_SMPTEBARS_FILTER 0
-diff --git a/chromium/config/Chromium/ios/arm64/libavutil/ffversion.h b/chromium/config/Chromium/ios/arm64/libavutil/ffversion.h
-index 9b26d87ca8b..71bdf19217c 100644
---- a/chromium/config/Chromium/ios/arm64/libavutil/ffversion.h
-+++ b/chromium/config/Chromium/ios/arm64/libavutil/ffversion.h
-@@ -1,5 +1,5 @@
- /* Automatically generated by version.sh, do not manually edit! */
- #ifndef AVUTIL_FFVERSION_H
- #define AVUTIL_FFVERSION_H
--#define FFMPEG_VERSION "N-116575-gd941d9677b"
-+#define FFMPEG_VERSION "N-118356-gdd11b92cac"
- #endif /* AVUTIL_FFVERSION_H */
-diff --git a/chromium/config/Chromium/ios/x64/config.asm b/chromium/config/Chromium/ios/x64/config.asm
-index 85470e7fa04..adb95d24add 100644
---- a/chromium/config/Chromium/ios/x64/config.asm
-+++ b/chromium/config/Chromium/ios/x64/config.asm
-@@ -1,11 +1,6 @@
- ; Automatically generated by configure - do not modify!
- %define ARCH_AARCH64 0
--%define ARCH_ALPHA 0
- %define ARCH_ARM 0
--%define ARCH_AVR32 0
--%define ARCH_AVR32_AP 0
--%define ARCH_AVR32_UC 0
--%define ARCH_BFIN 0
- %define ARCH_IA64 0
- %define ARCH_LOONGARCH 0
- %define ARCH_LOONGARCH32 0
-@@ -18,7 +13,6 @@
- %define ARCH_PPC64 0
- %define ARCH_RISCV 0
- %define ARCH_S390 0
--%define ARCH_SH4 0
- %define ARCH_SPARC 0
- %define ARCH_SPARC64 0
- %define ARCH_TILEGX 0
-@@ -44,6 +38,7 @@
- %define HAVE_VSX 0
- %define HAVE_RV 0
- %define HAVE_RVV 0
-+%define HAVE_RV_ZICBOP 1
- %define HAVE_RV_ZVBB 0
- %define HAVE_AESNI 1
- %define HAVE_AMD3DNOW 1
-@@ -96,6 +91,7 @@
- %define HAVE_VSX_EXTERNAL 0
- %define HAVE_RV_EXTERNAL 0
- %define HAVE_RVV_EXTERNAL 0
-+%define HAVE_RV_ZICBOP_EXTERNAL 0
- %define HAVE_RV_ZVBB_EXTERNAL 0
- %define HAVE_AESNI_EXTERNAL 1
- %define HAVE_AMD3DNOW_EXTERNAL 1
-@@ -148,6 +144,7 @@
- %define HAVE_VSX_INLINE 0
- %define HAVE_RV_INLINE 0
- %define HAVE_RVV_INLINE 0
-+%define HAVE_RV_ZICBOP_INLINE 0
- %define HAVE_RV_ZVBB_INLINE 0
- %define HAVE_AESNI_INLINE 1
- %define HAVE_AMD3DNOW_INLINE 1
-@@ -246,6 +243,7 @@
- %define HAVE_WINDOWS_H 0
- %define HAVE_WINSOCK2_H 0
- %define HAVE_INTRINSICS_NEON 0
-+%define HAVE_INTRINSICS_SSE2 1
- %define HAVE_ATANF 1
- %define HAVE_ATAN2F 1
- %define HAVE_CBRT 1
-@@ -288,6 +286,7 @@
- %define HAVE_CLOCK_GETTIME 0
- %define HAVE_CLOSESOCKET 0
- %define HAVE_COMMANDLINETOARGVW 0
-+%define HAVE_ELF_AUX_INFO 0
- %define HAVE_FCNTL 1
- %define HAVE_GETADDRINFO 0
- %define HAVE_GETAUXVAL 0
-@@ -336,6 +335,7 @@
- %define HAVE_SYSCONF 1
- %define HAVE_SYSCTL 1
- %define HAVE_SYSCTLBYNAME 1
-+%define HAVE_TEMPNAM 1
- %define HAVE_USLEEP 1
- %define HAVE_UTGETOSTYPEFROMSTRING 0
- %define HAVE_VIRTUALALLOC 0
-@@ -419,6 +419,7 @@
- %define HAVE_OPENCL_VIDEOTOOLBOX 0
- %define HAVE_PERL 1
- %define HAVE_POD2MAN 1
-+%define HAVE_POSIX_IOCTL 0
- %define HAVE_TEXI2HTML 0
- %define HAVE_XMLLINT 1
- %define HAVE_ZLIB_GZIP 0
-@@ -508,6 +509,7 @@
- %define CONFIG_LIBKLVANC 0
- %define CONFIG_LIBKVAZAAR 0
- %define CONFIG_LIBLC3 0
-+%define CONFIG_LIBLCEVC_DEC 0
- %define CONFIG_LIBMODPLUG 0
- %define CONFIG_LIBMP3LAME 0
- %define CONFIG_LIBMYSOFA 0
-@@ -545,6 +547,7 @@
- %define CONFIG_LIBVMAF 0
- %define CONFIG_LIBVORBIS 0
- %define CONFIG_LIBVPX 0
-+%define CONFIG_LIBVVENC 0
- %define CONFIG_LIBWEBP 0
- %define CONFIG_LIBXEVD 0
- %define CONFIG_LIBXEVE 0
-@@ -677,6 +680,7 @@
- %define CONFIG_CBS_MPEG2 0
- %define CONFIG_CBS_VP8 0
- %define CONFIG_CBS_VP9 0
-+%define CONFIG_D3D12VA_ENCODE 0
- %define CONFIG_DEFLATE_WRAPPER 0
- %define CONFIG_DIRAC_PARSE 1
- %define CONFIG_DNN 0
-@@ -763,5 +767,6 @@
- %define CONFIG_VP3DSP 0
- %define CONFIG_VP56DSP 0
- %define CONFIG_VP8DSP 0
-+%define CONFIG_VULKAN_ENCODE 0
- %define CONFIG_WMA_FREQS 0
- %define CONFIG_WMV2DSP 0
-diff --git a/chromium/config/Chromium/ios/x64/config.h b/chromium/config/Chromium/ios/x64/config.h
-index 2166b986706..da179f26484 100644
---- a/chromium/config/Chromium/ios/x64/config.h
-+++ b/chromium/config/Chromium/ios/x64/config.h
-@@ -1,12 +1,12 @@
- /* Automatically generated by configure - do not modify! */
- #ifndef FFMPEG_CONFIG_H
- #define FFMPEG_CONFIG_H
--/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-iamf --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/usr/local/google/home/dalecurtis/code/chrome/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\"-O2\"' --enable-pic --cc=clang --cxx=clang++ --ld=clang --enable-cross-compile --cc=clang --ld=ld64.lld --nm=llvm-nm --ar=llvm-ar --target-os=darwin --extra-cflags='--target=x86_64-apple-macosx' --extra-cflags=-F/usr/local/google/home/dalecurtis/code/chrome/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks --extra-cflags='-mmacosx-version-min=10.10' --extra-cflags=-fblocks --extra-cflags=-nostdinc --extra-cflags=-isystem/usr/local/google/home/dalecurtis/code/chrome/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include --extra-cflags=-isystem/usr/local/google/home/dalecurtis/code/chrome/src/third_party/llvm-build/Release+Asserts/lib/clang/19/include --extra-ldflags=-syslibroot --extra-ldflags=/usr/local/google/home/dalecurtis/code/chrome/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk --extra-ldflags=-L/usr/local/google/home/dalecurtis/code/chrome/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib --extra-ldflags=-lSystem --extra-ldflags=-macosx_version_min --extra-ldflags=10.10 --extra-ldflags=-sdk_version --extra-ldflags=10.10 --extra-ldflags=-platform_version --extra-ldflags=macos --extra-ldflags=10.10 --extra-ldflags=10.10 --arch=x86_64 --extra-cflags=-m64 --extra-ldflags='-arch x86_64'" -- elide long configuration string from binary */
-+/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-iamf --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/usr/local/google/home/sandersd/src/chromium/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\"-O2\"' --enable-pic --cc=clang --cxx=clang++ --ld=clang --enable-cross-compile --cc=clang --ld=ld64.lld --nm=llvm-nm --ar=llvm-ar --target-os=darwin --extra-cflags='--target=x86_64-apple-macosx' --extra-cflags=-F/usr/local/google/home/sandersd/src/chromium/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks --extra-cflags='-mmacosx-version-min=10.10' --extra-cflags=-fblocks --extra-cflags=-nostdinc --extra-cflags=-isystem/usr/local/google/home/sandersd/src/chromium/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include --extra-cflags=-isystem/usr/local/google/home/sandersd/src/chromium/src/third_party/llvm-build/Release+Asserts/lib/clang/20/include --extra-ldflags=-syslibroot --extra-ldflags=/usr/local/google/home/sandersd/src/chromium/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk --extra-ldflags=-L/usr/local/google/home/sandersd/src/chromium/src/build/mac_files/xcode_binaries/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/lib --extra-ldflags=-lSystem --extra-ldflags=-macosx_version_min --extra-ldflags=10.10 --extra-ldflags=-sdk_version --extra-ldflags=10.10 --extra-ldflags=-platform_version --extra-ldflags=macos --extra-ldflags=10.10 --extra-ldflags=10.10 --arch=x86_64 --extra-cflags=-m64 --extra-ldflags='-arch x86_64'" -- elide long configuration string from binary */
- #define FFMPEG_LICENSE "LGPL version 2.1 or later"
- #define CONFIG_THIS_YEAR 2024
- #define FFMPEG_DATADIR "/usr/local/share/ffmpeg"
- #define AVCONV_DATADIR "/usr/local/share/ffmpeg"
--#define CC_IDENT "clang version 19.0.0git (https://chromium.googlesource.com/a/external/github.com/llvm/llvm-project ecea8371ff03c15fb3dc27ee4108b98335fd2d63)"
-+#define CC_IDENT "clang version 20.0.0git (https://chromium.googlesource.com/a/external/github.com/llvm/llvm-project 6ee7e90a5d21cc0173dc5a0a344d230a80a46fd0)"
- #define OS_NAME darwin
- #define EXTERN_PREFIX "_"
- #define EXTERN_ASM _
-@@ -14,12 +14,7 @@
- #define SLIBSUF ".dylib"
- #define SWS_MAX_FILTER_SIZE 256
- #define ARCH_AARCH64 0
--#define ARCH_ALPHA 0
- #define ARCH_ARM 0
--#define ARCH_AVR32 0
--#define ARCH_AVR32_AP 0
--#define ARCH_AVR32_UC 0
--#define ARCH_BFIN 0
- #define ARCH_IA64 0
- #define ARCH_LOONGARCH 0
- #define ARCH_LOONGARCH32 0
-@@ -32,7 +27,6 @@
- #define ARCH_PPC64 0
- #define ARCH_RISCV 0
- #define ARCH_S390 0
--#define ARCH_SH4 0
- #define ARCH_SPARC 0
- #define ARCH_SPARC64 0
- #define ARCH_TILEGX 0
-@@ -58,6 +52,7 @@
- #define HAVE_VSX 0
- #define HAVE_RV 0
- #define HAVE_RVV 0
-+#define HAVE_RV_ZICBOP 1
- #define HAVE_RV_ZVBB 0
- #define HAVE_AESNI 1
- #define HAVE_AMD3DNOW 1
-@@ -110,6 +105,7 @@
- #define HAVE_VSX_EXTERNAL 0
- #define HAVE_RV_EXTERNAL 0
- #define HAVE_RVV_EXTERNAL 0
-+#define HAVE_RV_ZICBOP_EXTERNAL 0
- #define HAVE_RV_ZVBB_EXTERNAL 0
- #define HAVE_AESNI_EXTERNAL 1
- #define HAVE_AMD3DNOW_EXTERNAL 1
-@@ -162,6 +158,7 @@
- #define HAVE_VSX_INLINE 0
- #define HAVE_RV_INLINE 0
- #define HAVE_RVV_INLINE 0
-+#define HAVE_RV_ZICBOP_INLINE 0
- #define HAVE_RV_ZVBB_INLINE 0
- #define HAVE_AESNI_INLINE 1
- #define HAVE_AMD3DNOW_INLINE 1
-@@ -260,6 +257,7 @@
- #define HAVE_WINDOWS_H 0
- #define HAVE_WINSOCK2_H 0
- #define HAVE_INTRINSICS_NEON 0
-+#define HAVE_INTRINSICS_SSE2 1
- #define HAVE_ATANF 1
- #define HAVE_ATAN2F 1
- #define HAVE_CBRT 1
-@@ -302,6 +300,7 @@
- #define HAVE_CLOCK_GETTIME 0
- #define HAVE_CLOSESOCKET 0
- #define HAVE_COMMANDLINETOARGVW 0
-+#define HAVE_ELF_AUX_INFO 0
- #define HAVE_FCNTL 1
- #define HAVE_GETADDRINFO 0
- #define HAVE_GETAUXVAL 0
-@@ -350,6 +349,7 @@
- #define HAVE_SYSCONF 1
- #define HAVE_SYSCTL 1
- #define HAVE_SYSCTLBYNAME 1
-+#define HAVE_TEMPNAM 1
- #define HAVE_USLEEP 1
- #define HAVE_UTGETOSTYPEFROMSTRING 0
- #define HAVE_VIRTUALALLOC 0
-@@ -433,6 +433,7 @@
- #define HAVE_OPENCL_VIDEOTOOLBOX 0
- #define HAVE_PERL 1
- #define HAVE_POD2MAN 1
-+#define HAVE_POSIX_IOCTL 0
- #define HAVE_TEXI2HTML 0
- #define HAVE_XMLLINT 1
- #define HAVE_ZLIB_GZIP 0
-@@ -522,6 +523,7 @@
- #define CONFIG_LIBKLVANC 0
- #define CONFIG_LIBKVAZAAR 0
- #define CONFIG_LIBLC3 0
-+#define CONFIG_LIBLCEVC_DEC 0
- #define CONFIG_LIBMODPLUG 0
- #define CONFIG_LIBMP3LAME 0
- #define CONFIG_LIBMYSOFA 0
-@@ -559,6 +561,7 @@
- #define CONFIG_LIBVMAF 0
- #define CONFIG_LIBVORBIS 0
- #define CONFIG_LIBVPX 0
-+#define CONFIG_LIBVVENC 0
- #define CONFIG_LIBWEBP 0
- #define CONFIG_LIBXEVD 0
- #define CONFIG_LIBXEVE 0
-@@ -691,6 +694,7 @@
- #define CONFIG_CBS_MPEG2 0
- #define CONFIG_CBS_VP8 0
- #define CONFIG_CBS_VP9 0
-+#define CONFIG_D3D12VA_ENCODE 0
- #define CONFIG_DEFLATE_WRAPPER 0
- #define CONFIG_DIRAC_PARSE 1
- #define CONFIG_DNN 0
-@@ -777,6 +781,7 @@
- #define CONFIG_VP3DSP 0
- #define CONFIG_VP56DSP 0
- #define CONFIG_VP8DSP 0
-+#define CONFIG_VULKAN_ENCODE 0
- #define CONFIG_WMA_FREQS 0
- #define CONFIG_WMV2DSP 0
- #endif /* FFMPEG_CONFIG_H */
-diff --git a/chromium/config/Chromium/ios/x64/config_components.h b/chromium/config/Chromium/ios/x64/config_components.h
-index 9b4b898861d..fe3b62f8200 100644
---- a/chromium/config/Chromium/ios/x64/config_components.h
-+++ b/chromium/config/Chromium/ios/x64/config_components.h
-@@ -8,6 +8,7 @@
- #define CONFIG_CHOMP_BSF 0
- #define CONFIG_DUMP_EXTRADATA_BSF 0
- #define CONFIG_DCA_CORE_BSF 0
-+#define CONFIG_DOVI_RPU_BSF 0
- #define CONFIG_DTS2PTS_BSF 0
- #define CONFIG_DV_ERROR_MARKER_BSF 0
- #define CONFIG_EAC3_CORE_BSF 0
-@@ -599,6 +600,9 @@
- #define CONFIG_BINTEXT_DECODER 0
- #define CONFIG_XBIN_DECODER 0
- #define CONFIG_IDF_DECODER 0
-+#define CONFIG_AAC_MEDIACODEC_DECODER 0
-+#define CONFIG_AMRNB_MEDIACODEC_DECODER 0
-+#define CONFIG_AMRWB_MEDIACODEC_DECODER 0
- #define CONFIG_LIBAOM_AV1_DECODER 0
- #define CONFIG_AV1_DECODER 0
- #define CONFIG_AV1_CUVID_DECODER 0
-@@ -610,6 +614,7 @@
- #define CONFIG_HEVC_MEDIACODEC_DECODER 0
- #define CONFIG_MJPEG_CUVID_DECODER 0
- #define CONFIG_MJPEG_QSV_DECODER 0
-+#define CONFIG_MP3_MEDIACODEC_DECODER 0
- #define CONFIG_MPEG1_CUVID_DECODER 0
- #define CONFIG_MPEG2_CUVID_DECODER 0
- #define CONFIG_MPEG4_CUVID_DECODER 0
-@@ -621,6 +626,7 @@
- #define CONFIG_VP9_CUVID_DECODER 0
- #define CONFIG_VP9_MEDIACODEC_DECODER 0
- #define CONFIG_VP9_QSV_DECODER 0
-+#define CONFIG_VVC_QSV_DECODER 0
- #define CONFIG_VNULL_DECODER 0
- #define CONFIG_ANULL_DECODER 0
- #define CONFIG_A64MULTI_ENCODER 0
-@@ -828,6 +834,7 @@
- #define CONFIG_LIBVORBIS_ENCODER 0
- #define CONFIG_LIBVPX_VP8_ENCODER 0
- #define CONFIG_LIBVPX_VP9_ENCODER 0
-+#define CONFIG_LIBVVENC_ENCODER 0
- #define CONFIG_LIBWEBP_ANIM_ENCODER 0
- #define CONFIG_LIBWEBP_ENCODER 0
- #define CONFIG_LIBX262_ENCODER 0
-@@ -855,7 +862,9 @@
- #define CONFIG_H264_V4L2M2M_ENCODER 0
- #define CONFIG_H264_VAAPI_ENCODER 0
- #define CONFIG_H264_VIDEOTOOLBOX_ENCODER 0
-+#define CONFIG_H264_VULKAN_ENCODER 0
- #define CONFIG_HEVC_AMF_ENCODER 0
-+#define CONFIG_HEVC_D3D12VA_ENCODER 0
- #define CONFIG_HEVC_MEDIACODEC_ENCODER 0
- #define CONFIG_HEVC_MF_ENCODER 0
- #define CONFIG_HEVC_NVENC_ENCODER 0
-@@ -863,6 +872,7 @@
- #define CONFIG_HEVC_V4L2M2M_ENCODER 0
- #define CONFIG_HEVC_VAAPI_ENCODER 0
- #define CONFIG_HEVC_VIDEOTOOLBOX_ENCODER 0
-+#define CONFIG_HEVC_VULKAN_ENCODER 0
- #define CONFIG_LIBKVAZAAR_ENCODER 0
- #define CONFIG_MJPEG_QSV_ENCODER 0
- #define CONFIG_MJPEG_VAAPI_ENCODER 0
-@@ -1357,6 +1367,7 @@
- #define CONFIG_KIRSCH_FILTER 0
- #define CONFIG_LAGFUN_FILTER 0
- #define CONFIG_LATENCY_FILTER 0
-+#define CONFIG_LCEVC_FILTER 0
- #define CONFIG_LENSCORRECTION_FILTER 0
- #define CONFIG_LENSFUN_FILTER 0
- #define CONFIG_LIBPLACEBO_FILTER 0
-@@ -1552,6 +1563,7 @@
- #define CONFIG_XFADE_OPENCL_FILTER 0
- #define CONFIG_XFADE_VULKAN_FILTER 0
- #define CONFIG_XMEDIAN_FILTER 0
-+#define CONFIG_XPSNR_FILTER 0
- #define CONFIG_XSTACK_FILTER 0
- #define CONFIG_YADIF_FILTER 0
- #define CONFIG_YADIF_CUDA_FILTER 0
-@@ -1588,6 +1600,7 @@
- #define CONFIG_QRENCODESRC_FILTER 0
- #define CONFIG_PAL75BARS_FILTER 0
- #define CONFIG_PAL100BARS_FILTER 0
-+#define CONFIG_PERLIN_FILTER 0
- #define CONFIG_RGBTESTSRC_FILTER 0
- #define CONFIG_SIERPINSKI_FILTER 0
- #define CONFIG_SMPTEBARS_FILTER 0
-diff --git a/chromium/config/Chromium/ios/x64/libavutil/ffversion.h b/chromium/config/Chromium/ios/x64/libavutil/ffversion.h
-index 9b26d87ca8b..71bdf19217c 100644
---- a/chromium/config/Chromium/ios/x64/libavutil/ffversion.h
-+++ b/chromium/config/Chromium/ios/x64/libavutil/ffversion.h
-@@ -1,5 +1,5 @@
- /* Automatically generated by version.sh, do not manually edit! */
- #ifndef AVUTIL_FFVERSION_H
- #define AVUTIL_FFVERSION_H
--#define FFMPEG_VERSION "N-116575-gd941d9677b"
-+#define FFMPEG_VERSION "N-118356-gdd11b92cac"
- #endif /* AVUTIL_FFVERSION_H */
-diff --git a/chromium/config/Chromium/linux/riscv64/config.h b/chromium/config/Chromium/linux/riscv64/config.h
+diff --git a/chromium/config/ChromeOS/linux/riscv64/config.h b/chromium/config/ChromeOS/linux/riscv64/config.h
 new file mode 100644
-index 00000000000..f7c0d4639b5
+index 0000000000..d81d3dbfc0
 --- /dev/null
-+++ b/chromium/config/Chromium/linux/riscv64/config.h
-@@ -0,0 +1,787 @@
++++ b/chromium/config/ChromeOS/linux/riscv64/config.h
+@@ -0,0 +1,751 @@
 +/* Automatically generated by configure - do not modify! */
 +#ifndef FFMPEG_CONFIG_H
 +#define FFMPEG_CONFIG_H
-+/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-iamf --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/home/kxxt/Workspaces/chromium/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\"-O2\"' --arch=riscv64 --extra-cflags='-march=rv64gc' --enable-cross-compile --target-os=linux --sysroot=/home/kxxt/Workspaces/chromium/src/build/linux/debian_sid_riscv64-sysroot --extra-cflags='--target=riscv64-linux-gnu' --extra-ldflags='--target=riscv64-linux-gnu' --enable-pic --cc=clang --cxx=clang++ --ld=clang --extra-ldflags='-fuse-ld=lld'" -- elide long configuration string from binary */
++/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-fft --enable-rdft --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/home/kxxt/electron-ci/sources/electron/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\"-O2\"' --enable-decoder='theora,vp8' --enable-parser='vp3,vp8' --arch=riscv64 --extra-cflags='-march=rv64gc' --enable-cross-compile --target-os=linux --sysroot=/home/kxxt/electron-ci/sources/electron/src/build/linux/debian_sid_riscv64-sysroot --extra-cflags='--target=riscv64-linux-gnu' --extra-ldflags='--target=riscv64-linux-gnu' --enable-pic --cc=clang --cxx=clang++ --ld=clang --extra-ldflags='-fuse-ld=lld' --enable-decoder='aac,h264' --enable-demuxer=aac --enable-parser='aac,h264' --enable-decoder=mpeg4 --enable-parser='h263,mpeg4video' --enable-demuxer=avi" -- elide long configuration string from binary */
++#define FFMPEG_LICENSE "LGPL version 2.1 or later"
++#define CONFIG_THIS_YEAR 2023
++#define FFMPEG_DATADIR "/usr/local/share/ffmpeg"
++#define AVCONV_DATADIR "/usr/local/share/ffmpeg"
++#define CC_IDENT "clang version 17.0.0 (https://chromium.googlesource.com/external/github.com/llvm/llvm-project 7586aeab7ad3fb035752eea89fd2bb895de21143)"
++#define OS_NAME linux
++#define av_restrict restrict
++#define EXTERN_PREFIX ""
++#define EXTERN_ASM 
++#define BUILDSUF ""
++#define SLIBSUF ".so"
++#define HAVE_MMX2 HAVE_MMXEXT
++#define SWS_MAX_FILTER_SIZE 256
++#define ARCH_AARCH64 0
++#define ARCH_ALPHA 0
++#define ARCH_ARM 0
++#define ARCH_AVR32 0
++#define ARCH_AVR32_AP 0
++#define ARCH_AVR32_UC 0
++#define ARCH_BFIN 0
++#define ARCH_IA64 0
++#define ARCH_LOONGARCH 0
++#define ARCH_LOONGARCH32 0
++#define ARCH_LOONGARCH64 0
++#define ARCH_M68K 0
++#define ARCH_MIPS 0
++#define ARCH_MIPS64 0
++#define ARCH_PARISC 0
++#define ARCH_PPC 0
++#define ARCH_PPC64 0
++#define ARCH_RISCV 1
++#define ARCH_S390 0
++#define ARCH_SH4 0
++#define ARCH_SPARC 0
++#define ARCH_SPARC64 0
++#define ARCH_TILEGX 0
++#define ARCH_TILEPRO 0
++#define ARCH_TOMI 0
++#define ARCH_X86 0
++#define ARCH_X86_32 0
++#define ARCH_X86_64 0
++#define HAVE_ARMV5TE 0
++#define HAVE_ARMV6 0
++#define HAVE_ARMV6T2 0
++#define HAVE_ARMV8 0
++#define HAVE_NEON 0
++#define HAVE_VFP 0
++#define HAVE_VFPV3 0
++#define HAVE_SETEND 0
++#define HAVE_ALTIVEC 0
++#define HAVE_DCBZL 0
++#define HAVE_LDBRX 0
++#define HAVE_POWER8 0
++#define HAVE_PPC4XX 0
++#define HAVE_VSX 0
++#define HAVE_RVV 0
++#define HAVE_AESNI 0
++#define HAVE_AMD3DNOW 0
++#define HAVE_AMD3DNOWEXT 0
++#define HAVE_AVX 0
++#define HAVE_AVX2 0
++#define HAVE_AVX512 0
++#define HAVE_AVX512ICL 0
++#define HAVE_FMA3 0
++#define HAVE_FMA4 0
++#define HAVE_MMX 0
++#define HAVE_MMXEXT 0
++#define HAVE_SSE 0
++#define HAVE_SSE2 0
++#define HAVE_SSE3 0
++#define HAVE_SSE4 0
++#define HAVE_SSE42 0
++#define HAVE_SSSE3 0
++#define HAVE_XOP 0
++#define HAVE_CPUNOP 0
++#define HAVE_I686 0
++#define HAVE_MIPSFPU 0
++#define HAVE_MIPS32R2 0
++#define HAVE_MIPS32R5 0
++#define HAVE_MIPS64R2 0
++#define HAVE_MIPS32R6 0
++#define HAVE_MIPS64R6 0
++#define HAVE_MIPSDSP 0
++#define HAVE_MIPSDSPR2 0
++#define HAVE_MSA 0
++#define HAVE_LOONGSON2 0
++#define HAVE_LOONGSON3 0
++#define HAVE_MMI 0
++#define HAVE_LSX 0
++#define HAVE_LASX 0
++#define HAVE_ARMV5TE_EXTERNAL 0
++#define HAVE_ARMV6_EXTERNAL 0
++#define HAVE_ARMV6T2_EXTERNAL 0
++#define HAVE_ARMV8_EXTERNAL 0
++#define HAVE_NEON_EXTERNAL 0
++#define HAVE_VFP_EXTERNAL 0
++#define HAVE_VFPV3_EXTERNAL 0
++#define HAVE_SETEND_EXTERNAL 0
++#define HAVE_ALTIVEC_EXTERNAL 0
++#define HAVE_DCBZL_EXTERNAL 0
++#define HAVE_LDBRX_EXTERNAL 0
++#define HAVE_POWER8_EXTERNAL 0
++#define HAVE_PPC4XX_EXTERNAL 0
++#define HAVE_VSX_EXTERNAL 0
++#define HAVE_RVV_EXTERNAL 0
++#define HAVE_AESNI_EXTERNAL 0
++#define HAVE_AMD3DNOW_EXTERNAL 0
++#define HAVE_AMD3DNOWEXT_EXTERNAL 0
++#define HAVE_AVX_EXTERNAL 0
++#define HAVE_AVX2_EXTERNAL 0
++#define HAVE_AVX512_EXTERNAL 0
++#define HAVE_AVX512ICL_EXTERNAL 0
++#define HAVE_FMA3_EXTERNAL 0
++#define HAVE_FMA4_EXTERNAL 0
++#define HAVE_MMX_EXTERNAL 0
++#define HAVE_MMXEXT_EXTERNAL 0
++#define HAVE_SSE_EXTERNAL 0
++#define HAVE_SSE2_EXTERNAL 0
++#define HAVE_SSE3_EXTERNAL 0
++#define HAVE_SSE4_EXTERNAL 0
++#define HAVE_SSE42_EXTERNAL 0
++#define HAVE_SSSE3_EXTERNAL 0
++#define HAVE_XOP_EXTERNAL 0
++#define HAVE_CPUNOP_EXTERNAL 0
++#define HAVE_I686_EXTERNAL 0
++#define HAVE_MIPSFPU_EXTERNAL 0
++#define HAVE_MIPS32R2_EXTERNAL 0
++#define HAVE_MIPS32R5_EXTERNAL 0
++#define HAVE_MIPS64R2_EXTERNAL 0
++#define HAVE_MIPS32R6_EXTERNAL 0
++#define HAVE_MIPS64R6_EXTERNAL 0
++#define HAVE_MIPSDSP_EXTERNAL 0
++#define HAVE_MIPSDSPR2_EXTERNAL 0
++#define HAVE_MSA_EXTERNAL 0
++#define HAVE_LOONGSON2_EXTERNAL 0
++#define HAVE_LOONGSON3_EXTERNAL 0
++#define HAVE_MMI_EXTERNAL 0
++#define HAVE_LSX_EXTERNAL 0
++#define HAVE_LASX_EXTERNAL 0
++#define HAVE_ARMV5TE_INLINE 0
++#define HAVE_ARMV6_INLINE 0
++#define HAVE_ARMV6T2_INLINE 0
++#define HAVE_ARMV8_INLINE 0
++#define HAVE_NEON_INLINE 0
++#define HAVE_VFP_INLINE 0
++#define HAVE_VFPV3_INLINE 0
++#define HAVE_SETEND_INLINE 0
++#define HAVE_ALTIVEC_INLINE 0
++#define HAVE_DCBZL_INLINE 0
++#define HAVE_LDBRX_INLINE 0
++#define HAVE_POWER8_INLINE 0
++#define HAVE_PPC4XX_INLINE 0
++#define HAVE_VSX_INLINE 0
++#define HAVE_RVV_INLINE 0
++#define HAVE_AESNI_INLINE 0
++#define HAVE_AMD3DNOW_INLINE 0
++#define HAVE_AMD3DNOWEXT_INLINE 0
++#define HAVE_AVX_INLINE 0
++#define HAVE_AVX2_INLINE 0
++#define HAVE_AVX512_INLINE 0
++#define HAVE_AVX512ICL_INLINE 0
++#define HAVE_FMA3_INLINE 0
++#define HAVE_FMA4_INLINE 0
++#define HAVE_MMX_INLINE 0
++#define HAVE_MMXEXT_INLINE 0
++#define HAVE_SSE_INLINE 0
++#define HAVE_SSE2_INLINE 0
++#define HAVE_SSE3_INLINE 0
++#define HAVE_SSE4_INLINE 0
++#define HAVE_SSE42_INLINE 0
++#define HAVE_SSSE3_INLINE 0
++#define HAVE_XOP_INLINE 0
++#define HAVE_CPUNOP_INLINE 0
++#define HAVE_I686_INLINE 0
++#define HAVE_MIPSFPU_INLINE 0
++#define HAVE_MIPS32R2_INLINE 0
++#define HAVE_MIPS32R5_INLINE 0
++#define HAVE_MIPS64R2_INLINE 0
++#define HAVE_MIPS32R6_INLINE 0
++#define HAVE_MIPS64R6_INLINE 0
++#define HAVE_MIPSDSP_INLINE 0
++#define HAVE_MIPSDSPR2_INLINE 0
++#define HAVE_MSA_INLINE 0
++#define HAVE_LOONGSON2_INLINE 0
++#define HAVE_LOONGSON3_INLINE 0
++#define HAVE_MMI_INLINE 0
++#define HAVE_LSX_INLINE 0
++#define HAVE_LASX_INLINE 0
++#define HAVE_ALIGNED_STACK 0
++#define HAVE_FAST_64BIT 1
++#define HAVE_FAST_CLZ 0
++#define HAVE_FAST_CMOV 0
++#define HAVE_FAST_FLOAT16 0
++#define HAVE_LOCAL_ALIGNED 0
++#define HAVE_SIMD_ALIGN_16 0
++#define HAVE_SIMD_ALIGN_32 0
++#define HAVE_SIMD_ALIGN_64 0
++#define HAVE_ATOMIC_CAS_PTR 0
++#define HAVE_MACHINE_RW_BARRIER 0
++#define HAVE_MEMORYBARRIER 0
++#define HAVE_MM_EMPTY 0
++#define HAVE_RDTSC 0
++#define HAVE_SEM_TIMEDWAIT 1
++#define HAVE_SYNC_VAL_COMPARE_AND_SWAP 1
++#define HAVE_INLINE_ASM 1
++#define HAVE_SYMVER 0
++#define HAVE_X86ASM 0
++#define HAVE_BIGENDIAN 0
++#define HAVE_FAST_UNALIGNED 0
++#define HAVE_ARPA_INET_H 0
++#define HAVE_ASM_TYPES_H 1
++#define HAVE_CDIO_PARANOIA_H 0
++#define HAVE_CDIO_PARANOIA_PARANOIA_H 0
++#define HAVE_CUDA_H 0
++#define HAVE_DISPATCH_DISPATCH_H 0
++#define HAVE_DEV_BKTR_IOCTL_BT848_H 0
++#define HAVE_DEV_BKTR_IOCTL_METEOR_H 0
++#define HAVE_DEV_IC_BT8XX_H 0
++#define HAVE_DEV_VIDEO_BKTR_IOCTL_BT848_H 0
++#define HAVE_DEV_VIDEO_METEOR_IOCTL_METEOR_H 0
++#define HAVE_DIRECT_H 0
++#define HAVE_DIRENT_H 1
++#define HAVE_DXGIDEBUG_H 0
++#define HAVE_DXVA_H 0
++#define HAVE_ES2_GL_H 0
++#define HAVE_GSM_H 0
++#define HAVE_IO_H 0
++#define HAVE_LINUX_DMA_BUF_H 0
++#define HAVE_LINUX_PERF_EVENT_H 1
++#define HAVE_MACHINE_IOCTL_BT848_H 0
++#define HAVE_MACHINE_IOCTL_METEOR_H 0
++#define HAVE_MALLOC_H 1
++#define HAVE_OPENCV2_CORE_CORE_C_H 0
++#define HAVE_OPENGL_GL3_H 0
++#define HAVE_POLL_H 1
++#define HAVE_SYS_PARAM_H 1
++#define HAVE_SYS_RESOURCE_H 1
++#define HAVE_SYS_SELECT_H 1
++#define HAVE_SYS_SOUNDCARD_H 1
++#define HAVE_SYS_TIME_H 1
++#define HAVE_SYS_UN_H 1
++#define HAVE_SYS_VIDEOIO_H 0
++#define HAVE_TERMIOS_H 1
++#define HAVE_UDPLITE_H 0
++#define HAVE_UNISTD_H 1
++#define HAVE_VALGRIND_VALGRIND_H 0 /* #define HAVE_VALGRIND_VALGRIND_H 0 -- forced to 0. See https://crbug.com/590440 */
++#define HAVE_WINDOWS_H 0
++#define HAVE_WINSOCK2_H 0
++#define HAVE_INTRINSICS_NEON 0
++#define HAVE_ATANF 1
++#define HAVE_ATAN2F 1
++#define HAVE_CBRT 1
++#define HAVE_CBRTF 1
++#define HAVE_COPYSIGN 1
++#define HAVE_COSF 1
++#define HAVE_ERF 1
++#define HAVE_EXP2 1
++#define HAVE_EXP2F 1
++#define HAVE_EXPF 1
++#define HAVE_HYPOT 1
++#define HAVE_ISFINITE 1
++#define HAVE_ISINF 1
++#define HAVE_ISNAN 1
++#define HAVE_LDEXPF 1
++#define HAVE_LLRINT 1
++#define HAVE_LLRINTF 1
++#define HAVE_LOG2 1
++#define HAVE_LOG2F 1
++#define HAVE_LOG10F 1
++#define HAVE_LRINT 1
++#define HAVE_LRINTF 1
++#define HAVE_POWF 1
++#define HAVE_RINT 1
++#define HAVE_ROUND 1
++#define HAVE_ROUNDF 1
++#define HAVE_SINF 1
++#define HAVE_TRUNC 1
++#define HAVE_TRUNCF 1
++#define HAVE_DOS_PATHS 0
++#define HAVE_LIBC_MSVCRT 0
++#define HAVE_MMAL_PARAMETER_VIDEO_MAX_NUM_CALLBACKS 0
++#define HAVE_SECTION_DATA_REL_RO 1
++#define HAVE_THREADS 1
++#define HAVE_UWP 0
++#define HAVE_WINRT 0
++#define HAVE_ACCESS 1
++#define HAVE_ALIGNED_MALLOC 0
++#define HAVE_ARC4RANDOM 0
++#define HAVE_CLOCK_GETTIME 1
++#define HAVE_CLOSESOCKET 0
++#define HAVE_COMMANDLINETOARGVW 0
++#define HAVE_FCNTL 1
++#define HAVE_GETADDRINFO 0
++#define HAVE_GETAUXVAL 1
++#define HAVE_GETENV 1
++#define HAVE_GETHRTIME 0
++#define HAVE_GETOPT 1
++#define HAVE_GETMODULEHANDLE 0
++#define HAVE_GETPROCESSAFFINITYMASK 0
++#define HAVE_GETPROCESSMEMORYINFO 0
++#define HAVE_GETPROCESSTIMES 0
++#define HAVE_GETRUSAGE 1
++#define HAVE_GETSTDHANDLE 0
++#define HAVE_GETSYSTEMTIMEASFILETIME 0
++#define HAVE_GETTIMEOFDAY 1
++#define HAVE_GLOB 1
++#define HAVE_GLXGETPROCADDRESS 0
++#define HAVE_GMTIME_R 1
++#define HAVE_INET_ATON 0
++#define HAVE_ISATTY 1
++#define HAVE_KBHIT 0
++#define HAVE_LOCALTIME_R 1
++#define HAVE_LSTAT 1
++#define HAVE_LZO1X_999_COMPRESS 0
++#define HAVE_MACH_ABSOLUTE_TIME 0
++#define HAVE_MAPVIEWOFFILE 0
++#define HAVE_MEMALIGN 1
++#define HAVE_MKSTEMP 1
++#define HAVE_MMAP 1
++#define HAVE_MPROTECT 1
++#define HAVE_NANOSLEEP 1
++#define HAVE_PEEKNAMEDPIPE 0
++#define HAVE_POSIX_MEMALIGN 1
++#define HAVE_PRCTL 0 /* #define HAVE_PRCTL 1 -- forced to 0 for Fuchsia */
++#define HAVE_PTHREAD_CANCEL 1
++#define HAVE_SCHED_GETAFFINITY 1
++#define HAVE_SECITEMIMPORT 0
++#define HAVE_SETCONSOLETEXTATTRIBUTE 0
++#define HAVE_SETCONSOLECTRLHANDLER 0
++#define HAVE_SETDLLDIRECTORY 0
++#define HAVE_SETMODE 0
++#define HAVE_SETRLIMIT 1
++#define HAVE_SLEEP 0
++#define HAVE_STRERROR_R 1
++#define HAVE_SYSCONF 1
++#define HAVE_SYSCTL 0 /* #define HAVE_SYSCTL 0 -- forced to 0 for Fuchsia */
++#define HAVE_USLEEP 1
++#define HAVE_UTGETOSTYPEFROMSTRING 0
++#define HAVE_VIRTUALALLOC 0
++#define HAVE_WGLGETPROCADDRESS 0
++#define HAVE_BCRYPT 0
++#define HAVE_VAAPI_DRM 0
++#define HAVE_VAAPI_X11 0
++#define HAVE_VAAPI_WIN32 0
++#define HAVE_VDPAU_X11 0
++#define HAVE_PTHREADS 1
++#define HAVE_OS2THREADS 0
++#define HAVE_W32THREADS 0
++#define HAVE_AS_ARCH_DIRECTIVE 0
++#define HAVE_AS_DN_DIRECTIVE 0
++#define HAVE_AS_FPU_DIRECTIVE 0
++#define HAVE_AS_FUNC 0
++#define HAVE_AS_OBJECT_ARCH 0
++#define HAVE_ASM_MOD_Q 0
++#define HAVE_BLOCKS_EXTENSION 0
++#define HAVE_EBP_AVAILABLE 0
++#define HAVE_EBX_AVAILABLE 0
++#define HAVE_GNU_AS 0
++#define HAVE_GNU_WINDRES 0
++#define HAVE_IBM_ASM 0
++#define HAVE_INLINE_ASM_DIRECT_SYMBOL_REFS 0
++#define HAVE_INLINE_ASM_LABELS 1
++#define HAVE_INLINE_ASM_NONLOCAL_LABELS 1
++#define HAVE_PRAGMA_DEPRECATED 1
++#define HAVE_RSYNC_CONTIMEOUT 0
++#define HAVE_SYMVER_ASM_LABEL 1
++#define HAVE_SYMVER_GNU_ASM 1
++#define HAVE_VFP_ARGS 0
++#define HAVE_XFORM_ASM 0
++#define HAVE_XMM_CLOBBERS 0
++#define HAVE_DPI_AWARENESS_CONTEXT 0
++#define HAVE_IDXGIOUTPUT5 0
++#define HAVE_KCMVIDEOCODECTYPE_HEVC 0
++#define HAVE_KCMVIDEOCODECTYPE_HEVCWITHALPHA 0
++#define HAVE_KCMVIDEOCODECTYPE_VP9 0
++#define HAVE_KCVPIXELFORMATTYPE_420YPCBCR10BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR8BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR10BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR16BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR8BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR10BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR16BIPLANARVIDEORANGE 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_2084_PQ 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2100_HLG 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_LINEAR 0
++#define HAVE_KCVIMAGEBUFFERYCBCRMATRIX_ITU_R_2020 0
++#define HAVE_KCVIMAGEBUFFERCOLORPRIMARIES_ITU_R_2020 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2020 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_428_1 0
++#define HAVE_SOCKLEN_T 0
++#define HAVE_STRUCT_ADDRINFO 0
++#define HAVE_STRUCT_GROUP_SOURCE_REQ 0
++#define HAVE_STRUCT_IP_MREQ_SOURCE 0
++#define HAVE_STRUCT_IPV6_MREQ 0
++#define HAVE_STRUCT_MSGHDR_MSG_FLAGS 0
++#define HAVE_STRUCT_POLLFD 0
++#define HAVE_STRUCT_RUSAGE_RU_MAXRSS 1
++#define HAVE_STRUCT_SCTP_EVENT_SUBSCRIBE 0
++#define HAVE_STRUCT_SOCKADDR_IN6 0
++#define HAVE_STRUCT_SOCKADDR_SA_LEN 0
++#define HAVE_STRUCT_SOCKADDR_STORAGE 0
++#define HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC 1
++#define HAVE_STRUCT_V4L2_FRMIVALENUM_DISCRETE 0
++#define HAVE_GZIP 1
++#define HAVE_LIBDRM_GETFB2 0
++#define HAVE_MAKEINFO 0
++#define HAVE_MAKEINFO_HTML 0
++#define HAVE_OPENCL_D3D11 0
++#define HAVE_OPENCL_DRM_ARM 0
++#define HAVE_OPENCL_DRM_BEIGNET 0
++#define HAVE_OPENCL_DXVA2 0
++#define HAVE_OPENCL_VAAPI_BEIGNET 0
++#define HAVE_OPENCL_VAAPI_INTEL_MEDIA 0
++#define HAVE_PERL 1
++#define HAVE_POD2MAN 1
++#define HAVE_TEXI2HTML 0
++#define HAVE_XMLLINT 0
++#define HAVE_ZLIB_GZIP 0
++#define CONFIG_DOC 0
++#define CONFIG_HTMLPAGES 0
++#define CONFIG_MANPAGES 0
++#define CONFIG_PODPAGES 0
++#define CONFIG_TXTPAGES 0
++#define CONFIG_AVIO_HTTP_SERVE_FILES_EXAMPLE 1
++#define CONFIG_AVIO_LIST_DIR_EXAMPLE 1
++#define CONFIG_AVIO_READ_CALLBACK_EXAMPLE 1
++#define CONFIG_DECODE_AUDIO_EXAMPLE 1
++#define CONFIG_DECODE_FILTER_AUDIO_EXAMPLE 0
++#define CONFIG_DECODE_FILTER_VIDEO_EXAMPLE 0
++#define CONFIG_DECODE_VIDEO_EXAMPLE 1
++#define CONFIG_DEMUX_DECODE_EXAMPLE 1
++#define CONFIG_ENCODE_AUDIO_EXAMPLE 1
++#define CONFIG_ENCODE_VIDEO_EXAMPLE 1
++#define CONFIG_EXTRACT_MVS_EXAMPLE 1
++#define CONFIG_FILTER_AUDIO_EXAMPLE 0
++#define CONFIG_HW_DECODE_EXAMPLE 1
++#define CONFIG_MUX_EXAMPLE 0
++#define CONFIG_QSV_DECODE_EXAMPLE 0
++#define CONFIG_REMUX_EXAMPLE 1
++#define CONFIG_RESAMPLE_AUDIO_EXAMPLE 0
++#define CONFIG_SCALE_VIDEO_EXAMPLE 0
++#define CONFIG_SHOW_METADATA_EXAMPLE 1
++#define CONFIG_TRANSCODE_AAC_EXAMPLE 0
++#define CONFIG_TRANSCODE_EXAMPLE 0
++#define CONFIG_VAAPI_ENCODE_EXAMPLE 0
++#define CONFIG_VAAPI_TRANSCODE_EXAMPLE 0
++#define CONFIG_QSV_TRANSCODE_EXAMPLE 0
++#define CONFIG_AVISYNTH 0
++#define CONFIG_FREI0R 0
++#define CONFIG_LIBCDIO 0
++#define CONFIG_LIBDAVS2 0
++#define CONFIG_LIBRUBBERBAND 0
++#define CONFIG_LIBVIDSTAB 0
++#define CONFIG_LIBX264 0
++#define CONFIG_LIBX265 0
++#define CONFIG_LIBXAVS 0
++#define CONFIG_LIBXAVS2 0
++#define CONFIG_LIBXVID 0
++#define CONFIG_DECKLINK 0
++#define CONFIG_LIBFDK_AAC 0
++#define CONFIG_LIBTLS 0
++#define CONFIG_GMP 0
++#define CONFIG_LIBARIBB24 0
++#define CONFIG_LIBLENSFUN 0
++#define CONFIG_LIBOPENCORE_AMRNB 0
++#define CONFIG_LIBOPENCORE_AMRWB 0
++#define CONFIG_LIBVO_AMRWBENC 0
++#define CONFIG_MBEDTLS 0
++#define CONFIG_RKMPP 0
++#define CONFIG_LIBSMBCLIENT 0
++#define CONFIG_CHROMAPRINT 0
++#define CONFIG_GCRYPT 0
++#define CONFIG_GNUTLS 0
++#define CONFIG_JNI 0
++#define CONFIG_LADSPA 0
++#define CONFIG_LCMS2 0
++#define CONFIG_LIBAOM 0
++#define CONFIG_LIBARIBCAPTION 0
++#define CONFIG_LIBASS 0
++#define CONFIG_LIBBLURAY 0
++#define CONFIG_LIBBS2B 0
++#define CONFIG_LIBCACA 0
++#define CONFIG_LIBCELT 0
++#define CONFIG_LIBCODEC2 0
++#define CONFIG_LIBDAV1D 0
++#define CONFIG_LIBDC1394 0
++#define CONFIG_LIBDRM 0
++#define CONFIG_LIBFLITE 0
++#define CONFIG_LIBFONTCONFIG 0
++#define CONFIG_LIBFREETYPE 0
++#define CONFIG_LIBFRIBIDI 0
++#define CONFIG_LIBGLSLANG 0
++#define CONFIG_LIBGME 0
++#define CONFIG_LIBGSM 0
++#define CONFIG_LIBIEC61883 0
++#define CONFIG_LIBILBC 0
++#define CONFIG_LIBJACK 0
++#define CONFIG_LIBJXL 0
++#define CONFIG_LIBKLVANC 0
++#define CONFIG_LIBKVAZAAR 0
++#define CONFIG_LIBMODPLUG 0
++#define CONFIG_LIBMP3LAME 0
++#define CONFIG_LIBMYSOFA 0
++#define CONFIG_LIBOPENCV 0
++#define CONFIG_LIBOPENH264 0
++#define CONFIG_LIBOPENJPEG 0
++#define CONFIG_LIBOPENMPT 0
++#define CONFIG_LIBOPENVINO 0
++#define CONFIG_LIBOPUS 1
++#define CONFIG_LIBPLACEBO 0
++#define CONFIG_LIBPULSE 0
++#define CONFIG_LIBRABBITMQ 0
++#define CONFIG_LIBRAV1E 0
++#define CONFIG_LIBRIST 0
++#define CONFIG_LIBRSVG 0
++#define CONFIG_LIBRTMP 0
++#define CONFIG_LIBSHADERC 0
++#define CONFIG_LIBSHINE 0
++#define CONFIG_LIBSMBCLIENT 0
++#define CONFIG_LIBSNAPPY 0
++#define CONFIG_LIBSOXR 0
++#define CONFIG_LIBSPEEX 0
++#define CONFIG_LIBSRT 0
++#define CONFIG_LIBSSH 0
++#define CONFIG_LIBSVTAV1 0
++#define CONFIG_LIBTENSORFLOW 0
++#define CONFIG_LIBTESSERACT 0
++#define CONFIG_LIBTHEORA 0
++#define CONFIG_LIBTWOLAME 0
++#define CONFIG_LIBUAVS3D 0
++#define CONFIG_LIBV4L2 0
++#define CONFIG_LIBVMAF 0
++#define CONFIG_LIBVORBIS 0
++#define CONFIG_LIBVPX 0
++#define CONFIG_LIBWEBP 0
++#define CONFIG_LIBXML2 0
++#define CONFIG_LIBZIMG 0
++#define CONFIG_LIBZMQ 0
++#define CONFIG_LIBZVBI 0
++#define CONFIG_LV2 0
++#define CONFIG_MEDIACODEC 0
++#define CONFIG_OPENAL 0
++#define CONFIG_OPENGL 0
++#define CONFIG_OPENSSL 0
++#define CONFIG_POCKETSPHINX 0
++#define CONFIG_VAPOURSYNTH 0
++#define CONFIG_ALSA 0
++#define CONFIG_APPKIT 0
++#define CONFIG_AVFOUNDATION 0
++#define CONFIG_BZLIB 0
++#define CONFIG_COREIMAGE 0
++#define CONFIG_ICONV 0
++#define CONFIG_LIBXCB 0
++#define CONFIG_LIBXCB_SHM 0
++#define CONFIG_LIBXCB_SHAPE 0
++#define CONFIG_LIBXCB_XFIXES 0
++#define CONFIG_LZMA 0
++#define CONFIG_MEDIAFOUNDATION 0
++#define CONFIG_METAL 0
++#define CONFIG_SCHANNEL 0
++#define CONFIG_SDL2 0
++#define CONFIG_SECURETRANSPORT 0
++#define CONFIG_SNDIO 0
++#define CONFIG_XLIB 0
++#define CONFIG_ZLIB 0
++#define CONFIG_CUDA_NVCC 0
++#define CONFIG_CUDA_SDK 0
++#define CONFIG_LIBNPP 0
++#define CONFIG_LIBMFX 0
++#define CONFIG_LIBVPL 0
++#define CONFIG_MMAL 0
++#define CONFIG_OMX 0
++#define CONFIG_OPENCL 0
++#define CONFIG_AMF 0
++#define CONFIG_AUDIOTOOLBOX 0
++#define CONFIG_CRYSTALHD 0
++#define CONFIG_CUDA 0
++#define CONFIG_CUDA_LLVM 0
++#define CONFIG_CUVID 0
++#define CONFIG_D3D11VA 0
++#define CONFIG_DXVA2 0
++#define CONFIG_FFNVCODEC 0
++#define CONFIG_NVDEC 0
++#define CONFIG_NVENC 0
++#define CONFIG_VAAPI 0
++#define CONFIG_VDPAU 0
++#define CONFIG_VIDEOTOOLBOX 0
++#define CONFIG_VULKAN 0
++#define CONFIG_V4L2_M2M 0
++#define CONFIG_FTRAPV 0
++#define CONFIG_GRAY 0
++#define CONFIG_HARDCODED_TABLES 0
++#define CONFIG_OMX_RPI 0
++#define CONFIG_RUNTIME_CPUDETECT 1
++#define CONFIG_SAFE_BITSTREAM_READER 1
++#define CONFIG_SHARED 0
++#define CONFIG_SMALL 0
++#define CONFIG_STATIC 1
++#define CONFIG_SWSCALE_ALPHA 1
++#define CONFIG_GPL 0
++#define CONFIG_NONFREE 0
++#define CONFIG_VERSION3 0
++#define CONFIG_AVDEVICE 0
++#define CONFIG_AVFILTER 0
++#define CONFIG_SWSCALE 0
++#define CONFIG_POSTPROC 0
++#define CONFIG_AVFORMAT 1
++#define CONFIG_AVCODEC 1
++#define CONFIG_SWRESAMPLE 0
++#define CONFIG_AVUTIL 1
++#define CONFIG_FFPLAY 0
++#define CONFIG_FFPROBE 0
++#define CONFIG_FFMPEG 0
++#define CONFIG_DCT 1
++#define CONFIG_DWT 0
++#define CONFIG_ERROR_RESILIENCE 1
++#define CONFIG_FAAN 0
++#define CONFIG_FAST_UNALIGNED 0
++#define CONFIG_FFT 1
++#define CONFIG_LSP 0
++#define CONFIG_MDCT 0
++#define CONFIG_PIXELUTILS 0
++#define CONFIG_NETWORK 0
++#define CONFIG_RDFT 1
++#define CONFIG_AUTODETECT 0
++#define CONFIG_FONTCONFIG 0
++#define CONFIG_LARGE_TESTS 1
++#define CONFIG_LINUX_PERF 0
++#define CONFIG_MACOS_KPERF 0
++#define CONFIG_MEMORY_POISONING 0
++#define CONFIG_NEON_CLOBBER_TEST 0
++#define CONFIG_OSSFUZZ 0
++#define CONFIG_PIC 1
++#define CONFIG_PTX_COMPRESSION 0
++#define CONFIG_THUMB 0
++#define CONFIG_VALGRIND_BACKTRACE 0
++#define CONFIG_XMM_CLOBBER_TEST 0
++#define CONFIG_BSFS 0
++#define CONFIG_DECODERS 1
++#define CONFIG_ENCODERS 0
++#define CONFIG_HWACCELS 0
++#define CONFIG_PARSERS 1
++#define CONFIG_INDEVS 0
++#define CONFIG_OUTDEVS 0
++#define CONFIG_FILTERS 0
++#define CONFIG_DEMUXERS 1
++#define CONFIG_MUXERS 0
++#define CONFIG_PROTOCOLS 0
++#define CONFIG_AANDCTTABLES 0
++#define CONFIG_AC3DSP 0
++#define CONFIG_ADTS_HEADER 1
++#define CONFIG_ATSC_A53 1
++#define CONFIG_AUDIO_FRAME_QUEUE 0
++#define CONFIG_AUDIODSP 0
++#define CONFIG_BLOCKDSP 1
++#define CONFIG_BSWAPDSP 0
++#define CONFIG_CABAC 1
++#define CONFIG_CBS 0
++#define CONFIG_CBS_AV1 0
++#define CONFIG_CBS_H264 0
++#define CONFIG_CBS_H265 0
++#define CONFIG_CBS_JPEG 0
++#define CONFIG_CBS_MPEG2 0
++#define CONFIG_CBS_VP9 0
++#define CONFIG_DEFLATE_WRAPPER 0
++#define CONFIG_DIRAC_PARSE 1
++#define CONFIG_DNN 0
++#define CONFIG_DOVI_RPU 0
++#define CONFIG_DVPROFILE 0
++#define CONFIG_EXIF 1
++#define CONFIG_FAANDCT 0
++#define CONFIG_FAANIDCT 0
++#define CONFIG_FDCTDSP 0
++#define CONFIG_FMTCONVERT 0
++#define CONFIG_FRAME_THREAD_ENCODER 0
++#define CONFIG_G722DSP 0
++#define CONFIG_GOLOMB 1
++#define CONFIG_GPLV3 0
++#define CONFIG_H263DSP 1
++#define CONFIG_H264CHROMA 1
++#define CONFIG_H264DSP 1
++#define CONFIG_H264PARSE 1
++#define CONFIG_H264PRED 1
++#define CONFIG_H264QPEL 1
++#define CONFIG_H264_SEI 1
++#define CONFIG_HEVCPARSE 0
++#define CONFIG_HEVC_SEI 0
++#define CONFIG_HPELDSP 1
++#define CONFIG_HUFFMAN 0
++#define CONFIG_HUFFYUVDSP 0
++#define CONFIG_HUFFYUVENCDSP 0
++#define CONFIG_IDCTDSP 1
++#define CONFIG_IIRFILTER 0
++#define CONFIG_INFLATE_WRAPPER 0
++#define CONFIG_INTRAX8 0
++#define CONFIG_ISO_MEDIA 1
++#define CONFIG_IVIDSP 0
++#define CONFIG_JPEGTABLES 0
++#define CONFIG_LGPLV3 0
++#define CONFIG_LIBX262 0
++#define CONFIG_LLAUDDSP 0
++#define CONFIG_LLVIDDSP 0
++#define CONFIG_LLVIDENCDSP 0
++#define CONFIG_LPC 0
++#define CONFIG_LZF 0
++#define CONFIG_ME_CMP 1
++#define CONFIG_MPEG_ER 1
++#define CONFIG_MPEGAUDIO 1
++#define CONFIG_MPEGAUDIODSP 1
++#define CONFIG_MPEGAUDIOHEADER 1
++#define CONFIG_MPEG4AUDIO 1
++#define CONFIG_MPEGVIDEO 1
++#define CONFIG_MPEGVIDEODEC 1
++#define CONFIG_MPEGVIDEOENC 0
++#define CONFIG_MSMPEG4DEC 0
++#define CONFIG_MSMPEG4ENC 0
++#define CONFIG_MSS34DSP 0
++#define CONFIG_PIXBLOCKDSP 0
++#define CONFIG_QPELDSP 1
++#define CONFIG_QSV 0
++#define CONFIG_QSVDEC 0
++#define CONFIG_QSVENC 0
++#define CONFIG_QSVVPP 0
++#define CONFIG_RANGECODER 0
++#define CONFIG_RIFFDEC 1
++#define CONFIG_RIFFENC 0
++#define CONFIG_RTPDEC 0
++#define CONFIG_RTPENC_CHAIN 0
++#define CONFIG_RV34DSP 0
++#define CONFIG_SCENE_SAD 0
++#define CONFIG_SINEWIN 1
++#define CONFIG_SNAPPY 0
++#define CONFIG_SRTP 0
++#define CONFIG_STARTCODE 1
++#define CONFIG_TEXTUREDSP 0
++#define CONFIG_TEXTUREDSPENC 0
++#define CONFIG_TPELDSP 0
++#define CONFIG_VAAPI_1 0
++#define CONFIG_VAAPI_ENCODE 0
++#define CONFIG_VC1DSP 0
++#define CONFIG_VIDEODSP 1
++#define CONFIG_VP3DSP 1
++#define CONFIG_VP56DSP 0
++#define CONFIG_VP8DSP 1
++#define CONFIG_WMA_FREQS 0
++#define CONFIG_WMV2DSP 0
++#endif /* FFMPEG_CONFIG_H */
+diff --git a/chromium/config/ChromeOS/linux/riscv64/config_components.h b/chromium/config/ChromeOS/linux/riscv64/config_components.h
+new file mode 100644
+index 0000000000..4290dbef99
+--- /dev/null
++++ b/chromium/config/ChromeOS/linux/riscv64/config_components.h
+@@ -0,0 +1,2164 @@
++/* Automatically generated by configure - do not modify! */
++#ifndef FFMPEG_CONFIG_COMPONENTS_H
++#define FFMPEG_CONFIG_COMPONENTS_H
++#define CONFIG_AAC_ADTSTOASC_BSF 0
++#define CONFIG_AV1_FRAME_MERGE_BSF 0
++#define CONFIG_AV1_FRAME_SPLIT_BSF 0
++#define CONFIG_AV1_METADATA_BSF 0
++#define CONFIG_CHOMP_BSF 0
++#define CONFIG_DUMP_EXTRADATA_BSF 0
++#define CONFIG_DCA_CORE_BSF 0
++#define CONFIG_DTS2PTS_BSF 0
++#define CONFIG_DV_ERROR_MARKER_BSF 0
++#define CONFIG_EAC3_CORE_BSF 0
++#define CONFIG_EXTRACT_EXTRADATA_BSF 0
++#define CONFIG_FILTER_UNITS_BSF 0
++#define CONFIG_H264_METADATA_BSF 0
++#define CONFIG_H264_MP4TOANNEXB_BSF 0
++#define CONFIG_H264_REDUNDANT_PPS_BSF 0
++#define CONFIG_HAPQA_EXTRACT_BSF 0
++#define CONFIG_HEVC_METADATA_BSF 0
++#define CONFIG_HEVC_MP4TOANNEXB_BSF 0
++#define CONFIG_IMX_DUMP_HEADER_BSF 0
++#define CONFIG_MEDIA100_TO_MJPEGB_BSF 0
++#define CONFIG_MJPEG2JPEG_BSF 0
++#define CONFIG_MJPEGA_DUMP_HEADER_BSF 0
++#define CONFIG_MP3_HEADER_DECOMPRESS_BSF 0
++#define CONFIG_MPEG2_METADATA_BSF 0
++#define CONFIG_MPEG4_UNPACK_BFRAMES_BSF 0
++#define CONFIG_MOV2TEXTSUB_BSF 0
++#define CONFIG_NOISE_BSF 0
++#define CONFIG_NULL_BSF 0
++#define CONFIG_OPUS_METADATA_BSF 0
++#define CONFIG_PCM_RECHUNK_BSF 0
++#define CONFIG_PGS_FRAME_MERGE_BSF 0
++#define CONFIG_PRORES_METADATA_BSF 0
++#define CONFIG_REMOVE_EXTRADATA_BSF 0
++#define CONFIG_SETTS_BSF 0
++#define CONFIG_TEXT2MOVSUB_BSF 0
++#define CONFIG_TRACE_HEADERS_BSF 0
++#define CONFIG_TRUEHD_CORE_BSF 0
++#define CONFIG_VP9_METADATA_BSF 0
++#define CONFIG_VP9_RAW_REORDER_BSF 0
++#define CONFIG_VP9_SUPERFRAME_BSF 0
++#define CONFIG_VP9_SUPERFRAME_SPLIT_BSF 0
++#define CONFIG_AASC_DECODER 0
++#define CONFIG_AIC_DECODER 0
++#define CONFIG_ALIAS_PIX_DECODER 0
++#define CONFIG_AGM_DECODER 0
++#define CONFIG_AMV_DECODER 0
++#define CONFIG_ANM_DECODER 0
++#define CONFIG_ANSI_DECODER 0
++#define CONFIG_APNG_DECODER 0
++#define CONFIG_ARBC_DECODER 0
++#define CONFIG_ARGO_DECODER 0
++#define CONFIG_ASV1_DECODER 0
++#define CONFIG_ASV2_DECODER 0
++#define CONFIG_AURA_DECODER 0
++#define CONFIG_AURA2_DECODER 0
++#define CONFIG_AVRP_DECODER 0
++#define CONFIG_AVRN_DECODER 0
++#define CONFIG_AVS_DECODER 0
++#define CONFIG_AVUI_DECODER 0
++#define CONFIG_AYUV_DECODER 0
++#define CONFIG_BETHSOFTVID_DECODER 0
++#define CONFIG_BFI_DECODER 0
++#define CONFIG_BINK_DECODER 0
++#define CONFIG_BITPACKED_DECODER 0
++#define CONFIG_BMP_DECODER 0
++#define CONFIG_BMV_VIDEO_DECODER 0
++#define CONFIG_BRENDER_PIX_DECODER 0
++#define CONFIG_C93_DECODER 0
++#define CONFIG_CAVS_DECODER 0
++#define CONFIG_CDGRAPHICS_DECODER 0
++#define CONFIG_CDTOONS_DECODER 0
++#define CONFIG_CDXL_DECODER 0
++#define CONFIG_CFHD_DECODER 0
++#define CONFIG_CINEPAK_DECODER 0
++#define CONFIG_CLEARVIDEO_DECODER 0
++#define CONFIG_CLJR_DECODER 0
++#define CONFIG_CLLC_DECODER 0
++#define CONFIG_COMFORTNOISE_DECODER 0
++#define CONFIG_CPIA_DECODER 0
++#define CONFIG_CRI_DECODER 0
++#define CONFIG_CSCD_DECODER 0
++#define CONFIG_CYUV_DECODER 0
++#define CONFIG_DDS_DECODER 0
++#define CONFIG_DFA_DECODER 0
++#define CONFIG_DIRAC_DECODER 0
++#define CONFIG_DNXHD_DECODER 0
++#define CONFIG_DPX_DECODER 0
++#define CONFIG_DSICINVIDEO_DECODER 0
++#define CONFIG_DVAUDIO_DECODER 0
++#define CONFIG_DVVIDEO_DECODER 0
++#define CONFIG_DXA_DECODER 0
++#define CONFIG_DXTORY_DECODER 0
++#define CONFIG_DXV_DECODER 0
++#define CONFIG_EACMV_DECODER 0
++#define CONFIG_EAMAD_DECODER 0
++#define CONFIG_EATGQ_DECODER 0
++#define CONFIG_EATGV_DECODER 0
++#define CONFIG_EATQI_DECODER 0
++#define CONFIG_EIGHTBPS_DECODER 0
++#define CONFIG_EIGHTSVX_EXP_DECODER 0
++#define CONFIG_EIGHTSVX_FIB_DECODER 0
++#define CONFIG_ESCAPE124_DECODER 0
++#define CONFIG_ESCAPE130_DECODER 0
++#define CONFIG_EXR_DECODER 0
++#define CONFIG_FFV1_DECODER 0
++#define CONFIG_FFVHUFF_DECODER 0
++#define CONFIG_FIC_DECODER 0
++#define CONFIG_FITS_DECODER 0
++#define CONFIG_FLASHSV_DECODER 0
++#define CONFIG_FLASHSV2_DECODER 0
++#define CONFIG_FLIC_DECODER 0
++#define CONFIG_FLV_DECODER 0
++#define CONFIG_FMVC_DECODER 0
++#define CONFIG_FOURXM_DECODER 0
++#define CONFIG_FRAPS_DECODER 0
++#define CONFIG_FRWU_DECODER 0
++#define CONFIG_G2M_DECODER 0
++#define CONFIG_GDV_DECODER 0
++#define CONFIG_GEM_DECODER 0
++#define CONFIG_GIF_DECODER 0
++#define CONFIG_H261_DECODER 0
++#define CONFIG_H263_DECODER 1
++#define CONFIG_H263I_DECODER 0
++#define CONFIG_H263P_DECODER 0
++#define CONFIG_H263_V4L2M2M_DECODER 0
++#define CONFIG_H264_DECODER 1
++#define CONFIG_H264_CRYSTALHD_DECODER 0
++#define CONFIG_H264_V4L2M2M_DECODER 0
++#define CONFIG_H264_MEDIACODEC_DECODER 0
++#define CONFIG_H264_MMAL_DECODER 0
++#define CONFIG_H264_QSV_DECODER 0
++#define CONFIG_H264_RKMPP_DECODER 0
++#define CONFIG_HAP_DECODER 0
++#define CONFIG_HEVC_DECODER 0
++#define CONFIG_HEVC_QSV_DECODER 0
++#define CONFIG_HEVC_RKMPP_DECODER 0
++#define CONFIG_HEVC_V4L2M2M_DECODER 0
++#define CONFIG_HNM4_VIDEO_DECODER 0
++#define CONFIG_HQ_HQA_DECODER 0
++#define CONFIG_HQX_DECODER 0
++#define CONFIG_HUFFYUV_DECODER 0
++#define CONFIG_HYMT_DECODER 0
++#define CONFIG_IDCIN_DECODER 0
++#define CONFIG_IFF_ILBM_DECODER 0
++#define CONFIG_IMM4_DECODER 0
++#define CONFIG_IMM5_DECODER 0
++#define CONFIG_INDEO2_DECODER 0
++#define CONFIG_INDEO3_DECODER 0
++#define CONFIG_INDEO4_DECODER 0
++#define CONFIG_INDEO5_DECODER 0
++#define CONFIG_INTERPLAY_VIDEO_DECODER 0
++#define CONFIG_IPU_DECODER 0
++#define CONFIG_JPEG2000_DECODER 0
++#define CONFIG_JPEGLS_DECODER 0
++#define CONFIG_JV_DECODER 0
++#define CONFIG_KGV1_DECODER 0
++#define CONFIG_KMVC_DECODER 0
++#define CONFIG_LAGARITH_DECODER 0
++#define CONFIG_LOCO_DECODER 0
++#define CONFIG_LSCR_DECODER 0
++#define CONFIG_M101_DECODER 0
++#define CONFIG_MAGICYUV_DECODER 0
++#define CONFIG_MDEC_DECODER 0
++#define CONFIG_MEDIA100_DECODER 0
++#define CONFIG_MIMIC_DECODER 0
++#define CONFIG_MJPEG_DECODER 0
++#define CONFIG_MJPEGB_DECODER 0
++#define CONFIG_MMVIDEO_DECODER 0
++#define CONFIG_MOBICLIP_DECODER 0
++#define CONFIG_MOTIONPIXELS_DECODER 0
++#define CONFIG_MPEG1VIDEO_DECODER 0
++#define CONFIG_MPEG2VIDEO_DECODER 0
++#define CONFIG_MPEG4_DECODER 1
++#define CONFIG_MPEG4_CRYSTALHD_DECODER 0
++#define CONFIG_MPEG4_V4L2M2M_DECODER 0
++#define CONFIG_MPEG4_MMAL_DECODER 0
++#define CONFIG_MPEGVIDEO_DECODER 0
++#define CONFIG_MPEG1_V4L2M2M_DECODER 0
++#define CONFIG_MPEG2_MMAL_DECODER 0
++#define CONFIG_MPEG2_CRYSTALHD_DECODER 0
++#define CONFIG_MPEG2_V4L2M2M_DECODER 0
++#define CONFIG_MPEG2_QSV_DECODER 0
++#define CONFIG_MPEG2_MEDIACODEC_DECODER 0
++#define CONFIG_MSA1_DECODER 0
++#define CONFIG_MSCC_DECODER 0
++#define CONFIG_MSMPEG4V1_DECODER 0
++#define CONFIG_MSMPEG4V2_DECODER 0
++#define CONFIG_MSMPEG4V3_DECODER 0
++#define CONFIG_MSMPEG4_CRYSTALHD_DECODER 0
++#define CONFIG_MSP2_DECODER 0
++#define CONFIG_MSRLE_DECODER 0
++#define CONFIG_MSS1_DECODER 0
++#define CONFIG_MSS2_DECODER 0
++#define CONFIG_MSVIDEO1_DECODER 0
++#define CONFIG_MSZH_DECODER 0
++#define CONFIG_MTS2_DECODER 0
++#define CONFIG_MV30_DECODER 0
++#define CONFIG_MVC1_DECODER 0
++#define CONFIG_MVC2_DECODER 0
++#define CONFIG_MVDV_DECODER 0
++#define CONFIG_MVHA_DECODER 0
++#define CONFIG_MWSC_DECODER 0
++#define CONFIG_MXPEG_DECODER 0
++#define CONFIG_NOTCHLC_DECODER 0
++#define CONFIG_NUV_DECODER 0
++#define CONFIG_PAF_VIDEO_DECODER 0
++#define CONFIG_PAM_DECODER 0
++#define CONFIG_PBM_DECODER 0
++#define CONFIG_PCX_DECODER 0
++#define CONFIG_PDV_DECODER 0
++#define CONFIG_PFM_DECODER 0
++#define CONFIG_PGM_DECODER 0
++#define CONFIG_PGMYUV_DECODER 0
++#define CONFIG_PGX_DECODER 0
++#define CONFIG_PHM_DECODER 0
++#define CONFIG_PHOTOCD_DECODER 0
++#define CONFIG_PICTOR_DECODER 0
++#define CONFIG_PIXLET_DECODER 0
++#define CONFIG_PNG_DECODER 0
++#define CONFIG_PPM_DECODER 0
++#define CONFIG_PRORES_DECODER 0
++#define CONFIG_PROSUMER_DECODER 0
++#define CONFIG_PSD_DECODER 0
++#define CONFIG_PTX_DECODER 0
++#define CONFIG_QDRAW_DECODER 0
++#define CONFIG_QOI_DECODER 0
++#define CONFIG_QPEG_DECODER 0
++#define CONFIG_QTRLE_DECODER 0
++#define CONFIG_R10K_DECODER 0
++#define CONFIG_R210_DECODER 0
++#define CONFIG_RASC_DECODER 0
++#define CONFIG_RAWVIDEO_DECODER 0
++#define CONFIG_RKA_DECODER 0
++#define CONFIG_RL2_DECODER 0
++#define CONFIG_ROQ_DECODER 0
++#define CONFIG_RPZA_DECODER 0
++#define CONFIG_RSCC_DECODER 0
++#define CONFIG_RV10_DECODER 0
++#define CONFIG_RV20_DECODER 0
++#define CONFIG_RV30_DECODER 0
++#define CONFIG_RV40_DECODER 0
++#define CONFIG_S302M_DECODER 0
++#define CONFIG_SANM_DECODER 0
++#define CONFIG_SCPR_DECODER 0
++#define CONFIG_SCREENPRESSO_DECODER 0
++#define CONFIG_SGA_DECODER 0
++#define CONFIG_SGI_DECODER 0
++#define CONFIG_SGIRLE_DECODER 0
++#define CONFIG_SHEERVIDEO_DECODER 0
++#define CONFIG_SIMBIOSIS_IMX_DECODER 0
++#define CONFIG_SMACKER_DECODER 0
++#define CONFIG_SMC_DECODER 0
++#define CONFIG_SMVJPEG_DECODER 0
++#define CONFIG_SNOW_DECODER 0
++#define CONFIG_SP5X_DECODER 0
++#define CONFIG_SPEEDHQ_DECODER 0
++#define CONFIG_SPEEX_DECODER 0
++#define CONFIG_SRGC_DECODER 0
++#define CONFIG_SUNRAST_DECODER 0
++#define CONFIG_SVQ1_DECODER 0
++#define CONFIG_SVQ3_DECODER 0
++#define CONFIG_TARGA_DECODER 0
++#define CONFIG_TARGA_Y216_DECODER 0
++#define CONFIG_TDSC_DECODER 0
++#define CONFIG_THEORA_DECODER 1
++#define CONFIG_THP_DECODER 0
++#define CONFIG_TIERTEXSEQVIDEO_DECODER 0
++#define CONFIG_TIFF_DECODER 0
++#define CONFIG_TMV_DECODER 0
++#define CONFIG_TRUEMOTION1_DECODER 0
++#define CONFIG_TRUEMOTION2_DECODER 0
++#define CONFIG_TRUEMOTION2RT_DECODER 0
++#define CONFIG_TSCC_DECODER 0
++#define CONFIG_TSCC2_DECODER 0
++#define CONFIG_TXD_DECODER 0
++#define CONFIG_ULTI_DECODER 0
++#define CONFIG_UTVIDEO_DECODER 0
++#define CONFIG_V210_DECODER 0
++#define CONFIG_V210X_DECODER 0
++#define CONFIG_V308_DECODER 0
++#define CONFIG_V408_DECODER 0
++#define CONFIG_V410_DECODER 0
++#define CONFIG_VB_DECODER 0
++#define CONFIG_VBN_DECODER 0
++#define CONFIG_VBLE_DECODER 0
++#define CONFIG_VC1_DECODER 0
++#define CONFIG_VC1_CRYSTALHD_DECODER 0
++#define CONFIG_VC1IMAGE_DECODER 0
++#define CONFIG_VC1_MMAL_DECODER 0
++#define CONFIG_VC1_QSV_DECODER 0
++#define CONFIG_VC1_V4L2M2M_DECODER 0
++#define CONFIG_VCR1_DECODER 0
++#define CONFIG_VMDVIDEO_DECODER 0
++#define CONFIG_VMNC_DECODER 0
++#define CONFIG_VP3_DECODER 1
++#define CONFIG_VP4_DECODER 0
++#define CONFIG_VP5_DECODER 0
++#define CONFIG_VP6_DECODER 0
++#define CONFIG_VP6A_DECODER 0
++#define CONFIG_VP6F_DECODER 0
++#define CONFIG_VP7_DECODER 0
++#define CONFIG_VP8_DECODER 1
++#define CONFIG_VP8_RKMPP_DECODER 0
++#define CONFIG_VP8_V4L2M2M_DECODER 0
++#define CONFIG_VP9_DECODER 0
++#define CONFIG_VP9_RKMPP_DECODER 0
++#define CONFIG_VP9_V4L2M2M_DECODER 0
++#define CONFIG_VQA_DECODER 0
++#define CONFIG_VQC_DECODER 0
++#define CONFIG_WBMP_DECODER 0
++#define CONFIG_WEBP_DECODER 0
++#define CONFIG_WCMV_DECODER 0
++#define CONFIG_WRAPPED_AVFRAME_DECODER 0
++#define CONFIG_WMV1_DECODER 0
++#define CONFIG_WMV2_DECODER 0
++#define CONFIG_WMV3_DECODER 0
++#define CONFIG_WMV3_CRYSTALHD_DECODER 0
++#define CONFIG_WMV3IMAGE_DECODER 0
++#define CONFIG_WNV1_DECODER 0
++#define CONFIG_XAN_WC3_DECODER 0
++#define CONFIG_XAN_WC4_DECODER 0
++#define CONFIG_XBM_DECODER 0
++#define CONFIG_XFACE_DECODER 0
++#define CONFIG_XL_DECODER 0
++#define CONFIG_XPM_DECODER 0
++#define CONFIG_XWD_DECODER 0
++#define CONFIG_Y41P_DECODER 0
++#define CONFIG_YLC_DECODER 0
++#define CONFIG_YOP_DECODER 0
++#define CONFIG_YUV4_DECODER 0
++#define CONFIG_ZERO12V_DECODER 0
++#define CONFIG_ZEROCODEC_DECODER 0
++#define CONFIG_ZLIB_DECODER 0
++#define CONFIG_ZMBV_DECODER 0
++#define CONFIG_AAC_DECODER 1
++#define CONFIG_AAC_FIXED_DECODER 0
++#define CONFIG_AAC_LATM_DECODER 0
++#define CONFIG_AC3_DECODER 0
++#define CONFIG_AC3_FIXED_DECODER 0
++#define CONFIG_ACELP_KELVIN_DECODER 0
++#define CONFIG_ALAC_DECODER 0
++#define CONFIG_ALS_DECODER 0
++#define CONFIG_AMRNB_DECODER 0
++#define CONFIG_AMRWB_DECODER 0
++#define CONFIG_APAC_DECODER 0
++#define CONFIG_APE_DECODER 0
++#define CONFIG_APTX_DECODER 0
++#define CONFIG_APTX_HD_DECODER 0
++#define CONFIG_ATRAC1_DECODER 0
++#define CONFIG_ATRAC3_DECODER 0
++#define CONFIG_ATRAC3AL_DECODER 0
++#define CONFIG_ATRAC3P_DECODER 0
++#define CONFIG_ATRAC3PAL_DECODER 0
++#define CONFIG_ATRAC9_DECODER 0
++#define CONFIG_BINKAUDIO_DCT_DECODER 0
++#define CONFIG_BINKAUDIO_RDFT_DECODER 0
++#define CONFIG_BMV_AUDIO_DECODER 0
++#define CONFIG_BONK_DECODER 0
++#define CONFIG_COOK_DECODER 0
++#define CONFIG_DCA_DECODER 0
++#define CONFIG_DFPWM_DECODER 0
++#define CONFIG_DOLBY_E_DECODER 0
++#define CONFIG_DSD_LSBF_DECODER 0
++#define CONFIG_DSD_MSBF_DECODER 0
++#define CONFIG_DSD_LSBF_PLANAR_DECODER 0
++#define CONFIG_DSD_MSBF_PLANAR_DECODER 0
++#define CONFIG_DSICINAUDIO_DECODER 0
++#define CONFIG_DSS_SP_DECODER 0
++#define CONFIG_DST_DECODER 0
++#define CONFIG_EAC3_DECODER 0
++#define CONFIG_EVRC_DECODER 0
++#define CONFIG_FASTAUDIO_DECODER 0
++#define CONFIG_FFWAVESYNTH_DECODER 0
++#define CONFIG_FLAC_DECODER 1
++#define CONFIG_FTR_DECODER 0
++#define CONFIG_G723_1_DECODER 0
++#define CONFIG_G729_DECODER 0
++#define CONFIG_GSM_DECODER 0
++#define CONFIG_GSM_MS_DECODER 0
++#define CONFIG_HCA_DECODER 0
++#define CONFIG_HCOM_DECODER 0
++#define CONFIG_HDR_DECODER 0
++#define CONFIG_IAC_DECODER 0
++#define CONFIG_ILBC_DECODER 0
++#define CONFIG_IMC_DECODER 0
++#define CONFIG_INTERPLAY_ACM_DECODER 0
++#define CONFIG_MACE3_DECODER 0
++#define CONFIG_MACE6_DECODER 0
++#define CONFIG_METASOUND_DECODER 0
++#define CONFIG_MISC4_DECODER 0
++#define CONFIG_MLP_DECODER 0
++#define CONFIG_MP1_DECODER 0
++#define CONFIG_MP1FLOAT_DECODER 0
++#define CONFIG_MP2_DECODER 0
++#define CONFIG_MP2FLOAT_DECODER 0
++#define CONFIG_MP3FLOAT_DECODER 0
++#define CONFIG_MP3_DECODER 1
++#define CONFIG_MP3ADUFLOAT_DECODER 0
++#define CONFIG_MP3ADU_DECODER 0
++#define CONFIG_MP3ON4FLOAT_DECODER 0
++#define CONFIG_MP3ON4_DECODER 0
++#define CONFIG_MPC7_DECODER 0
++#define CONFIG_MPC8_DECODER 0
++#define CONFIG_MSNSIREN_DECODER 0
++#define CONFIG_NELLYMOSER_DECODER 0
++#define CONFIG_ON2AVC_DECODER 0
++#define CONFIG_OPUS_DECODER 0
++#define CONFIG_PAF_AUDIO_DECODER 0
++#define CONFIG_QCELP_DECODER 0
++#define CONFIG_QDM2_DECODER 0
++#define CONFIG_QDMC_DECODER 0
++#define CONFIG_RA_144_DECODER 0
++#define CONFIG_RA_288_DECODER 0
++#define CONFIG_RALF_DECODER 0
++#define CONFIG_SBC_DECODER 0
++#define CONFIG_SHORTEN_DECODER 0
++#define CONFIG_SIPR_DECODER 0
++#define CONFIG_SIREN_DECODER 0
++#define CONFIG_SMACKAUD_DECODER 0
++#define CONFIG_SONIC_DECODER 0
++#define CONFIG_TAK_DECODER 0
++#define CONFIG_TRUEHD_DECODER 0
++#define CONFIG_TRUESPEECH_DECODER 0
++#define CONFIG_TTA_DECODER 0
++#define CONFIG_TWINVQ_DECODER 0
++#define CONFIG_VMDAUDIO_DECODER 0
++#define CONFIG_VORBIS_DECODER 1
++#define CONFIG_WAVARC_DECODER 0
++#define CONFIG_WAVPACK_DECODER 0
++#define CONFIG_WMALOSSLESS_DECODER 0
++#define CONFIG_WMAPRO_DECODER 0
++#define CONFIG_WMAV1_DECODER 0
++#define CONFIG_WMAV2_DECODER 0
++#define CONFIG_WMAVOICE_DECODER 0
++#define CONFIG_WS_SND1_DECODER 0
++#define CONFIG_XMA1_DECODER 0
++#define CONFIG_XMA2_DECODER 0
++#define CONFIG_PCM_ALAW_DECODER 1
++#define CONFIG_PCM_BLURAY_DECODER 0
++#define CONFIG_PCM_DVD_DECODER 0
++#define CONFIG_PCM_F16LE_DECODER 0
++#define CONFIG_PCM_F24LE_DECODER 0
++#define CONFIG_PCM_F32BE_DECODER 0
++#define CONFIG_PCM_F32LE_DECODER 1
++#define CONFIG_PCM_F64BE_DECODER 0
++#define CONFIG_PCM_F64LE_DECODER 0
++#define CONFIG_PCM_LXF_DECODER 0
++#define CONFIG_PCM_MULAW_DECODER 1
++#define CONFIG_PCM_S8_DECODER 0
++#define CONFIG_PCM_S8_PLANAR_DECODER 0
++#define CONFIG_PCM_S16BE_DECODER 1
++#define CONFIG_PCM_S16BE_PLANAR_DECODER 0
++#define CONFIG_PCM_S16LE_DECODER 1
++#define CONFIG_PCM_S16LE_PLANAR_DECODER 0
++#define CONFIG_PCM_S24BE_DECODER 1
++#define CONFIG_PCM_S24DAUD_DECODER 0
++#define CONFIG_PCM_S24LE_DECODER 1
++#define CONFIG_PCM_S24LE_PLANAR_DECODER 0
++#define CONFIG_PCM_S32BE_DECODER 0
++#define CONFIG_PCM_S32LE_DECODER 1
++#define CONFIG_PCM_S32LE_PLANAR_DECODER 0
++#define CONFIG_PCM_S64BE_DECODER 0
++#define CONFIG_PCM_S64LE_DECODER 0
++#define CONFIG_PCM_SGA_DECODER 0
++#define CONFIG_PCM_U8_DECODER 1
++#define CONFIG_PCM_U16BE_DECODER 0
++#define CONFIG_PCM_U16LE_DECODER 0
++#define CONFIG_PCM_U24BE_DECODER 0
++#define CONFIG_PCM_U24LE_DECODER 0
++#define CONFIG_PCM_U32BE_DECODER 0
++#define CONFIG_PCM_U32LE_DECODER 0
++#define CONFIG_PCM_VIDC_DECODER 0
++#define CONFIG_CBD2_DPCM_DECODER 0
++#define CONFIG_DERF_DPCM_DECODER 0
++#define CONFIG_GREMLIN_DPCM_DECODER 0
++#define CONFIG_INTERPLAY_DPCM_DECODER 0
++#define CONFIG_ROQ_DPCM_DECODER 0
++#define CONFIG_SDX2_DPCM_DECODER 0
++#define CONFIG_SOL_DPCM_DECODER 0
++#define CONFIG_XAN_DPCM_DECODER 0
++#define CONFIG_WADY_DPCM_DECODER 0
++#define CONFIG_ADPCM_4XM_DECODER 0
++#define CONFIG_ADPCM_ADX_DECODER 0
++#define CONFIG_ADPCM_AFC_DECODER 0
++#define CONFIG_ADPCM_AGM_DECODER 0
++#define CONFIG_ADPCM_AICA_DECODER 0
++#define CONFIG_ADPCM_ARGO_DECODER 0
++#define CONFIG_ADPCM_CT_DECODER 0
++#define CONFIG_ADPCM_DTK_DECODER 0
++#define CONFIG_ADPCM_EA_DECODER 0
++#define CONFIG_ADPCM_EA_MAXIS_XA_DECODER 0
++#define CONFIG_ADPCM_EA_R1_DECODER 0
++#define CONFIG_ADPCM_EA_R2_DECODER 0
++#define CONFIG_ADPCM_EA_R3_DECODER 0
++#define CONFIG_ADPCM_EA_XAS_DECODER 0
++#define CONFIG_ADPCM_G722_DECODER 0
++#define CONFIG_ADPCM_G726_DECODER 0
++#define CONFIG_ADPCM_G726LE_DECODER 0
++#define CONFIG_ADPCM_IMA_ACORN_DECODER 0
++#define CONFIG_ADPCM_IMA_AMV_DECODER 0
++#define CONFIG_ADPCM_IMA_ALP_DECODER 0
++#define CONFIG_ADPCM_IMA_APC_DECODER 0
++#define CONFIG_ADPCM_IMA_APM_DECODER 0
++#define CONFIG_ADPCM_IMA_CUNNING_DECODER 0
++#define CONFIG_ADPCM_IMA_DAT4_DECODER 0
++#define CONFIG_ADPCM_IMA_DK3_DECODER 0
++#define CONFIG_ADPCM_IMA_DK4_DECODER 0
++#define CONFIG_ADPCM_IMA_EA_EACS_DECODER 0
++#define CONFIG_ADPCM_IMA_EA_SEAD_DECODER 0
++#define CONFIG_ADPCM_IMA_ISS_DECODER 0
++#define CONFIG_ADPCM_IMA_MOFLEX_DECODER 0
++#define CONFIG_ADPCM_IMA_MTF_DECODER 0
++#define CONFIG_ADPCM_IMA_OKI_DECODER 0
++#define CONFIG_ADPCM_IMA_QT_DECODER 0
++#define CONFIG_ADPCM_IMA_RAD_DECODER 0
++#define CONFIG_ADPCM_IMA_SSI_DECODER 0
++#define CONFIG_ADPCM_IMA_SMJPEG_DECODER 0
++#define CONFIG_ADPCM_IMA_WAV_DECODER 0
++#define CONFIG_ADPCM_IMA_WS_DECODER 0
++#define CONFIG_ADPCM_MS_DECODER 0
++#define CONFIG_ADPCM_MTAF_DECODER 0
++#define CONFIG_ADPCM_PSX_DECODER 0
++#define CONFIG_ADPCM_SBPRO_2_DECODER 0
++#define CONFIG_ADPCM_SBPRO_3_DECODER 0
++#define CONFIG_ADPCM_SBPRO_4_DECODER 0
++#define CONFIG_ADPCM_SWF_DECODER 0
++#define CONFIG_ADPCM_THP_DECODER 0
++#define CONFIG_ADPCM_THP_LE_DECODER 0
++#define CONFIG_ADPCM_VIMA_DECODER 0
++#define CONFIG_ADPCM_XA_DECODER 0
++#define CONFIG_ADPCM_XMD_DECODER 0
++#define CONFIG_ADPCM_YAMAHA_DECODER 0
++#define CONFIG_ADPCM_ZORK_DECODER 0
++#define CONFIG_SSA_DECODER 0
++#define CONFIG_ASS_DECODER 0
++#define CONFIG_CCAPTION_DECODER 0
++#define CONFIG_DVBSUB_DECODER 0
++#define CONFIG_DVDSUB_DECODER 0
++#define CONFIG_JACOSUB_DECODER 0
++#define CONFIG_MICRODVD_DECODER 0
++#define CONFIG_MOVTEXT_DECODER 0
++#define CONFIG_MPL2_DECODER 0
++#define CONFIG_PGSSUB_DECODER 0
++#define CONFIG_PJS_DECODER 0
++#define CONFIG_REALTEXT_DECODER 0
++#define CONFIG_SAMI_DECODER 0
++#define CONFIG_SRT_DECODER 0
++#define CONFIG_STL_DECODER 0
++#define CONFIG_SUBRIP_DECODER 0
++#define CONFIG_SUBVIEWER_DECODER 0
++#define CONFIG_SUBVIEWER1_DECODER 0
++#define CONFIG_TEXT_DECODER 0
++#define CONFIG_VPLAYER_DECODER 0
++#define CONFIG_WEBVTT_DECODER 0
++#define CONFIG_XSUB_DECODER 0
++#define CONFIG_AAC_AT_DECODER 0
++#define CONFIG_AC3_AT_DECODER 0
++#define CONFIG_ADPCM_IMA_QT_AT_DECODER 0
++#define CONFIG_ALAC_AT_DECODER 0
++#define CONFIG_AMR_NB_AT_DECODER 0
++#define CONFIG_EAC3_AT_DECODER 0
++#define CONFIG_GSM_MS_AT_DECODER 0
++#define CONFIG_ILBC_AT_DECODER 0
++#define CONFIG_MP1_AT_DECODER 0
++#define CONFIG_MP2_AT_DECODER 0
++#define CONFIG_MP3_AT_DECODER 0
++#define CONFIG_PCM_ALAW_AT_DECODER 0
++#define CONFIG_PCM_MULAW_AT_DECODER 0
++#define CONFIG_QDMC_AT_DECODER 0
++#define CONFIG_QDM2_AT_DECODER 0
++#define CONFIG_LIBARIBCAPTION_DECODER 0
++#define CONFIG_LIBARIBB24_DECODER 0
++#define CONFIG_LIBCELT_DECODER 0
++#define CONFIG_LIBCODEC2_DECODER 0
++#define CONFIG_LIBDAV1D_DECODER 0
++#define CONFIG_LIBDAVS2_DECODER 0
++#define CONFIG_LIBFDK_AAC_DECODER 0
++#define CONFIG_LIBGSM_DECODER 0
++#define CONFIG_LIBGSM_MS_DECODER 0
++#define CONFIG_LIBILBC_DECODER 0
++#define CONFIG_LIBJXL_DECODER 0
++#define CONFIG_LIBOPENCORE_AMRNB_DECODER 0
++#define CONFIG_LIBOPENCORE_AMRWB_DECODER 0
++#define CONFIG_LIBOPUS_DECODER 1
++#define CONFIG_LIBRSVG_DECODER 0
++#define CONFIG_LIBSPEEX_DECODER 0
++#define CONFIG_LIBUAVS3D_DECODER 0
++#define CONFIG_LIBVORBIS_DECODER 0
++#define CONFIG_LIBVPX_VP8_DECODER 0
++#define CONFIG_LIBVPX_VP9_DECODER 0
++#define CONFIG_LIBZVBI_TELETEXT_DECODER 0
++#define CONFIG_BINTEXT_DECODER 0
++#define CONFIG_XBIN_DECODER 0
++#define CONFIG_IDF_DECODER 0
++#define CONFIG_LIBAOM_AV1_DECODER 0
++#define CONFIG_AV1_DECODER 0
++#define CONFIG_AV1_CUVID_DECODER 0
++#define CONFIG_AV1_MEDIACODEC_DECODER 0
++#define CONFIG_AV1_QSV_DECODER 0
++#define CONFIG_LIBOPENH264_DECODER 0
++#define CONFIG_H264_CUVID_DECODER 0
++#define CONFIG_HEVC_CUVID_DECODER 0
++#define CONFIG_HEVC_MEDIACODEC_DECODER 0
++#define CONFIG_MJPEG_CUVID_DECODER 0
++#define CONFIG_MJPEG_QSV_DECODER 0
++#define CONFIG_MPEG1_CUVID_DECODER 0
++#define CONFIG_MPEG2_CUVID_DECODER 0
++#define CONFIG_MPEG4_CUVID_DECODER 0
++#define CONFIG_MPEG4_MEDIACODEC_DECODER 0
++#define CONFIG_VC1_CUVID_DECODER 0
++#define CONFIG_VP8_CUVID_DECODER 0
++#define CONFIG_VP8_MEDIACODEC_DECODER 0
++#define CONFIG_VP8_QSV_DECODER 0
++#define CONFIG_VP9_CUVID_DECODER 0
++#define CONFIG_VP9_MEDIACODEC_DECODER 0
++#define CONFIG_VP9_QSV_DECODER 0
++#define CONFIG_VNULL_DECODER 0
++#define CONFIG_ANULL_DECODER 0
++#define CONFIG_A64MULTI_ENCODER 0
++#define CONFIG_A64MULTI5_ENCODER 0
++#define CONFIG_ALIAS_PIX_ENCODER 0
++#define CONFIG_AMV_ENCODER 0
++#define CONFIG_APNG_ENCODER 0
++#define CONFIG_ASV1_ENCODER 0
++#define CONFIG_ASV2_ENCODER 0
++#define CONFIG_AVRP_ENCODER 0
++#define CONFIG_AVUI_ENCODER 0
++#define CONFIG_AYUV_ENCODER 0
++#define CONFIG_BITPACKED_ENCODER 0
++#define CONFIG_BMP_ENCODER 0
++#define CONFIG_CFHD_ENCODER 0
++#define CONFIG_CINEPAK_ENCODER 0
++#define CONFIG_CLJR_ENCODER 0
++#define CONFIG_COMFORTNOISE_ENCODER 0
++#define CONFIG_DNXHD_ENCODER 0
++#define CONFIG_DPX_ENCODER 0
++#define CONFIG_DVVIDEO_ENCODER 0
++#define CONFIG_EXR_ENCODER 0
++#define CONFIG_FFV1_ENCODER 0
++#define CONFIG_FFVHUFF_ENCODER 0
++#define CONFIG_FITS_ENCODER 0
++#define CONFIG_FLASHSV_ENCODER 0
++#define CONFIG_FLASHSV2_ENCODER 0
++#define CONFIG_FLV_ENCODER 0
++#define CONFIG_GIF_ENCODER 0
++#define CONFIG_H261_ENCODER 0
++#define CONFIG_H263_ENCODER 0
++#define CONFIG_H263P_ENCODER 0
++#define CONFIG_H264_MEDIACODEC_ENCODER 0
++#define CONFIG_HAP_ENCODER 0
++#define CONFIG_HUFFYUV_ENCODER 0
++#define CONFIG_JPEG2000_ENCODER 0
++#define CONFIG_JPEGLS_ENCODER 0
++#define CONFIG_LJPEG_ENCODER 0
++#define CONFIG_MAGICYUV_ENCODER 0
++#define CONFIG_MJPEG_ENCODER 0
++#define CONFIG_MPEG1VIDEO_ENCODER 0
++#define CONFIG_MPEG2VIDEO_ENCODER 0
++#define CONFIG_MPEG4_ENCODER 0
++#define CONFIG_MSMPEG4V2_ENCODER 0
++#define CONFIG_MSMPEG4V3_ENCODER 0
++#define CONFIG_MSVIDEO1_ENCODER 0
++#define CONFIG_PAM_ENCODER 0
++#define CONFIG_PBM_ENCODER 0
++#define CONFIG_PCX_ENCODER 0
++#define CONFIG_PFM_ENCODER 0
++#define CONFIG_PGM_ENCODER 0
++#define CONFIG_PGMYUV_ENCODER 0
++#define CONFIG_PHM_ENCODER 0
++#define CONFIG_PNG_ENCODER 0
++#define CONFIG_PPM_ENCODER 0
++#define CONFIG_PRORES_ENCODER 0
++#define CONFIG_PRORES_AW_ENCODER 0
++#define CONFIG_PRORES_KS_ENCODER 0
++#define CONFIG_QOI_ENCODER 0
++#define CONFIG_QTRLE_ENCODER 0
++#define CONFIG_R10K_ENCODER 0
++#define CONFIG_R210_ENCODER 0
++#define CONFIG_RAWVIDEO_ENCODER 0
++#define CONFIG_ROQ_ENCODER 0
++#define CONFIG_RPZA_ENCODER 0
++#define CONFIG_RV10_ENCODER 0
++#define CONFIG_RV20_ENCODER 0
++#define CONFIG_S302M_ENCODER 0
++#define CONFIG_SGI_ENCODER 0
++#define CONFIG_SMC_ENCODER 0
++#define CONFIG_SNOW_ENCODER 0
++#define CONFIG_SPEEDHQ_ENCODER 0
++#define CONFIG_SUNRAST_ENCODER 0
++#define CONFIG_SVQ1_ENCODER 0
++#define CONFIG_TARGA_ENCODER 0
++#define CONFIG_TIFF_ENCODER 0
++#define CONFIG_UTVIDEO_ENCODER 0
++#define CONFIG_V210_ENCODER 0
++#define CONFIG_V308_ENCODER 0
++#define CONFIG_V408_ENCODER 0
++#define CONFIG_V410_ENCODER 0
++#define CONFIG_VBN_ENCODER 0
++#define CONFIG_VC2_ENCODER 0
++#define CONFIG_WBMP_ENCODER 0
++#define CONFIG_WRAPPED_AVFRAME_ENCODER 0
++#define CONFIG_WMV1_ENCODER 0
++#define CONFIG_WMV2_ENCODER 0
++#define CONFIG_XBM_ENCODER 0
++#define CONFIG_XFACE_ENCODER 0
++#define CONFIG_XWD_ENCODER 0
++#define CONFIG_Y41P_ENCODER 0
++#define CONFIG_YUV4_ENCODER 0
++#define CONFIG_ZLIB_ENCODER 0
++#define CONFIG_ZMBV_ENCODER 0
++#define CONFIG_AAC_ENCODER 0
++#define CONFIG_AC3_ENCODER 0
++#define CONFIG_AC3_FIXED_ENCODER 0
++#define CONFIG_ALAC_ENCODER 0
++#define CONFIG_APTX_ENCODER 0
++#define CONFIG_APTX_HD_ENCODER 0
++#define CONFIG_DCA_ENCODER 0
++#define CONFIG_DFPWM_ENCODER 0
++#define CONFIG_EAC3_ENCODER 0
++#define CONFIG_FLAC_ENCODER 0
++#define CONFIG_G723_1_ENCODER 0
++#define CONFIG_HDR_ENCODER 0
++#define CONFIG_MLP_ENCODER 0
++#define CONFIG_MP2_ENCODER 0
++#define CONFIG_MP2FIXED_ENCODER 0
++#define CONFIG_NELLYMOSER_ENCODER 0
++#define CONFIG_OPUS_ENCODER 0
++#define CONFIG_RA_144_ENCODER 0
++#define CONFIG_SBC_ENCODER 0
++#define CONFIG_SONIC_ENCODER 0
++#define CONFIG_SONIC_LS_ENCODER 0
++#define CONFIG_TRUEHD_ENCODER 0
++#define CONFIG_TTA_ENCODER 0
++#define CONFIG_VORBIS_ENCODER 0
++#define CONFIG_WAVPACK_ENCODER 0
++#define CONFIG_WMAV1_ENCODER 0
++#define CONFIG_WMAV2_ENCODER 0
++#define CONFIG_PCM_ALAW_ENCODER 0
++#define CONFIG_PCM_BLURAY_ENCODER 0
++#define CONFIG_PCM_DVD_ENCODER 0
++#define CONFIG_PCM_F32BE_ENCODER 0
++#define CONFIG_PCM_F32LE_ENCODER 0
++#define CONFIG_PCM_F64BE_ENCODER 0
++#define CONFIG_PCM_F64LE_ENCODER 0
++#define CONFIG_PCM_MULAW_ENCODER 0
++#define CONFIG_PCM_S8_ENCODER 0
++#define CONFIG_PCM_S8_PLANAR_ENCODER 0
++#define CONFIG_PCM_S16BE_ENCODER 0
++#define CONFIG_PCM_S16BE_PLANAR_ENCODER 0
++#define CONFIG_PCM_S16LE_ENCODER 0
++#define CONFIG_PCM_S16LE_PLANAR_ENCODER 0
++#define CONFIG_PCM_S24BE_ENCODER 0
++#define CONFIG_PCM_S24DAUD_ENCODER 0
++#define CONFIG_PCM_S24LE_ENCODER 0
++#define CONFIG_PCM_S24LE_PLANAR_ENCODER 0
++#define CONFIG_PCM_S32BE_ENCODER 0
++#define CONFIG_PCM_S32LE_ENCODER 0
++#define CONFIG_PCM_S32LE_PLANAR_ENCODER 0
++#define CONFIG_PCM_S64BE_ENCODER 0
++#define CONFIG_PCM_S64LE_ENCODER 0
++#define CONFIG_PCM_U8_ENCODER 0
++#define CONFIG_PCM_U16BE_ENCODER 0
++#define CONFIG_PCM_U16LE_ENCODER 0
++#define CONFIG_PCM_U24BE_ENCODER 0
++#define CONFIG_PCM_U24LE_ENCODER 0
++#define CONFIG_PCM_U32BE_ENCODER 0
++#define CONFIG_PCM_U32LE_ENCODER 0
++#define CONFIG_PCM_VIDC_ENCODER 0
++#define CONFIG_ROQ_DPCM_ENCODER 0
++#define CONFIG_ADPCM_ADX_ENCODER 0
++#define CONFIG_ADPCM_ARGO_ENCODER 0
++#define CONFIG_ADPCM_G722_ENCODER 0
++#define CONFIG_ADPCM_G726_ENCODER 0
++#define CONFIG_ADPCM_G726LE_ENCODER 0
++#define CONFIG_ADPCM_IMA_AMV_ENCODER 0
++#define CONFIG_ADPCM_IMA_ALP_ENCODER 0
++#define CONFIG_ADPCM_IMA_APM_ENCODER 0
++#define CONFIG_ADPCM_IMA_QT_ENCODER 0
++#define CONFIG_ADPCM_IMA_SSI_ENCODER 0
++#define CONFIG_ADPCM_IMA_WAV_ENCODER 0
++#define CONFIG_ADPCM_IMA_WS_ENCODER 0
++#define CONFIG_ADPCM_MS_ENCODER 0
++#define CONFIG_ADPCM_SWF_ENCODER 0
++#define CONFIG_ADPCM_YAMAHA_ENCODER 0
++#define CONFIG_SSA_ENCODER 0
++#define CONFIG_ASS_ENCODER 0
++#define CONFIG_DVBSUB_ENCODER 0
++#define CONFIG_DVDSUB_ENCODER 0
++#define CONFIG_MOVTEXT_ENCODER 0
++#define CONFIG_SRT_ENCODER 0
++#define CONFIG_SUBRIP_ENCODER 0
++#define CONFIG_TEXT_ENCODER 0
++#define CONFIG_TTML_ENCODER 0
++#define CONFIG_WEBVTT_ENCODER 0
++#define CONFIG_XSUB_ENCODER 0
++#define CONFIG_AAC_AT_ENCODER 0
++#define CONFIG_ALAC_AT_ENCODER 0
++#define CONFIG_ILBC_AT_ENCODER 0
++#define CONFIG_PCM_ALAW_AT_ENCODER 0
++#define CONFIG_PCM_MULAW_AT_ENCODER 0
++#define CONFIG_LIBAOM_AV1_ENCODER 0
++#define CONFIG_LIBCODEC2_ENCODER 0
++#define CONFIG_LIBFDK_AAC_ENCODER 0
++#define CONFIG_LIBGSM_ENCODER 0
++#define CONFIG_LIBGSM_MS_ENCODER 0
++#define CONFIG_LIBILBC_ENCODER 0
++#define CONFIG_LIBJXL_ENCODER 0
++#define CONFIG_LIBMP3LAME_ENCODER 0
++#define CONFIG_LIBOPENCORE_AMRNB_ENCODER 0
++#define CONFIG_LIBOPENJPEG_ENCODER 0
++#define CONFIG_LIBOPUS_ENCODER 0
++#define CONFIG_LIBRAV1E_ENCODER 0
++#define CONFIG_LIBSHINE_ENCODER 0
++#define CONFIG_LIBSPEEX_ENCODER 0
++#define CONFIG_LIBSVTAV1_ENCODER 0
++#define CONFIG_LIBTHEORA_ENCODER 0
++#define CONFIG_LIBTWOLAME_ENCODER 0
++#define CONFIG_LIBVO_AMRWBENC_ENCODER 0
++#define CONFIG_LIBVORBIS_ENCODER 0
++#define CONFIG_LIBVPX_VP8_ENCODER 0
++#define CONFIG_LIBVPX_VP9_ENCODER 0
++#define CONFIG_LIBWEBP_ANIM_ENCODER 0
++#define CONFIG_LIBWEBP_ENCODER 0
++#define CONFIG_LIBX262_ENCODER 0
++#define CONFIG_LIBX264_ENCODER 0
++#define CONFIG_LIBX264RGB_ENCODER 0
++#define CONFIG_LIBX265_ENCODER 0
++#define CONFIG_LIBXAVS_ENCODER 0
++#define CONFIG_LIBXAVS2_ENCODER 0
++#define CONFIG_LIBXVID_ENCODER 0
++#define CONFIG_AAC_MF_ENCODER 0
++#define CONFIG_AC3_MF_ENCODER 0
++#define CONFIG_H263_V4L2M2M_ENCODER 0
++#define CONFIG_AV1_MEDIACODEC_ENCODER 0
++#define CONFIG_AV1_NVENC_ENCODER 0
++#define CONFIG_AV1_QSV_ENCODER 0
++#define CONFIG_AV1_AMF_ENCODER 0
++#define CONFIG_LIBOPENH264_ENCODER 0
++#define CONFIG_H264_AMF_ENCODER 0
++#define CONFIG_H264_MF_ENCODER 0
++#define CONFIG_H264_NVENC_ENCODER 0
++#define CONFIG_H264_OMX_ENCODER 0
++#define CONFIG_H264_QSV_ENCODER 0
++#define CONFIG_H264_V4L2M2M_ENCODER 0
++#define CONFIG_H264_VAAPI_ENCODER 0
++#define CONFIG_H264_VIDEOTOOLBOX_ENCODER 0
++#define CONFIG_HEVC_AMF_ENCODER 0
++#define CONFIG_HEVC_MEDIACODEC_ENCODER 0
++#define CONFIG_HEVC_MF_ENCODER 0
++#define CONFIG_HEVC_NVENC_ENCODER 0
++#define CONFIG_HEVC_QSV_ENCODER 0
++#define CONFIG_HEVC_V4L2M2M_ENCODER 0
++#define CONFIG_HEVC_VAAPI_ENCODER 0
++#define CONFIG_HEVC_VIDEOTOOLBOX_ENCODER 0
++#define CONFIG_LIBKVAZAAR_ENCODER 0
++#define CONFIG_MJPEG_QSV_ENCODER 0
++#define CONFIG_MJPEG_VAAPI_ENCODER 0
++#define CONFIG_MP3_MF_ENCODER 0
++#define CONFIG_MPEG2_QSV_ENCODER 0
++#define CONFIG_MPEG2_VAAPI_ENCODER 0
++#define CONFIG_MPEG4_MEDIACODEC_ENCODER 0
++#define CONFIG_MPEG4_OMX_ENCODER 0
++#define CONFIG_MPEG4_V4L2M2M_ENCODER 0
++#define CONFIG_PRORES_VIDEOTOOLBOX_ENCODER 0
++#define CONFIG_VP8_MEDIACODEC_ENCODER 0
++#define CONFIG_VP8_V4L2M2M_ENCODER 0
++#define CONFIG_VP8_VAAPI_ENCODER 0
++#define CONFIG_VP9_MEDIACODEC_ENCODER 0
++#define CONFIG_VP9_VAAPI_ENCODER 0
++#define CONFIG_VP9_QSV_ENCODER 0
++#define CONFIG_VNULL_ENCODER 0
++#define CONFIG_ANULL_ENCODER 0
++#define CONFIG_AV1_D3D11VA_HWACCEL 0
++#define CONFIG_AV1_D3D11VA2_HWACCEL 0
++#define CONFIG_AV1_DXVA2_HWACCEL 0
++#define CONFIG_AV1_NVDEC_HWACCEL 0
++#define CONFIG_AV1_VAAPI_HWACCEL 0
++#define CONFIG_AV1_VDPAU_HWACCEL 0
++#define CONFIG_H263_VAAPI_HWACCEL 0
++#define CONFIG_H263_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_H264_D3D11VA_HWACCEL 0
++#define CONFIG_H264_D3D11VA2_HWACCEL 0
++#define CONFIG_H264_DXVA2_HWACCEL 0
++#define CONFIG_H264_NVDEC_HWACCEL 0
++#define CONFIG_H264_VAAPI_HWACCEL 0
++#define CONFIG_H264_VDPAU_HWACCEL 0
++#define CONFIG_H264_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_HEVC_D3D11VA_HWACCEL 0
++#define CONFIG_HEVC_D3D11VA2_HWACCEL 0
++#define CONFIG_HEVC_DXVA2_HWACCEL 0
++#define CONFIG_HEVC_NVDEC_HWACCEL 0
++#define CONFIG_HEVC_VAAPI_HWACCEL 0
++#define CONFIG_HEVC_VDPAU_HWACCEL 0
++#define CONFIG_HEVC_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_MJPEG_NVDEC_HWACCEL 0
++#define CONFIG_MJPEG_VAAPI_HWACCEL 0
++#define CONFIG_MPEG1_NVDEC_HWACCEL 0
++#define CONFIG_MPEG1_VDPAU_HWACCEL 0
++#define CONFIG_MPEG1_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_MPEG2_D3D11VA_HWACCEL 0
++#define CONFIG_MPEG2_D3D11VA2_HWACCEL 0
++#define CONFIG_MPEG2_NVDEC_HWACCEL 0
++#define CONFIG_MPEG2_DXVA2_HWACCEL 0
++#define CONFIG_MPEG2_VAAPI_HWACCEL 0
++#define CONFIG_MPEG2_VDPAU_HWACCEL 0
++#define CONFIG_MPEG2_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_MPEG4_NVDEC_HWACCEL 0
++#define CONFIG_MPEG4_VAAPI_HWACCEL 0
++#define CONFIG_MPEG4_VDPAU_HWACCEL 0
++#define CONFIG_MPEG4_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_PRORES_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_VC1_D3D11VA_HWACCEL 0
++#define CONFIG_VC1_D3D11VA2_HWACCEL 0
++#define CONFIG_VC1_DXVA2_HWACCEL 0
++#define CONFIG_VC1_NVDEC_HWACCEL 0
++#define CONFIG_VC1_VAAPI_HWACCEL 0
++#define CONFIG_VC1_VDPAU_HWACCEL 0
++#define CONFIG_VP8_NVDEC_HWACCEL 0
++#define CONFIG_VP8_VAAPI_HWACCEL 0
++#define CONFIG_VP9_D3D11VA_HWACCEL 0
++#define CONFIG_VP9_D3D11VA2_HWACCEL 0
++#define CONFIG_VP9_DXVA2_HWACCEL 0
++#define CONFIG_VP9_NVDEC_HWACCEL 0
++#define CONFIG_VP9_VAAPI_HWACCEL 0
++#define CONFIG_VP9_VDPAU_HWACCEL 0
++#define CONFIG_VP9_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_WMV3_D3D11VA_HWACCEL 0
++#define CONFIG_WMV3_D3D11VA2_HWACCEL 0
++#define CONFIG_WMV3_DXVA2_HWACCEL 0
++#define CONFIG_WMV3_NVDEC_HWACCEL 0
++#define CONFIG_WMV3_VAAPI_HWACCEL 0
++#define CONFIG_WMV3_VDPAU_HWACCEL 0
++#define CONFIG_AAC_PARSER 1
++#define CONFIG_AAC_LATM_PARSER 0
++#define CONFIG_AC3_PARSER 0
++#define CONFIG_ADX_PARSER 0
++#define CONFIG_AMR_PARSER 0
++#define CONFIG_AV1_PARSER 0
++#define CONFIG_AVS2_PARSER 0
++#define CONFIG_AVS3_PARSER 0
++#define CONFIG_BMP_PARSER 0
++#define CONFIG_CAVSVIDEO_PARSER 0
++#define CONFIG_COOK_PARSER 0
++#define CONFIG_CRI_PARSER 0
++#define CONFIG_DCA_PARSER 0
++#define CONFIG_DIRAC_PARSER 0
++#define CONFIG_DNXHD_PARSER 0
++#define CONFIG_DOLBY_E_PARSER 0
++#define CONFIG_DPX_PARSER 0
++#define CONFIG_DVAUDIO_PARSER 0
++#define CONFIG_DVBSUB_PARSER 0
++#define CONFIG_DVDSUB_PARSER 0
++#define CONFIG_DVD_NAV_PARSER 0
++#define CONFIG_FLAC_PARSER 1
++#define CONFIG_FTR_PARSER 0
++#define CONFIG_G723_1_PARSER 0
++#define CONFIG_G729_PARSER 0
++#define CONFIG_GIF_PARSER 0
++#define CONFIG_GSM_PARSER 0
++#define CONFIG_H261_PARSER 0
++#define CONFIG_H263_PARSER 1
++#define CONFIG_H264_PARSER 1
++#define CONFIG_HEVC_PARSER 0
++#define CONFIG_HDR_PARSER 0
++#define CONFIG_IPU_PARSER 0
++#define CONFIG_JPEG2000_PARSER 0
++#define CONFIG_MISC4_PARSER 0
++#define CONFIG_MJPEG_PARSER 0
++#define CONFIG_MLP_PARSER 0
++#define CONFIG_MPEG4VIDEO_PARSER 1
++#define CONFIG_MPEGAUDIO_PARSER 1
++#define CONFIG_MPEGVIDEO_PARSER 0
++#define CONFIG_OPUS_PARSER 1
++#define CONFIG_PNG_PARSER 0
++#define CONFIG_PNM_PARSER 0
++#define CONFIG_QOI_PARSER 0
++#define CONFIG_RV30_PARSER 0
++#define CONFIG_RV40_PARSER 0
++#define CONFIG_SBC_PARSER 0
++#define CONFIG_SIPR_PARSER 0
++#define CONFIG_TAK_PARSER 0
++#define CONFIG_VC1_PARSER 0
++#define CONFIG_VORBIS_PARSER 1
++#define CONFIG_VP3_PARSER 1
++#define CONFIG_VP8_PARSER 1
++#define CONFIG_VP9_PARSER 1
++#define CONFIG_WEBP_PARSER 0
++#define CONFIG_XBM_PARSER 0
++#define CONFIG_XMA_PARSER 0
++#define CONFIG_XWD_PARSER 0
++#define CONFIG_ALSA_INDEV 0
++#define CONFIG_ANDROID_CAMERA_INDEV 0
++#define CONFIG_AVFOUNDATION_INDEV 0
++#define CONFIG_BKTR_INDEV 0
++#define CONFIG_DECKLINK_INDEV 0
++#define CONFIG_DSHOW_INDEV 0
++#define CONFIG_FBDEV_INDEV 0
++#define CONFIG_GDIGRAB_INDEV 0
++#define CONFIG_IEC61883_INDEV 0
++#define CONFIG_JACK_INDEV 0
++#define CONFIG_KMSGRAB_INDEV 0
++#define CONFIG_LAVFI_INDEV 0
++#define CONFIG_OPENAL_INDEV 0
++#define CONFIG_OSS_INDEV 0
++#define CONFIG_PULSE_INDEV 0
++#define CONFIG_SNDIO_INDEV 0
++#define CONFIG_V4L2_INDEV 0
++#define CONFIG_VFWCAP_INDEV 0
++#define CONFIG_XCBGRAB_INDEV 0
++#define CONFIG_LIBCDIO_INDEV 0
++#define CONFIG_LIBDC1394_INDEV 0
++#define CONFIG_ALSA_OUTDEV 0
++#define CONFIG_AUDIOTOOLBOX_OUTDEV 0
++#define CONFIG_CACA_OUTDEV 0
++#define CONFIG_DECKLINK_OUTDEV 0
++#define CONFIG_FBDEV_OUTDEV 0
++#define CONFIG_OPENGL_OUTDEV 0
++#define CONFIG_OSS_OUTDEV 0
++#define CONFIG_PULSE_OUTDEV 0
++#define CONFIG_SDL2_OUTDEV 0
++#define CONFIG_SNDIO_OUTDEV 0
++#define CONFIG_V4L2_OUTDEV 0
++#define CONFIG_XV_OUTDEV 0
++#define CONFIG_ABENCH_FILTER 0
++#define CONFIG_ACOMPRESSOR_FILTER 0
++#define CONFIG_ACONTRAST_FILTER 0
++#define CONFIG_ACOPY_FILTER 0
++#define CONFIG_ACUE_FILTER 0
++#define CONFIG_ACROSSFADE_FILTER 0
++#define CONFIG_ACROSSOVER_FILTER 0
++#define CONFIG_ACRUSHER_FILTER 0
++#define CONFIG_ADECLICK_FILTER 0
++#define CONFIG_ADECLIP_FILTER 0
++#define CONFIG_ADECORRELATE_FILTER 0
++#define CONFIG_ADELAY_FILTER 0
++#define CONFIG_ADENORM_FILTER 0
++#define CONFIG_ADERIVATIVE_FILTER 0
++#define CONFIG_ADRC_FILTER 0
++#define CONFIG_ADYNAMICEQUALIZER_FILTER 0
++#define CONFIG_ADYNAMICSMOOTH_FILTER 0
++#define CONFIG_AECHO_FILTER 0
++#define CONFIG_AEMPHASIS_FILTER 0
++#define CONFIG_AEVAL_FILTER 0
++#define CONFIG_AEXCITER_FILTER 0
++#define CONFIG_AFADE_FILTER 0
++#define CONFIG_AFFTDN_FILTER 0
++#define CONFIG_AFFTFILT_FILTER 0
++#define CONFIG_AFIR_FILTER 0
++#define CONFIG_AFORMAT_FILTER 0
++#define CONFIG_AFREQSHIFT_FILTER 0
++#define CONFIG_AFWTDN_FILTER 0
++#define CONFIG_AGATE_FILTER 0
++#define CONFIG_AIIR_FILTER 0
++#define CONFIG_AINTEGRAL_FILTER 0
++#define CONFIG_AINTERLEAVE_FILTER 0
++#define CONFIG_ALATENCY_FILTER 0
++#define CONFIG_ALIMITER_FILTER 0
++#define CONFIG_ALLPASS_FILTER 0
++#define CONFIG_ALOOP_FILTER 0
++#define CONFIG_AMERGE_FILTER 0
++#define CONFIG_AMETADATA_FILTER 0
++#define CONFIG_AMIX_FILTER 0
++#define CONFIG_AMULTIPLY_FILTER 0
++#define CONFIG_ANEQUALIZER_FILTER 0
++#define CONFIG_ANLMDN_FILTER 0
++#define CONFIG_ANLMF_FILTER 0
++#define CONFIG_ANLMS_FILTER 0
++#define CONFIG_ANULL_FILTER 0
++#define CONFIG_APAD_FILTER 0
++#define CONFIG_APERMS_FILTER 0
++#define CONFIG_APHASER_FILTER 0
++#define CONFIG_APHASESHIFT_FILTER 0
++#define CONFIG_APSYCLIP_FILTER 0
++#define CONFIG_APULSATOR_FILTER 0
++#define CONFIG_AREALTIME_FILTER 0
++#define CONFIG_ARESAMPLE_FILTER 0
++#define CONFIG_AREVERSE_FILTER 0
++#define CONFIG_ARLS_FILTER 0
++#define CONFIG_ARNNDN_FILTER 0
++#define CONFIG_ASDR_FILTER 0
++#define CONFIG_ASEGMENT_FILTER 0
++#define CONFIG_ASELECT_FILTER 0
++#define CONFIG_ASENDCMD_FILTER 0
++#define CONFIG_ASETNSAMPLES_FILTER 0
++#define CONFIG_ASETPTS_FILTER 0
++#define CONFIG_ASETRATE_FILTER 0
++#define CONFIG_ASETTB_FILTER 0
++#define CONFIG_ASHOWINFO_FILTER 0
++#define CONFIG_ASIDEDATA_FILTER 0
++#define CONFIG_ASOFTCLIP_FILTER 0
++#define CONFIG_ASPECTRALSTATS_FILTER 0
++#define CONFIG_ASPLIT_FILTER 0
++#define CONFIG_ASR_FILTER 0
++#define CONFIG_ASTATS_FILTER 0
++#define CONFIG_ASTREAMSELECT_FILTER 0
++#define CONFIG_ASUBBOOST_FILTER 0
++#define CONFIG_ASUBCUT_FILTER 0
++#define CONFIG_ASUPERCUT_FILTER 0
++#define CONFIG_ASUPERPASS_FILTER 0
++#define CONFIG_ASUPERSTOP_FILTER 0
++#define CONFIG_ATEMPO_FILTER 0
++#define CONFIG_ATILT_FILTER 0
++#define CONFIG_ATRIM_FILTER 0
++#define CONFIG_AXCORRELATE_FILTER 0
++#define CONFIG_AZMQ_FILTER 0
++#define CONFIG_BANDPASS_FILTER 0
++#define CONFIG_BANDREJECT_FILTER 0
++#define CONFIG_BASS_FILTER 0
++#define CONFIG_BIQUAD_FILTER 0
++#define CONFIG_BS2B_FILTER 0
++#define CONFIG_CHANNELMAP_FILTER 0
++#define CONFIG_CHANNELSPLIT_FILTER 0
++#define CONFIG_CHORUS_FILTER 0
++#define CONFIG_COMPAND_FILTER 0
++#define CONFIG_COMPENSATIONDELAY_FILTER 0
++#define CONFIG_CROSSFEED_FILTER 0
++#define CONFIG_CRYSTALIZER_FILTER 0
++#define CONFIG_DCSHIFT_FILTER 0
++#define CONFIG_DEESSER_FILTER 0
++#define CONFIG_DIALOGUENHANCE_FILTER 0
++#define CONFIG_DRMETER_FILTER 0
++#define CONFIG_DYNAUDNORM_FILTER 0
++#define CONFIG_EARWAX_FILTER 0
++#define CONFIG_EBUR128_FILTER 0
++#define CONFIG_EQUALIZER_FILTER 0
++#define CONFIG_EXTRASTEREO_FILTER 0
++#define CONFIG_FIREQUALIZER_FILTER 0
++#define CONFIG_FLANGER_FILTER 0
++#define CONFIG_HAAS_FILTER 0
++#define CONFIG_HDCD_FILTER 0
++#define CONFIG_HEADPHONE_FILTER 0
++#define CONFIG_HIGHPASS_FILTER 0
++#define CONFIG_HIGHSHELF_FILTER 0
++#define CONFIG_JOIN_FILTER 0
++#define CONFIG_LADSPA_FILTER 0
++#define CONFIG_LOUDNORM_FILTER 0
++#define CONFIG_LOWPASS_FILTER 0
++#define CONFIG_LOWSHELF_FILTER 0
++#define CONFIG_LV2_FILTER 0
++#define CONFIG_MCOMPAND_FILTER 0
++#define CONFIG_PAN_FILTER 0
++#define CONFIG_REPLAYGAIN_FILTER 0
++#define CONFIG_RUBBERBAND_FILTER 0
++#define CONFIG_SIDECHAINCOMPRESS_FILTER 0
++#define CONFIG_SIDECHAINGATE_FILTER 0
++#define CONFIG_SILENCEDETECT_FILTER 0
++#define CONFIG_SILENCEREMOVE_FILTER 0
++#define CONFIG_SOFALIZER_FILTER 0
++#define CONFIG_SPEECHNORM_FILTER 0
++#define CONFIG_STEREOTOOLS_FILTER 0
++#define CONFIG_STEREOWIDEN_FILTER 0
++#define CONFIG_SUPEREQUALIZER_FILTER 0
++#define CONFIG_SURROUND_FILTER 0
++#define CONFIG_TILTSHELF_FILTER 0
++#define CONFIG_TREBLE_FILTER 0
++#define CONFIG_TREMOLO_FILTER 0
++#define CONFIG_VIBRATO_FILTER 0
++#define CONFIG_VIRTUALBASS_FILTER 0
++#define CONFIG_VOLUME_FILTER 0
++#define CONFIG_VOLUMEDETECT_FILTER 0
++#define CONFIG_AEVALSRC_FILTER 0
++#define CONFIG_AFDELAYSRC_FILTER 0
++#define CONFIG_AFIREQSRC_FILTER 0
++#define CONFIG_AFIRSRC_FILTER 0
++#define CONFIG_ANOISESRC_FILTER 0
++#define CONFIG_ANULLSRC_FILTER 0
++#define CONFIG_FLITE_FILTER 0
++#define CONFIG_HILBERT_FILTER 0
++#define CONFIG_SINC_FILTER 0
++#define CONFIG_SINE_FILTER 0
++#define CONFIG_ANULLSINK_FILTER 0
++#define CONFIG_ADDROI_FILTER 0
++#define CONFIG_ALPHAEXTRACT_FILTER 0
++#define CONFIG_ALPHAMERGE_FILTER 0
++#define CONFIG_AMPLIFY_FILTER 0
++#define CONFIG_ASS_FILTER 0
++#define CONFIG_ATADENOISE_FILTER 0
++#define CONFIG_AVGBLUR_FILTER 0
++#define CONFIG_AVGBLUR_OPENCL_FILTER 0
++#define CONFIG_AVGBLUR_VULKAN_FILTER 0
++#define CONFIG_BACKGROUNDKEY_FILTER 0
++#define CONFIG_BBOX_FILTER 0
++#define CONFIG_BENCH_FILTER 0
++#define CONFIG_BILATERAL_FILTER 0
++#define CONFIG_BILATERAL_CUDA_FILTER 0
++#define CONFIG_BITPLANENOISE_FILTER 0
++#define CONFIG_BLACKDETECT_FILTER 0
++#define CONFIG_BLACKFRAME_FILTER 0
++#define CONFIG_BLEND_FILTER 0
++#define CONFIG_BLEND_VULKAN_FILTER 0
++#define CONFIG_BLOCKDETECT_FILTER 0
++#define CONFIG_BLURDETECT_FILTER 0
++#define CONFIG_BM3D_FILTER 0
++#define CONFIG_BOXBLUR_FILTER 0
++#define CONFIG_BOXBLUR_OPENCL_FILTER 0
++#define CONFIG_BWDIF_FILTER 0
++#define CONFIG_CAS_FILTER 0
++#define CONFIG_CCREPACK_FILTER 0
++#define CONFIG_CHROMABER_VULKAN_FILTER 0
++#define CONFIG_CHROMAHOLD_FILTER 0
++#define CONFIG_CHROMAKEY_FILTER 0
++#define CONFIG_CHROMAKEY_CUDA_FILTER 0
++#define CONFIG_CHROMANR_FILTER 0
++#define CONFIG_CHROMASHIFT_FILTER 0
++#define CONFIG_CIESCOPE_FILTER 0
++#define CONFIG_CODECVIEW_FILTER 0
++#define CONFIG_COLORBALANCE_FILTER 0
++#define CONFIG_COLORCHANNELMIXER_FILTER 0
++#define CONFIG_COLORCONTRAST_FILTER 0
++#define CONFIG_COLORCORRECT_FILTER 0
++#define CONFIG_COLORIZE_FILTER 0
++#define CONFIG_COLORKEY_FILTER 0
++#define CONFIG_COLORKEY_OPENCL_FILTER 0
++#define CONFIG_COLORHOLD_FILTER 0
++#define CONFIG_COLORLEVELS_FILTER 0
++#define CONFIG_COLORMAP_FILTER 0
++#define CONFIG_COLORMATRIX_FILTER 0
++#define CONFIG_COLORSPACE_FILTER 0
++#define CONFIG_COLORSPACE_CUDA_FILTER 0
++#define CONFIG_COLORTEMPERATURE_FILTER 0
++#define CONFIG_CONVOLUTION_FILTER 0
++#define CONFIG_CONVOLUTION_OPENCL_FILTER 0
++#define CONFIG_CONVOLVE_FILTER 0
++#define CONFIG_COPY_FILTER 0
++#define CONFIG_COREIMAGE_FILTER 0
++#define CONFIG_CORR_FILTER 0
++#define CONFIG_COVER_RECT_FILTER 0
++#define CONFIG_CROP_FILTER 0
++#define CONFIG_CROPDETECT_FILTER 0
++#define CONFIG_CUE_FILTER 0
++#define CONFIG_CURVES_FILTER 0
++#define CONFIG_DATASCOPE_FILTER 0
++#define CONFIG_DBLUR_FILTER 0
++#define CONFIG_DCTDNOIZ_FILTER 0
++#define CONFIG_DEBAND_FILTER 0
++#define CONFIG_DEBLOCK_FILTER 0
++#define CONFIG_DECIMATE_FILTER 0
++#define CONFIG_DECONVOLVE_FILTER 0
++#define CONFIG_DEDOT_FILTER 0
++#define CONFIG_DEFLATE_FILTER 0
++#define CONFIG_DEFLICKER_FILTER 0
++#define CONFIG_DEINTERLACE_QSV_FILTER 0
++#define CONFIG_DEINTERLACE_VAAPI_FILTER 0
++#define CONFIG_DEJUDDER_FILTER 0
++#define CONFIG_DELOGO_FILTER 0
++#define CONFIG_DENOISE_VAAPI_FILTER 0
++#define CONFIG_DERAIN_FILTER 0
++#define CONFIG_DESHAKE_FILTER 0
++#define CONFIG_DESHAKE_OPENCL_FILTER 0
++#define CONFIG_DESPILL_FILTER 0
++#define CONFIG_DETELECINE_FILTER 0
++#define CONFIG_DILATION_FILTER 0
++#define CONFIG_DILATION_OPENCL_FILTER 0
++#define CONFIG_DISPLACE_FILTER 0
++#define CONFIG_DNN_CLASSIFY_FILTER 0
++#define CONFIG_DNN_DETECT_FILTER 0
++#define CONFIG_DNN_PROCESSING_FILTER 0
++#define CONFIG_DOUBLEWEAVE_FILTER 0
++#define CONFIG_DRAWBOX_FILTER 0
++#define CONFIG_DRAWGRAPH_FILTER 0
++#define CONFIG_DRAWGRID_FILTER 0
++#define CONFIG_DRAWTEXT_FILTER 0
++#define CONFIG_EDGEDETECT_FILTER 0
++#define CONFIG_ELBG_FILTER 0
++#define CONFIG_ENTROPY_FILTER 0
++#define CONFIG_EPX_FILTER 0
++#define CONFIG_EQ_FILTER 0
++#define CONFIG_EROSION_FILTER 0
++#define CONFIG_EROSION_OPENCL_FILTER 0
++#define CONFIG_ESTDIF_FILTER 0
++#define CONFIG_EXPOSURE_FILTER 0
++#define CONFIG_EXTRACTPLANES_FILTER 0
++#define CONFIG_FADE_FILTER 0
++#define CONFIG_FEEDBACK_FILTER 0
++#define CONFIG_FFTDNOIZ_FILTER 0
++#define CONFIG_FFTFILT_FILTER 0
++#define CONFIG_FIELD_FILTER 0
++#define CONFIG_FIELDHINT_FILTER 0
++#define CONFIG_FIELDMATCH_FILTER 0
++#define CONFIG_FIELDORDER_FILTER 0
++#define CONFIG_FILLBORDERS_FILTER 0
++#define CONFIG_FIND_RECT_FILTER 0
++#define CONFIG_FLIP_VULKAN_FILTER 0
++#define CONFIG_FLOODFILL_FILTER 0
++#define CONFIG_FORMAT_FILTER 0
++#define CONFIG_FPS_FILTER 0
++#define CONFIG_FRAMEPACK_FILTER 0
++#define CONFIG_FRAMERATE_FILTER 0
++#define CONFIG_FRAMESTEP_FILTER 0
++#define CONFIG_FREEZEDETECT_FILTER 0
++#define CONFIG_FREEZEFRAMES_FILTER 0
++#define CONFIG_FREI0R_FILTER 0
++#define CONFIG_FSPP_FILTER 0
++#define CONFIG_GBLUR_FILTER 0
++#define CONFIG_GBLUR_VULKAN_FILTER 0
++#define CONFIG_GEQ_FILTER 0
++#define CONFIG_GRADFUN_FILTER 0
++#define CONFIG_GRAPHMONITOR_FILTER 0
++#define CONFIG_GRAYWORLD_FILTER 0
++#define CONFIG_GREYEDGE_FILTER 0
++#define CONFIG_GUIDED_FILTER 0
++#define CONFIG_HALDCLUT_FILTER 0
++#define CONFIG_HFLIP_FILTER 0
++#define CONFIG_HFLIP_VULKAN_FILTER 0
++#define CONFIG_HISTEQ_FILTER 0
++#define CONFIG_HISTOGRAM_FILTER 0
++#define CONFIG_HQDN3D_FILTER 0
++#define CONFIG_HQX_FILTER 0
++#define CONFIG_HSTACK_FILTER 0
++#define CONFIG_HSVHOLD_FILTER 0
++#define CONFIG_HSVKEY_FILTER 0
++#define CONFIG_HUE_FILTER 0
++#define CONFIG_HUESATURATION_FILTER 0
++#define CONFIG_HWDOWNLOAD_FILTER 0
++#define CONFIG_HWMAP_FILTER 0
++#define CONFIG_HWUPLOAD_FILTER 0
++#define CONFIG_HWUPLOAD_CUDA_FILTER 0
++#define CONFIG_HYSTERESIS_FILTER 0
++#define CONFIG_ICCDETECT_FILTER 0
++#define CONFIG_ICCGEN_FILTER 0
++#define CONFIG_IDENTITY_FILTER 0
++#define CONFIG_IDET_FILTER 0
++#define CONFIG_IL_FILTER 0
++#define CONFIG_INFLATE_FILTER 0
++#define CONFIG_INTERLACE_FILTER 0
++#define CONFIG_INTERLEAVE_FILTER 0
++#define CONFIG_KERNDEINT_FILTER 0
++#define CONFIG_KIRSCH_FILTER 0
++#define CONFIG_LAGFUN_FILTER 0
++#define CONFIG_LATENCY_FILTER 0
++#define CONFIG_LENSCORRECTION_FILTER 0
++#define CONFIG_LENSFUN_FILTER 0
++#define CONFIG_LIBPLACEBO_FILTER 0
++#define CONFIG_LIBVMAF_FILTER 0
++#define CONFIG_LIMITDIFF_FILTER 0
++#define CONFIG_LIMITER_FILTER 0
++#define CONFIG_LOOP_FILTER 0
++#define CONFIG_LUMAKEY_FILTER 0
++#define CONFIG_LUT_FILTER 0
++#define CONFIG_LUT1D_FILTER 0
++#define CONFIG_LUT2_FILTER 0
++#define CONFIG_LUT3D_FILTER 0
++#define CONFIG_LUTRGB_FILTER 0
++#define CONFIG_LUTYUV_FILTER 0
++#define CONFIG_MASKEDCLAMP_FILTER 0
++#define CONFIG_MASKEDMAX_FILTER 0
++#define CONFIG_MASKEDMERGE_FILTER 0
++#define CONFIG_MASKEDMIN_FILTER 0
++#define CONFIG_MASKEDTHRESHOLD_FILTER 0
++#define CONFIG_MASKFUN_FILTER 0
++#define CONFIG_MCDEINT_FILTER 0
++#define CONFIG_MEDIAN_FILTER 0
++#define CONFIG_MERGEPLANES_FILTER 0
++#define CONFIG_MESTIMATE_FILTER 0
++#define CONFIG_METADATA_FILTER 0
++#define CONFIG_MIDEQUALIZER_FILTER 0
++#define CONFIG_MINTERPOLATE_FILTER 0
++#define CONFIG_MIX_FILTER 0
++#define CONFIG_MONOCHROME_FILTER 0
++#define CONFIG_MORPHO_FILTER 0
++#define CONFIG_MPDECIMATE_FILTER 0
++#define CONFIG_MSAD_FILTER 0
++#define CONFIG_MULTIPLY_FILTER 0
++#define CONFIG_NEGATE_FILTER 0
++#define CONFIG_NLMEANS_FILTER 0
++#define CONFIG_NLMEANS_OPENCL_FILTER 0
++#define CONFIG_NNEDI_FILTER 0
++#define CONFIG_NOFORMAT_FILTER 0
++#define CONFIG_NOISE_FILTER 0
++#define CONFIG_NORMALIZE_FILTER 0
++#define CONFIG_NULL_FILTER 0
++#define CONFIG_OCR_FILTER 0
++#define CONFIG_OCV_FILTER 0
++#define CONFIG_OSCILLOSCOPE_FILTER 0
++#define CONFIG_OVERLAY_FILTER 0
++#define CONFIG_OVERLAY_OPENCL_FILTER 0
++#define CONFIG_OVERLAY_QSV_FILTER 0
++#define CONFIG_OVERLAY_VAAPI_FILTER 0
++#define CONFIG_OVERLAY_VULKAN_FILTER 0
++#define CONFIG_OVERLAY_CUDA_FILTER 0
++#define CONFIG_OWDENOISE_FILTER 0
++#define CONFIG_PAD_FILTER 0
++#define CONFIG_PAD_OPENCL_FILTER 0
++#define CONFIG_PALETTEGEN_FILTER 0
++#define CONFIG_PALETTEUSE_FILTER 0
++#define CONFIG_PERMS_FILTER 0
++#define CONFIG_PERSPECTIVE_FILTER 0
++#define CONFIG_PHASE_FILTER 0
++#define CONFIG_PHOTOSENSITIVITY_FILTER 0
++#define CONFIG_PIXDESCTEST_FILTER 0
++#define CONFIG_PIXELIZE_FILTER 0
++#define CONFIG_PIXSCOPE_FILTER 0
++#define CONFIG_PP_FILTER 0
++#define CONFIG_PP7_FILTER 0
++#define CONFIG_PREMULTIPLY_FILTER 0
++#define CONFIG_PREWITT_FILTER 0
++#define CONFIG_PREWITT_OPENCL_FILTER 0
++#define CONFIG_PROCAMP_VAAPI_FILTER 0
++#define CONFIG_PROGRAM_OPENCL_FILTER 0
++#define CONFIG_PSEUDOCOLOR_FILTER 0
++#define CONFIG_PSNR_FILTER 0
++#define CONFIG_PULLUP_FILTER 0
++#define CONFIG_QP_FILTER 0
++#define CONFIG_RANDOM_FILTER 0
++#define CONFIG_READEIA608_FILTER 0
++#define CONFIG_READVITC_FILTER 0
++#define CONFIG_REALTIME_FILTER 0
++#define CONFIG_REMAP_FILTER 0
++#define CONFIG_REMAP_OPENCL_FILTER 0
++#define CONFIG_REMOVEGRAIN_FILTER 0
++#define CONFIG_REMOVELOGO_FILTER 0
++#define CONFIG_REPEATFIELDS_FILTER 0
++#define CONFIG_REVERSE_FILTER 0
++#define CONFIG_RGBASHIFT_FILTER 0
++#define CONFIG_ROBERTS_FILTER 0
++#define CONFIG_ROBERTS_OPENCL_FILTER 0
++#define CONFIG_ROTATE_FILTER 0
++#define CONFIG_SAB_FILTER 0
++#define CONFIG_SCALE_FILTER 0
++#define CONFIG_SCALE_CUDA_FILTER 0
++#define CONFIG_SCALE_NPP_FILTER 0
++#define CONFIG_SCALE_QSV_FILTER 0
++#define CONFIG_SCALE_VAAPI_FILTER 0
++#define CONFIG_SCALE_VULKAN_FILTER 0
++#define CONFIG_SCALE2REF_FILTER 0
++#define CONFIG_SCALE2REF_NPP_FILTER 0
++#define CONFIG_SCDET_FILTER 0
++#define CONFIG_SCHARR_FILTER 0
++#define CONFIG_SCROLL_FILTER 0
++#define CONFIG_SEGMENT_FILTER 0
++#define CONFIG_SELECT_FILTER 0
++#define CONFIG_SELECTIVECOLOR_FILTER 0
++#define CONFIG_SENDCMD_FILTER 0
++#define CONFIG_SEPARATEFIELDS_FILTER 0
++#define CONFIG_SETDAR_FILTER 0
++#define CONFIG_SETFIELD_FILTER 0
++#define CONFIG_SETPARAMS_FILTER 0
++#define CONFIG_SETPTS_FILTER 0
++#define CONFIG_SETRANGE_FILTER 0
++#define CONFIG_SETSAR_FILTER 0
++#define CONFIG_SETTB_FILTER 0
++#define CONFIG_SHARPEN_NPP_FILTER 0
++#define CONFIG_SHARPNESS_VAAPI_FILTER 0
++#define CONFIG_SHEAR_FILTER 0
++#define CONFIG_SHOWINFO_FILTER 0
++#define CONFIG_SHOWPALETTE_FILTER 0
++#define CONFIG_SHUFFLEFRAMES_FILTER 0
++#define CONFIG_SHUFFLEPIXELS_FILTER 0
++#define CONFIG_SHUFFLEPLANES_FILTER 0
++#define CONFIG_SIDEDATA_FILTER 0
++#define CONFIG_SIGNALSTATS_FILTER 0
++#define CONFIG_SIGNATURE_FILTER 0
++#define CONFIG_SITI_FILTER 0
++#define CONFIG_SMARTBLUR_FILTER 0
++#define CONFIG_SOBEL_FILTER 0
++#define CONFIG_SOBEL_OPENCL_FILTER 0
++#define CONFIG_SPLIT_FILTER 0
++#define CONFIG_SPP_FILTER 0
++#define CONFIG_SR_FILTER 0
++#define CONFIG_SSIM_FILTER 0
++#define CONFIG_SSIM360_FILTER 0
++#define CONFIG_STEREO3D_FILTER 0
++#define CONFIG_STREAMSELECT_FILTER 0
++#define CONFIG_SUBTITLES_FILTER 0
++#define CONFIG_SUPER2XSAI_FILTER 0
++#define CONFIG_SWAPRECT_FILTER 0
++#define CONFIG_SWAPUV_FILTER 0
++#define CONFIG_TBLEND_FILTER 0
++#define CONFIG_TELECINE_FILTER 0
++#define CONFIG_THISTOGRAM_FILTER 0
++#define CONFIG_THRESHOLD_FILTER 0
++#define CONFIG_THUMBNAIL_FILTER 0
++#define CONFIG_THUMBNAIL_CUDA_FILTER 0
++#define CONFIG_TILE_FILTER 0
++#define CONFIG_TINTERLACE_FILTER 0
++#define CONFIG_TLUT2_FILTER 0
++#define CONFIG_TMEDIAN_FILTER 0
++#define CONFIG_TMIDEQUALIZER_FILTER 0
++#define CONFIG_TMIX_FILTER 0
++#define CONFIG_TONEMAP_FILTER 0
++#define CONFIG_TONEMAP_OPENCL_FILTER 0
++#define CONFIG_TONEMAP_VAAPI_FILTER 0
++#define CONFIG_TPAD_FILTER 0
++#define CONFIG_TRANSPOSE_FILTER 0
++#define CONFIG_TRANSPOSE_NPP_FILTER 0
++#define CONFIG_TRANSPOSE_OPENCL_FILTER 0
++#define CONFIG_TRANSPOSE_VAAPI_FILTER 0
++#define CONFIG_TRANSPOSE_VULKAN_FILTER 0
++#define CONFIG_TRIM_FILTER 0
++#define CONFIG_UNPREMULTIPLY_FILTER 0
++#define CONFIG_UNSHARP_FILTER 0
++#define CONFIG_UNSHARP_OPENCL_FILTER 0
++#define CONFIG_UNTILE_FILTER 0
++#define CONFIG_USPP_FILTER 0
++#define CONFIG_V360_FILTER 0
++#define CONFIG_VAGUEDENOISER_FILTER 0
++#define CONFIG_VARBLUR_FILTER 0
++#define CONFIG_VECTORSCOPE_FILTER 0
++#define CONFIG_VFLIP_FILTER 0
++#define CONFIG_VFLIP_VULKAN_FILTER 0
++#define CONFIG_VFRDET_FILTER 0
++#define CONFIG_VIBRANCE_FILTER 0
++#define CONFIG_VIDSTABDETECT_FILTER 0
++#define CONFIG_VIDSTABTRANSFORM_FILTER 0
++#define CONFIG_VIF_FILTER 0
++#define CONFIG_VIGNETTE_FILTER 0
++#define CONFIG_VMAFMOTION_FILTER 0
++#define CONFIG_VPP_QSV_FILTER 0
++#define CONFIG_VSTACK_FILTER 0
++#define CONFIG_W3FDIF_FILTER 0
++#define CONFIG_WAVEFORM_FILTER 0
++#define CONFIG_WEAVE_FILTER 0
++#define CONFIG_XBR_FILTER 0
++#define CONFIG_XCORRELATE_FILTER 0
++#define CONFIG_XFADE_FILTER 0
++#define CONFIG_XFADE_OPENCL_FILTER 0
++#define CONFIG_XMEDIAN_FILTER 0
++#define CONFIG_XSTACK_FILTER 0
++#define CONFIG_YADIF_FILTER 0
++#define CONFIG_YADIF_CUDA_FILTER 0
++#define CONFIG_YADIF_VIDEOTOOLBOX_FILTER 0
++#define CONFIG_YAEPBLUR_FILTER 0
++#define CONFIG_ZMQ_FILTER 0
++#define CONFIG_ZOOMPAN_FILTER 0
++#define CONFIG_ZSCALE_FILTER 0
++#define CONFIG_HSTACK_VAAPI_FILTER 0
++#define CONFIG_VSTACK_VAAPI_FILTER 0
++#define CONFIG_XSTACK_VAAPI_FILTER 0
++#define CONFIG_HSTACK_QSV_FILTER 0
++#define CONFIG_VSTACK_QSV_FILTER 0
++#define CONFIG_XSTACK_QSV_FILTER 0
++#define CONFIG_ALLRGB_FILTER 0
++#define CONFIG_ALLYUV_FILTER 0
++#define CONFIG_CELLAUTO_FILTER 0
++#define CONFIG_COLOR_FILTER 0
++#define CONFIG_COLORCHART_FILTER 0
++#define CONFIG_COLORSPECTRUM_FILTER 0
++#define CONFIG_COREIMAGESRC_FILTER 0
++#define CONFIG_DDAGRAB_FILTER 0
++#define CONFIG_FREI0R_SRC_FILTER 0
++#define CONFIG_GRADIENTS_FILTER 0
++#define CONFIG_HALDCLUTSRC_FILTER 0
++#define CONFIG_LIFE_FILTER 0
++#define CONFIG_MANDELBROT_FILTER 0
++#define CONFIG_MPTESTSRC_FILTER 0
++#define CONFIG_NULLSRC_FILTER 0
++#define CONFIG_OPENCLSRC_FILTER 0
++#define CONFIG_PAL75BARS_FILTER 0
++#define CONFIG_PAL100BARS_FILTER 0
++#define CONFIG_RGBTESTSRC_FILTER 0
++#define CONFIG_SIERPINSKI_FILTER 0
++#define CONFIG_SMPTEBARS_FILTER 0
++#define CONFIG_SMPTEHDBARS_FILTER 0
++#define CONFIG_TESTSRC_FILTER 0
++#define CONFIG_TESTSRC2_FILTER 0
++#define CONFIG_YUVTESTSRC_FILTER 0
++#define CONFIG_ZONEPLATE_FILTER 0
++#define CONFIG_NULLSINK_FILTER 0
++#define CONFIG_A3DSCOPE_FILTER 0
++#define CONFIG_ABITSCOPE_FILTER 0
++#define CONFIG_ADRAWGRAPH_FILTER 0
++#define CONFIG_AGRAPHMONITOR_FILTER 0
++#define CONFIG_AHISTOGRAM_FILTER 0
++#define CONFIG_APHASEMETER_FILTER 0
++#define CONFIG_AVECTORSCOPE_FILTER 0
++#define CONFIG_CONCAT_FILTER 0
++#define CONFIG_SHOWCQT_FILTER 0
++#define CONFIG_SHOWCWT_FILTER 0
++#define CONFIG_SHOWFREQS_FILTER 0
++#define CONFIG_SHOWSPATIAL_FILTER 0
++#define CONFIG_SHOWSPECTRUM_FILTER 0
++#define CONFIG_SHOWSPECTRUMPIC_FILTER 0
++#define CONFIG_SHOWVOLUME_FILTER 0
++#define CONFIG_SHOWWAVES_FILTER 0
++#define CONFIG_SHOWWAVESPIC_FILTER 0
++#define CONFIG_SPECTRUMSYNTH_FILTER 0
++#define CONFIG_AVSYNCTEST_FILTER 0
++#define CONFIG_AMOVIE_FILTER 0
++#define CONFIG_MOVIE_FILTER 0
++#define CONFIG_AFIFO_FILTER 0
++#define CONFIG_FIFO_FILTER 0
++#define CONFIG_AA_DEMUXER 0
++#define CONFIG_AAC_DEMUXER 1
++#define CONFIG_AAX_DEMUXER 0
++#define CONFIG_AC3_DEMUXER 0
++#define CONFIG_ACE_DEMUXER 0
++#define CONFIG_ACM_DEMUXER 0
++#define CONFIG_ACT_DEMUXER 0
++#define CONFIG_ADF_DEMUXER 0
++#define CONFIG_ADP_DEMUXER 0
++#define CONFIG_ADS_DEMUXER 0
++#define CONFIG_ADX_DEMUXER 0
++#define CONFIG_AEA_DEMUXER 0
++#define CONFIG_AFC_DEMUXER 0
++#define CONFIG_AIFF_DEMUXER 0
++#define CONFIG_AIX_DEMUXER 0
++#define CONFIG_ALP_DEMUXER 0
++#define CONFIG_AMR_DEMUXER 0
++#define CONFIG_AMRNB_DEMUXER 0
++#define CONFIG_AMRWB_DEMUXER 0
++#define CONFIG_ANM_DEMUXER 0
++#define CONFIG_APAC_DEMUXER 0
++#define CONFIG_APC_DEMUXER 0
++#define CONFIG_APE_DEMUXER 0
++#define CONFIG_APM_DEMUXER 0
++#define CONFIG_APNG_DEMUXER 0
++#define CONFIG_APTX_DEMUXER 0
++#define CONFIG_APTX_HD_DEMUXER 0
++#define CONFIG_AQTITLE_DEMUXER 0
++#define CONFIG_ARGO_ASF_DEMUXER 0
++#define CONFIG_ARGO_BRP_DEMUXER 0
++#define CONFIG_ARGO_CVG_DEMUXER 0
++#define CONFIG_ASF_DEMUXER 0
++#define CONFIG_ASF_O_DEMUXER 0
++#define CONFIG_ASS_DEMUXER 0
++#define CONFIG_AST_DEMUXER 0
++#define CONFIG_AU_DEMUXER 0
++#define CONFIG_AV1_DEMUXER 0
++#define CONFIG_AVI_DEMUXER 1
++#define CONFIG_AVISYNTH_DEMUXER 0
++#define CONFIG_AVR_DEMUXER 0
++#define CONFIG_AVS_DEMUXER 0
++#define CONFIG_AVS2_DEMUXER 0
++#define CONFIG_AVS3_DEMUXER 0
++#define CONFIG_BETHSOFTVID_DEMUXER 0
++#define CONFIG_BFI_DEMUXER 0
++#define CONFIG_BINTEXT_DEMUXER 0
++#define CONFIG_BINK_DEMUXER 0
++#define CONFIG_BINKA_DEMUXER 0
++#define CONFIG_BIT_DEMUXER 0
++#define CONFIG_BITPACKED_DEMUXER 0
++#define CONFIG_BMV_DEMUXER 0
++#define CONFIG_BFSTM_DEMUXER 0
++#define CONFIG_BRSTM_DEMUXER 0
++#define CONFIG_BOA_DEMUXER 0
++#define CONFIG_BONK_DEMUXER 0
++#define CONFIG_C93_DEMUXER 0
++#define CONFIG_CAF_DEMUXER 0
++#define CONFIG_CAVSVIDEO_DEMUXER 0
++#define CONFIG_CDG_DEMUXER 0
++#define CONFIG_CDXL_DEMUXER 0
++#define CONFIG_CINE_DEMUXER 0
++#define CONFIG_CODEC2_DEMUXER 0
++#define CONFIG_CODEC2RAW_DEMUXER 0
++#define CONFIG_CONCAT_DEMUXER 0
++#define CONFIG_DASH_DEMUXER 0
++#define CONFIG_DATA_DEMUXER 0
++#define CONFIG_DAUD_DEMUXER 0
++#define CONFIG_DCSTR_DEMUXER 0
++#define CONFIG_DERF_DEMUXER 0
++#define CONFIG_DFA_DEMUXER 0
++#define CONFIG_DFPWM_DEMUXER 0
++#define CONFIG_DHAV_DEMUXER 0
++#define CONFIG_DIRAC_DEMUXER 0
++#define CONFIG_DNXHD_DEMUXER 0
++#define CONFIG_DSF_DEMUXER 0
++#define CONFIG_DSICIN_DEMUXER 0
++#define CONFIG_DSS_DEMUXER 0
++#define CONFIG_DTS_DEMUXER 0
++#define CONFIG_DTSHD_DEMUXER 0
++#define CONFIG_DV_DEMUXER 0
++#define CONFIG_DVBSUB_DEMUXER 0
++#define CONFIG_DVBTXT_DEMUXER 0
++#define CONFIG_DXA_DEMUXER 0
++#define CONFIG_EA_DEMUXER 0
++#define CONFIG_EA_CDATA_DEMUXER 0
++#define CONFIG_EAC3_DEMUXER 0
++#define CONFIG_EPAF_DEMUXER 0
++#define CONFIG_FFMETADATA_DEMUXER 0
++#define CONFIG_FILMSTRIP_DEMUXER 0
++#define CONFIG_FITS_DEMUXER 0
++#define CONFIG_FLAC_DEMUXER 1
++#define CONFIG_FLIC_DEMUXER 0
++#define CONFIG_FLV_DEMUXER 0
++#define CONFIG_LIVE_FLV_DEMUXER 0
++#define CONFIG_FOURXM_DEMUXER 0
++#define CONFIG_FRM_DEMUXER 0
++#define CONFIG_FSB_DEMUXER 0
++#define CONFIG_FWSE_DEMUXER 0
++#define CONFIG_G722_DEMUXER 0
++#define CONFIG_G723_1_DEMUXER 0
++#define CONFIG_G726_DEMUXER 0
++#define CONFIG_G726LE_DEMUXER 0
++#define CONFIG_G729_DEMUXER 0
++#define CONFIG_GDV_DEMUXER 0
++#define CONFIG_GENH_DEMUXER 0
++#define CONFIG_GIF_DEMUXER 0
++#define CONFIG_GSM_DEMUXER 0
++#define CONFIG_GXF_DEMUXER 0
++#define CONFIG_H261_DEMUXER 0
++#define CONFIG_H263_DEMUXER 0
++#define CONFIG_H264_DEMUXER 0
++#define CONFIG_HCA_DEMUXER 0
++#define CONFIG_HCOM_DEMUXER 0
++#define CONFIG_HEVC_DEMUXER 0
++#define CONFIG_HLS_DEMUXER 0
++#define CONFIG_HNM_DEMUXER 0
++#define CONFIG_ICO_DEMUXER 0
++#define CONFIG_IDCIN_DEMUXER 0
++#define CONFIG_IDF_DEMUXER 0
++#define CONFIG_IFF_DEMUXER 0
++#define CONFIG_IFV_DEMUXER 0
++#define CONFIG_ILBC_DEMUXER 0
++#define CONFIG_IMAGE2_DEMUXER 0
++#define CONFIG_IMAGE2PIPE_DEMUXER 0
++#define CONFIG_IMAGE2_ALIAS_PIX_DEMUXER 0
++#define CONFIG_IMAGE2_BRENDER_PIX_DEMUXER 0
++#define CONFIG_IMF_DEMUXER 0
++#define CONFIG_INGENIENT_DEMUXER 0
++#define CONFIG_IPMOVIE_DEMUXER 0
++#define CONFIG_IPU_DEMUXER 0
++#define CONFIG_IRCAM_DEMUXER 0
++#define CONFIG_ISS_DEMUXER 0
++#define CONFIG_IV8_DEMUXER 0
++#define CONFIG_IVF_DEMUXER 0
++#define CONFIG_IVR_DEMUXER 0
++#define CONFIG_JACOSUB_DEMUXER 0
++#define CONFIG_JV_DEMUXER 0
++#define CONFIG_KUX_DEMUXER 0
++#define CONFIG_KVAG_DEMUXER 0
++#define CONFIG_LAF_DEMUXER 0
++#define CONFIG_LMLM4_DEMUXER 0
++#define CONFIG_LOAS_DEMUXER 0
++#define CONFIG_LUODAT_DEMUXER 0
++#define CONFIG_LRC_DEMUXER 0
++#define CONFIG_LVF_DEMUXER 0
++#define CONFIG_LXF_DEMUXER 0
++#define CONFIG_M4V_DEMUXER 0
++#define CONFIG_MCA_DEMUXER 0
++#define CONFIG_MCC_DEMUXER 0
++#define CONFIG_MATROSKA_DEMUXER 1
++#define CONFIG_MGSTS_DEMUXER 0
++#define CONFIG_MICRODVD_DEMUXER 0
++#define CONFIG_MJPEG_DEMUXER 0
++#define CONFIG_MJPEG_2000_DEMUXER 0
++#define CONFIG_MLP_DEMUXER 0
++#define CONFIG_MLV_DEMUXER 0
++#define CONFIG_MM_DEMUXER 0
++#define CONFIG_MMF_DEMUXER 0
++#define CONFIG_MODS_DEMUXER 0
++#define CONFIG_MOFLEX_DEMUXER 0
++#define CONFIG_MOV_DEMUXER 1
++#define CONFIG_MP3_DEMUXER 1
++#define CONFIG_MPC_DEMUXER 0
++#define CONFIG_MPC8_DEMUXER 0
++#define CONFIG_MPEGPS_DEMUXER 0
++#define CONFIG_MPEGTS_DEMUXER 0
++#define CONFIG_MPEGTSRAW_DEMUXER 0
++#define CONFIG_MPEGVIDEO_DEMUXER 0
++#define CONFIG_MPJPEG_DEMUXER 0
++#define CONFIG_MPL2_DEMUXER 0
++#define CONFIG_MPSUB_DEMUXER 0
++#define CONFIG_MSF_DEMUXER 0
++#define CONFIG_MSNWC_TCP_DEMUXER 0
++#define CONFIG_MSP_DEMUXER 0
++#define CONFIG_MTAF_DEMUXER 0
++#define CONFIG_MTV_DEMUXER 0
++#define CONFIG_MUSX_DEMUXER 0
++#define CONFIG_MV_DEMUXER 0
++#define CONFIG_MVI_DEMUXER 0
++#define CONFIG_MXF_DEMUXER 0
++#define CONFIG_MXG_DEMUXER 0
++#define CONFIG_NC_DEMUXER 0
++#define CONFIG_NISTSPHERE_DEMUXER 0
++#define CONFIG_NSP_DEMUXER 0
++#define CONFIG_NSV_DEMUXER 0
++#define CONFIG_NUT_DEMUXER 0
++#define CONFIG_NUV_DEMUXER 0
++#define CONFIG_OBU_DEMUXER 0
++#define CONFIG_OGG_DEMUXER 1
++#define CONFIG_OMA_DEMUXER 0
++#define CONFIG_PAF_DEMUXER 0
++#define CONFIG_PCM_ALAW_DEMUXER 0
++#define CONFIG_PCM_MULAW_DEMUXER 0
++#define CONFIG_PCM_VIDC_DEMUXER 0
++#define CONFIG_PCM_F64BE_DEMUXER 0
++#define CONFIG_PCM_F64LE_DEMUXER 0
++#define CONFIG_PCM_F32BE_DEMUXER 0
++#define CONFIG_PCM_F32LE_DEMUXER 0
++#define CONFIG_PCM_S32BE_DEMUXER 0
++#define CONFIG_PCM_S32LE_DEMUXER 0
++#define CONFIG_PCM_S24BE_DEMUXER 0
++#define CONFIG_PCM_S24LE_DEMUXER 0
++#define CONFIG_PCM_S16BE_DEMUXER 0
++#define CONFIG_PCM_S16LE_DEMUXER 0
++#define CONFIG_PCM_S8_DEMUXER 0
++#define CONFIG_PCM_U32BE_DEMUXER 0
++#define CONFIG_PCM_U32LE_DEMUXER 0
++#define CONFIG_PCM_U24BE_DEMUXER 0
++#define CONFIG_PCM_U24LE_DEMUXER 0
++#define CONFIG_PCM_U16BE_DEMUXER 0
++#define CONFIG_PCM_U16LE_DEMUXER 0
++#define CONFIG_PCM_U8_DEMUXER 0
++#define CONFIG_PDV_DEMUXER 0
++#define CONFIG_PJS_DEMUXER 0
++#define CONFIG_PMP_DEMUXER 0
++#define CONFIG_PP_BNK_DEMUXER 0
++#define CONFIG_PVA_DEMUXER 0
++#define CONFIG_PVF_DEMUXER 0
++#define CONFIG_QCP_DEMUXER 0
++#define CONFIG_R3D_DEMUXER 0
++#define CONFIG_RAWVIDEO_DEMUXER 0
++#define CONFIG_REALTEXT_DEMUXER 0
++#define CONFIG_REDSPARK_DEMUXER 0
++#define CONFIG_RKA_DEMUXER 0
++#define CONFIG_RL2_DEMUXER 0
++#define CONFIG_RM_DEMUXER 0
++#define CONFIG_ROQ_DEMUXER 0
++#define CONFIG_RPL_DEMUXER 0
++#define CONFIG_RSD_DEMUXER 0
++#define CONFIG_RSO_DEMUXER 0
++#define CONFIG_RTP_DEMUXER 0
++#define CONFIG_RTSP_DEMUXER 0
++#define CONFIG_S337M_DEMUXER 0
++#define CONFIG_SAMI_DEMUXER 0
++#define CONFIG_SAP_DEMUXER 0
++#define CONFIG_SBC_DEMUXER 0
++#define CONFIG_SBG_DEMUXER 0
++#define CONFIG_SCC_DEMUXER 0
++#define CONFIG_SCD_DEMUXER 0
++#define CONFIG_SDNS_DEMUXER 0
++#define CONFIG_SDP_DEMUXER 0
++#define CONFIG_SDR2_DEMUXER 0
++#define CONFIG_SDS_DEMUXER 0
++#define CONFIG_SDX_DEMUXER 0
++#define CONFIG_SEGAFILM_DEMUXER 0
++#define CONFIG_SER_DEMUXER 0
++#define CONFIG_SGA_DEMUXER 0
++#define CONFIG_SHORTEN_DEMUXER 0
++#define CONFIG_SIFF_DEMUXER 0
++#define CONFIG_SIMBIOSIS_IMX_DEMUXER 0
++#define CONFIG_SLN_DEMUXER 0
++#define CONFIG_SMACKER_DEMUXER 0
++#define CONFIG_SMJPEG_DEMUXER 0
++#define CONFIG_SMUSH_DEMUXER 0
++#define CONFIG_SOL_DEMUXER 0
++#define CONFIG_SOX_DEMUXER 0
++#define CONFIG_SPDIF_DEMUXER 0
++#define CONFIG_SRT_DEMUXER 0
++#define CONFIG_STR_DEMUXER 0
++#define CONFIG_STL_DEMUXER 0
++#define CONFIG_SUBVIEWER1_DEMUXER 0
++#define CONFIG_SUBVIEWER_DEMUXER 0
++#define CONFIG_SUP_DEMUXER 0
++#define CONFIG_SVAG_DEMUXER 0
++#define CONFIG_SVS_DEMUXER 0
++#define CONFIG_SWF_DEMUXER 0
++#define CONFIG_TAK_DEMUXER 0
++#define CONFIG_TEDCAPTIONS_DEMUXER 0
++#define CONFIG_THP_DEMUXER 0
++#define CONFIG_THREEDOSTR_DEMUXER 0
++#define CONFIG_TIERTEXSEQ_DEMUXER 0
++#define CONFIG_TMV_DEMUXER 0
++#define CONFIG_TRUEHD_DEMUXER 0
++#define CONFIG_TTA_DEMUXER 0
++#define CONFIG_TXD_DEMUXER 0
++#define CONFIG_TTY_DEMUXER 0
++#define CONFIG_TY_DEMUXER 0
++#define CONFIG_V210_DEMUXER 0
++#define CONFIG_V210X_DEMUXER 0
++#define CONFIG_VAG_DEMUXER 0
++#define CONFIG_VC1_DEMUXER 0
++#define CONFIG_VC1T_DEMUXER 0
++#define CONFIG_VIVIDAS_DEMUXER 0
++#define CONFIG_VIVO_DEMUXER 0
++#define CONFIG_VMD_DEMUXER 0
++#define CONFIG_VOBSUB_DEMUXER 0
++#define CONFIG_VOC_DEMUXER 0
++#define CONFIG_VPK_DEMUXER 0
++#define CONFIG_VPLAYER_DEMUXER 0
++#define CONFIG_VQF_DEMUXER 0
++#define CONFIG_W64_DEMUXER 0
++#define CONFIG_WADY_DEMUXER 0
++#define CONFIG_WAVARC_DEMUXER 0
++#define CONFIG_WAV_DEMUXER 1
++#define CONFIG_WC3_DEMUXER 0
++#define CONFIG_WEBM_DASH_MANIFEST_DEMUXER 0
++#define CONFIG_WEBVTT_DEMUXER 0
++#define CONFIG_WSAUD_DEMUXER 0
++#define CONFIG_WSD_DEMUXER 0
++#define CONFIG_WSVQA_DEMUXER 0
++#define CONFIG_WTV_DEMUXER 0
++#define CONFIG_WVE_DEMUXER 0
++#define CONFIG_WV_DEMUXER 0
++#define CONFIG_XA_DEMUXER 0
++#define CONFIG_XBIN_DEMUXER 0
++#define CONFIG_XMD_DEMUXER 0
++#define CONFIG_XMV_DEMUXER 0
++#define CONFIG_XVAG_DEMUXER 0
++#define CONFIG_XWMA_DEMUXER 0
++#define CONFIG_YOP_DEMUXER 0
++#define CONFIG_YUV4MPEGPIPE_DEMUXER 0
++#define CONFIG_IMAGE_BMP_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_CRI_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_DDS_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_DPX_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_EXR_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_GEM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_GIF_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_HDR_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_J2K_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_JPEG_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_JPEGLS_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_JPEGXL_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PAM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PBM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PCX_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PFM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PGMYUV_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PGM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PGX_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PHM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PHOTOCD_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PICTOR_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PNG_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PPM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PSD_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_QDRAW_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_QOI_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_SGI_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_SVG_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_SUNRAST_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_TIFF_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_VBN_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_WEBP_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_XBM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_XPM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_XWD_PIPE_DEMUXER 0
++#define CONFIG_LIBGME_DEMUXER 0
++#define CONFIG_LIBMODPLUG_DEMUXER 0
++#define CONFIG_LIBOPENMPT_DEMUXER 0
++#define CONFIG_VAPOURSYNTH_DEMUXER 0
++#define CONFIG_A64_MUXER 0
++#define CONFIG_AC3_MUXER 0
++#define CONFIG_ADTS_MUXER 0
++#define CONFIG_ADX_MUXER 0
++#define CONFIG_AIFF_MUXER 0
++#define CONFIG_ALP_MUXER 0
++#define CONFIG_AMR_MUXER 0
++#define CONFIG_AMV_MUXER 0
++#define CONFIG_APM_MUXER 0
++#define CONFIG_APNG_MUXER 0
++#define CONFIG_APTX_MUXER 0
++#define CONFIG_APTX_HD_MUXER 0
++#define CONFIG_ARGO_ASF_MUXER 0
++#define CONFIG_ARGO_CVG_MUXER 0
++#define CONFIG_ASF_MUXER 0
++#define CONFIG_ASS_MUXER 0
++#define CONFIG_AST_MUXER 0
++#define CONFIG_ASF_STREAM_MUXER 0
++#define CONFIG_AU_MUXER 0
++#define CONFIG_AVI_MUXER 0
++#define CONFIG_AVIF_MUXER 0
++#define CONFIG_AVM2_MUXER 0
++#define CONFIG_AVS2_MUXER 0
++#define CONFIG_AVS3_MUXER 0
++#define CONFIG_BIT_MUXER 0
++#define CONFIG_CAF_MUXER 0
++#define CONFIG_CAVSVIDEO_MUXER 0
++#define CONFIG_CODEC2_MUXER 0
++#define CONFIG_CODEC2RAW_MUXER 0
++#define CONFIG_CRC_MUXER 0
++#define CONFIG_DASH_MUXER 0
++#define CONFIG_DATA_MUXER 0
++#define CONFIG_DAUD_MUXER 0
++#define CONFIG_DFPWM_MUXER 0
++#define CONFIG_DIRAC_MUXER 0
++#define CONFIG_DNXHD_MUXER 0
++#define CONFIG_DTS_MUXER 0
++#define CONFIG_DV_MUXER 0
++#define CONFIG_EAC3_MUXER 0
++#define CONFIG_F4V_MUXER 0
++#define CONFIG_FFMETADATA_MUXER 0
++#define CONFIG_FIFO_MUXER 0
++#define CONFIG_FIFO_TEST_MUXER 0
++#define CONFIG_FILMSTRIP_MUXER 0
++#define CONFIG_FITS_MUXER 0
++#define CONFIG_FLAC_MUXER 0
++#define CONFIG_FLV_MUXER 0
++#define CONFIG_FRAMECRC_MUXER 0
++#define CONFIG_FRAMEHASH_MUXER 0
++#define CONFIG_FRAMEMD5_MUXER 0
++#define CONFIG_G722_MUXER 0
++#define CONFIG_G723_1_MUXER 0
++#define CONFIG_G726_MUXER 0
++#define CONFIG_G726LE_MUXER 0
++#define CONFIG_GIF_MUXER 0
++#define CONFIG_GSM_MUXER 0
++#define CONFIG_GXF_MUXER 0
++#define CONFIG_H261_MUXER 0
++#define CONFIG_H263_MUXER 0
++#define CONFIG_H264_MUXER 0
++#define CONFIG_HASH_MUXER 0
++#define CONFIG_HDS_MUXER 0
++#define CONFIG_HEVC_MUXER 0
++#define CONFIG_HLS_MUXER 0
++#define CONFIG_ICO_MUXER 0
++#define CONFIG_ILBC_MUXER 0
++#define CONFIG_IMAGE2_MUXER 0
++#define CONFIG_IMAGE2PIPE_MUXER 0
++#define CONFIG_IPOD_MUXER 0
++#define CONFIG_IRCAM_MUXER 0
++#define CONFIG_ISMV_MUXER 0
++#define CONFIG_IVF_MUXER 0
++#define CONFIG_JACOSUB_MUXER 0
++#define CONFIG_KVAG_MUXER 0
++#define CONFIG_LATM_MUXER 0
++#define CONFIG_LRC_MUXER 0
++#define CONFIG_M4V_MUXER 0
++#define CONFIG_MD5_MUXER 0
++#define CONFIG_MATROSKA_MUXER 0
++#define CONFIG_MATROSKA_AUDIO_MUXER 0
++#define CONFIG_MICRODVD_MUXER 0
++#define CONFIG_MJPEG_MUXER 0
++#define CONFIG_MLP_MUXER 0
++#define CONFIG_MMF_MUXER 0
++#define CONFIG_MOV_MUXER 0
++#define CONFIG_MP2_MUXER 0
++#define CONFIG_MP3_MUXER 0
++#define CONFIG_MP4_MUXER 0
++#define CONFIG_MPEG1SYSTEM_MUXER 0
++#define CONFIG_MPEG1VCD_MUXER 0
++#define CONFIG_MPEG1VIDEO_MUXER 0
++#define CONFIG_MPEG2DVD_MUXER 0
++#define CONFIG_MPEG2SVCD_MUXER 0
++#define CONFIG_MPEG2VIDEO_MUXER 0
++#define CONFIG_MPEG2VOB_MUXER 0
++#define CONFIG_MPEGTS_MUXER 0
++#define CONFIG_MPJPEG_MUXER 0
++#define CONFIG_MXF_MUXER 0
++#define CONFIG_MXF_D10_MUXER 0
++#define CONFIG_MXF_OPATOM_MUXER 0
++#define CONFIG_NULL_MUXER 0
++#define CONFIG_NUT_MUXER 0
++#define CONFIG_OBU_MUXER 0
++#define CONFIG_OGA_MUXER 0
++#define CONFIG_OGG_MUXER 0
++#define CONFIG_OGV_MUXER 0
++#define CONFIG_OMA_MUXER 0
++#define CONFIG_OPUS_MUXER 0
++#define CONFIG_PCM_ALAW_MUXER 0
++#define CONFIG_PCM_MULAW_MUXER 0
++#define CONFIG_PCM_VIDC_MUXER 0
++#define CONFIG_PCM_F64BE_MUXER 0
++#define CONFIG_PCM_F64LE_MUXER 0
++#define CONFIG_PCM_F32BE_MUXER 0
++#define CONFIG_PCM_F32LE_MUXER 0
++#define CONFIG_PCM_S32BE_MUXER 0
++#define CONFIG_PCM_S32LE_MUXER 0
++#define CONFIG_PCM_S24BE_MUXER 0
++#define CONFIG_PCM_S24LE_MUXER 0
++#define CONFIG_PCM_S16BE_MUXER 0
++#define CONFIG_PCM_S16LE_MUXER 0
++#define CONFIG_PCM_S8_MUXER 0
++#define CONFIG_PCM_U32BE_MUXER 0
++#define CONFIG_PCM_U32LE_MUXER 0
++#define CONFIG_PCM_U24BE_MUXER 0
++#define CONFIG_PCM_U24LE_MUXER 0
++#define CONFIG_PCM_U16BE_MUXER 0
++#define CONFIG_PCM_U16LE_MUXER 0
++#define CONFIG_PCM_U8_MUXER 0
++#define CONFIG_PSP_MUXER 0
++#define CONFIG_RAWVIDEO_MUXER 0
++#define CONFIG_RM_MUXER 0
++#define CONFIG_ROQ_MUXER 0
++#define CONFIG_RSO_MUXER 0
++#define CONFIG_RTP_MUXER 0
++#define CONFIG_RTP_MPEGTS_MUXER 0
++#define CONFIG_RTSP_MUXER 0
++#define CONFIG_SAP_MUXER 0
++#define CONFIG_SBC_MUXER 0
++#define CONFIG_SCC_MUXER 0
++#define CONFIG_SEGAFILM_MUXER 0
++#define CONFIG_SEGMENT_MUXER 0
++#define CONFIG_STREAM_SEGMENT_MUXER 0
++#define CONFIG_SMJPEG_MUXER 0
++#define CONFIG_SMOOTHSTREAMING_MUXER 0
++#define CONFIG_SOX_MUXER 0
++#define CONFIG_SPX_MUXER 0
++#define CONFIG_SPDIF_MUXER 0
++#define CONFIG_SRT_MUXER 0
++#define CONFIG_STREAMHASH_MUXER 0
++#define CONFIG_SUP_MUXER 0
++#define CONFIG_SWF_MUXER 0
++#define CONFIG_TEE_MUXER 0
++#define CONFIG_TG2_MUXER 0
++#define CONFIG_TGP_MUXER 0
++#define CONFIG_MKVTIMESTAMP_V2_MUXER 0
++#define CONFIG_TRUEHD_MUXER 0
++#define CONFIG_TTA_MUXER 0
++#define CONFIG_TTML_MUXER 0
++#define CONFIG_UNCODEDFRAMECRC_MUXER 0
++#define CONFIG_VC1_MUXER 0
++#define CONFIG_VC1T_MUXER 0
++#define CONFIG_VOC_MUXER 0
++#define CONFIG_W64_MUXER 0
++#define CONFIG_WAV_MUXER 0
++#define CONFIG_WEBM_MUXER 0
++#define CONFIG_WEBM_DASH_MANIFEST_MUXER 0
++#define CONFIG_WEBM_CHUNK_MUXER 0
++#define CONFIG_WEBP_MUXER 0
++#define CONFIG_WEBVTT_MUXER 0
++#define CONFIG_WSAUD_MUXER 0
++#define CONFIG_WTV_MUXER 0
++#define CONFIG_WV_MUXER 0
++#define CONFIG_YUV4MPEGPIPE_MUXER 0
++#define CONFIG_CHROMAPRINT_MUXER 0
++#define CONFIG_ASYNC_PROTOCOL 0
++#define CONFIG_BLURAY_PROTOCOL 0
++#define CONFIG_CACHE_PROTOCOL 0
++#define CONFIG_CONCAT_PROTOCOL 0
++#define CONFIG_CONCATF_PROTOCOL 0
++#define CONFIG_CRYPTO_PROTOCOL 0
++#define CONFIG_DATA_PROTOCOL 0
++#define CONFIG_FD_PROTOCOL 0
++#define CONFIG_FFRTMPCRYPT_PROTOCOL 0
++#define CONFIG_FFRTMPHTTP_PROTOCOL 0
++#define CONFIG_FILE_PROTOCOL 0
++#define CONFIG_FTP_PROTOCOL 0
++#define CONFIG_GOPHER_PROTOCOL 0
++#define CONFIG_GOPHERS_PROTOCOL 0
++#define CONFIG_HLS_PROTOCOL 0
++#define CONFIG_HTTP_PROTOCOL 0
++#define CONFIG_HTTPPROXY_PROTOCOL 0
++#define CONFIG_HTTPS_PROTOCOL 0
++#define CONFIG_ICECAST_PROTOCOL 0
++#define CONFIG_MMSH_PROTOCOL 0
++#define CONFIG_MMST_PROTOCOL 0
++#define CONFIG_MD5_PROTOCOL 0
++#define CONFIG_PIPE_PROTOCOL 0
++#define CONFIG_PROMPEG_PROTOCOL 0
++#define CONFIG_RTMP_PROTOCOL 0
++#define CONFIG_RTMPE_PROTOCOL 0
++#define CONFIG_RTMPS_PROTOCOL 0
++#define CONFIG_RTMPT_PROTOCOL 0
++#define CONFIG_RTMPTE_PROTOCOL 0
++#define CONFIG_RTMPTS_PROTOCOL 0
++#define CONFIG_RTP_PROTOCOL 0
++#define CONFIG_SCTP_PROTOCOL 0
++#define CONFIG_SRTP_PROTOCOL 0
++#define CONFIG_SUBFILE_PROTOCOL 0
++#define CONFIG_TEE_PROTOCOL 0
++#define CONFIG_TCP_PROTOCOL 0
++#define CONFIG_TLS_PROTOCOL 0
++#define CONFIG_UDP_PROTOCOL 0
++#define CONFIG_UDPLITE_PROTOCOL 0
++#define CONFIG_UNIX_PROTOCOL 0
++#define CONFIG_LIBAMQP_PROTOCOL 0
++#define CONFIG_LIBRIST_PROTOCOL 0
++#define CONFIG_LIBRTMP_PROTOCOL 0
++#define CONFIG_LIBRTMPE_PROTOCOL 0
++#define CONFIG_LIBRTMPS_PROTOCOL 0
++#define CONFIG_LIBRTMPT_PROTOCOL 0
++#define CONFIG_LIBRTMPTE_PROTOCOL 0
++#define CONFIG_LIBSRT_PROTOCOL 0
++#define CONFIG_LIBSSH_PROTOCOL 0
++#define CONFIG_LIBSMBCLIENT_PROTOCOL 0
++#define CONFIG_LIBZMQ_PROTOCOL 0
++#define CONFIG_IPFS_GATEWAY_PROTOCOL 0
++#define CONFIG_IPNS_GATEWAY_PROTOCOL 0
++#endif /* FFMPEG_CONFIG_COMPONENTS_H */
+diff --git a/chromium/config/ChromeOS/linux/riscv64/libavcodec/bsf_list.c b/chromium/config/ChromeOS/linux/riscv64/libavcodec/bsf_list.c
+new file mode 100644
+index 0000000000..7ff70c6e2d
+--- /dev/null
++++ b/chromium/config/ChromeOS/linux/riscv64/libavcodec/bsf_list.c
+@@ -0,0 +1,2 @@
++static const FFBitStreamFilter * const bitstream_filters[] = {
++    NULL };
+diff --git a/chromium/config/ChromeOS/linux/riscv64/libavcodec/codec_list.c b/chromium/config/ChromeOS/linux/riscv64/libavcodec/codec_list.c
+new file mode 100644
+index 0000000000..0cc2135452
+--- /dev/null
++++ b/chromium/config/ChromeOS/linux/riscv64/libavcodec/codec_list.c
+@@ -0,0 +1,22 @@
++static const FFCodec * const codec_list[] = {
++    &ff_h263_decoder,
++    &ff_h264_decoder,
++    &ff_mpeg4_decoder,
++    &ff_theora_decoder,
++    &ff_vp3_decoder,
++    &ff_vp8_decoder,
++    &ff_aac_decoder,
++    &ff_flac_decoder,
++    &ff_mp3_decoder,
++    &ff_vorbis_decoder,
++    &ff_pcm_alaw_decoder,
++    &ff_pcm_f32le_decoder,
++    &ff_pcm_mulaw_decoder,
++    &ff_pcm_s16be_decoder,
++    &ff_pcm_s16le_decoder,
++    &ff_pcm_s24be_decoder,
++    &ff_pcm_s24le_decoder,
++    &ff_pcm_s32le_decoder,
++    &ff_pcm_u8_decoder,
++    &ff_libopus_decoder,
++    NULL };
+diff --git a/chromium/config/ChromeOS/linux/riscv64/libavcodec/parser_list.c b/chromium/config/ChromeOS/linux/riscv64/libavcodec/parser_list.c
+new file mode 100644
+index 0000000000..e1652f8b9d
+--- /dev/null
++++ b/chromium/config/ChromeOS/linux/riscv64/libavcodec/parser_list.c
+@@ -0,0 +1,13 @@
++static const AVCodecParser * const parser_list[] = {
++    &ff_aac_parser,
++    &ff_flac_parser,
++    &ff_h263_parser,
++    &ff_h264_parser,
++    &ff_mpeg4video_parser,
++    &ff_mpegaudio_parser,
++    &ff_opus_parser,
++    &ff_vorbis_parser,
++    &ff_vp3_parser,
++    &ff_vp8_parser,
++    &ff_vp9_parser,
++    NULL };
+diff --git a/chromium/config/ChromeOS/linux/riscv64/libavformat/demuxer_list.c b/chromium/config/ChromeOS/linux/riscv64/libavformat/demuxer_list.c
+new file mode 100644
+index 0000000000..74870b99d2
+--- /dev/null
++++ b/chromium/config/ChromeOS/linux/riscv64/libavformat/demuxer_list.c
+@@ -0,0 +1,10 @@
++static const AVInputFormat * const demuxer_list[] = {
++    &ff_aac_demuxer,
++    &ff_avi_demuxer,
++    &ff_flac_demuxer,
++    &ff_matroska_demuxer,
++    &ff_mov_demuxer,
++    &ff_mp3_demuxer,
++    &ff_ogg_demuxer,
++    &ff_wav_demuxer,
++    NULL };
+diff --git a/chromium/config/ChromeOS/linux/riscv64/libavformat/muxer_list.c b/chromium/config/ChromeOS/linux/riscv64/libavformat/muxer_list.c
+new file mode 100644
+index 0000000000..ae54c39f23
+--- /dev/null
++++ b/chromium/config/ChromeOS/linux/riscv64/libavformat/muxer_list.c
+@@ -0,0 +1,2 @@
++static const FFOutputFormat * const muxer_list[] = {
++    NULL };
+diff --git a/chromium/config/ChromeOS/linux/riscv64/libavformat/protocol_list.c b/chromium/config/ChromeOS/linux/riscv64/libavformat/protocol_list.c
+new file mode 100644
+index 0000000000..247e1e4c3a
+--- /dev/null
++++ b/chromium/config/ChromeOS/linux/riscv64/libavformat/protocol_list.c
+@@ -0,0 +1,2 @@
++static const URLProtocol * const url_protocols[] = {
++    NULL };
+diff --git a/chromium/config/ChromeOS/linux/riscv64/libavutil/avconfig.h b/chromium/config/ChromeOS/linux/riscv64/libavutil/avconfig.h
+new file mode 100644
+index 0000000000..8558b35027
+--- /dev/null
++++ b/chromium/config/ChromeOS/linux/riscv64/libavutil/avconfig.h
+@@ -0,0 +1,6 @@
++/* Generated by ffmpeg configure */
++#ifndef AVUTIL_AVCONFIG_H
++#define AVUTIL_AVCONFIG_H
++#define AV_HAVE_BIGENDIAN 0
++#define AV_HAVE_FAST_UNALIGNED 0
++#endif /* AVUTIL_AVCONFIG_H */
+diff --git a/chromium/config/ChromeOS/linux/riscv64/libavutil/ffversion.h b/chromium/config/ChromeOS/linux/riscv64/libavutil/ffversion.h
+new file mode 100644
+index 0000000000..a29e9ec3ff
+--- /dev/null
++++ b/chromium/config/ChromeOS/linux/riscv64/libavutil/ffversion.h
+@@ -0,0 +1,5 @@
++/* Automatically generated by version.sh, do not manually edit! */
++#ifndef AVUTIL_FFVERSION_H
++#define AVUTIL_FFVERSION_H
++#define FFMPEG_VERSION "git-2023-06-02-881c5c3f64"
++#endif /* AVUTIL_FFVERSION_H */
+diff --git a/chromium/config/ChromeOS/linux/x64/config.asm b/chromium/config/ChromeOS/linux/x64/config.asm
+new file mode 100644
+index 0000000000..c927d6273f
+--- /dev/null
++++ b/chromium/config/ChromeOS/linux/x64/config.asm
+@@ -0,0 +1,734 @@
++; Automatically generated by configure - do not modify!
++%define ARCH_AARCH64 0
++%define ARCH_ALPHA 0
++%define ARCH_ARM 0
++%define ARCH_AVR32 0
++%define ARCH_AVR32_AP 0
++%define ARCH_AVR32_UC 0
++%define ARCH_BFIN 0
++%define ARCH_IA64 0
++%define ARCH_LOONGARCH 0
++%define ARCH_LOONGARCH32 0
++%define ARCH_LOONGARCH64 0
++%define ARCH_M68K 0
++%define ARCH_MIPS 0
++%define ARCH_MIPS64 0
++%define ARCH_PARISC 0
++%define ARCH_PPC 0
++%define ARCH_PPC64 0
++%define ARCH_RISCV 0
++%define ARCH_S390 0
++%define ARCH_SH4 0
++%define ARCH_SPARC 0
++%define ARCH_SPARC64 0
++%define ARCH_TILEGX 0
++%define ARCH_TILEPRO 0
++%define ARCH_TOMI 0
++%define ARCH_X86 1
++%define ARCH_X86_32 0
++%define ARCH_X86_64 1
++%define HAVE_ARMV5TE 0
++%define HAVE_ARMV6 0
++%define HAVE_ARMV6T2 0
++%define HAVE_ARMV8 0
++%define HAVE_NEON 0
++%define HAVE_VFP 0
++%define HAVE_VFPV3 0
++%define HAVE_SETEND 0
++%define HAVE_ALTIVEC 0
++%define HAVE_DCBZL 0
++%define HAVE_LDBRX 0
++%define HAVE_POWER8 0
++%define HAVE_PPC4XX 0
++%define HAVE_VSX 0
++%define HAVE_RVV 0
++%define HAVE_AESNI 1
++%define HAVE_AMD3DNOW 1
++%define HAVE_AMD3DNOWEXT 1
++%define HAVE_AVX 1
++%define HAVE_AVX2 1
++%define HAVE_AVX512 1
++%define HAVE_AVX512ICL 1
++%define HAVE_FMA3 1
++%define HAVE_FMA4 1
++%define HAVE_MMX 1
++%define HAVE_MMXEXT 1
++%define HAVE_SSE 1
++%define HAVE_SSE2 1
++%define HAVE_SSE3 1
++%define HAVE_SSE4 1
++%define HAVE_SSE42 1
++%define HAVE_SSSE3 1
++%define HAVE_XOP 1
++%define HAVE_CPUNOP 0
++%define HAVE_I686 1
++%define HAVE_MIPSFPU 0
++%define HAVE_MIPS32R2 0
++%define HAVE_MIPS32R5 0
++%define HAVE_MIPS64R2 0
++%define HAVE_MIPS32R6 0
++%define HAVE_MIPS64R6 0
++%define HAVE_MIPSDSP 0
++%define HAVE_MIPSDSPR2 0
++%define HAVE_MSA 0
++%define HAVE_LOONGSON2 0
++%define HAVE_LOONGSON3 0
++%define HAVE_MMI 0
++%define HAVE_LSX 0
++%define HAVE_LASX 0
++%define HAVE_ARMV5TE_EXTERNAL 0
++%define HAVE_ARMV6_EXTERNAL 0
++%define HAVE_ARMV6T2_EXTERNAL 0
++%define HAVE_ARMV8_EXTERNAL 0
++%define HAVE_NEON_EXTERNAL 0
++%define HAVE_VFP_EXTERNAL 0
++%define HAVE_VFPV3_EXTERNAL 0
++%define HAVE_SETEND_EXTERNAL 0
++%define HAVE_ALTIVEC_EXTERNAL 0
++%define HAVE_DCBZL_EXTERNAL 0
++%define HAVE_LDBRX_EXTERNAL 0
++%define HAVE_POWER8_EXTERNAL 0
++%define HAVE_PPC4XX_EXTERNAL 0
++%define HAVE_VSX_EXTERNAL 0
++%define HAVE_RVV_EXTERNAL 0
++%define HAVE_AESNI_EXTERNAL 1
++%define HAVE_AMD3DNOW_EXTERNAL 1
++%define HAVE_AMD3DNOWEXT_EXTERNAL 1
++%define HAVE_AVX_EXTERNAL 1
++%define HAVE_AVX2_EXTERNAL 1
++%define HAVE_AVX512_EXTERNAL 1
++%define HAVE_AVX512ICL_EXTERNAL 1
++%define HAVE_FMA3_EXTERNAL 1
++%define HAVE_FMA4_EXTERNAL 1
++%define HAVE_MMX_EXTERNAL 1
++%define HAVE_MMXEXT_EXTERNAL 1
++%define HAVE_SSE_EXTERNAL 1
++%define HAVE_SSE2_EXTERNAL 1
++%define HAVE_SSE3_EXTERNAL 1
++%define HAVE_SSE4_EXTERNAL 1
++%define HAVE_SSE42_EXTERNAL 1
++%define HAVE_SSSE3_EXTERNAL 1
++%define HAVE_XOP_EXTERNAL 1
++%define HAVE_CPUNOP_EXTERNAL 0
++%define HAVE_I686_EXTERNAL 0
++%define HAVE_MIPSFPU_EXTERNAL 0
++%define HAVE_MIPS32R2_EXTERNAL 0
++%define HAVE_MIPS32R5_EXTERNAL 0
++%define HAVE_MIPS64R2_EXTERNAL 0
++%define HAVE_MIPS32R6_EXTERNAL 0
++%define HAVE_MIPS64R6_EXTERNAL 0
++%define HAVE_MIPSDSP_EXTERNAL 0
++%define HAVE_MIPSDSPR2_EXTERNAL 0
++%define HAVE_MSA_EXTERNAL 0
++%define HAVE_LOONGSON2_EXTERNAL 0
++%define HAVE_LOONGSON3_EXTERNAL 0
++%define HAVE_MMI_EXTERNAL 0
++%define HAVE_LSX_EXTERNAL 0
++%define HAVE_LASX_EXTERNAL 0
++%define HAVE_ARMV5TE_INLINE 0
++%define HAVE_ARMV6_INLINE 0
++%define HAVE_ARMV6T2_INLINE 0
++%define HAVE_ARMV8_INLINE 0
++%define HAVE_NEON_INLINE 0
++%define HAVE_VFP_INLINE 0
++%define HAVE_VFPV3_INLINE 0
++%define HAVE_SETEND_INLINE 0
++%define HAVE_ALTIVEC_INLINE 0
++%define HAVE_DCBZL_INLINE 0
++%define HAVE_LDBRX_INLINE 0
++%define HAVE_POWER8_INLINE 0
++%define HAVE_PPC4XX_INLINE 0
++%define HAVE_VSX_INLINE 0
++%define HAVE_RVV_INLINE 0
++%define HAVE_AESNI_INLINE 1
++%define HAVE_AMD3DNOW_INLINE 1
++%define HAVE_AMD3DNOWEXT_INLINE 1
++%define HAVE_AVX_INLINE 1
++%define HAVE_AVX2_INLINE 1
++%define HAVE_AVX512_INLINE 1
++%define HAVE_AVX512ICL_INLINE 1
++%define HAVE_FMA3_INLINE 1
++%define HAVE_FMA4_INLINE 1
++%define HAVE_MMX_INLINE 1
++%define HAVE_MMXEXT_INLINE 1
++%define HAVE_SSE_INLINE 1
++%define HAVE_SSE2_INLINE 1
++%define HAVE_SSE3_INLINE 1
++%define HAVE_SSE4_INLINE 1
++%define HAVE_SSE42_INLINE 1
++%define HAVE_SSSE3_INLINE 1
++%define HAVE_XOP_INLINE 1
++%define HAVE_CPUNOP_INLINE 0
++%define HAVE_I686_INLINE 0
++%define HAVE_MIPSFPU_INLINE 0
++%define HAVE_MIPS32R2_INLINE 0
++%define HAVE_MIPS32R5_INLINE 0
++%define HAVE_MIPS64R2_INLINE 0
++%define HAVE_MIPS32R6_INLINE 0
++%define HAVE_MIPS64R6_INLINE 0
++%define HAVE_MIPSDSP_INLINE 0
++%define HAVE_MIPSDSPR2_INLINE 0
++%define HAVE_MSA_INLINE 0
++%define HAVE_LOONGSON2_INLINE 0
++%define HAVE_LOONGSON3_INLINE 0
++%define HAVE_MMI_INLINE 0
++%define HAVE_LSX_INLINE 0
++%define HAVE_LASX_INLINE 0
++%define HAVE_ALIGNED_STACK 1
++%define HAVE_FAST_64BIT 1
++%define HAVE_FAST_CLZ 1
++%define HAVE_FAST_CMOV 1
++%define HAVE_FAST_FLOAT16 0
++%define HAVE_LOCAL_ALIGNED 1
++%define HAVE_SIMD_ALIGN_16 1
++%define HAVE_SIMD_ALIGN_32 1
++%define HAVE_SIMD_ALIGN_64 1
++%define HAVE_ATOMIC_CAS_PTR 0
++%define HAVE_MACHINE_RW_BARRIER 0
++%define HAVE_MEMORYBARRIER 0
++%define HAVE_MM_EMPTY 1
++%define HAVE_RDTSC 0
++%define HAVE_SEM_TIMEDWAIT 1
++%define HAVE_SYNC_VAL_COMPARE_AND_SWAP 1
++%define HAVE_INLINE_ASM 1
++%define HAVE_SYMVER 0
++%define HAVE_X86ASM 1
++%define HAVE_BIGENDIAN 0
++%define HAVE_FAST_UNALIGNED 1
++%define HAVE_ARPA_INET_H 0
++%define HAVE_ASM_TYPES_H 1
++%define HAVE_CDIO_PARANOIA_H 0
++%define HAVE_CDIO_PARANOIA_PARANOIA_H 0
++%define HAVE_CUDA_H 0
++%define HAVE_DISPATCH_DISPATCH_H 0
++%define HAVE_DEV_BKTR_IOCTL_BT848_H 0
++%define HAVE_DEV_BKTR_IOCTL_METEOR_H 0
++%define HAVE_DEV_IC_BT8XX_H 0
++%define HAVE_DEV_VIDEO_BKTR_IOCTL_BT848_H 0
++%define HAVE_DEV_VIDEO_METEOR_IOCTL_METEOR_H 0
++%define HAVE_DIRECT_H 0
++%define HAVE_DIRENT_H 1
++%define HAVE_DXGIDEBUG_H 0
++%define HAVE_DXVA_H 0
++%define HAVE_ES2_GL_H 0
++%define HAVE_GSM_H 0
++%define HAVE_IO_H 0
++%define HAVE_LINUX_DMA_BUF_H 0
++%define HAVE_LINUX_PERF_EVENT_H 1
++%define HAVE_MACHINE_IOCTL_BT848_H 0
++%define HAVE_MACHINE_IOCTL_METEOR_H 0
++%define HAVE_MALLOC_H 1
++%define HAVE_OPENCV2_CORE_CORE_C_H 0
++%define HAVE_OPENGL_GL3_H 0
++%define HAVE_POLL_H 1
++%define HAVE_SYS_PARAM_H 1
++%define HAVE_SYS_RESOURCE_H 1
++%define HAVE_SYS_SELECT_H 1
++%define HAVE_SYS_SOUNDCARD_H 1
++%define HAVE_SYS_TIME_H 1
++%define HAVE_SYS_UN_H 1
++%define HAVE_SYS_VIDEOIO_H 0
++%define HAVE_TERMIOS_H 1
++%define HAVE_UDPLITE_H 0
++%define HAVE_UNISTD_H 1
++%define HAVE_VALGRIND_VALGRIND_H 0 ; %define HAVE_VALGRIND_VALGRIND_H 0 -- forced to 0. See https://crbug.com/590440
++%define HAVE_WINDOWS_H 0
++%define HAVE_WINSOCK2_H 0
++%define HAVE_INTRINSICS_NEON 0
++%define HAVE_ATANF 1
++%define HAVE_ATAN2F 1
++%define HAVE_CBRT 1
++%define HAVE_CBRTF 1
++%define HAVE_COPYSIGN 1
++%define HAVE_COSF 1
++%define HAVE_ERF 1
++%define HAVE_EXP2 1
++%define HAVE_EXP2F 1
++%define HAVE_EXPF 1
++%define HAVE_HYPOT 1
++%define HAVE_ISFINITE 1
++%define HAVE_ISINF 1
++%define HAVE_ISNAN 1
++%define HAVE_LDEXPF 1
++%define HAVE_LLRINT 1
++%define HAVE_LLRINTF 1
++%define HAVE_LOG2 1
++%define HAVE_LOG2F 1
++%define HAVE_LOG10F 1
++%define HAVE_LRINT 1
++%define HAVE_LRINTF 1
++%define HAVE_POWF 1
++%define HAVE_RINT 1
++%define HAVE_ROUND 1
++%define HAVE_ROUNDF 1
++%define HAVE_SINF 1
++%define HAVE_TRUNC 1
++%define HAVE_TRUNCF 1
++%define HAVE_DOS_PATHS 0
++%define HAVE_LIBC_MSVCRT 0
++%define HAVE_MMAL_PARAMETER_VIDEO_MAX_NUM_CALLBACKS 0
++%define HAVE_SECTION_DATA_REL_RO 1
++%define HAVE_THREADS 1
++%define HAVE_UWP 0
++%define HAVE_WINRT 0
++%define HAVE_ACCESS 1
++%define HAVE_ALIGNED_MALLOC 0
++%define HAVE_ARC4RANDOM 0
++%define HAVE_CLOCK_GETTIME 1
++%define HAVE_CLOSESOCKET 0
++%define HAVE_COMMANDLINETOARGVW 0
++%define HAVE_FCNTL 1
++%define HAVE_GETADDRINFO 0
++%define HAVE_GETAUXVAL 1
++%define HAVE_GETENV 1
++%define HAVE_GETHRTIME 0
++%define HAVE_GETOPT 1
++%define HAVE_GETMODULEHANDLE 0
++%define HAVE_GETPROCESSAFFINITYMASK 0
++%define HAVE_GETPROCESSMEMORYINFO 0
++%define HAVE_GETPROCESSTIMES 0
++%define HAVE_GETRUSAGE 1
++%define HAVE_GETSTDHANDLE 0
++%define HAVE_GETSYSTEMTIMEASFILETIME 0
++%define HAVE_GETTIMEOFDAY 1
++%define HAVE_GLOB 1
++%define HAVE_GLXGETPROCADDRESS 0
++%define HAVE_GMTIME_R 1
++%define HAVE_INET_ATON 0
++%define HAVE_ISATTY 1
++%define HAVE_KBHIT 0
++%define HAVE_LOCALTIME_R 1
++%define HAVE_LSTAT 1
++%define HAVE_LZO1X_999_COMPRESS 0
++%define HAVE_MACH_ABSOLUTE_TIME 0
++%define HAVE_MAPVIEWOFFILE 0
++%define HAVE_MEMALIGN 1
++%define HAVE_MKSTEMP 1
++%define HAVE_MMAP 1
++%define HAVE_MPROTECT 1
++%define HAVE_NANOSLEEP 1
++%define HAVE_PEEKNAMEDPIPE 0
++%define HAVE_POSIX_MEMALIGN 1
++%define HAVE_PRCTL 1
++%define HAVE_PTHREAD_CANCEL 1
++%define HAVE_SCHED_GETAFFINITY 1
++%define HAVE_SECITEMIMPORT 0
++%define HAVE_SETCONSOLETEXTATTRIBUTE 0
++%define HAVE_SETCONSOLECTRLHANDLER 0
++%define HAVE_SETDLLDIRECTORY 0
++%define HAVE_SETMODE 0
++%define HAVE_SETRLIMIT 1
++%define HAVE_SLEEP 0
++%define HAVE_STRERROR_R 1
++%define HAVE_SYSCONF 1
++%define HAVE_SYSCTL 0
++%define HAVE_USLEEP 1
++%define HAVE_UTGETOSTYPEFROMSTRING 0
++%define HAVE_VIRTUALALLOC 0
++%define HAVE_WGLGETPROCADDRESS 0
++%define HAVE_BCRYPT 0
++%define HAVE_VAAPI_DRM 0
++%define HAVE_VAAPI_X11 0
++%define HAVE_VAAPI_WIN32 0
++%define HAVE_VDPAU_X11 0
++%define HAVE_PTHREADS 1
++%define HAVE_OS2THREADS 0
++%define HAVE_W32THREADS 0
++%define HAVE_AS_ARCH_DIRECTIVE 0
++%define HAVE_AS_DN_DIRECTIVE 0
++%define HAVE_AS_FPU_DIRECTIVE 0
++%define HAVE_AS_FUNC 0
++%define HAVE_AS_OBJECT_ARCH 0
++%define HAVE_ASM_MOD_Q 0
++%define HAVE_BLOCKS_EXTENSION 0
++%define HAVE_EBP_AVAILABLE 1
++%define HAVE_EBX_AVAILABLE 1
++%define HAVE_GNU_AS 0
++%define HAVE_GNU_WINDRES 0
++%define HAVE_IBM_ASM 0
++%define HAVE_INLINE_ASM_DIRECT_SYMBOL_REFS 0
++%define HAVE_INLINE_ASM_LABELS 1
++%define HAVE_INLINE_ASM_NONLOCAL_LABELS 1
++%define HAVE_PRAGMA_DEPRECATED 1
++%define HAVE_RSYNC_CONTIMEOUT 0
++%define HAVE_SYMVER_ASM_LABEL 1
++%define HAVE_SYMVER_GNU_ASM 1
++%define HAVE_VFP_ARGS 0
++%define HAVE_XFORM_ASM 0
++%define HAVE_XMM_CLOBBERS 1
++%define HAVE_DPI_AWARENESS_CONTEXT 0
++%define HAVE_IDXGIOUTPUT5 0
++%define HAVE_KCMVIDEOCODECTYPE_HEVC 0
++%define HAVE_KCMVIDEOCODECTYPE_HEVCWITHALPHA 0
++%define HAVE_KCMVIDEOCODECTYPE_VP9 0
++%define HAVE_KCVPIXELFORMATTYPE_420YPCBCR10BIPLANARVIDEORANGE 0
++%define HAVE_KCVPIXELFORMATTYPE_422YPCBCR8BIPLANARVIDEORANGE 0
++%define HAVE_KCVPIXELFORMATTYPE_422YPCBCR10BIPLANARVIDEORANGE 0
++%define HAVE_KCVPIXELFORMATTYPE_422YPCBCR16BIPLANARVIDEORANGE 0
++%define HAVE_KCVPIXELFORMATTYPE_444YPCBCR8BIPLANARVIDEORANGE 0
++%define HAVE_KCVPIXELFORMATTYPE_444YPCBCR10BIPLANARVIDEORANGE 0
++%define HAVE_KCVPIXELFORMATTYPE_444YPCBCR16BIPLANARVIDEORANGE 0
++%define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_2084_PQ 0
++%define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2100_HLG 0
++%define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_LINEAR 0
++%define HAVE_KCVIMAGEBUFFERYCBCRMATRIX_ITU_R_2020 0
++%define HAVE_KCVIMAGEBUFFERCOLORPRIMARIES_ITU_R_2020 0
++%define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2020 0
++%define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_428_1 0
++%define HAVE_SOCKLEN_T 0
++%define HAVE_STRUCT_ADDRINFO 0
++%define HAVE_STRUCT_GROUP_SOURCE_REQ 0
++%define HAVE_STRUCT_IP_MREQ_SOURCE 0
++%define HAVE_STRUCT_IPV6_MREQ 0
++%define HAVE_STRUCT_MSGHDR_MSG_FLAGS 0
++%define HAVE_STRUCT_POLLFD 0
++%define HAVE_STRUCT_RUSAGE_RU_MAXRSS 1
++%define HAVE_STRUCT_SCTP_EVENT_SUBSCRIBE 0
++%define HAVE_STRUCT_SOCKADDR_IN6 0
++%define HAVE_STRUCT_SOCKADDR_SA_LEN 0
++%define HAVE_STRUCT_SOCKADDR_STORAGE 0
++%define HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC 1
++%define HAVE_STRUCT_V4L2_FRMIVALENUM_DISCRETE 0
++%define HAVE_GZIP 1
++%define HAVE_LIBDRM_GETFB2 0
++%define HAVE_MAKEINFO 0
++%define HAVE_MAKEINFO_HTML 0
++%define HAVE_OPENCL_D3D11 0
++%define HAVE_OPENCL_DRM_ARM 0
++%define HAVE_OPENCL_DRM_BEIGNET 0
++%define HAVE_OPENCL_DXVA2 0
++%define HAVE_OPENCL_VAAPI_BEIGNET 0
++%define HAVE_OPENCL_VAAPI_INTEL_MEDIA 0
++%define HAVE_PERL 1
++%define HAVE_POD2MAN 1
++%define HAVE_TEXI2HTML 0
++%define HAVE_XMLLINT 0
++%define HAVE_ZLIB_GZIP 0
++%define CONFIG_DOC 0
++%define CONFIG_HTMLPAGES 0
++%define CONFIG_MANPAGES 0
++%define CONFIG_PODPAGES 0
++%define CONFIG_TXTPAGES 0
++%define CONFIG_AVIO_HTTP_SERVE_FILES_EXAMPLE 1
++%define CONFIG_AVIO_LIST_DIR_EXAMPLE 1
++%define CONFIG_AVIO_READ_CALLBACK_EXAMPLE 1
++%define CONFIG_DECODE_AUDIO_EXAMPLE 1
++%define CONFIG_DECODE_FILTER_AUDIO_EXAMPLE 0
++%define CONFIG_DECODE_FILTER_VIDEO_EXAMPLE 0
++%define CONFIG_DECODE_VIDEO_EXAMPLE 1
++%define CONFIG_DEMUX_DECODE_EXAMPLE 1
++%define CONFIG_ENCODE_AUDIO_EXAMPLE 1
++%define CONFIG_ENCODE_VIDEO_EXAMPLE 1
++%define CONFIG_EXTRACT_MVS_EXAMPLE 1
++%define CONFIG_FILTER_AUDIO_EXAMPLE 0
++%define CONFIG_HW_DECODE_EXAMPLE 1
++%define CONFIG_MUX_EXAMPLE 0
++%define CONFIG_QSV_DECODE_EXAMPLE 0
++%define CONFIG_REMUX_EXAMPLE 1
++%define CONFIG_RESAMPLE_AUDIO_EXAMPLE 0
++%define CONFIG_SCALE_VIDEO_EXAMPLE 0
++%define CONFIG_SHOW_METADATA_EXAMPLE 1
++%define CONFIG_TRANSCODE_AAC_EXAMPLE 0
++%define CONFIG_TRANSCODE_EXAMPLE 0
++%define CONFIG_VAAPI_ENCODE_EXAMPLE 0
++%define CONFIG_VAAPI_TRANSCODE_EXAMPLE 0
++%define CONFIG_QSV_TRANSCODE_EXAMPLE 0
++%define CONFIG_AVISYNTH 0
++%define CONFIG_FREI0R 0
++%define CONFIG_LIBCDIO 0
++%define CONFIG_LIBDAVS2 0
++%define CONFIG_LIBRUBBERBAND 0
++%define CONFIG_LIBVIDSTAB 0
++%define CONFIG_LIBX264 0
++%define CONFIG_LIBX265 0
++%define CONFIG_LIBXAVS 0
++%define CONFIG_LIBXAVS2 0
++%define CONFIG_LIBXVID 0
++%define CONFIG_DECKLINK 0
++%define CONFIG_LIBFDK_AAC 0
++%define CONFIG_LIBTLS 0
++%define CONFIG_GMP 0
++%define CONFIG_LIBARIBB24 0
++%define CONFIG_LIBLENSFUN 0
++%define CONFIG_LIBOPENCORE_AMRNB 0
++%define CONFIG_LIBOPENCORE_AMRWB 0
++%define CONFIG_LIBVO_AMRWBENC 0
++%define CONFIG_MBEDTLS 0
++%define CONFIG_RKMPP 0
++%define CONFIG_LIBSMBCLIENT 0
++%define CONFIG_CHROMAPRINT 0
++%define CONFIG_GCRYPT 0
++%define CONFIG_GNUTLS 0
++%define CONFIG_JNI 0
++%define CONFIG_LADSPA 0
++%define CONFIG_LCMS2 0
++%define CONFIG_LIBAOM 0
++%define CONFIG_LIBARIBCAPTION 0
++%define CONFIG_LIBASS 0
++%define CONFIG_LIBBLURAY 0
++%define CONFIG_LIBBS2B 0
++%define CONFIG_LIBCACA 0
++%define CONFIG_LIBCELT 0
++%define CONFIG_LIBCODEC2 0
++%define CONFIG_LIBDAV1D 0
++%define CONFIG_LIBDC1394 0
++%define CONFIG_LIBDRM 0
++%define CONFIG_LIBFLITE 0
++%define CONFIG_LIBFONTCONFIG 0
++%define CONFIG_LIBFREETYPE 0
++%define CONFIG_LIBFRIBIDI 0
++%define CONFIG_LIBGLSLANG 0
++%define CONFIG_LIBGME 0
++%define CONFIG_LIBGSM 0
++%define CONFIG_LIBIEC61883 0
++%define CONFIG_LIBILBC 0
++%define CONFIG_LIBJACK 0
++%define CONFIG_LIBJXL 0
++%define CONFIG_LIBKLVANC 0
++%define CONFIG_LIBKVAZAAR 0
++%define CONFIG_LIBMODPLUG 0
++%define CONFIG_LIBMP3LAME 0
++%define CONFIG_LIBMYSOFA 0
++%define CONFIG_LIBOPENCV 0
++%define CONFIG_LIBOPENH264 0
++%define CONFIG_LIBOPENJPEG 0
++%define CONFIG_LIBOPENMPT 0
++%define CONFIG_LIBOPENVINO 0
++%define CONFIG_LIBOPUS 1
++%define CONFIG_LIBPLACEBO 0
++%define CONFIG_LIBPULSE 0
++%define CONFIG_LIBRABBITMQ 0
++%define CONFIG_LIBRAV1E 0
++%define CONFIG_LIBRIST 0
++%define CONFIG_LIBRSVG 0
++%define CONFIG_LIBRTMP 0
++%define CONFIG_LIBSHADERC 0
++%define CONFIG_LIBSHINE 0
++%define CONFIG_LIBSMBCLIENT 0
++%define CONFIG_LIBSNAPPY 0
++%define CONFIG_LIBSOXR 0
++%define CONFIG_LIBSPEEX 0
++%define CONFIG_LIBSRT 0
++%define CONFIG_LIBSSH 0
++%define CONFIG_LIBSVTAV1 0
++%define CONFIG_LIBTENSORFLOW 0
++%define CONFIG_LIBTESSERACT 0
++%define CONFIG_LIBTHEORA 0
++%define CONFIG_LIBTWOLAME 0
++%define CONFIG_LIBUAVS3D 0
++%define CONFIG_LIBV4L2 0
++%define CONFIG_LIBVMAF 0
++%define CONFIG_LIBVORBIS 0
++%define CONFIG_LIBVPX 0
++%define CONFIG_LIBWEBP 0
++%define CONFIG_LIBXML2 0
++%define CONFIG_LIBZIMG 0
++%define CONFIG_LIBZMQ 0
++%define CONFIG_LIBZVBI 0
++%define CONFIG_LV2 0
++%define CONFIG_MEDIACODEC 0
++%define CONFIG_OPENAL 0
++%define CONFIG_OPENGL 0
++%define CONFIG_OPENSSL 0
++%define CONFIG_POCKETSPHINX 0
++%define CONFIG_VAPOURSYNTH 0
++%define CONFIG_ALSA 0
++%define CONFIG_APPKIT 0
++%define CONFIG_AVFOUNDATION 0
++%define CONFIG_BZLIB 0
++%define CONFIG_COREIMAGE 0
++%define CONFIG_ICONV 0
++%define CONFIG_LIBXCB 0
++%define CONFIG_LIBXCB_SHM 0
++%define CONFIG_LIBXCB_SHAPE 0
++%define CONFIG_LIBXCB_XFIXES 0
++%define CONFIG_LZMA 0
++%define CONFIG_MEDIAFOUNDATION 0
++%define CONFIG_METAL 0
++%define CONFIG_SCHANNEL 0
++%define CONFIG_SDL2 0
++%define CONFIG_SECURETRANSPORT 0
++%define CONFIG_SNDIO 0
++%define CONFIG_XLIB 0
++%define CONFIG_ZLIB 0
++%define CONFIG_CUDA_NVCC 0
++%define CONFIG_CUDA_SDK 0
++%define CONFIG_LIBNPP 0
++%define CONFIG_LIBMFX 0
++%define CONFIG_LIBVPL 0
++%define CONFIG_MMAL 0
++%define CONFIG_OMX 0
++%define CONFIG_OPENCL 0
++%define CONFIG_AMF 0
++%define CONFIG_AUDIOTOOLBOX 0
++%define CONFIG_CRYSTALHD 0
++%define CONFIG_CUDA 0
++%define CONFIG_CUDA_LLVM 0
++%define CONFIG_CUVID 0
++%define CONFIG_D3D11VA 0
++%define CONFIG_DXVA2 0
++%define CONFIG_FFNVCODEC 0
++%define CONFIG_NVDEC 0
++%define CONFIG_NVENC 0
++%define CONFIG_VAAPI 0
++%define CONFIG_VDPAU 0
++%define CONFIG_VIDEOTOOLBOX 0
++%define CONFIG_VULKAN 0
++%define CONFIG_V4L2_M2M 0
++%define CONFIG_FTRAPV 0
++%define CONFIG_GRAY 0
++%define CONFIG_HARDCODED_TABLES 0
++%define CONFIG_OMX_RPI 0
++%define CONFIG_RUNTIME_CPUDETECT 1
++%define CONFIG_SAFE_BITSTREAM_READER 1
++%define CONFIG_SHARED 0
++%define CONFIG_SMALL 0
++%define CONFIG_STATIC 1
++%define CONFIG_SWSCALE_ALPHA 1
++%define CONFIG_GPL 0
++%define CONFIG_NONFREE 0
++%define CONFIG_VERSION3 0
++%define CONFIG_AVDEVICE 0
++%define CONFIG_AVFILTER 0
++%define CONFIG_SWSCALE 0
++%define CONFIG_POSTPROC 0
++%define CONFIG_AVFORMAT 1
++%define CONFIG_AVCODEC 1
++%define CONFIG_SWRESAMPLE 0
++%define CONFIG_AVUTIL 1
++%define CONFIG_FFPLAY 0
++%define CONFIG_FFPROBE 0
++%define CONFIG_FFMPEG 0
++%define CONFIG_DCT 1
++%define CONFIG_DWT 0
++%define CONFIG_ERROR_RESILIENCE 1
++%define CONFIG_FAAN 0
++%define CONFIG_FAST_UNALIGNED 1
++%define CONFIG_FFT 1
++%define CONFIG_LSP 0
++%define CONFIG_MDCT 0
++%define CONFIG_PIXELUTILS 0
++%define CONFIG_NETWORK 0
++%define CONFIG_RDFT 1
++%define CONFIG_AUTODETECT 0
++%define CONFIG_FONTCONFIG 0
++%define CONFIG_LARGE_TESTS 1
++%define CONFIG_LINUX_PERF 0
++%define CONFIG_MACOS_KPERF 0
++%define CONFIG_MEMORY_POISONING 0
++%define CONFIG_NEON_CLOBBER_TEST 0
++%define CONFIG_OSSFUZZ 0
++%define CONFIG_PIC 1
++%define CONFIG_PTX_COMPRESSION 0
++%define CONFIG_THUMB 0
++%define CONFIG_VALGRIND_BACKTRACE 0
++%define CONFIG_XMM_CLOBBER_TEST 0
++%define CONFIG_BSFS 0
++%define CONFIG_DECODERS 1
++%define CONFIG_ENCODERS 0
++%define CONFIG_HWACCELS 0
++%define CONFIG_PARSERS 1
++%define CONFIG_INDEVS 0
++%define CONFIG_OUTDEVS 0
++%define CONFIG_FILTERS 0
++%define CONFIG_DEMUXERS 1
++%define CONFIG_MUXERS 0
++%define CONFIG_PROTOCOLS 0
++%define CONFIG_AANDCTTABLES 0
++%define CONFIG_AC3DSP 0
++%define CONFIG_ADTS_HEADER 1
++%define CONFIG_ATSC_A53 1
++%define CONFIG_AUDIO_FRAME_QUEUE 0
++%define CONFIG_AUDIODSP 0
++%define CONFIG_BLOCKDSP 1
++%define CONFIG_BSWAPDSP 0
++%define CONFIG_CABAC 1
++%define CONFIG_CBS 0
++%define CONFIG_CBS_AV1 0
++%define CONFIG_CBS_H264 0
++%define CONFIG_CBS_H265 0
++%define CONFIG_CBS_JPEG 0
++%define CONFIG_CBS_MPEG2 0
++%define CONFIG_CBS_VP9 0
++%define CONFIG_DEFLATE_WRAPPER 0
++%define CONFIG_DIRAC_PARSE 1
++%define CONFIG_DNN 0
++%define CONFIG_DOVI_RPU 0
++%define CONFIG_DVPROFILE 0
++%define CONFIG_EXIF 1
++%define CONFIG_FAANDCT 0
++%define CONFIG_FAANIDCT 0
++%define CONFIG_FDCTDSP 0
++%define CONFIG_FMTCONVERT 0
++%define CONFIG_FRAME_THREAD_ENCODER 0
++%define CONFIG_G722DSP 0
++%define CONFIG_GOLOMB 1
++%define CONFIG_GPLV3 0
++%define CONFIG_H263DSP 1
++%define CONFIG_H264CHROMA 1
++%define CONFIG_H264DSP 1
++%define CONFIG_H264PARSE 1
++%define CONFIG_H264PRED 1
++%define CONFIG_H264QPEL 1
++%define CONFIG_H264_SEI 1
++%define CONFIG_HEVCPARSE 0
++%define CONFIG_HEVC_SEI 0
++%define CONFIG_HPELDSP 1
++%define CONFIG_HUFFMAN 0
++%define CONFIG_HUFFYUVDSP 0
++%define CONFIG_HUFFYUVENCDSP 0
++%define CONFIG_IDCTDSP 1
++%define CONFIG_IIRFILTER 0
++%define CONFIG_INFLATE_WRAPPER 0
++%define CONFIG_INTRAX8 0
++%define CONFIG_ISO_MEDIA 1
++%define CONFIG_IVIDSP 0
++%define CONFIG_JPEGTABLES 0
++%define CONFIG_LGPLV3 0
++%define CONFIG_LIBX262 0
++%define CONFIG_LLAUDDSP 0
++%define CONFIG_LLVIDDSP 0
++%define CONFIG_LLVIDENCDSP 0
++%define CONFIG_LPC 0
++%define CONFIG_LZF 0
++%define CONFIG_ME_CMP 1
++%define CONFIG_MPEG_ER 1
++%define CONFIG_MPEGAUDIO 1
++%define CONFIG_MPEGAUDIODSP 1
++%define CONFIG_MPEGAUDIOHEADER 1
++%define CONFIG_MPEG4AUDIO 1
++%define CONFIG_MPEGVIDEO 1
++%define CONFIG_MPEGVIDEODEC 1
++%define CONFIG_MPEGVIDEOENC 0
++%define CONFIG_MSMPEG4DEC 0
++%define CONFIG_MSMPEG4ENC 0
++%define CONFIG_MSS34DSP 0
++%define CONFIG_PIXBLOCKDSP 0
++%define CONFIG_QPELDSP 1
++%define CONFIG_QSV 0
++%define CONFIG_QSVDEC 0
++%define CONFIG_QSVENC 0
++%define CONFIG_QSVVPP 0
++%define CONFIG_RANGECODER 0
++%define CONFIG_RIFFDEC 1
++%define CONFIG_RIFFENC 0
++%define CONFIG_RTPDEC 0
++%define CONFIG_RTPENC_CHAIN 0
++%define CONFIG_RV34DSP 0
++%define CONFIG_SCENE_SAD 0
++%define CONFIG_SINEWIN 1
++%define CONFIG_SNAPPY 0
++%define CONFIG_SRTP 0
++%define CONFIG_STARTCODE 1
++%define CONFIG_TEXTUREDSP 0
++%define CONFIG_TEXTUREDSPENC 0
++%define CONFIG_TPELDSP 0
++%define CONFIG_VAAPI_1 0
++%define CONFIG_VAAPI_ENCODE 0
++%define CONFIG_VC1DSP 0
++%define CONFIG_VIDEODSP 1
++%define CONFIG_VP3DSP 1
++%define CONFIG_VP56DSP 0
++%define CONFIG_VP8DSP 1
++%define CONFIG_WMA_FREQS 0
++%define CONFIG_WMV2DSP 0
+diff --git a/chromium/config/ChromeOS/linux/x64/config.h b/chromium/config/ChromeOS/linux/x64/config.h
+new file mode 100644
+index 0000000000..be8d6c4a7f
+--- /dev/null
++++ b/chromium/config/ChromeOS/linux/x64/config.h
+@@ -0,0 +1,751 @@
++/* Automatically generated by configure - do not modify! */
++#ifndef FFMPEG_CONFIG_H
++#define FFMPEG_CONFIG_H
++/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-fft --enable-rdft --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/home/kxxt/electron-ci/sources/electron/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\"-O2\"' --enable-decoder='theora,vp8' --enable-parser='vp3,vp8' --enable-lto --arch=x86_64 --target-os=linux --enable-pic --cc=clang --cxx=clang++ --ld=clang --extra-ldflags='-fuse-ld=lld' --enable-decoder='aac,h264' --enable-demuxer=aac --enable-parser='aac,h264' --enable-decoder=mpeg4 --enable-parser='h263,mpeg4video' --enable-demuxer=avi" -- elide long configuration string from binary */
++#define FFMPEG_LICENSE "LGPL version 2.1 or later"
++#define CONFIG_THIS_YEAR 2023
++#define FFMPEG_DATADIR "/usr/local/share/ffmpeg"
++#define AVCONV_DATADIR "/usr/local/share/ffmpeg"
++#define CC_IDENT "clang version 17.0.0 (https://chromium.googlesource.com/external/github.com/llvm/llvm-project 7586aeab7ad3fb035752eea89fd2bb895de21143)"
++#define OS_NAME linux
++#define av_restrict restrict
++#define EXTERN_PREFIX ""
++#define EXTERN_ASM 
++#define BUILDSUF ""
++#define SLIBSUF ".so"
++#define HAVE_MMX2 HAVE_MMXEXT
++#define SWS_MAX_FILTER_SIZE 256
++#define ARCH_AARCH64 0
++#define ARCH_ALPHA 0
++#define ARCH_ARM 0
++#define ARCH_AVR32 0
++#define ARCH_AVR32_AP 0
++#define ARCH_AVR32_UC 0
++#define ARCH_BFIN 0
++#define ARCH_IA64 0
++#define ARCH_LOONGARCH 0
++#define ARCH_LOONGARCH32 0
++#define ARCH_LOONGARCH64 0
++#define ARCH_M68K 0
++#define ARCH_MIPS 0
++#define ARCH_MIPS64 0
++#define ARCH_PARISC 0
++#define ARCH_PPC 0
++#define ARCH_PPC64 0
++#define ARCH_RISCV 0
++#define ARCH_S390 0
++#define ARCH_SH4 0
++#define ARCH_SPARC 0
++#define ARCH_SPARC64 0
++#define ARCH_TILEGX 0
++#define ARCH_TILEPRO 0
++#define ARCH_TOMI 0
++#define ARCH_X86 1
++#define ARCH_X86_32 0
++#define ARCH_X86_64 1
++#define HAVE_ARMV5TE 0
++#define HAVE_ARMV6 0
++#define HAVE_ARMV6T2 0
++#define HAVE_ARMV8 0
++#define HAVE_NEON 0
++#define HAVE_VFP 0
++#define HAVE_VFPV3 0
++#define HAVE_SETEND 0
++#define HAVE_ALTIVEC 0
++#define HAVE_DCBZL 0
++#define HAVE_LDBRX 0
++#define HAVE_POWER8 0
++#define HAVE_PPC4XX 0
++#define HAVE_VSX 0
++#define HAVE_RVV 0
++#define HAVE_AESNI 1
++#define HAVE_AMD3DNOW 1
++#define HAVE_AMD3DNOWEXT 1
++#define HAVE_AVX 1
++#define HAVE_AVX2 1
++#define HAVE_AVX512 1
++#define HAVE_AVX512ICL 1
++#define HAVE_FMA3 1
++#define HAVE_FMA4 1
++#define HAVE_MMX 1
++#define HAVE_MMXEXT 1
++#define HAVE_SSE 1
++#define HAVE_SSE2 1
++#define HAVE_SSE3 1
++#define HAVE_SSE4 1
++#define HAVE_SSE42 1
++#define HAVE_SSSE3 1
++#define HAVE_XOP 1
++#define HAVE_CPUNOP 0
++#define HAVE_I686 1
++#define HAVE_MIPSFPU 0
++#define HAVE_MIPS32R2 0
++#define HAVE_MIPS32R5 0
++#define HAVE_MIPS64R2 0
++#define HAVE_MIPS32R6 0
++#define HAVE_MIPS64R6 0
++#define HAVE_MIPSDSP 0
++#define HAVE_MIPSDSPR2 0
++#define HAVE_MSA 0
++#define HAVE_LOONGSON2 0
++#define HAVE_LOONGSON3 0
++#define HAVE_MMI 0
++#define HAVE_LSX 0
++#define HAVE_LASX 0
++#define HAVE_ARMV5TE_EXTERNAL 0
++#define HAVE_ARMV6_EXTERNAL 0
++#define HAVE_ARMV6T2_EXTERNAL 0
++#define HAVE_ARMV8_EXTERNAL 0
++#define HAVE_NEON_EXTERNAL 0
++#define HAVE_VFP_EXTERNAL 0
++#define HAVE_VFPV3_EXTERNAL 0
++#define HAVE_SETEND_EXTERNAL 0
++#define HAVE_ALTIVEC_EXTERNAL 0
++#define HAVE_DCBZL_EXTERNAL 0
++#define HAVE_LDBRX_EXTERNAL 0
++#define HAVE_POWER8_EXTERNAL 0
++#define HAVE_PPC4XX_EXTERNAL 0
++#define HAVE_VSX_EXTERNAL 0
++#define HAVE_RVV_EXTERNAL 0
++#define HAVE_AESNI_EXTERNAL 1
++#define HAVE_AMD3DNOW_EXTERNAL 1
++#define HAVE_AMD3DNOWEXT_EXTERNAL 1
++#define HAVE_AVX_EXTERNAL 1
++#define HAVE_AVX2_EXTERNAL 1
++#define HAVE_AVX512_EXTERNAL 1
++#define HAVE_AVX512ICL_EXTERNAL 1
++#define HAVE_FMA3_EXTERNAL 1
++#define HAVE_FMA4_EXTERNAL 1
++#define HAVE_MMX_EXTERNAL 1
++#define HAVE_MMXEXT_EXTERNAL 1
++#define HAVE_SSE_EXTERNAL 1
++#define HAVE_SSE2_EXTERNAL 1
++#define HAVE_SSE3_EXTERNAL 1
++#define HAVE_SSE4_EXTERNAL 1
++#define HAVE_SSE42_EXTERNAL 1
++#define HAVE_SSSE3_EXTERNAL 1
++#define HAVE_XOP_EXTERNAL 1
++#define HAVE_CPUNOP_EXTERNAL 0
++#define HAVE_I686_EXTERNAL 0
++#define HAVE_MIPSFPU_EXTERNAL 0
++#define HAVE_MIPS32R2_EXTERNAL 0
++#define HAVE_MIPS32R5_EXTERNAL 0
++#define HAVE_MIPS64R2_EXTERNAL 0
++#define HAVE_MIPS32R6_EXTERNAL 0
++#define HAVE_MIPS64R6_EXTERNAL 0
++#define HAVE_MIPSDSP_EXTERNAL 0
++#define HAVE_MIPSDSPR2_EXTERNAL 0
++#define HAVE_MSA_EXTERNAL 0
++#define HAVE_LOONGSON2_EXTERNAL 0
++#define HAVE_LOONGSON3_EXTERNAL 0
++#define HAVE_MMI_EXTERNAL 0
++#define HAVE_LSX_EXTERNAL 0
++#define HAVE_LASX_EXTERNAL 0
++#define HAVE_ARMV5TE_INLINE 0
++#define HAVE_ARMV6_INLINE 0
++#define HAVE_ARMV6T2_INLINE 0
++#define HAVE_ARMV8_INLINE 0
++#define HAVE_NEON_INLINE 0
++#define HAVE_VFP_INLINE 0
++#define HAVE_VFPV3_INLINE 0
++#define HAVE_SETEND_INLINE 0
++#define HAVE_ALTIVEC_INLINE 0
++#define HAVE_DCBZL_INLINE 0
++#define HAVE_LDBRX_INLINE 0
++#define HAVE_POWER8_INLINE 0
++#define HAVE_PPC4XX_INLINE 0
++#define HAVE_VSX_INLINE 0
++#define HAVE_RVV_INLINE 0
++#define HAVE_AESNI_INLINE 1
++#define HAVE_AMD3DNOW_INLINE 1
++#define HAVE_AMD3DNOWEXT_INLINE 1
++#define HAVE_AVX_INLINE 1
++#define HAVE_AVX2_INLINE 1
++#define HAVE_AVX512_INLINE 1
++#define HAVE_AVX512ICL_INLINE 1
++#define HAVE_FMA3_INLINE 1
++#define HAVE_FMA4_INLINE 1
++#define HAVE_MMX_INLINE 1
++#define HAVE_MMXEXT_INLINE 1
++#define HAVE_SSE_INLINE 1
++#define HAVE_SSE2_INLINE 1
++#define HAVE_SSE3_INLINE 1
++#define HAVE_SSE4_INLINE 1
++#define HAVE_SSE42_INLINE 1
++#define HAVE_SSSE3_INLINE 1
++#define HAVE_XOP_INLINE 1
++#define HAVE_CPUNOP_INLINE 0
++#define HAVE_I686_INLINE 0
++#define HAVE_MIPSFPU_INLINE 0
++#define HAVE_MIPS32R2_INLINE 0
++#define HAVE_MIPS32R5_INLINE 0
++#define HAVE_MIPS64R2_INLINE 0
++#define HAVE_MIPS32R6_INLINE 0
++#define HAVE_MIPS64R6_INLINE 0
++#define HAVE_MIPSDSP_INLINE 0
++#define HAVE_MIPSDSPR2_INLINE 0
++#define HAVE_MSA_INLINE 0
++#define HAVE_LOONGSON2_INLINE 0
++#define HAVE_LOONGSON3_INLINE 0
++#define HAVE_MMI_INLINE 0
++#define HAVE_LSX_INLINE 0
++#define HAVE_LASX_INLINE 0
++#define HAVE_ALIGNED_STACK 1
++#define HAVE_FAST_64BIT 1
++#define HAVE_FAST_CLZ 1
++#define HAVE_FAST_CMOV 1
++#define HAVE_FAST_FLOAT16 0
++#define HAVE_LOCAL_ALIGNED 1
++#define HAVE_SIMD_ALIGN_16 1
++#define HAVE_SIMD_ALIGN_32 1
++#define HAVE_SIMD_ALIGN_64 1
++#define HAVE_ATOMIC_CAS_PTR 0
++#define HAVE_MACHINE_RW_BARRIER 0
++#define HAVE_MEMORYBARRIER 0
++#define HAVE_MM_EMPTY 1
++#define HAVE_RDTSC 0
++#define HAVE_SEM_TIMEDWAIT 1
++#define HAVE_SYNC_VAL_COMPARE_AND_SWAP 1
++#define HAVE_INLINE_ASM 1
++#define HAVE_SYMVER 0
++#define HAVE_X86ASM 1
++#define HAVE_BIGENDIAN 0
++#define HAVE_FAST_UNALIGNED 1
++#define HAVE_ARPA_INET_H 0
++#define HAVE_ASM_TYPES_H 1
++#define HAVE_CDIO_PARANOIA_H 0
++#define HAVE_CDIO_PARANOIA_PARANOIA_H 0
++#define HAVE_CUDA_H 0
++#define HAVE_DISPATCH_DISPATCH_H 0
++#define HAVE_DEV_BKTR_IOCTL_BT848_H 0
++#define HAVE_DEV_BKTR_IOCTL_METEOR_H 0
++#define HAVE_DEV_IC_BT8XX_H 0
++#define HAVE_DEV_VIDEO_BKTR_IOCTL_BT848_H 0
++#define HAVE_DEV_VIDEO_METEOR_IOCTL_METEOR_H 0
++#define HAVE_DIRECT_H 0
++#define HAVE_DIRENT_H 1
++#define HAVE_DXGIDEBUG_H 0
++#define HAVE_DXVA_H 0
++#define HAVE_ES2_GL_H 0
++#define HAVE_GSM_H 0
++#define HAVE_IO_H 0
++#define HAVE_LINUX_DMA_BUF_H 0
++#define HAVE_LINUX_PERF_EVENT_H 1
++#define HAVE_MACHINE_IOCTL_BT848_H 0
++#define HAVE_MACHINE_IOCTL_METEOR_H 0
++#define HAVE_MALLOC_H 1
++#define HAVE_OPENCV2_CORE_CORE_C_H 0
++#define HAVE_OPENGL_GL3_H 0
++#define HAVE_POLL_H 1
++#define HAVE_SYS_PARAM_H 1
++#define HAVE_SYS_RESOURCE_H 1
++#define HAVE_SYS_SELECT_H 1
++#define HAVE_SYS_SOUNDCARD_H 1
++#define HAVE_SYS_TIME_H 1
++#define HAVE_SYS_UN_H 1
++#define HAVE_SYS_VIDEOIO_H 0
++#define HAVE_TERMIOS_H 1
++#define HAVE_UDPLITE_H 0
++#define HAVE_UNISTD_H 1
++#define HAVE_VALGRIND_VALGRIND_H 0 /* #define HAVE_VALGRIND_VALGRIND_H 0 -- forced to 0. See https://crbug.com/590440 */
++#define HAVE_WINDOWS_H 0
++#define HAVE_WINSOCK2_H 0
++#define HAVE_INTRINSICS_NEON 0
++#define HAVE_ATANF 1
++#define HAVE_ATAN2F 1
++#define HAVE_CBRT 1
++#define HAVE_CBRTF 1
++#define HAVE_COPYSIGN 1
++#define HAVE_COSF 1
++#define HAVE_ERF 1
++#define HAVE_EXP2 1
++#define HAVE_EXP2F 1
++#define HAVE_EXPF 1
++#define HAVE_HYPOT 1
++#define HAVE_ISFINITE 1
++#define HAVE_ISINF 1
++#define HAVE_ISNAN 1
++#define HAVE_LDEXPF 1
++#define HAVE_LLRINT 1
++#define HAVE_LLRINTF 1
++#define HAVE_LOG2 1
++#define HAVE_LOG2F 1
++#define HAVE_LOG10F 1
++#define HAVE_LRINT 1
++#define HAVE_LRINTF 1
++#define HAVE_POWF 1
++#define HAVE_RINT 1
++#define HAVE_ROUND 1
++#define HAVE_ROUNDF 1
++#define HAVE_SINF 1
++#define HAVE_TRUNC 1
++#define HAVE_TRUNCF 1
++#define HAVE_DOS_PATHS 0
++#define HAVE_LIBC_MSVCRT 0
++#define HAVE_MMAL_PARAMETER_VIDEO_MAX_NUM_CALLBACKS 0
++#define HAVE_SECTION_DATA_REL_RO 1
++#define HAVE_THREADS 1
++#define HAVE_UWP 0
++#define HAVE_WINRT 0
++#define HAVE_ACCESS 1
++#define HAVE_ALIGNED_MALLOC 0
++#define HAVE_ARC4RANDOM 0
++#define HAVE_CLOCK_GETTIME 1
++#define HAVE_CLOSESOCKET 0
++#define HAVE_COMMANDLINETOARGVW 0
++#define HAVE_FCNTL 1
++#define HAVE_GETADDRINFO 0
++#define HAVE_GETAUXVAL 1
++#define HAVE_GETENV 1
++#define HAVE_GETHRTIME 0
++#define HAVE_GETOPT 1
++#define HAVE_GETMODULEHANDLE 0
++#define HAVE_GETPROCESSAFFINITYMASK 0
++#define HAVE_GETPROCESSMEMORYINFO 0
++#define HAVE_GETPROCESSTIMES 0
++#define HAVE_GETRUSAGE 1
++#define HAVE_GETSTDHANDLE 0
++#define HAVE_GETSYSTEMTIMEASFILETIME 0
++#define HAVE_GETTIMEOFDAY 1
++#define HAVE_GLOB 1
++#define HAVE_GLXGETPROCADDRESS 0
++#define HAVE_GMTIME_R 1
++#define HAVE_INET_ATON 0
++#define HAVE_ISATTY 1
++#define HAVE_KBHIT 0
++#define HAVE_LOCALTIME_R 1
++#define HAVE_LSTAT 1
++#define HAVE_LZO1X_999_COMPRESS 0
++#define HAVE_MACH_ABSOLUTE_TIME 0
++#define HAVE_MAPVIEWOFFILE 0
++#define HAVE_MEMALIGN 1
++#define HAVE_MKSTEMP 1
++#define HAVE_MMAP 1
++#define HAVE_MPROTECT 1
++#define HAVE_NANOSLEEP 1
++#define HAVE_PEEKNAMEDPIPE 0
++#define HAVE_POSIX_MEMALIGN 1
++#define HAVE_PRCTL 0 /* #define HAVE_PRCTL 1 -- forced to 0 for Fuchsia */
++#define HAVE_PTHREAD_CANCEL 1
++#define HAVE_SCHED_GETAFFINITY 1
++#define HAVE_SECITEMIMPORT 0
++#define HAVE_SETCONSOLETEXTATTRIBUTE 0
++#define HAVE_SETCONSOLECTRLHANDLER 0
++#define HAVE_SETDLLDIRECTORY 0
++#define HAVE_SETMODE 0
++#define HAVE_SETRLIMIT 1
++#define HAVE_SLEEP 0
++#define HAVE_STRERROR_R 1
++#define HAVE_SYSCONF 1
++#define HAVE_SYSCTL 0 /* #define HAVE_SYSCTL 0 -- forced to 0 for Fuchsia */
++#define HAVE_USLEEP 1
++#define HAVE_UTGETOSTYPEFROMSTRING 0
++#define HAVE_VIRTUALALLOC 0
++#define HAVE_WGLGETPROCADDRESS 0
++#define HAVE_BCRYPT 0
++#define HAVE_VAAPI_DRM 0
++#define HAVE_VAAPI_X11 0
++#define HAVE_VAAPI_WIN32 0
++#define HAVE_VDPAU_X11 0
++#define HAVE_PTHREADS 1
++#define HAVE_OS2THREADS 0
++#define HAVE_W32THREADS 0
++#define HAVE_AS_ARCH_DIRECTIVE 0
++#define HAVE_AS_DN_DIRECTIVE 0
++#define HAVE_AS_FPU_DIRECTIVE 0
++#define HAVE_AS_FUNC 0
++#define HAVE_AS_OBJECT_ARCH 0
++#define HAVE_ASM_MOD_Q 0
++#define HAVE_BLOCKS_EXTENSION 0
++#define HAVE_EBP_AVAILABLE 1
++#define HAVE_EBX_AVAILABLE 1
++#define HAVE_GNU_AS 0
++#define HAVE_GNU_WINDRES 0
++#define HAVE_IBM_ASM 0
++#define HAVE_INLINE_ASM_DIRECT_SYMBOL_REFS 0
++#define HAVE_INLINE_ASM_LABELS 1
++#define HAVE_INLINE_ASM_NONLOCAL_LABELS 1
++#define HAVE_PRAGMA_DEPRECATED 1
++#define HAVE_RSYNC_CONTIMEOUT 0
++#define HAVE_SYMVER_ASM_LABEL 1
++#define HAVE_SYMVER_GNU_ASM 1
++#define HAVE_VFP_ARGS 0
++#define HAVE_XFORM_ASM 0
++#define HAVE_XMM_CLOBBERS 1
++#define HAVE_DPI_AWARENESS_CONTEXT 0
++#define HAVE_IDXGIOUTPUT5 0
++#define HAVE_KCMVIDEOCODECTYPE_HEVC 0
++#define HAVE_KCMVIDEOCODECTYPE_HEVCWITHALPHA 0
++#define HAVE_KCMVIDEOCODECTYPE_VP9 0
++#define HAVE_KCVPIXELFORMATTYPE_420YPCBCR10BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR8BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR10BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR16BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR8BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR10BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR16BIPLANARVIDEORANGE 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_2084_PQ 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2100_HLG 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_LINEAR 0
++#define HAVE_KCVIMAGEBUFFERYCBCRMATRIX_ITU_R_2020 0
++#define HAVE_KCVIMAGEBUFFERCOLORPRIMARIES_ITU_R_2020 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2020 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_428_1 0
++#define HAVE_SOCKLEN_T 0
++#define HAVE_STRUCT_ADDRINFO 0
++#define HAVE_STRUCT_GROUP_SOURCE_REQ 0
++#define HAVE_STRUCT_IP_MREQ_SOURCE 0
++#define HAVE_STRUCT_IPV6_MREQ 0
++#define HAVE_STRUCT_MSGHDR_MSG_FLAGS 0
++#define HAVE_STRUCT_POLLFD 0
++#define HAVE_STRUCT_RUSAGE_RU_MAXRSS 1
++#define HAVE_STRUCT_SCTP_EVENT_SUBSCRIBE 0
++#define HAVE_STRUCT_SOCKADDR_IN6 0
++#define HAVE_STRUCT_SOCKADDR_SA_LEN 0
++#define HAVE_STRUCT_SOCKADDR_STORAGE 0
++#define HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC 1
++#define HAVE_STRUCT_V4L2_FRMIVALENUM_DISCRETE 0
++#define HAVE_GZIP 1
++#define HAVE_LIBDRM_GETFB2 0
++#define HAVE_MAKEINFO 0
++#define HAVE_MAKEINFO_HTML 0
++#define HAVE_OPENCL_D3D11 0
++#define HAVE_OPENCL_DRM_ARM 0
++#define HAVE_OPENCL_DRM_BEIGNET 0
++#define HAVE_OPENCL_DXVA2 0
++#define HAVE_OPENCL_VAAPI_BEIGNET 0
++#define HAVE_OPENCL_VAAPI_INTEL_MEDIA 0
++#define HAVE_PERL 1
++#define HAVE_POD2MAN 1
++#define HAVE_TEXI2HTML 0
++#define HAVE_XMLLINT 0
++#define HAVE_ZLIB_GZIP 0
++#define CONFIG_DOC 0
++#define CONFIG_HTMLPAGES 0
++#define CONFIG_MANPAGES 0
++#define CONFIG_PODPAGES 0
++#define CONFIG_TXTPAGES 0
++#define CONFIG_AVIO_HTTP_SERVE_FILES_EXAMPLE 1
++#define CONFIG_AVIO_LIST_DIR_EXAMPLE 1
++#define CONFIG_AVIO_READ_CALLBACK_EXAMPLE 1
++#define CONFIG_DECODE_AUDIO_EXAMPLE 1
++#define CONFIG_DECODE_FILTER_AUDIO_EXAMPLE 0
++#define CONFIG_DECODE_FILTER_VIDEO_EXAMPLE 0
++#define CONFIG_DECODE_VIDEO_EXAMPLE 1
++#define CONFIG_DEMUX_DECODE_EXAMPLE 1
++#define CONFIG_ENCODE_AUDIO_EXAMPLE 1
++#define CONFIG_ENCODE_VIDEO_EXAMPLE 1
++#define CONFIG_EXTRACT_MVS_EXAMPLE 1
++#define CONFIG_FILTER_AUDIO_EXAMPLE 0
++#define CONFIG_HW_DECODE_EXAMPLE 1
++#define CONFIG_MUX_EXAMPLE 0
++#define CONFIG_QSV_DECODE_EXAMPLE 0
++#define CONFIG_REMUX_EXAMPLE 1
++#define CONFIG_RESAMPLE_AUDIO_EXAMPLE 0
++#define CONFIG_SCALE_VIDEO_EXAMPLE 0
++#define CONFIG_SHOW_METADATA_EXAMPLE 1
++#define CONFIG_TRANSCODE_AAC_EXAMPLE 0
++#define CONFIG_TRANSCODE_EXAMPLE 0
++#define CONFIG_VAAPI_ENCODE_EXAMPLE 0
++#define CONFIG_VAAPI_TRANSCODE_EXAMPLE 0
++#define CONFIG_QSV_TRANSCODE_EXAMPLE 0
++#define CONFIG_AVISYNTH 0
++#define CONFIG_FREI0R 0
++#define CONFIG_LIBCDIO 0
++#define CONFIG_LIBDAVS2 0
++#define CONFIG_LIBRUBBERBAND 0
++#define CONFIG_LIBVIDSTAB 0
++#define CONFIG_LIBX264 0
++#define CONFIG_LIBX265 0
++#define CONFIG_LIBXAVS 0
++#define CONFIG_LIBXAVS2 0
++#define CONFIG_LIBXVID 0
++#define CONFIG_DECKLINK 0
++#define CONFIG_LIBFDK_AAC 0
++#define CONFIG_LIBTLS 0
++#define CONFIG_GMP 0
++#define CONFIG_LIBARIBB24 0
++#define CONFIG_LIBLENSFUN 0
++#define CONFIG_LIBOPENCORE_AMRNB 0
++#define CONFIG_LIBOPENCORE_AMRWB 0
++#define CONFIG_LIBVO_AMRWBENC 0
++#define CONFIG_MBEDTLS 0
++#define CONFIG_RKMPP 0
++#define CONFIG_LIBSMBCLIENT 0
++#define CONFIG_CHROMAPRINT 0
++#define CONFIG_GCRYPT 0
++#define CONFIG_GNUTLS 0
++#define CONFIG_JNI 0
++#define CONFIG_LADSPA 0
++#define CONFIG_LCMS2 0
++#define CONFIG_LIBAOM 0
++#define CONFIG_LIBARIBCAPTION 0
++#define CONFIG_LIBASS 0
++#define CONFIG_LIBBLURAY 0
++#define CONFIG_LIBBS2B 0
++#define CONFIG_LIBCACA 0
++#define CONFIG_LIBCELT 0
++#define CONFIG_LIBCODEC2 0
++#define CONFIG_LIBDAV1D 0
++#define CONFIG_LIBDC1394 0
++#define CONFIG_LIBDRM 0
++#define CONFIG_LIBFLITE 0
++#define CONFIG_LIBFONTCONFIG 0
++#define CONFIG_LIBFREETYPE 0
++#define CONFIG_LIBFRIBIDI 0
++#define CONFIG_LIBGLSLANG 0
++#define CONFIG_LIBGME 0
++#define CONFIG_LIBGSM 0
++#define CONFIG_LIBIEC61883 0
++#define CONFIG_LIBILBC 0
++#define CONFIG_LIBJACK 0
++#define CONFIG_LIBJXL 0
++#define CONFIG_LIBKLVANC 0
++#define CONFIG_LIBKVAZAAR 0
++#define CONFIG_LIBMODPLUG 0
++#define CONFIG_LIBMP3LAME 0
++#define CONFIG_LIBMYSOFA 0
++#define CONFIG_LIBOPENCV 0
++#define CONFIG_LIBOPENH264 0
++#define CONFIG_LIBOPENJPEG 0
++#define CONFIG_LIBOPENMPT 0
++#define CONFIG_LIBOPENVINO 0
++#define CONFIG_LIBOPUS 1
++#define CONFIG_LIBPLACEBO 0
++#define CONFIG_LIBPULSE 0
++#define CONFIG_LIBRABBITMQ 0
++#define CONFIG_LIBRAV1E 0
++#define CONFIG_LIBRIST 0
++#define CONFIG_LIBRSVG 0
++#define CONFIG_LIBRTMP 0
++#define CONFIG_LIBSHADERC 0
++#define CONFIG_LIBSHINE 0
++#define CONFIG_LIBSMBCLIENT 0
++#define CONFIG_LIBSNAPPY 0
++#define CONFIG_LIBSOXR 0
++#define CONFIG_LIBSPEEX 0
++#define CONFIG_LIBSRT 0
++#define CONFIG_LIBSSH 0
++#define CONFIG_LIBSVTAV1 0
++#define CONFIG_LIBTENSORFLOW 0
++#define CONFIG_LIBTESSERACT 0
++#define CONFIG_LIBTHEORA 0
++#define CONFIG_LIBTWOLAME 0
++#define CONFIG_LIBUAVS3D 0
++#define CONFIG_LIBV4L2 0
++#define CONFIG_LIBVMAF 0
++#define CONFIG_LIBVORBIS 0
++#define CONFIG_LIBVPX 0
++#define CONFIG_LIBWEBP 0
++#define CONFIG_LIBXML2 0
++#define CONFIG_LIBZIMG 0
++#define CONFIG_LIBZMQ 0
++#define CONFIG_LIBZVBI 0
++#define CONFIG_LV2 0
++#define CONFIG_MEDIACODEC 0
++#define CONFIG_OPENAL 0
++#define CONFIG_OPENGL 0
++#define CONFIG_OPENSSL 0
++#define CONFIG_POCKETSPHINX 0
++#define CONFIG_VAPOURSYNTH 0
++#define CONFIG_ALSA 0
++#define CONFIG_APPKIT 0
++#define CONFIG_AVFOUNDATION 0
++#define CONFIG_BZLIB 0
++#define CONFIG_COREIMAGE 0
++#define CONFIG_ICONV 0
++#define CONFIG_LIBXCB 0
++#define CONFIG_LIBXCB_SHM 0
++#define CONFIG_LIBXCB_SHAPE 0
++#define CONFIG_LIBXCB_XFIXES 0
++#define CONFIG_LZMA 0
++#define CONFIG_MEDIAFOUNDATION 0
++#define CONFIG_METAL 0
++#define CONFIG_SCHANNEL 0
++#define CONFIG_SDL2 0
++#define CONFIG_SECURETRANSPORT 0
++#define CONFIG_SNDIO 0
++#define CONFIG_XLIB 0
++#define CONFIG_ZLIB 0
++#define CONFIG_CUDA_NVCC 0
++#define CONFIG_CUDA_SDK 0
++#define CONFIG_LIBNPP 0
++#define CONFIG_LIBMFX 0
++#define CONFIG_LIBVPL 0
++#define CONFIG_MMAL 0
++#define CONFIG_OMX 0
++#define CONFIG_OPENCL 0
++#define CONFIG_AMF 0
++#define CONFIG_AUDIOTOOLBOX 0
++#define CONFIG_CRYSTALHD 0
++#define CONFIG_CUDA 0
++#define CONFIG_CUDA_LLVM 0
++#define CONFIG_CUVID 0
++#define CONFIG_D3D11VA 0
++#define CONFIG_DXVA2 0
++#define CONFIG_FFNVCODEC 0
++#define CONFIG_NVDEC 0
++#define CONFIG_NVENC 0
++#define CONFIG_VAAPI 0
++#define CONFIG_VDPAU 0
++#define CONFIG_VIDEOTOOLBOX 0
++#define CONFIG_VULKAN 0
++#define CONFIG_V4L2_M2M 0
++#define CONFIG_FTRAPV 0
++#define CONFIG_GRAY 0
++#define CONFIG_HARDCODED_TABLES 0
++#define CONFIG_OMX_RPI 0
++#define CONFIG_RUNTIME_CPUDETECT 1
++#define CONFIG_SAFE_BITSTREAM_READER 1
++#define CONFIG_SHARED 0
++#define CONFIG_SMALL 0
++#define CONFIG_STATIC 1
++#define CONFIG_SWSCALE_ALPHA 1
++#define CONFIG_GPL 0
++#define CONFIG_NONFREE 0
++#define CONFIG_VERSION3 0
++#define CONFIG_AVDEVICE 0
++#define CONFIG_AVFILTER 0
++#define CONFIG_SWSCALE 0
++#define CONFIG_POSTPROC 0
++#define CONFIG_AVFORMAT 1
++#define CONFIG_AVCODEC 1
++#define CONFIG_SWRESAMPLE 0
++#define CONFIG_AVUTIL 1
++#define CONFIG_FFPLAY 0
++#define CONFIG_FFPROBE 0
++#define CONFIG_FFMPEG 0
++#define CONFIG_DCT 1
++#define CONFIG_DWT 0
++#define CONFIG_ERROR_RESILIENCE 1
++#define CONFIG_FAAN 0
++#define CONFIG_FAST_UNALIGNED 1
++#define CONFIG_FFT 1
++#define CONFIG_LSP 0
++#define CONFIG_MDCT 0
++#define CONFIG_PIXELUTILS 0
++#define CONFIG_NETWORK 0
++#define CONFIG_RDFT 1
++#define CONFIG_AUTODETECT 0
++#define CONFIG_FONTCONFIG 0
++#define CONFIG_LARGE_TESTS 1
++#define CONFIG_LINUX_PERF 0
++#define CONFIG_MACOS_KPERF 0
++#define CONFIG_MEMORY_POISONING 0
++#define CONFIG_NEON_CLOBBER_TEST 0
++#define CONFIG_OSSFUZZ 0
++#define CONFIG_PIC 1
++#define CONFIG_PTX_COMPRESSION 0
++#define CONFIG_THUMB 0
++#define CONFIG_VALGRIND_BACKTRACE 0
++#define CONFIG_XMM_CLOBBER_TEST 0
++#define CONFIG_BSFS 0
++#define CONFIG_DECODERS 1
++#define CONFIG_ENCODERS 0
++#define CONFIG_HWACCELS 0
++#define CONFIG_PARSERS 1
++#define CONFIG_INDEVS 0
++#define CONFIG_OUTDEVS 0
++#define CONFIG_FILTERS 0
++#define CONFIG_DEMUXERS 1
++#define CONFIG_MUXERS 0
++#define CONFIG_PROTOCOLS 0
++#define CONFIG_AANDCTTABLES 0
++#define CONFIG_AC3DSP 0
++#define CONFIG_ADTS_HEADER 1
++#define CONFIG_ATSC_A53 1
++#define CONFIG_AUDIO_FRAME_QUEUE 0
++#define CONFIG_AUDIODSP 0
++#define CONFIG_BLOCKDSP 1
++#define CONFIG_BSWAPDSP 0
++#define CONFIG_CABAC 1
++#define CONFIG_CBS 0
++#define CONFIG_CBS_AV1 0
++#define CONFIG_CBS_H264 0
++#define CONFIG_CBS_H265 0
++#define CONFIG_CBS_JPEG 0
++#define CONFIG_CBS_MPEG2 0
++#define CONFIG_CBS_VP9 0
++#define CONFIG_DEFLATE_WRAPPER 0
++#define CONFIG_DIRAC_PARSE 1
++#define CONFIG_DNN 0
++#define CONFIG_DOVI_RPU 0
++#define CONFIG_DVPROFILE 0
++#define CONFIG_EXIF 1
++#define CONFIG_FAANDCT 0
++#define CONFIG_FAANIDCT 0
++#define CONFIG_FDCTDSP 0
++#define CONFIG_FMTCONVERT 0
++#define CONFIG_FRAME_THREAD_ENCODER 0
++#define CONFIG_G722DSP 0
++#define CONFIG_GOLOMB 1
++#define CONFIG_GPLV3 0
++#define CONFIG_H263DSP 1
++#define CONFIG_H264CHROMA 1
++#define CONFIG_H264DSP 1
++#define CONFIG_H264PARSE 1
++#define CONFIG_H264PRED 1
++#define CONFIG_H264QPEL 1
++#define CONFIG_H264_SEI 1
++#define CONFIG_HEVCPARSE 0
++#define CONFIG_HEVC_SEI 0
++#define CONFIG_HPELDSP 1
++#define CONFIG_HUFFMAN 0
++#define CONFIG_HUFFYUVDSP 0
++#define CONFIG_HUFFYUVENCDSP 0
++#define CONFIG_IDCTDSP 1
++#define CONFIG_IIRFILTER 0
++#define CONFIG_INFLATE_WRAPPER 0
++#define CONFIG_INTRAX8 0
++#define CONFIG_ISO_MEDIA 1
++#define CONFIG_IVIDSP 0
++#define CONFIG_JPEGTABLES 0
++#define CONFIG_LGPLV3 0
++#define CONFIG_LIBX262 0
++#define CONFIG_LLAUDDSP 0
++#define CONFIG_LLVIDDSP 0
++#define CONFIG_LLVIDENCDSP 0
++#define CONFIG_LPC 0
++#define CONFIG_LZF 0
++#define CONFIG_ME_CMP 1
++#define CONFIG_MPEG_ER 1
++#define CONFIG_MPEGAUDIO 1
++#define CONFIG_MPEGAUDIODSP 1
++#define CONFIG_MPEGAUDIOHEADER 1
++#define CONFIG_MPEG4AUDIO 1
++#define CONFIG_MPEGVIDEO 1
++#define CONFIG_MPEGVIDEODEC 1
++#define CONFIG_MPEGVIDEOENC 0
++#define CONFIG_MSMPEG4DEC 0
++#define CONFIG_MSMPEG4ENC 0
++#define CONFIG_MSS34DSP 0
++#define CONFIG_PIXBLOCKDSP 0
++#define CONFIG_QPELDSP 1
++#define CONFIG_QSV 0
++#define CONFIG_QSVDEC 0
++#define CONFIG_QSVENC 0
++#define CONFIG_QSVVPP 0
++#define CONFIG_RANGECODER 0
++#define CONFIG_RIFFDEC 1
++#define CONFIG_RIFFENC 0
++#define CONFIG_RTPDEC 0
++#define CONFIG_RTPENC_CHAIN 0
++#define CONFIG_RV34DSP 0
++#define CONFIG_SCENE_SAD 0
++#define CONFIG_SINEWIN 1
++#define CONFIG_SNAPPY 0
++#define CONFIG_SRTP 0
++#define CONFIG_STARTCODE 1
++#define CONFIG_TEXTUREDSP 0
++#define CONFIG_TEXTUREDSPENC 0
++#define CONFIG_TPELDSP 0
++#define CONFIG_VAAPI_1 0
++#define CONFIG_VAAPI_ENCODE 0
++#define CONFIG_VC1DSP 0
++#define CONFIG_VIDEODSP 1
++#define CONFIG_VP3DSP 1
++#define CONFIG_VP56DSP 0
++#define CONFIG_VP8DSP 1
++#define CONFIG_WMA_FREQS 0
++#define CONFIG_WMV2DSP 0
++#endif /* FFMPEG_CONFIG_H */
+diff --git a/chromium/config/ChromeOS/linux/x64/config_components.h b/chromium/config/ChromeOS/linux/x64/config_components.h
+new file mode 100644
+index 0000000000..4290dbef99
+--- /dev/null
++++ b/chromium/config/ChromeOS/linux/x64/config_components.h
+@@ -0,0 +1,2164 @@
++/* Automatically generated by configure - do not modify! */
++#ifndef FFMPEG_CONFIG_COMPONENTS_H
++#define FFMPEG_CONFIG_COMPONENTS_H
++#define CONFIG_AAC_ADTSTOASC_BSF 0
++#define CONFIG_AV1_FRAME_MERGE_BSF 0
++#define CONFIG_AV1_FRAME_SPLIT_BSF 0
++#define CONFIG_AV1_METADATA_BSF 0
++#define CONFIG_CHOMP_BSF 0
++#define CONFIG_DUMP_EXTRADATA_BSF 0
++#define CONFIG_DCA_CORE_BSF 0
++#define CONFIG_DTS2PTS_BSF 0
++#define CONFIG_DV_ERROR_MARKER_BSF 0
++#define CONFIG_EAC3_CORE_BSF 0
++#define CONFIG_EXTRACT_EXTRADATA_BSF 0
++#define CONFIG_FILTER_UNITS_BSF 0
++#define CONFIG_H264_METADATA_BSF 0
++#define CONFIG_H264_MP4TOANNEXB_BSF 0
++#define CONFIG_H264_REDUNDANT_PPS_BSF 0
++#define CONFIG_HAPQA_EXTRACT_BSF 0
++#define CONFIG_HEVC_METADATA_BSF 0
++#define CONFIG_HEVC_MP4TOANNEXB_BSF 0
++#define CONFIG_IMX_DUMP_HEADER_BSF 0
++#define CONFIG_MEDIA100_TO_MJPEGB_BSF 0
++#define CONFIG_MJPEG2JPEG_BSF 0
++#define CONFIG_MJPEGA_DUMP_HEADER_BSF 0
++#define CONFIG_MP3_HEADER_DECOMPRESS_BSF 0
++#define CONFIG_MPEG2_METADATA_BSF 0
++#define CONFIG_MPEG4_UNPACK_BFRAMES_BSF 0
++#define CONFIG_MOV2TEXTSUB_BSF 0
++#define CONFIG_NOISE_BSF 0
++#define CONFIG_NULL_BSF 0
++#define CONFIG_OPUS_METADATA_BSF 0
++#define CONFIG_PCM_RECHUNK_BSF 0
++#define CONFIG_PGS_FRAME_MERGE_BSF 0
++#define CONFIG_PRORES_METADATA_BSF 0
++#define CONFIG_REMOVE_EXTRADATA_BSF 0
++#define CONFIG_SETTS_BSF 0
++#define CONFIG_TEXT2MOVSUB_BSF 0
++#define CONFIG_TRACE_HEADERS_BSF 0
++#define CONFIG_TRUEHD_CORE_BSF 0
++#define CONFIG_VP9_METADATA_BSF 0
++#define CONFIG_VP9_RAW_REORDER_BSF 0
++#define CONFIG_VP9_SUPERFRAME_BSF 0
++#define CONFIG_VP9_SUPERFRAME_SPLIT_BSF 0
++#define CONFIG_AASC_DECODER 0
++#define CONFIG_AIC_DECODER 0
++#define CONFIG_ALIAS_PIX_DECODER 0
++#define CONFIG_AGM_DECODER 0
++#define CONFIG_AMV_DECODER 0
++#define CONFIG_ANM_DECODER 0
++#define CONFIG_ANSI_DECODER 0
++#define CONFIG_APNG_DECODER 0
++#define CONFIG_ARBC_DECODER 0
++#define CONFIG_ARGO_DECODER 0
++#define CONFIG_ASV1_DECODER 0
++#define CONFIG_ASV2_DECODER 0
++#define CONFIG_AURA_DECODER 0
++#define CONFIG_AURA2_DECODER 0
++#define CONFIG_AVRP_DECODER 0
++#define CONFIG_AVRN_DECODER 0
++#define CONFIG_AVS_DECODER 0
++#define CONFIG_AVUI_DECODER 0
++#define CONFIG_AYUV_DECODER 0
++#define CONFIG_BETHSOFTVID_DECODER 0
++#define CONFIG_BFI_DECODER 0
++#define CONFIG_BINK_DECODER 0
++#define CONFIG_BITPACKED_DECODER 0
++#define CONFIG_BMP_DECODER 0
++#define CONFIG_BMV_VIDEO_DECODER 0
++#define CONFIG_BRENDER_PIX_DECODER 0
++#define CONFIG_C93_DECODER 0
++#define CONFIG_CAVS_DECODER 0
++#define CONFIG_CDGRAPHICS_DECODER 0
++#define CONFIG_CDTOONS_DECODER 0
++#define CONFIG_CDXL_DECODER 0
++#define CONFIG_CFHD_DECODER 0
++#define CONFIG_CINEPAK_DECODER 0
++#define CONFIG_CLEARVIDEO_DECODER 0
++#define CONFIG_CLJR_DECODER 0
++#define CONFIG_CLLC_DECODER 0
++#define CONFIG_COMFORTNOISE_DECODER 0
++#define CONFIG_CPIA_DECODER 0
++#define CONFIG_CRI_DECODER 0
++#define CONFIG_CSCD_DECODER 0
++#define CONFIG_CYUV_DECODER 0
++#define CONFIG_DDS_DECODER 0
++#define CONFIG_DFA_DECODER 0
++#define CONFIG_DIRAC_DECODER 0
++#define CONFIG_DNXHD_DECODER 0
++#define CONFIG_DPX_DECODER 0
++#define CONFIG_DSICINVIDEO_DECODER 0
++#define CONFIG_DVAUDIO_DECODER 0
++#define CONFIG_DVVIDEO_DECODER 0
++#define CONFIG_DXA_DECODER 0
++#define CONFIG_DXTORY_DECODER 0
++#define CONFIG_DXV_DECODER 0
++#define CONFIG_EACMV_DECODER 0
++#define CONFIG_EAMAD_DECODER 0
++#define CONFIG_EATGQ_DECODER 0
++#define CONFIG_EATGV_DECODER 0
++#define CONFIG_EATQI_DECODER 0
++#define CONFIG_EIGHTBPS_DECODER 0
++#define CONFIG_EIGHTSVX_EXP_DECODER 0
++#define CONFIG_EIGHTSVX_FIB_DECODER 0
++#define CONFIG_ESCAPE124_DECODER 0
++#define CONFIG_ESCAPE130_DECODER 0
++#define CONFIG_EXR_DECODER 0
++#define CONFIG_FFV1_DECODER 0
++#define CONFIG_FFVHUFF_DECODER 0
++#define CONFIG_FIC_DECODER 0
++#define CONFIG_FITS_DECODER 0
++#define CONFIG_FLASHSV_DECODER 0
++#define CONFIG_FLASHSV2_DECODER 0
++#define CONFIG_FLIC_DECODER 0
++#define CONFIG_FLV_DECODER 0
++#define CONFIG_FMVC_DECODER 0
++#define CONFIG_FOURXM_DECODER 0
++#define CONFIG_FRAPS_DECODER 0
++#define CONFIG_FRWU_DECODER 0
++#define CONFIG_G2M_DECODER 0
++#define CONFIG_GDV_DECODER 0
++#define CONFIG_GEM_DECODER 0
++#define CONFIG_GIF_DECODER 0
++#define CONFIG_H261_DECODER 0
++#define CONFIG_H263_DECODER 1
++#define CONFIG_H263I_DECODER 0
++#define CONFIG_H263P_DECODER 0
++#define CONFIG_H263_V4L2M2M_DECODER 0
++#define CONFIG_H264_DECODER 1
++#define CONFIG_H264_CRYSTALHD_DECODER 0
++#define CONFIG_H264_V4L2M2M_DECODER 0
++#define CONFIG_H264_MEDIACODEC_DECODER 0
++#define CONFIG_H264_MMAL_DECODER 0
++#define CONFIG_H264_QSV_DECODER 0
++#define CONFIG_H264_RKMPP_DECODER 0
++#define CONFIG_HAP_DECODER 0
++#define CONFIG_HEVC_DECODER 0
++#define CONFIG_HEVC_QSV_DECODER 0
++#define CONFIG_HEVC_RKMPP_DECODER 0
++#define CONFIG_HEVC_V4L2M2M_DECODER 0
++#define CONFIG_HNM4_VIDEO_DECODER 0
++#define CONFIG_HQ_HQA_DECODER 0
++#define CONFIG_HQX_DECODER 0
++#define CONFIG_HUFFYUV_DECODER 0
++#define CONFIG_HYMT_DECODER 0
++#define CONFIG_IDCIN_DECODER 0
++#define CONFIG_IFF_ILBM_DECODER 0
++#define CONFIG_IMM4_DECODER 0
++#define CONFIG_IMM5_DECODER 0
++#define CONFIG_INDEO2_DECODER 0
++#define CONFIG_INDEO3_DECODER 0
++#define CONFIG_INDEO4_DECODER 0
++#define CONFIG_INDEO5_DECODER 0
++#define CONFIG_INTERPLAY_VIDEO_DECODER 0
++#define CONFIG_IPU_DECODER 0
++#define CONFIG_JPEG2000_DECODER 0
++#define CONFIG_JPEGLS_DECODER 0
++#define CONFIG_JV_DECODER 0
++#define CONFIG_KGV1_DECODER 0
++#define CONFIG_KMVC_DECODER 0
++#define CONFIG_LAGARITH_DECODER 0
++#define CONFIG_LOCO_DECODER 0
++#define CONFIG_LSCR_DECODER 0
++#define CONFIG_M101_DECODER 0
++#define CONFIG_MAGICYUV_DECODER 0
++#define CONFIG_MDEC_DECODER 0
++#define CONFIG_MEDIA100_DECODER 0
++#define CONFIG_MIMIC_DECODER 0
++#define CONFIG_MJPEG_DECODER 0
++#define CONFIG_MJPEGB_DECODER 0
++#define CONFIG_MMVIDEO_DECODER 0
++#define CONFIG_MOBICLIP_DECODER 0
++#define CONFIG_MOTIONPIXELS_DECODER 0
++#define CONFIG_MPEG1VIDEO_DECODER 0
++#define CONFIG_MPEG2VIDEO_DECODER 0
++#define CONFIG_MPEG4_DECODER 1
++#define CONFIG_MPEG4_CRYSTALHD_DECODER 0
++#define CONFIG_MPEG4_V4L2M2M_DECODER 0
++#define CONFIG_MPEG4_MMAL_DECODER 0
++#define CONFIG_MPEGVIDEO_DECODER 0
++#define CONFIG_MPEG1_V4L2M2M_DECODER 0
++#define CONFIG_MPEG2_MMAL_DECODER 0
++#define CONFIG_MPEG2_CRYSTALHD_DECODER 0
++#define CONFIG_MPEG2_V4L2M2M_DECODER 0
++#define CONFIG_MPEG2_QSV_DECODER 0
++#define CONFIG_MPEG2_MEDIACODEC_DECODER 0
++#define CONFIG_MSA1_DECODER 0
++#define CONFIG_MSCC_DECODER 0
++#define CONFIG_MSMPEG4V1_DECODER 0
++#define CONFIG_MSMPEG4V2_DECODER 0
++#define CONFIG_MSMPEG4V3_DECODER 0
++#define CONFIG_MSMPEG4_CRYSTALHD_DECODER 0
++#define CONFIG_MSP2_DECODER 0
++#define CONFIG_MSRLE_DECODER 0
++#define CONFIG_MSS1_DECODER 0
++#define CONFIG_MSS2_DECODER 0
++#define CONFIG_MSVIDEO1_DECODER 0
++#define CONFIG_MSZH_DECODER 0
++#define CONFIG_MTS2_DECODER 0
++#define CONFIG_MV30_DECODER 0
++#define CONFIG_MVC1_DECODER 0
++#define CONFIG_MVC2_DECODER 0
++#define CONFIG_MVDV_DECODER 0
++#define CONFIG_MVHA_DECODER 0
++#define CONFIG_MWSC_DECODER 0
++#define CONFIG_MXPEG_DECODER 0
++#define CONFIG_NOTCHLC_DECODER 0
++#define CONFIG_NUV_DECODER 0
++#define CONFIG_PAF_VIDEO_DECODER 0
++#define CONFIG_PAM_DECODER 0
++#define CONFIG_PBM_DECODER 0
++#define CONFIG_PCX_DECODER 0
++#define CONFIG_PDV_DECODER 0
++#define CONFIG_PFM_DECODER 0
++#define CONFIG_PGM_DECODER 0
++#define CONFIG_PGMYUV_DECODER 0
++#define CONFIG_PGX_DECODER 0
++#define CONFIG_PHM_DECODER 0
++#define CONFIG_PHOTOCD_DECODER 0
++#define CONFIG_PICTOR_DECODER 0
++#define CONFIG_PIXLET_DECODER 0
++#define CONFIG_PNG_DECODER 0
++#define CONFIG_PPM_DECODER 0
++#define CONFIG_PRORES_DECODER 0
++#define CONFIG_PROSUMER_DECODER 0
++#define CONFIG_PSD_DECODER 0
++#define CONFIG_PTX_DECODER 0
++#define CONFIG_QDRAW_DECODER 0
++#define CONFIG_QOI_DECODER 0
++#define CONFIG_QPEG_DECODER 0
++#define CONFIG_QTRLE_DECODER 0
++#define CONFIG_R10K_DECODER 0
++#define CONFIG_R210_DECODER 0
++#define CONFIG_RASC_DECODER 0
++#define CONFIG_RAWVIDEO_DECODER 0
++#define CONFIG_RKA_DECODER 0
++#define CONFIG_RL2_DECODER 0
++#define CONFIG_ROQ_DECODER 0
++#define CONFIG_RPZA_DECODER 0
++#define CONFIG_RSCC_DECODER 0
++#define CONFIG_RV10_DECODER 0
++#define CONFIG_RV20_DECODER 0
++#define CONFIG_RV30_DECODER 0
++#define CONFIG_RV40_DECODER 0
++#define CONFIG_S302M_DECODER 0
++#define CONFIG_SANM_DECODER 0
++#define CONFIG_SCPR_DECODER 0
++#define CONFIG_SCREENPRESSO_DECODER 0
++#define CONFIG_SGA_DECODER 0
++#define CONFIG_SGI_DECODER 0
++#define CONFIG_SGIRLE_DECODER 0
++#define CONFIG_SHEERVIDEO_DECODER 0
++#define CONFIG_SIMBIOSIS_IMX_DECODER 0
++#define CONFIG_SMACKER_DECODER 0
++#define CONFIG_SMC_DECODER 0
++#define CONFIG_SMVJPEG_DECODER 0
++#define CONFIG_SNOW_DECODER 0
++#define CONFIG_SP5X_DECODER 0
++#define CONFIG_SPEEDHQ_DECODER 0
++#define CONFIG_SPEEX_DECODER 0
++#define CONFIG_SRGC_DECODER 0
++#define CONFIG_SUNRAST_DECODER 0
++#define CONFIG_SVQ1_DECODER 0
++#define CONFIG_SVQ3_DECODER 0
++#define CONFIG_TARGA_DECODER 0
++#define CONFIG_TARGA_Y216_DECODER 0
++#define CONFIG_TDSC_DECODER 0
++#define CONFIG_THEORA_DECODER 1
++#define CONFIG_THP_DECODER 0
++#define CONFIG_TIERTEXSEQVIDEO_DECODER 0
++#define CONFIG_TIFF_DECODER 0
++#define CONFIG_TMV_DECODER 0
++#define CONFIG_TRUEMOTION1_DECODER 0
++#define CONFIG_TRUEMOTION2_DECODER 0
++#define CONFIG_TRUEMOTION2RT_DECODER 0
++#define CONFIG_TSCC_DECODER 0
++#define CONFIG_TSCC2_DECODER 0
++#define CONFIG_TXD_DECODER 0
++#define CONFIG_ULTI_DECODER 0
++#define CONFIG_UTVIDEO_DECODER 0
++#define CONFIG_V210_DECODER 0
++#define CONFIG_V210X_DECODER 0
++#define CONFIG_V308_DECODER 0
++#define CONFIG_V408_DECODER 0
++#define CONFIG_V410_DECODER 0
++#define CONFIG_VB_DECODER 0
++#define CONFIG_VBN_DECODER 0
++#define CONFIG_VBLE_DECODER 0
++#define CONFIG_VC1_DECODER 0
++#define CONFIG_VC1_CRYSTALHD_DECODER 0
++#define CONFIG_VC1IMAGE_DECODER 0
++#define CONFIG_VC1_MMAL_DECODER 0
++#define CONFIG_VC1_QSV_DECODER 0
++#define CONFIG_VC1_V4L2M2M_DECODER 0
++#define CONFIG_VCR1_DECODER 0
++#define CONFIG_VMDVIDEO_DECODER 0
++#define CONFIG_VMNC_DECODER 0
++#define CONFIG_VP3_DECODER 1
++#define CONFIG_VP4_DECODER 0
++#define CONFIG_VP5_DECODER 0
++#define CONFIG_VP6_DECODER 0
++#define CONFIG_VP6A_DECODER 0
++#define CONFIG_VP6F_DECODER 0
++#define CONFIG_VP7_DECODER 0
++#define CONFIG_VP8_DECODER 1
++#define CONFIG_VP8_RKMPP_DECODER 0
++#define CONFIG_VP8_V4L2M2M_DECODER 0
++#define CONFIG_VP9_DECODER 0
++#define CONFIG_VP9_RKMPP_DECODER 0
++#define CONFIG_VP9_V4L2M2M_DECODER 0
++#define CONFIG_VQA_DECODER 0
++#define CONFIG_VQC_DECODER 0
++#define CONFIG_WBMP_DECODER 0
++#define CONFIG_WEBP_DECODER 0
++#define CONFIG_WCMV_DECODER 0
++#define CONFIG_WRAPPED_AVFRAME_DECODER 0
++#define CONFIG_WMV1_DECODER 0
++#define CONFIG_WMV2_DECODER 0
++#define CONFIG_WMV3_DECODER 0
++#define CONFIG_WMV3_CRYSTALHD_DECODER 0
++#define CONFIG_WMV3IMAGE_DECODER 0
++#define CONFIG_WNV1_DECODER 0
++#define CONFIG_XAN_WC3_DECODER 0
++#define CONFIG_XAN_WC4_DECODER 0
++#define CONFIG_XBM_DECODER 0
++#define CONFIG_XFACE_DECODER 0
++#define CONFIG_XL_DECODER 0
++#define CONFIG_XPM_DECODER 0
++#define CONFIG_XWD_DECODER 0
++#define CONFIG_Y41P_DECODER 0
++#define CONFIG_YLC_DECODER 0
++#define CONFIG_YOP_DECODER 0
++#define CONFIG_YUV4_DECODER 0
++#define CONFIG_ZERO12V_DECODER 0
++#define CONFIG_ZEROCODEC_DECODER 0
++#define CONFIG_ZLIB_DECODER 0
++#define CONFIG_ZMBV_DECODER 0
++#define CONFIG_AAC_DECODER 1
++#define CONFIG_AAC_FIXED_DECODER 0
++#define CONFIG_AAC_LATM_DECODER 0
++#define CONFIG_AC3_DECODER 0
++#define CONFIG_AC3_FIXED_DECODER 0
++#define CONFIG_ACELP_KELVIN_DECODER 0
++#define CONFIG_ALAC_DECODER 0
++#define CONFIG_ALS_DECODER 0
++#define CONFIG_AMRNB_DECODER 0
++#define CONFIG_AMRWB_DECODER 0
++#define CONFIG_APAC_DECODER 0
++#define CONFIG_APE_DECODER 0
++#define CONFIG_APTX_DECODER 0
++#define CONFIG_APTX_HD_DECODER 0
++#define CONFIG_ATRAC1_DECODER 0
++#define CONFIG_ATRAC3_DECODER 0
++#define CONFIG_ATRAC3AL_DECODER 0
++#define CONFIG_ATRAC3P_DECODER 0
++#define CONFIG_ATRAC3PAL_DECODER 0
++#define CONFIG_ATRAC9_DECODER 0
++#define CONFIG_BINKAUDIO_DCT_DECODER 0
++#define CONFIG_BINKAUDIO_RDFT_DECODER 0
++#define CONFIG_BMV_AUDIO_DECODER 0
++#define CONFIG_BONK_DECODER 0
++#define CONFIG_COOK_DECODER 0
++#define CONFIG_DCA_DECODER 0
++#define CONFIG_DFPWM_DECODER 0
++#define CONFIG_DOLBY_E_DECODER 0
++#define CONFIG_DSD_LSBF_DECODER 0
++#define CONFIG_DSD_MSBF_DECODER 0
++#define CONFIG_DSD_LSBF_PLANAR_DECODER 0
++#define CONFIG_DSD_MSBF_PLANAR_DECODER 0
++#define CONFIG_DSICINAUDIO_DECODER 0
++#define CONFIG_DSS_SP_DECODER 0
++#define CONFIG_DST_DECODER 0
++#define CONFIG_EAC3_DECODER 0
++#define CONFIG_EVRC_DECODER 0
++#define CONFIG_FASTAUDIO_DECODER 0
++#define CONFIG_FFWAVESYNTH_DECODER 0
++#define CONFIG_FLAC_DECODER 1
++#define CONFIG_FTR_DECODER 0
++#define CONFIG_G723_1_DECODER 0
++#define CONFIG_G729_DECODER 0
++#define CONFIG_GSM_DECODER 0
++#define CONFIG_GSM_MS_DECODER 0
++#define CONFIG_HCA_DECODER 0
++#define CONFIG_HCOM_DECODER 0
++#define CONFIG_HDR_DECODER 0
++#define CONFIG_IAC_DECODER 0
++#define CONFIG_ILBC_DECODER 0
++#define CONFIG_IMC_DECODER 0
++#define CONFIG_INTERPLAY_ACM_DECODER 0
++#define CONFIG_MACE3_DECODER 0
++#define CONFIG_MACE6_DECODER 0
++#define CONFIG_METASOUND_DECODER 0
++#define CONFIG_MISC4_DECODER 0
++#define CONFIG_MLP_DECODER 0
++#define CONFIG_MP1_DECODER 0
++#define CONFIG_MP1FLOAT_DECODER 0
++#define CONFIG_MP2_DECODER 0
++#define CONFIG_MP2FLOAT_DECODER 0
++#define CONFIG_MP3FLOAT_DECODER 0
++#define CONFIG_MP3_DECODER 1
++#define CONFIG_MP3ADUFLOAT_DECODER 0
++#define CONFIG_MP3ADU_DECODER 0
++#define CONFIG_MP3ON4FLOAT_DECODER 0
++#define CONFIG_MP3ON4_DECODER 0
++#define CONFIG_MPC7_DECODER 0
++#define CONFIG_MPC8_DECODER 0
++#define CONFIG_MSNSIREN_DECODER 0
++#define CONFIG_NELLYMOSER_DECODER 0
++#define CONFIG_ON2AVC_DECODER 0
++#define CONFIG_OPUS_DECODER 0
++#define CONFIG_PAF_AUDIO_DECODER 0
++#define CONFIG_QCELP_DECODER 0
++#define CONFIG_QDM2_DECODER 0
++#define CONFIG_QDMC_DECODER 0
++#define CONFIG_RA_144_DECODER 0
++#define CONFIG_RA_288_DECODER 0
++#define CONFIG_RALF_DECODER 0
++#define CONFIG_SBC_DECODER 0
++#define CONFIG_SHORTEN_DECODER 0
++#define CONFIG_SIPR_DECODER 0
++#define CONFIG_SIREN_DECODER 0
++#define CONFIG_SMACKAUD_DECODER 0
++#define CONFIG_SONIC_DECODER 0
++#define CONFIG_TAK_DECODER 0
++#define CONFIG_TRUEHD_DECODER 0
++#define CONFIG_TRUESPEECH_DECODER 0
++#define CONFIG_TTA_DECODER 0
++#define CONFIG_TWINVQ_DECODER 0
++#define CONFIG_VMDAUDIO_DECODER 0
++#define CONFIG_VORBIS_DECODER 1
++#define CONFIG_WAVARC_DECODER 0
++#define CONFIG_WAVPACK_DECODER 0
++#define CONFIG_WMALOSSLESS_DECODER 0
++#define CONFIG_WMAPRO_DECODER 0
++#define CONFIG_WMAV1_DECODER 0
++#define CONFIG_WMAV2_DECODER 0
++#define CONFIG_WMAVOICE_DECODER 0
++#define CONFIG_WS_SND1_DECODER 0
++#define CONFIG_XMA1_DECODER 0
++#define CONFIG_XMA2_DECODER 0
++#define CONFIG_PCM_ALAW_DECODER 1
++#define CONFIG_PCM_BLURAY_DECODER 0
++#define CONFIG_PCM_DVD_DECODER 0
++#define CONFIG_PCM_F16LE_DECODER 0
++#define CONFIG_PCM_F24LE_DECODER 0
++#define CONFIG_PCM_F32BE_DECODER 0
++#define CONFIG_PCM_F32LE_DECODER 1
++#define CONFIG_PCM_F64BE_DECODER 0
++#define CONFIG_PCM_F64LE_DECODER 0
++#define CONFIG_PCM_LXF_DECODER 0
++#define CONFIG_PCM_MULAW_DECODER 1
++#define CONFIG_PCM_S8_DECODER 0
++#define CONFIG_PCM_S8_PLANAR_DECODER 0
++#define CONFIG_PCM_S16BE_DECODER 1
++#define CONFIG_PCM_S16BE_PLANAR_DECODER 0
++#define CONFIG_PCM_S16LE_DECODER 1
++#define CONFIG_PCM_S16LE_PLANAR_DECODER 0
++#define CONFIG_PCM_S24BE_DECODER 1
++#define CONFIG_PCM_S24DAUD_DECODER 0
++#define CONFIG_PCM_S24LE_DECODER 1
++#define CONFIG_PCM_S24LE_PLANAR_DECODER 0
++#define CONFIG_PCM_S32BE_DECODER 0
++#define CONFIG_PCM_S32LE_DECODER 1
++#define CONFIG_PCM_S32LE_PLANAR_DECODER 0
++#define CONFIG_PCM_S64BE_DECODER 0
++#define CONFIG_PCM_S64LE_DECODER 0
++#define CONFIG_PCM_SGA_DECODER 0
++#define CONFIG_PCM_U8_DECODER 1
++#define CONFIG_PCM_U16BE_DECODER 0
++#define CONFIG_PCM_U16LE_DECODER 0
++#define CONFIG_PCM_U24BE_DECODER 0
++#define CONFIG_PCM_U24LE_DECODER 0
++#define CONFIG_PCM_U32BE_DECODER 0
++#define CONFIG_PCM_U32LE_DECODER 0
++#define CONFIG_PCM_VIDC_DECODER 0
++#define CONFIG_CBD2_DPCM_DECODER 0
++#define CONFIG_DERF_DPCM_DECODER 0
++#define CONFIG_GREMLIN_DPCM_DECODER 0
++#define CONFIG_INTERPLAY_DPCM_DECODER 0
++#define CONFIG_ROQ_DPCM_DECODER 0
++#define CONFIG_SDX2_DPCM_DECODER 0
++#define CONFIG_SOL_DPCM_DECODER 0
++#define CONFIG_XAN_DPCM_DECODER 0
++#define CONFIG_WADY_DPCM_DECODER 0
++#define CONFIG_ADPCM_4XM_DECODER 0
++#define CONFIG_ADPCM_ADX_DECODER 0
++#define CONFIG_ADPCM_AFC_DECODER 0
++#define CONFIG_ADPCM_AGM_DECODER 0
++#define CONFIG_ADPCM_AICA_DECODER 0
++#define CONFIG_ADPCM_ARGO_DECODER 0
++#define CONFIG_ADPCM_CT_DECODER 0
++#define CONFIG_ADPCM_DTK_DECODER 0
++#define CONFIG_ADPCM_EA_DECODER 0
++#define CONFIG_ADPCM_EA_MAXIS_XA_DECODER 0
++#define CONFIG_ADPCM_EA_R1_DECODER 0
++#define CONFIG_ADPCM_EA_R2_DECODER 0
++#define CONFIG_ADPCM_EA_R3_DECODER 0
++#define CONFIG_ADPCM_EA_XAS_DECODER 0
++#define CONFIG_ADPCM_G722_DECODER 0
++#define CONFIG_ADPCM_G726_DECODER 0
++#define CONFIG_ADPCM_G726LE_DECODER 0
++#define CONFIG_ADPCM_IMA_ACORN_DECODER 0
++#define CONFIG_ADPCM_IMA_AMV_DECODER 0
++#define CONFIG_ADPCM_IMA_ALP_DECODER 0
++#define CONFIG_ADPCM_IMA_APC_DECODER 0
++#define CONFIG_ADPCM_IMA_APM_DECODER 0
++#define CONFIG_ADPCM_IMA_CUNNING_DECODER 0
++#define CONFIG_ADPCM_IMA_DAT4_DECODER 0
++#define CONFIG_ADPCM_IMA_DK3_DECODER 0
++#define CONFIG_ADPCM_IMA_DK4_DECODER 0
++#define CONFIG_ADPCM_IMA_EA_EACS_DECODER 0
++#define CONFIG_ADPCM_IMA_EA_SEAD_DECODER 0
++#define CONFIG_ADPCM_IMA_ISS_DECODER 0
++#define CONFIG_ADPCM_IMA_MOFLEX_DECODER 0
++#define CONFIG_ADPCM_IMA_MTF_DECODER 0
++#define CONFIG_ADPCM_IMA_OKI_DECODER 0
++#define CONFIG_ADPCM_IMA_QT_DECODER 0
++#define CONFIG_ADPCM_IMA_RAD_DECODER 0
++#define CONFIG_ADPCM_IMA_SSI_DECODER 0
++#define CONFIG_ADPCM_IMA_SMJPEG_DECODER 0
++#define CONFIG_ADPCM_IMA_WAV_DECODER 0
++#define CONFIG_ADPCM_IMA_WS_DECODER 0
++#define CONFIG_ADPCM_MS_DECODER 0
++#define CONFIG_ADPCM_MTAF_DECODER 0
++#define CONFIG_ADPCM_PSX_DECODER 0
++#define CONFIG_ADPCM_SBPRO_2_DECODER 0
++#define CONFIG_ADPCM_SBPRO_3_DECODER 0
++#define CONFIG_ADPCM_SBPRO_4_DECODER 0
++#define CONFIG_ADPCM_SWF_DECODER 0
++#define CONFIG_ADPCM_THP_DECODER 0
++#define CONFIG_ADPCM_THP_LE_DECODER 0
++#define CONFIG_ADPCM_VIMA_DECODER 0
++#define CONFIG_ADPCM_XA_DECODER 0
++#define CONFIG_ADPCM_XMD_DECODER 0
++#define CONFIG_ADPCM_YAMAHA_DECODER 0
++#define CONFIG_ADPCM_ZORK_DECODER 0
++#define CONFIG_SSA_DECODER 0
++#define CONFIG_ASS_DECODER 0
++#define CONFIG_CCAPTION_DECODER 0
++#define CONFIG_DVBSUB_DECODER 0
++#define CONFIG_DVDSUB_DECODER 0
++#define CONFIG_JACOSUB_DECODER 0
++#define CONFIG_MICRODVD_DECODER 0
++#define CONFIG_MOVTEXT_DECODER 0
++#define CONFIG_MPL2_DECODER 0
++#define CONFIG_PGSSUB_DECODER 0
++#define CONFIG_PJS_DECODER 0
++#define CONFIG_REALTEXT_DECODER 0
++#define CONFIG_SAMI_DECODER 0
++#define CONFIG_SRT_DECODER 0
++#define CONFIG_STL_DECODER 0
++#define CONFIG_SUBRIP_DECODER 0
++#define CONFIG_SUBVIEWER_DECODER 0
++#define CONFIG_SUBVIEWER1_DECODER 0
++#define CONFIG_TEXT_DECODER 0
++#define CONFIG_VPLAYER_DECODER 0
++#define CONFIG_WEBVTT_DECODER 0
++#define CONFIG_XSUB_DECODER 0
++#define CONFIG_AAC_AT_DECODER 0
++#define CONFIG_AC3_AT_DECODER 0
++#define CONFIG_ADPCM_IMA_QT_AT_DECODER 0
++#define CONFIG_ALAC_AT_DECODER 0
++#define CONFIG_AMR_NB_AT_DECODER 0
++#define CONFIG_EAC3_AT_DECODER 0
++#define CONFIG_GSM_MS_AT_DECODER 0
++#define CONFIG_ILBC_AT_DECODER 0
++#define CONFIG_MP1_AT_DECODER 0
++#define CONFIG_MP2_AT_DECODER 0
++#define CONFIG_MP3_AT_DECODER 0
++#define CONFIG_PCM_ALAW_AT_DECODER 0
++#define CONFIG_PCM_MULAW_AT_DECODER 0
++#define CONFIG_QDMC_AT_DECODER 0
++#define CONFIG_QDM2_AT_DECODER 0
++#define CONFIG_LIBARIBCAPTION_DECODER 0
++#define CONFIG_LIBARIBB24_DECODER 0
++#define CONFIG_LIBCELT_DECODER 0
++#define CONFIG_LIBCODEC2_DECODER 0
++#define CONFIG_LIBDAV1D_DECODER 0
++#define CONFIG_LIBDAVS2_DECODER 0
++#define CONFIG_LIBFDK_AAC_DECODER 0
++#define CONFIG_LIBGSM_DECODER 0
++#define CONFIG_LIBGSM_MS_DECODER 0
++#define CONFIG_LIBILBC_DECODER 0
++#define CONFIG_LIBJXL_DECODER 0
++#define CONFIG_LIBOPENCORE_AMRNB_DECODER 0
++#define CONFIG_LIBOPENCORE_AMRWB_DECODER 0
++#define CONFIG_LIBOPUS_DECODER 1
++#define CONFIG_LIBRSVG_DECODER 0
++#define CONFIG_LIBSPEEX_DECODER 0
++#define CONFIG_LIBUAVS3D_DECODER 0
++#define CONFIG_LIBVORBIS_DECODER 0
++#define CONFIG_LIBVPX_VP8_DECODER 0
++#define CONFIG_LIBVPX_VP9_DECODER 0
++#define CONFIG_LIBZVBI_TELETEXT_DECODER 0
++#define CONFIG_BINTEXT_DECODER 0
++#define CONFIG_XBIN_DECODER 0
++#define CONFIG_IDF_DECODER 0
++#define CONFIG_LIBAOM_AV1_DECODER 0
++#define CONFIG_AV1_DECODER 0
++#define CONFIG_AV1_CUVID_DECODER 0
++#define CONFIG_AV1_MEDIACODEC_DECODER 0
++#define CONFIG_AV1_QSV_DECODER 0
++#define CONFIG_LIBOPENH264_DECODER 0
++#define CONFIG_H264_CUVID_DECODER 0
++#define CONFIG_HEVC_CUVID_DECODER 0
++#define CONFIG_HEVC_MEDIACODEC_DECODER 0
++#define CONFIG_MJPEG_CUVID_DECODER 0
++#define CONFIG_MJPEG_QSV_DECODER 0
++#define CONFIG_MPEG1_CUVID_DECODER 0
++#define CONFIG_MPEG2_CUVID_DECODER 0
++#define CONFIG_MPEG4_CUVID_DECODER 0
++#define CONFIG_MPEG4_MEDIACODEC_DECODER 0
++#define CONFIG_VC1_CUVID_DECODER 0
++#define CONFIG_VP8_CUVID_DECODER 0
++#define CONFIG_VP8_MEDIACODEC_DECODER 0
++#define CONFIG_VP8_QSV_DECODER 0
++#define CONFIG_VP9_CUVID_DECODER 0
++#define CONFIG_VP9_MEDIACODEC_DECODER 0
++#define CONFIG_VP9_QSV_DECODER 0
++#define CONFIG_VNULL_DECODER 0
++#define CONFIG_ANULL_DECODER 0
++#define CONFIG_A64MULTI_ENCODER 0
++#define CONFIG_A64MULTI5_ENCODER 0
++#define CONFIG_ALIAS_PIX_ENCODER 0
++#define CONFIG_AMV_ENCODER 0
++#define CONFIG_APNG_ENCODER 0
++#define CONFIG_ASV1_ENCODER 0
++#define CONFIG_ASV2_ENCODER 0
++#define CONFIG_AVRP_ENCODER 0
++#define CONFIG_AVUI_ENCODER 0
++#define CONFIG_AYUV_ENCODER 0
++#define CONFIG_BITPACKED_ENCODER 0
++#define CONFIG_BMP_ENCODER 0
++#define CONFIG_CFHD_ENCODER 0
++#define CONFIG_CINEPAK_ENCODER 0
++#define CONFIG_CLJR_ENCODER 0
++#define CONFIG_COMFORTNOISE_ENCODER 0
++#define CONFIG_DNXHD_ENCODER 0
++#define CONFIG_DPX_ENCODER 0
++#define CONFIG_DVVIDEO_ENCODER 0
++#define CONFIG_EXR_ENCODER 0
++#define CONFIG_FFV1_ENCODER 0
++#define CONFIG_FFVHUFF_ENCODER 0
++#define CONFIG_FITS_ENCODER 0
++#define CONFIG_FLASHSV_ENCODER 0
++#define CONFIG_FLASHSV2_ENCODER 0
++#define CONFIG_FLV_ENCODER 0
++#define CONFIG_GIF_ENCODER 0
++#define CONFIG_H261_ENCODER 0
++#define CONFIG_H263_ENCODER 0
++#define CONFIG_H263P_ENCODER 0
++#define CONFIG_H264_MEDIACODEC_ENCODER 0
++#define CONFIG_HAP_ENCODER 0
++#define CONFIG_HUFFYUV_ENCODER 0
++#define CONFIG_JPEG2000_ENCODER 0
++#define CONFIG_JPEGLS_ENCODER 0
++#define CONFIG_LJPEG_ENCODER 0
++#define CONFIG_MAGICYUV_ENCODER 0
++#define CONFIG_MJPEG_ENCODER 0
++#define CONFIG_MPEG1VIDEO_ENCODER 0
++#define CONFIG_MPEG2VIDEO_ENCODER 0
++#define CONFIG_MPEG4_ENCODER 0
++#define CONFIG_MSMPEG4V2_ENCODER 0
++#define CONFIG_MSMPEG4V3_ENCODER 0
++#define CONFIG_MSVIDEO1_ENCODER 0
++#define CONFIG_PAM_ENCODER 0
++#define CONFIG_PBM_ENCODER 0
++#define CONFIG_PCX_ENCODER 0
++#define CONFIG_PFM_ENCODER 0
++#define CONFIG_PGM_ENCODER 0
++#define CONFIG_PGMYUV_ENCODER 0
++#define CONFIG_PHM_ENCODER 0
++#define CONFIG_PNG_ENCODER 0
++#define CONFIG_PPM_ENCODER 0
++#define CONFIG_PRORES_ENCODER 0
++#define CONFIG_PRORES_AW_ENCODER 0
++#define CONFIG_PRORES_KS_ENCODER 0
++#define CONFIG_QOI_ENCODER 0
++#define CONFIG_QTRLE_ENCODER 0
++#define CONFIG_R10K_ENCODER 0
++#define CONFIG_R210_ENCODER 0
++#define CONFIG_RAWVIDEO_ENCODER 0
++#define CONFIG_ROQ_ENCODER 0
++#define CONFIG_RPZA_ENCODER 0
++#define CONFIG_RV10_ENCODER 0
++#define CONFIG_RV20_ENCODER 0
++#define CONFIG_S302M_ENCODER 0
++#define CONFIG_SGI_ENCODER 0
++#define CONFIG_SMC_ENCODER 0
++#define CONFIG_SNOW_ENCODER 0
++#define CONFIG_SPEEDHQ_ENCODER 0
++#define CONFIG_SUNRAST_ENCODER 0
++#define CONFIG_SVQ1_ENCODER 0
++#define CONFIG_TARGA_ENCODER 0
++#define CONFIG_TIFF_ENCODER 0
++#define CONFIG_UTVIDEO_ENCODER 0
++#define CONFIG_V210_ENCODER 0
++#define CONFIG_V308_ENCODER 0
++#define CONFIG_V408_ENCODER 0
++#define CONFIG_V410_ENCODER 0
++#define CONFIG_VBN_ENCODER 0
++#define CONFIG_VC2_ENCODER 0
++#define CONFIG_WBMP_ENCODER 0
++#define CONFIG_WRAPPED_AVFRAME_ENCODER 0
++#define CONFIG_WMV1_ENCODER 0
++#define CONFIG_WMV2_ENCODER 0
++#define CONFIG_XBM_ENCODER 0
++#define CONFIG_XFACE_ENCODER 0
++#define CONFIG_XWD_ENCODER 0
++#define CONFIG_Y41P_ENCODER 0
++#define CONFIG_YUV4_ENCODER 0
++#define CONFIG_ZLIB_ENCODER 0
++#define CONFIG_ZMBV_ENCODER 0
++#define CONFIG_AAC_ENCODER 0
++#define CONFIG_AC3_ENCODER 0
++#define CONFIG_AC3_FIXED_ENCODER 0
++#define CONFIG_ALAC_ENCODER 0
++#define CONFIG_APTX_ENCODER 0
++#define CONFIG_APTX_HD_ENCODER 0
++#define CONFIG_DCA_ENCODER 0
++#define CONFIG_DFPWM_ENCODER 0
++#define CONFIG_EAC3_ENCODER 0
++#define CONFIG_FLAC_ENCODER 0
++#define CONFIG_G723_1_ENCODER 0
++#define CONFIG_HDR_ENCODER 0
++#define CONFIG_MLP_ENCODER 0
++#define CONFIG_MP2_ENCODER 0
++#define CONFIG_MP2FIXED_ENCODER 0
++#define CONFIG_NELLYMOSER_ENCODER 0
++#define CONFIG_OPUS_ENCODER 0
++#define CONFIG_RA_144_ENCODER 0
++#define CONFIG_SBC_ENCODER 0
++#define CONFIG_SONIC_ENCODER 0
++#define CONFIG_SONIC_LS_ENCODER 0
++#define CONFIG_TRUEHD_ENCODER 0
++#define CONFIG_TTA_ENCODER 0
++#define CONFIG_VORBIS_ENCODER 0
++#define CONFIG_WAVPACK_ENCODER 0
++#define CONFIG_WMAV1_ENCODER 0
++#define CONFIG_WMAV2_ENCODER 0
++#define CONFIG_PCM_ALAW_ENCODER 0
++#define CONFIG_PCM_BLURAY_ENCODER 0
++#define CONFIG_PCM_DVD_ENCODER 0
++#define CONFIG_PCM_F32BE_ENCODER 0
++#define CONFIG_PCM_F32LE_ENCODER 0
++#define CONFIG_PCM_F64BE_ENCODER 0
++#define CONFIG_PCM_F64LE_ENCODER 0
++#define CONFIG_PCM_MULAW_ENCODER 0
++#define CONFIG_PCM_S8_ENCODER 0
++#define CONFIG_PCM_S8_PLANAR_ENCODER 0
++#define CONFIG_PCM_S16BE_ENCODER 0
++#define CONFIG_PCM_S16BE_PLANAR_ENCODER 0
++#define CONFIG_PCM_S16LE_ENCODER 0
++#define CONFIG_PCM_S16LE_PLANAR_ENCODER 0
++#define CONFIG_PCM_S24BE_ENCODER 0
++#define CONFIG_PCM_S24DAUD_ENCODER 0
++#define CONFIG_PCM_S24LE_ENCODER 0
++#define CONFIG_PCM_S24LE_PLANAR_ENCODER 0
++#define CONFIG_PCM_S32BE_ENCODER 0
++#define CONFIG_PCM_S32LE_ENCODER 0
++#define CONFIG_PCM_S32LE_PLANAR_ENCODER 0
++#define CONFIG_PCM_S64BE_ENCODER 0
++#define CONFIG_PCM_S64LE_ENCODER 0
++#define CONFIG_PCM_U8_ENCODER 0
++#define CONFIG_PCM_U16BE_ENCODER 0
++#define CONFIG_PCM_U16LE_ENCODER 0
++#define CONFIG_PCM_U24BE_ENCODER 0
++#define CONFIG_PCM_U24LE_ENCODER 0
++#define CONFIG_PCM_U32BE_ENCODER 0
++#define CONFIG_PCM_U32LE_ENCODER 0
++#define CONFIG_PCM_VIDC_ENCODER 0
++#define CONFIG_ROQ_DPCM_ENCODER 0
++#define CONFIG_ADPCM_ADX_ENCODER 0
++#define CONFIG_ADPCM_ARGO_ENCODER 0
++#define CONFIG_ADPCM_G722_ENCODER 0
++#define CONFIG_ADPCM_G726_ENCODER 0
++#define CONFIG_ADPCM_G726LE_ENCODER 0
++#define CONFIG_ADPCM_IMA_AMV_ENCODER 0
++#define CONFIG_ADPCM_IMA_ALP_ENCODER 0
++#define CONFIG_ADPCM_IMA_APM_ENCODER 0
++#define CONFIG_ADPCM_IMA_QT_ENCODER 0
++#define CONFIG_ADPCM_IMA_SSI_ENCODER 0
++#define CONFIG_ADPCM_IMA_WAV_ENCODER 0
++#define CONFIG_ADPCM_IMA_WS_ENCODER 0
++#define CONFIG_ADPCM_MS_ENCODER 0
++#define CONFIG_ADPCM_SWF_ENCODER 0
++#define CONFIG_ADPCM_YAMAHA_ENCODER 0
++#define CONFIG_SSA_ENCODER 0
++#define CONFIG_ASS_ENCODER 0
++#define CONFIG_DVBSUB_ENCODER 0
++#define CONFIG_DVDSUB_ENCODER 0
++#define CONFIG_MOVTEXT_ENCODER 0
++#define CONFIG_SRT_ENCODER 0
++#define CONFIG_SUBRIP_ENCODER 0
++#define CONFIG_TEXT_ENCODER 0
++#define CONFIG_TTML_ENCODER 0
++#define CONFIG_WEBVTT_ENCODER 0
++#define CONFIG_XSUB_ENCODER 0
++#define CONFIG_AAC_AT_ENCODER 0
++#define CONFIG_ALAC_AT_ENCODER 0
++#define CONFIG_ILBC_AT_ENCODER 0
++#define CONFIG_PCM_ALAW_AT_ENCODER 0
++#define CONFIG_PCM_MULAW_AT_ENCODER 0
++#define CONFIG_LIBAOM_AV1_ENCODER 0
++#define CONFIG_LIBCODEC2_ENCODER 0
++#define CONFIG_LIBFDK_AAC_ENCODER 0
++#define CONFIG_LIBGSM_ENCODER 0
++#define CONFIG_LIBGSM_MS_ENCODER 0
++#define CONFIG_LIBILBC_ENCODER 0
++#define CONFIG_LIBJXL_ENCODER 0
++#define CONFIG_LIBMP3LAME_ENCODER 0
++#define CONFIG_LIBOPENCORE_AMRNB_ENCODER 0
++#define CONFIG_LIBOPENJPEG_ENCODER 0
++#define CONFIG_LIBOPUS_ENCODER 0
++#define CONFIG_LIBRAV1E_ENCODER 0
++#define CONFIG_LIBSHINE_ENCODER 0
++#define CONFIG_LIBSPEEX_ENCODER 0
++#define CONFIG_LIBSVTAV1_ENCODER 0
++#define CONFIG_LIBTHEORA_ENCODER 0
++#define CONFIG_LIBTWOLAME_ENCODER 0
++#define CONFIG_LIBVO_AMRWBENC_ENCODER 0
++#define CONFIG_LIBVORBIS_ENCODER 0
++#define CONFIG_LIBVPX_VP8_ENCODER 0
++#define CONFIG_LIBVPX_VP9_ENCODER 0
++#define CONFIG_LIBWEBP_ANIM_ENCODER 0
++#define CONFIG_LIBWEBP_ENCODER 0
++#define CONFIG_LIBX262_ENCODER 0
++#define CONFIG_LIBX264_ENCODER 0
++#define CONFIG_LIBX264RGB_ENCODER 0
++#define CONFIG_LIBX265_ENCODER 0
++#define CONFIG_LIBXAVS_ENCODER 0
++#define CONFIG_LIBXAVS2_ENCODER 0
++#define CONFIG_LIBXVID_ENCODER 0
++#define CONFIG_AAC_MF_ENCODER 0
++#define CONFIG_AC3_MF_ENCODER 0
++#define CONFIG_H263_V4L2M2M_ENCODER 0
++#define CONFIG_AV1_MEDIACODEC_ENCODER 0
++#define CONFIG_AV1_NVENC_ENCODER 0
++#define CONFIG_AV1_QSV_ENCODER 0
++#define CONFIG_AV1_AMF_ENCODER 0
++#define CONFIG_LIBOPENH264_ENCODER 0
++#define CONFIG_H264_AMF_ENCODER 0
++#define CONFIG_H264_MF_ENCODER 0
++#define CONFIG_H264_NVENC_ENCODER 0
++#define CONFIG_H264_OMX_ENCODER 0
++#define CONFIG_H264_QSV_ENCODER 0
++#define CONFIG_H264_V4L2M2M_ENCODER 0
++#define CONFIG_H264_VAAPI_ENCODER 0
++#define CONFIG_H264_VIDEOTOOLBOX_ENCODER 0
++#define CONFIG_HEVC_AMF_ENCODER 0
++#define CONFIG_HEVC_MEDIACODEC_ENCODER 0
++#define CONFIG_HEVC_MF_ENCODER 0
++#define CONFIG_HEVC_NVENC_ENCODER 0
++#define CONFIG_HEVC_QSV_ENCODER 0
++#define CONFIG_HEVC_V4L2M2M_ENCODER 0
++#define CONFIG_HEVC_VAAPI_ENCODER 0
++#define CONFIG_HEVC_VIDEOTOOLBOX_ENCODER 0
++#define CONFIG_LIBKVAZAAR_ENCODER 0
++#define CONFIG_MJPEG_QSV_ENCODER 0
++#define CONFIG_MJPEG_VAAPI_ENCODER 0
++#define CONFIG_MP3_MF_ENCODER 0
++#define CONFIG_MPEG2_QSV_ENCODER 0
++#define CONFIG_MPEG2_VAAPI_ENCODER 0
++#define CONFIG_MPEG4_MEDIACODEC_ENCODER 0
++#define CONFIG_MPEG4_OMX_ENCODER 0
++#define CONFIG_MPEG4_V4L2M2M_ENCODER 0
++#define CONFIG_PRORES_VIDEOTOOLBOX_ENCODER 0
++#define CONFIG_VP8_MEDIACODEC_ENCODER 0
++#define CONFIG_VP8_V4L2M2M_ENCODER 0
++#define CONFIG_VP8_VAAPI_ENCODER 0
++#define CONFIG_VP9_MEDIACODEC_ENCODER 0
++#define CONFIG_VP9_VAAPI_ENCODER 0
++#define CONFIG_VP9_QSV_ENCODER 0
++#define CONFIG_VNULL_ENCODER 0
++#define CONFIG_ANULL_ENCODER 0
++#define CONFIG_AV1_D3D11VA_HWACCEL 0
++#define CONFIG_AV1_D3D11VA2_HWACCEL 0
++#define CONFIG_AV1_DXVA2_HWACCEL 0
++#define CONFIG_AV1_NVDEC_HWACCEL 0
++#define CONFIG_AV1_VAAPI_HWACCEL 0
++#define CONFIG_AV1_VDPAU_HWACCEL 0
++#define CONFIG_H263_VAAPI_HWACCEL 0
++#define CONFIG_H263_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_H264_D3D11VA_HWACCEL 0
++#define CONFIG_H264_D3D11VA2_HWACCEL 0
++#define CONFIG_H264_DXVA2_HWACCEL 0
++#define CONFIG_H264_NVDEC_HWACCEL 0
++#define CONFIG_H264_VAAPI_HWACCEL 0
++#define CONFIG_H264_VDPAU_HWACCEL 0
++#define CONFIG_H264_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_HEVC_D3D11VA_HWACCEL 0
++#define CONFIG_HEVC_D3D11VA2_HWACCEL 0
++#define CONFIG_HEVC_DXVA2_HWACCEL 0
++#define CONFIG_HEVC_NVDEC_HWACCEL 0
++#define CONFIG_HEVC_VAAPI_HWACCEL 0
++#define CONFIG_HEVC_VDPAU_HWACCEL 0
++#define CONFIG_HEVC_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_MJPEG_NVDEC_HWACCEL 0
++#define CONFIG_MJPEG_VAAPI_HWACCEL 0
++#define CONFIG_MPEG1_NVDEC_HWACCEL 0
++#define CONFIG_MPEG1_VDPAU_HWACCEL 0
++#define CONFIG_MPEG1_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_MPEG2_D3D11VA_HWACCEL 0
++#define CONFIG_MPEG2_D3D11VA2_HWACCEL 0
++#define CONFIG_MPEG2_NVDEC_HWACCEL 0
++#define CONFIG_MPEG2_DXVA2_HWACCEL 0
++#define CONFIG_MPEG2_VAAPI_HWACCEL 0
++#define CONFIG_MPEG2_VDPAU_HWACCEL 0
++#define CONFIG_MPEG2_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_MPEG4_NVDEC_HWACCEL 0
++#define CONFIG_MPEG4_VAAPI_HWACCEL 0
++#define CONFIG_MPEG4_VDPAU_HWACCEL 0
++#define CONFIG_MPEG4_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_PRORES_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_VC1_D3D11VA_HWACCEL 0
++#define CONFIG_VC1_D3D11VA2_HWACCEL 0
++#define CONFIG_VC1_DXVA2_HWACCEL 0
++#define CONFIG_VC1_NVDEC_HWACCEL 0
++#define CONFIG_VC1_VAAPI_HWACCEL 0
++#define CONFIG_VC1_VDPAU_HWACCEL 0
++#define CONFIG_VP8_NVDEC_HWACCEL 0
++#define CONFIG_VP8_VAAPI_HWACCEL 0
++#define CONFIG_VP9_D3D11VA_HWACCEL 0
++#define CONFIG_VP9_D3D11VA2_HWACCEL 0
++#define CONFIG_VP9_DXVA2_HWACCEL 0
++#define CONFIG_VP9_NVDEC_HWACCEL 0
++#define CONFIG_VP9_VAAPI_HWACCEL 0
++#define CONFIG_VP9_VDPAU_HWACCEL 0
++#define CONFIG_VP9_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_WMV3_D3D11VA_HWACCEL 0
++#define CONFIG_WMV3_D3D11VA2_HWACCEL 0
++#define CONFIG_WMV3_DXVA2_HWACCEL 0
++#define CONFIG_WMV3_NVDEC_HWACCEL 0
++#define CONFIG_WMV3_VAAPI_HWACCEL 0
++#define CONFIG_WMV3_VDPAU_HWACCEL 0
++#define CONFIG_AAC_PARSER 1
++#define CONFIG_AAC_LATM_PARSER 0
++#define CONFIG_AC3_PARSER 0
++#define CONFIG_ADX_PARSER 0
++#define CONFIG_AMR_PARSER 0
++#define CONFIG_AV1_PARSER 0
++#define CONFIG_AVS2_PARSER 0
++#define CONFIG_AVS3_PARSER 0
++#define CONFIG_BMP_PARSER 0
++#define CONFIG_CAVSVIDEO_PARSER 0
++#define CONFIG_COOK_PARSER 0
++#define CONFIG_CRI_PARSER 0
++#define CONFIG_DCA_PARSER 0
++#define CONFIG_DIRAC_PARSER 0
++#define CONFIG_DNXHD_PARSER 0
++#define CONFIG_DOLBY_E_PARSER 0
++#define CONFIG_DPX_PARSER 0
++#define CONFIG_DVAUDIO_PARSER 0
++#define CONFIG_DVBSUB_PARSER 0
++#define CONFIG_DVDSUB_PARSER 0
++#define CONFIG_DVD_NAV_PARSER 0
++#define CONFIG_FLAC_PARSER 1
++#define CONFIG_FTR_PARSER 0
++#define CONFIG_G723_1_PARSER 0
++#define CONFIG_G729_PARSER 0
++#define CONFIG_GIF_PARSER 0
++#define CONFIG_GSM_PARSER 0
++#define CONFIG_H261_PARSER 0
++#define CONFIG_H263_PARSER 1
++#define CONFIG_H264_PARSER 1
++#define CONFIG_HEVC_PARSER 0
++#define CONFIG_HDR_PARSER 0
++#define CONFIG_IPU_PARSER 0
++#define CONFIG_JPEG2000_PARSER 0
++#define CONFIG_MISC4_PARSER 0
++#define CONFIG_MJPEG_PARSER 0
++#define CONFIG_MLP_PARSER 0
++#define CONFIG_MPEG4VIDEO_PARSER 1
++#define CONFIG_MPEGAUDIO_PARSER 1
++#define CONFIG_MPEGVIDEO_PARSER 0
++#define CONFIG_OPUS_PARSER 1
++#define CONFIG_PNG_PARSER 0
++#define CONFIG_PNM_PARSER 0
++#define CONFIG_QOI_PARSER 0
++#define CONFIG_RV30_PARSER 0
++#define CONFIG_RV40_PARSER 0
++#define CONFIG_SBC_PARSER 0
++#define CONFIG_SIPR_PARSER 0
++#define CONFIG_TAK_PARSER 0
++#define CONFIG_VC1_PARSER 0
++#define CONFIG_VORBIS_PARSER 1
++#define CONFIG_VP3_PARSER 1
++#define CONFIG_VP8_PARSER 1
++#define CONFIG_VP9_PARSER 1
++#define CONFIG_WEBP_PARSER 0
++#define CONFIG_XBM_PARSER 0
++#define CONFIG_XMA_PARSER 0
++#define CONFIG_XWD_PARSER 0
++#define CONFIG_ALSA_INDEV 0
++#define CONFIG_ANDROID_CAMERA_INDEV 0
++#define CONFIG_AVFOUNDATION_INDEV 0
++#define CONFIG_BKTR_INDEV 0
++#define CONFIG_DECKLINK_INDEV 0
++#define CONFIG_DSHOW_INDEV 0
++#define CONFIG_FBDEV_INDEV 0
++#define CONFIG_GDIGRAB_INDEV 0
++#define CONFIG_IEC61883_INDEV 0
++#define CONFIG_JACK_INDEV 0
++#define CONFIG_KMSGRAB_INDEV 0
++#define CONFIG_LAVFI_INDEV 0
++#define CONFIG_OPENAL_INDEV 0
++#define CONFIG_OSS_INDEV 0
++#define CONFIG_PULSE_INDEV 0
++#define CONFIG_SNDIO_INDEV 0
++#define CONFIG_V4L2_INDEV 0
++#define CONFIG_VFWCAP_INDEV 0
++#define CONFIG_XCBGRAB_INDEV 0
++#define CONFIG_LIBCDIO_INDEV 0
++#define CONFIG_LIBDC1394_INDEV 0
++#define CONFIG_ALSA_OUTDEV 0
++#define CONFIG_AUDIOTOOLBOX_OUTDEV 0
++#define CONFIG_CACA_OUTDEV 0
++#define CONFIG_DECKLINK_OUTDEV 0
++#define CONFIG_FBDEV_OUTDEV 0
++#define CONFIG_OPENGL_OUTDEV 0
++#define CONFIG_OSS_OUTDEV 0
++#define CONFIG_PULSE_OUTDEV 0
++#define CONFIG_SDL2_OUTDEV 0
++#define CONFIG_SNDIO_OUTDEV 0
++#define CONFIG_V4L2_OUTDEV 0
++#define CONFIG_XV_OUTDEV 0
++#define CONFIG_ABENCH_FILTER 0
++#define CONFIG_ACOMPRESSOR_FILTER 0
++#define CONFIG_ACONTRAST_FILTER 0
++#define CONFIG_ACOPY_FILTER 0
++#define CONFIG_ACUE_FILTER 0
++#define CONFIG_ACROSSFADE_FILTER 0
++#define CONFIG_ACROSSOVER_FILTER 0
++#define CONFIG_ACRUSHER_FILTER 0
++#define CONFIG_ADECLICK_FILTER 0
++#define CONFIG_ADECLIP_FILTER 0
++#define CONFIG_ADECORRELATE_FILTER 0
++#define CONFIG_ADELAY_FILTER 0
++#define CONFIG_ADENORM_FILTER 0
++#define CONFIG_ADERIVATIVE_FILTER 0
++#define CONFIG_ADRC_FILTER 0
++#define CONFIG_ADYNAMICEQUALIZER_FILTER 0
++#define CONFIG_ADYNAMICSMOOTH_FILTER 0
++#define CONFIG_AECHO_FILTER 0
++#define CONFIG_AEMPHASIS_FILTER 0
++#define CONFIG_AEVAL_FILTER 0
++#define CONFIG_AEXCITER_FILTER 0
++#define CONFIG_AFADE_FILTER 0
++#define CONFIG_AFFTDN_FILTER 0
++#define CONFIG_AFFTFILT_FILTER 0
++#define CONFIG_AFIR_FILTER 0
++#define CONFIG_AFORMAT_FILTER 0
++#define CONFIG_AFREQSHIFT_FILTER 0
++#define CONFIG_AFWTDN_FILTER 0
++#define CONFIG_AGATE_FILTER 0
++#define CONFIG_AIIR_FILTER 0
++#define CONFIG_AINTEGRAL_FILTER 0
++#define CONFIG_AINTERLEAVE_FILTER 0
++#define CONFIG_ALATENCY_FILTER 0
++#define CONFIG_ALIMITER_FILTER 0
++#define CONFIG_ALLPASS_FILTER 0
++#define CONFIG_ALOOP_FILTER 0
++#define CONFIG_AMERGE_FILTER 0
++#define CONFIG_AMETADATA_FILTER 0
++#define CONFIG_AMIX_FILTER 0
++#define CONFIG_AMULTIPLY_FILTER 0
++#define CONFIG_ANEQUALIZER_FILTER 0
++#define CONFIG_ANLMDN_FILTER 0
++#define CONFIG_ANLMF_FILTER 0
++#define CONFIG_ANLMS_FILTER 0
++#define CONFIG_ANULL_FILTER 0
++#define CONFIG_APAD_FILTER 0
++#define CONFIG_APERMS_FILTER 0
++#define CONFIG_APHASER_FILTER 0
++#define CONFIG_APHASESHIFT_FILTER 0
++#define CONFIG_APSYCLIP_FILTER 0
++#define CONFIG_APULSATOR_FILTER 0
++#define CONFIG_AREALTIME_FILTER 0
++#define CONFIG_ARESAMPLE_FILTER 0
++#define CONFIG_AREVERSE_FILTER 0
++#define CONFIG_ARLS_FILTER 0
++#define CONFIG_ARNNDN_FILTER 0
++#define CONFIG_ASDR_FILTER 0
++#define CONFIG_ASEGMENT_FILTER 0
++#define CONFIG_ASELECT_FILTER 0
++#define CONFIG_ASENDCMD_FILTER 0
++#define CONFIG_ASETNSAMPLES_FILTER 0
++#define CONFIG_ASETPTS_FILTER 0
++#define CONFIG_ASETRATE_FILTER 0
++#define CONFIG_ASETTB_FILTER 0
++#define CONFIG_ASHOWINFO_FILTER 0
++#define CONFIG_ASIDEDATA_FILTER 0
++#define CONFIG_ASOFTCLIP_FILTER 0
++#define CONFIG_ASPECTRALSTATS_FILTER 0
++#define CONFIG_ASPLIT_FILTER 0
++#define CONFIG_ASR_FILTER 0
++#define CONFIG_ASTATS_FILTER 0
++#define CONFIG_ASTREAMSELECT_FILTER 0
++#define CONFIG_ASUBBOOST_FILTER 0
++#define CONFIG_ASUBCUT_FILTER 0
++#define CONFIG_ASUPERCUT_FILTER 0
++#define CONFIG_ASUPERPASS_FILTER 0
++#define CONFIG_ASUPERSTOP_FILTER 0
++#define CONFIG_ATEMPO_FILTER 0
++#define CONFIG_ATILT_FILTER 0
++#define CONFIG_ATRIM_FILTER 0
++#define CONFIG_AXCORRELATE_FILTER 0
++#define CONFIG_AZMQ_FILTER 0
++#define CONFIG_BANDPASS_FILTER 0
++#define CONFIG_BANDREJECT_FILTER 0
++#define CONFIG_BASS_FILTER 0
++#define CONFIG_BIQUAD_FILTER 0
++#define CONFIG_BS2B_FILTER 0
++#define CONFIG_CHANNELMAP_FILTER 0
++#define CONFIG_CHANNELSPLIT_FILTER 0
++#define CONFIG_CHORUS_FILTER 0
++#define CONFIG_COMPAND_FILTER 0
++#define CONFIG_COMPENSATIONDELAY_FILTER 0
++#define CONFIG_CROSSFEED_FILTER 0
++#define CONFIG_CRYSTALIZER_FILTER 0
++#define CONFIG_DCSHIFT_FILTER 0
++#define CONFIG_DEESSER_FILTER 0
++#define CONFIG_DIALOGUENHANCE_FILTER 0
++#define CONFIG_DRMETER_FILTER 0
++#define CONFIG_DYNAUDNORM_FILTER 0
++#define CONFIG_EARWAX_FILTER 0
++#define CONFIG_EBUR128_FILTER 0
++#define CONFIG_EQUALIZER_FILTER 0
++#define CONFIG_EXTRASTEREO_FILTER 0
++#define CONFIG_FIREQUALIZER_FILTER 0
++#define CONFIG_FLANGER_FILTER 0
++#define CONFIG_HAAS_FILTER 0
++#define CONFIG_HDCD_FILTER 0
++#define CONFIG_HEADPHONE_FILTER 0
++#define CONFIG_HIGHPASS_FILTER 0
++#define CONFIG_HIGHSHELF_FILTER 0
++#define CONFIG_JOIN_FILTER 0
++#define CONFIG_LADSPA_FILTER 0
++#define CONFIG_LOUDNORM_FILTER 0
++#define CONFIG_LOWPASS_FILTER 0
++#define CONFIG_LOWSHELF_FILTER 0
++#define CONFIG_LV2_FILTER 0
++#define CONFIG_MCOMPAND_FILTER 0
++#define CONFIG_PAN_FILTER 0
++#define CONFIG_REPLAYGAIN_FILTER 0
++#define CONFIG_RUBBERBAND_FILTER 0
++#define CONFIG_SIDECHAINCOMPRESS_FILTER 0
++#define CONFIG_SIDECHAINGATE_FILTER 0
++#define CONFIG_SILENCEDETECT_FILTER 0
++#define CONFIG_SILENCEREMOVE_FILTER 0
++#define CONFIG_SOFALIZER_FILTER 0
++#define CONFIG_SPEECHNORM_FILTER 0
++#define CONFIG_STEREOTOOLS_FILTER 0
++#define CONFIG_STEREOWIDEN_FILTER 0
++#define CONFIG_SUPEREQUALIZER_FILTER 0
++#define CONFIG_SURROUND_FILTER 0
++#define CONFIG_TILTSHELF_FILTER 0
++#define CONFIG_TREBLE_FILTER 0
++#define CONFIG_TREMOLO_FILTER 0
++#define CONFIG_VIBRATO_FILTER 0
++#define CONFIG_VIRTUALBASS_FILTER 0
++#define CONFIG_VOLUME_FILTER 0
++#define CONFIG_VOLUMEDETECT_FILTER 0
++#define CONFIG_AEVALSRC_FILTER 0
++#define CONFIG_AFDELAYSRC_FILTER 0
++#define CONFIG_AFIREQSRC_FILTER 0
++#define CONFIG_AFIRSRC_FILTER 0
++#define CONFIG_ANOISESRC_FILTER 0
++#define CONFIG_ANULLSRC_FILTER 0
++#define CONFIG_FLITE_FILTER 0
++#define CONFIG_HILBERT_FILTER 0
++#define CONFIG_SINC_FILTER 0
++#define CONFIG_SINE_FILTER 0
++#define CONFIG_ANULLSINK_FILTER 0
++#define CONFIG_ADDROI_FILTER 0
++#define CONFIG_ALPHAEXTRACT_FILTER 0
++#define CONFIG_ALPHAMERGE_FILTER 0
++#define CONFIG_AMPLIFY_FILTER 0
++#define CONFIG_ASS_FILTER 0
++#define CONFIG_ATADENOISE_FILTER 0
++#define CONFIG_AVGBLUR_FILTER 0
++#define CONFIG_AVGBLUR_OPENCL_FILTER 0
++#define CONFIG_AVGBLUR_VULKAN_FILTER 0
++#define CONFIG_BACKGROUNDKEY_FILTER 0
++#define CONFIG_BBOX_FILTER 0
++#define CONFIG_BENCH_FILTER 0
++#define CONFIG_BILATERAL_FILTER 0
++#define CONFIG_BILATERAL_CUDA_FILTER 0
++#define CONFIG_BITPLANENOISE_FILTER 0
++#define CONFIG_BLACKDETECT_FILTER 0
++#define CONFIG_BLACKFRAME_FILTER 0
++#define CONFIG_BLEND_FILTER 0
++#define CONFIG_BLEND_VULKAN_FILTER 0
++#define CONFIG_BLOCKDETECT_FILTER 0
++#define CONFIG_BLURDETECT_FILTER 0
++#define CONFIG_BM3D_FILTER 0
++#define CONFIG_BOXBLUR_FILTER 0
++#define CONFIG_BOXBLUR_OPENCL_FILTER 0
++#define CONFIG_BWDIF_FILTER 0
++#define CONFIG_CAS_FILTER 0
++#define CONFIG_CCREPACK_FILTER 0
++#define CONFIG_CHROMABER_VULKAN_FILTER 0
++#define CONFIG_CHROMAHOLD_FILTER 0
++#define CONFIG_CHROMAKEY_FILTER 0
++#define CONFIG_CHROMAKEY_CUDA_FILTER 0
++#define CONFIG_CHROMANR_FILTER 0
++#define CONFIG_CHROMASHIFT_FILTER 0
++#define CONFIG_CIESCOPE_FILTER 0
++#define CONFIG_CODECVIEW_FILTER 0
++#define CONFIG_COLORBALANCE_FILTER 0
++#define CONFIG_COLORCHANNELMIXER_FILTER 0
++#define CONFIG_COLORCONTRAST_FILTER 0
++#define CONFIG_COLORCORRECT_FILTER 0
++#define CONFIG_COLORIZE_FILTER 0
++#define CONFIG_COLORKEY_FILTER 0
++#define CONFIG_COLORKEY_OPENCL_FILTER 0
++#define CONFIG_COLORHOLD_FILTER 0
++#define CONFIG_COLORLEVELS_FILTER 0
++#define CONFIG_COLORMAP_FILTER 0
++#define CONFIG_COLORMATRIX_FILTER 0
++#define CONFIG_COLORSPACE_FILTER 0
++#define CONFIG_COLORSPACE_CUDA_FILTER 0
++#define CONFIG_COLORTEMPERATURE_FILTER 0
++#define CONFIG_CONVOLUTION_FILTER 0
++#define CONFIG_CONVOLUTION_OPENCL_FILTER 0
++#define CONFIG_CONVOLVE_FILTER 0
++#define CONFIG_COPY_FILTER 0
++#define CONFIG_COREIMAGE_FILTER 0
++#define CONFIG_CORR_FILTER 0
++#define CONFIG_COVER_RECT_FILTER 0
++#define CONFIG_CROP_FILTER 0
++#define CONFIG_CROPDETECT_FILTER 0
++#define CONFIG_CUE_FILTER 0
++#define CONFIG_CURVES_FILTER 0
++#define CONFIG_DATASCOPE_FILTER 0
++#define CONFIG_DBLUR_FILTER 0
++#define CONFIG_DCTDNOIZ_FILTER 0
++#define CONFIG_DEBAND_FILTER 0
++#define CONFIG_DEBLOCK_FILTER 0
++#define CONFIG_DECIMATE_FILTER 0
++#define CONFIG_DECONVOLVE_FILTER 0
++#define CONFIG_DEDOT_FILTER 0
++#define CONFIG_DEFLATE_FILTER 0
++#define CONFIG_DEFLICKER_FILTER 0
++#define CONFIG_DEINTERLACE_QSV_FILTER 0
++#define CONFIG_DEINTERLACE_VAAPI_FILTER 0
++#define CONFIG_DEJUDDER_FILTER 0
++#define CONFIG_DELOGO_FILTER 0
++#define CONFIG_DENOISE_VAAPI_FILTER 0
++#define CONFIG_DERAIN_FILTER 0
++#define CONFIG_DESHAKE_FILTER 0
++#define CONFIG_DESHAKE_OPENCL_FILTER 0
++#define CONFIG_DESPILL_FILTER 0
++#define CONFIG_DETELECINE_FILTER 0
++#define CONFIG_DILATION_FILTER 0
++#define CONFIG_DILATION_OPENCL_FILTER 0
++#define CONFIG_DISPLACE_FILTER 0
++#define CONFIG_DNN_CLASSIFY_FILTER 0
++#define CONFIG_DNN_DETECT_FILTER 0
++#define CONFIG_DNN_PROCESSING_FILTER 0
++#define CONFIG_DOUBLEWEAVE_FILTER 0
++#define CONFIG_DRAWBOX_FILTER 0
++#define CONFIG_DRAWGRAPH_FILTER 0
++#define CONFIG_DRAWGRID_FILTER 0
++#define CONFIG_DRAWTEXT_FILTER 0
++#define CONFIG_EDGEDETECT_FILTER 0
++#define CONFIG_ELBG_FILTER 0
++#define CONFIG_ENTROPY_FILTER 0
++#define CONFIG_EPX_FILTER 0
++#define CONFIG_EQ_FILTER 0
++#define CONFIG_EROSION_FILTER 0
++#define CONFIG_EROSION_OPENCL_FILTER 0
++#define CONFIG_ESTDIF_FILTER 0
++#define CONFIG_EXPOSURE_FILTER 0
++#define CONFIG_EXTRACTPLANES_FILTER 0
++#define CONFIG_FADE_FILTER 0
++#define CONFIG_FEEDBACK_FILTER 0
++#define CONFIG_FFTDNOIZ_FILTER 0
++#define CONFIG_FFTFILT_FILTER 0
++#define CONFIG_FIELD_FILTER 0
++#define CONFIG_FIELDHINT_FILTER 0
++#define CONFIG_FIELDMATCH_FILTER 0
++#define CONFIG_FIELDORDER_FILTER 0
++#define CONFIG_FILLBORDERS_FILTER 0
++#define CONFIG_FIND_RECT_FILTER 0
++#define CONFIG_FLIP_VULKAN_FILTER 0
++#define CONFIG_FLOODFILL_FILTER 0
++#define CONFIG_FORMAT_FILTER 0
++#define CONFIG_FPS_FILTER 0
++#define CONFIG_FRAMEPACK_FILTER 0
++#define CONFIG_FRAMERATE_FILTER 0
++#define CONFIG_FRAMESTEP_FILTER 0
++#define CONFIG_FREEZEDETECT_FILTER 0
++#define CONFIG_FREEZEFRAMES_FILTER 0
++#define CONFIG_FREI0R_FILTER 0
++#define CONFIG_FSPP_FILTER 0
++#define CONFIG_GBLUR_FILTER 0
++#define CONFIG_GBLUR_VULKAN_FILTER 0
++#define CONFIG_GEQ_FILTER 0
++#define CONFIG_GRADFUN_FILTER 0
++#define CONFIG_GRAPHMONITOR_FILTER 0
++#define CONFIG_GRAYWORLD_FILTER 0
++#define CONFIG_GREYEDGE_FILTER 0
++#define CONFIG_GUIDED_FILTER 0
++#define CONFIG_HALDCLUT_FILTER 0
++#define CONFIG_HFLIP_FILTER 0
++#define CONFIG_HFLIP_VULKAN_FILTER 0
++#define CONFIG_HISTEQ_FILTER 0
++#define CONFIG_HISTOGRAM_FILTER 0
++#define CONFIG_HQDN3D_FILTER 0
++#define CONFIG_HQX_FILTER 0
++#define CONFIG_HSTACK_FILTER 0
++#define CONFIG_HSVHOLD_FILTER 0
++#define CONFIG_HSVKEY_FILTER 0
++#define CONFIG_HUE_FILTER 0
++#define CONFIG_HUESATURATION_FILTER 0
++#define CONFIG_HWDOWNLOAD_FILTER 0
++#define CONFIG_HWMAP_FILTER 0
++#define CONFIG_HWUPLOAD_FILTER 0
++#define CONFIG_HWUPLOAD_CUDA_FILTER 0
++#define CONFIG_HYSTERESIS_FILTER 0
++#define CONFIG_ICCDETECT_FILTER 0
++#define CONFIG_ICCGEN_FILTER 0
++#define CONFIG_IDENTITY_FILTER 0
++#define CONFIG_IDET_FILTER 0
++#define CONFIG_IL_FILTER 0
++#define CONFIG_INFLATE_FILTER 0
++#define CONFIG_INTERLACE_FILTER 0
++#define CONFIG_INTERLEAVE_FILTER 0
++#define CONFIG_KERNDEINT_FILTER 0
++#define CONFIG_KIRSCH_FILTER 0
++#define CONFIG_LAGFUN_FILTER 0
++#define CONFIG_LATENCY_FILTER 0
++#define CONFIG_LENSCORRECTION_FILTER 0
++#define CONFIG_LENSFUN_FILTER 0
++#define CONFIG_LIBPLACEBO_FILTER 0
++#define CONFIG_LIBVMAF_FILTER 0
++#define CONFIG_LIMITDIFF_FILTER 0
++#define CONFIG_LIMITER_FILTER 0
++#define CONFIG_LOOP_FILTER 0
++#define CONFIG_LUMAKEY_FILTER 0
++#define CONFIG_LUT_FILTER 0
++#define CONFIG_LUT1D_FILTER 0
++#define CONFIG_LUT2_FILTER 0
++#define CONFIG_LUT3D_FILTER 0
++#define CONFIG_LUTRGB_FILTER 0
++#define CONFIG_LUTYUV_FILTER 0
++#define CONFIG_MASKEDCLAMP_FILTER 0
++#define CONFIG_MASKEDMAX_FILTER 0
++#define CONFIG_MASKEDMERGE_FILTER 0
++#define CONFIG_MASKEDMIN_FILTER 0
++#define CONFIG_MASKEDTHRESHOLD_FILTER 0
++#define CONFIG_MASKFUN_FILTER 0
++#define CONFIG_MCDEINT_FILTER 0
++#define CONFIG_MEDIAN_FILTER 0
++#define CONFIG_MERGEPLANES_FILTER 0
++#define CONFIG_MESTIMATE_FILTER 0
++#define CONFIG_METADATA_FILTER 0
++#define CONFIG_MIDEQUALIZER_FILTER 0
++#define CONFIG_MINTERPOLATE_FILTER 0
++#define CONFIG_MIX_FILTER 0
++#define CONFIG_MONOCHROME_FILTER 0
++#define CONFIG_MORPHO_FILTER 0
++#define CONFIG_MPDECIMATE_FILTER 0
++#define CONFIG_MSAD_FILTER 0
++#define CONFIG_MULTIPLY_FILTER 0
++#define CONFIG_NEGATE_FILTER 0
++#define CONFIG_NLMEANS_FILTER 0
++#define CONFIG_NLMEANS_OPENCL_FILTER 0
++#define CONFIG_NNEDI_FILTER 0
++#define CONFIG_NOFORMAT_FILTER 0
++#define CONFIG_NOISE_FILTER 0
++#define CONFIG_NORMALIZE_FILTER 0
++#define CONFIG_NULL_FILTER 0
++#define CONFIG_OCR_FILTER 0
++#define CONFIG_OCV_FILTER 0
++#define CONFIG_OSCILLOSCOPE_FILTER 0
++#define CONFIG_OVERLAY_FILTER 0
++#define CONFIG_OVERLAY_OPENCL_FILTER 0
++#define CONFIG_OVERLAY_QSV_FILTER 0
++#define CONFIG_OVERLAY_VAAPI_FILTER 0
++#define CONFIG_OVERLAY_VULKAN_FILTER 0
++#define CONFIG_OVERLAY_CUDA_FILTER 0
++#define CONFIG_OWDENOISE_FILTER 0
++#define CONFIG_PAD_FILTER 0
++#define CONFIG_PAD_OPENCL_FILTER 0
++#define CONFIG_PALETTEGEN_FILTER 0
++#define CONFIG_PALETTEUSE_FILTER 0
++#define CONFIG_PERMS_FILTER 0
++#define CONFIG_PERSPECTIVE_FILTER 0
++#define CONFIG_PHASE_FILTER 0
++#define CONFIG_PHOTOSENSITIVITY_FILTER 0
++#define CONFIG_PIXDESCTEST_FILTER 0
++#define CONFIG_PIXELIZE_FILTER 0
++#define CONFIG_PIXSCOPE_FILTER 0
++#define CONFIG_PP_FILTER 0
++#define CONFIG_PP7_FILTER 0
++#define CONFIG_PREMULTIPLY_FILTER 0
++#define CONFIG_PREWITT_FILTER 0
++#define CONFIG_PREWITT_OPENCL_FILTER 0
++#define CONFIG_PROCAMP_VAAPI_FILTER 0
++#define CONFIG_PROGRAM_OPENCL_FILTER 0
++#define CONFIG_PSEUDOCOLOR_FILTER 0
++#define CONFIG_PSNR_FILTER 0
++#define CONFIG_PULLUP_FILTER 0
++#define CONFIG_QP_FILTER 0
++#define CONFIG_RANDOM_FILTER 0
++#define CONFIG_READEIA608_FILTER 0
++#define CONFIG_READVITC_FILTER 0
++#define CONFIG_REALTIME_FILTER 0
++#define CONFIG_REMAP_FILTER 0
++#define CONFIG_REMAP_OPENCL_FILTER 0
++#define CONFIG_REMOVEGRAIN_FILTER 0
++#define CONFIG_REMOVELOGO_FILTER 0
++#define CONFIG_REPEATFIELDS_FILTER 0
++#define CONFIG_REVERSE_FILTER 0
++#define CONFIG_RGBASHIFT_FILTER 0
++#define CONFIG_ROBERTS_FILTER 0
++#define CONFIG_ROBERTS_OPENCL_FILTER 0
++#define CONFIG_ROTATE_FILTER 0
++#define CONFIG_SAB_FILTER 0
++#define CONFIG_SCALE_FILTER 0
++#define CONFIG_SCALE_CUDA_FILTER 0
++#define CONFIG_SCALE_NPP_FILTER 0
++#define CONFIG_SCALE_QSV_FILTER 0
++#define CONFIG_SCALE_VAAPI_FILTER 0
++#define CONFIG_SCALE_VULKAN_FILTER 0
++#define CONFIG_SCALE2REF_FILTER 0
++#define CONFIG_SCALE2REF_NPP_FILTER 0
++#define CONFIG_SCDET_FILTER 0
++#define CONFIG_SCHARR_FILTER 0
++#define CONFIG_SCROLL_FILTER 0
++#define CONFIG_SEGMENT_FILTER 0
++#define CONFIG_SELECT_FILTER 0
++#define CONFIG_SELECTIVECOLOR_FILTER 0
++#define CONFIG_SENDCMD_FILTER 0
++#define CONFIG_SEPARATEFIELDS_FILTER 0
++#define CONFIG_SETDAR_FILTER 0
++#define CONFIG_SETFIELD_FILTER 0
++#define CONFIG_SETPARAMS_FILTER 0
++#define CONFIG_SETPTS_FILTER 0
++#define CONFIG_SETRANGE_FILTER 0
++#define CONFIG_SETSAR_FILTER 0
++#define CONFIG_SETTB_FILTER 0
++#define CONFIG_SHARPEN_NPP_FILTER 0
++#define CONFIG_SHARPNESS_VAAPI_FILTER 0
++#define CONFIG_SHEAR_FILTER 0
++#define CONFIG_SHOWINFO_FILTER 0
++#define CONFIG_SHOWPALETTE_FILTER 0
++#define CONFIG_SHUFFLEFRAMES_FILTER 0
++#define CONFIG_SHUFFLEPIXELS_FILTER 0
++#define CONFIG_SHUFFLEPLANES_FILTER 0
++#define CONFIG_SIDEDATA_FILTER 0
++#define CONFIG_SIGNALSTATS_FILTER 0
++#define CONFIG_SIGNATURE_FILTER 0
++#define CONFIG_SITI_FILTER 0
++#define CONFIG_SMARTBLUR_FILTER 0
++#define CONFIG_SOBEL_FILTER 0
++#define CONFIG_SOBEL_OPENCL_FILTER 0
++#define CONFIG_SPLIT_FILTER 0
++#define CONFIG_SPP_FILTER 0
++#define CONFIG_SR_FILTER 0
++#define CONFIG_SSIM_FILTER 0
++#define CONFIG_SSIM360_FILTER 0
++#define CONFIG_STEREO3D_FILTER 0
++#define CONFIG_STREAMSELECT_FILTER 0
++#define CONFIG_SUBTITLES_FILTER 0
++#define CONFIG_SUPER2XSAI_FILTER 0
++#define CONFIG_SWAPRECT_FILTER 0
++#define CONFIG_SWAPUV_FILTER 0
++#define CONFIG_TBLEND_FILTER 0
++#define CONFIG_TELECINE_FILTER 0
++#define CONFIG_THISTOGRAM_FILTER 0
++#define CONFIG_THRESHOLD_FILTER 0
++#define CONFIG_THUMBNAIL_FILTER 0
++#define CONFIG_THUMBNAIL_CUDA_FILTER 0
++#define CONFIG_TILE_FILTER 0
++#define CONFIG_TINTERLACE_FILTER 0
++#define CONFIG_TLUT2_FILTER 0
++#define CONFIG_TMEDIAN_FILTER 0
++#define CONFIG_TMIDEQUALIZER_FILTER 0
++#define CONFIG_TMIX_FILTER 0
++#define CONFIG_TONEMAP_FILTER 0
++#define CONFIG_TONEMAP_OPENCL_FILTER 0
++#define CONFIG_TONEMAP_VAAPI_FILTER 0
++#define CONFIG_TPAD_FILTER 0
++#define CONFIG_TRANSPOSE_FILTER 0
++#define CONFIG_TRANSPOSE_NPP_FILTER 0
++#define CONFIG_TRANSPOSE_OPENCL_FILTER 0
++#define CONFIG_TRANSPOSE_VAAPI_FILTER 0
++#define CONFIG_TRANSPOSE_VULKAN_FILTER 0
++#define CONFIG_TRIM_FILTER 0
++#define CONFIG_UNPREMULTIPLY_FILTER 0
++#define CONFIG_UNSHARP_FILTER 0
++#define CONFIG_UNSHARP_OPENCL_FILTER 0
++#define CONFIG_UNTILE_FILTER 0
++#define CONFIG_USPP_FILTER 0
++#define CONFIG_V360_FILTER 0
++#define CONFIG_VAGUEDENOISER_FILTER 0
++#define CONFIG_VARBLUR_FILTER 0
++#define CONFIG_VECTORSCOPE_FILTER 0
++#define CONFIG_VFLIP_FILTER 0
++#define CONFIG_VFLIP_VULKAN_FILTER 0
++#define CONFIG_VFRDET_FILTER 0
++#define CONFIG_VIBRANCE_FILTER 0
++#define CONFIG_VIDSTABDETECT_FILTER 0
++#define CONFIG_VIDSTABTRANSFORM_FILTER 0
++#define CONFIG_VIF_FILTER 0
++#define CONFIG_VIGNETTE_FILTER 0
++#define CONFIG_VMAFMOTION_FILTER 0
++#define CONFIG_VPP_QSV_FILTER 0
++#define CONFIG_VSTACK_FILTER 0
++#define CONFIG_W3FDIF_FILTER 0
++#define CONFIG_WAVEFORM_FILTER 0
++#define CONFIG_WEAVE_FILTER 0
++#define CONFIG_XBR_FILTER 0
++#define CONFIG_XCORRELATE_FILTER 0
++#define CONFIG_XFADE_FILTER 0
++#define CONFIG_XFADE_OPENCL_FILTER 0
++#define CONFIG_XMEDIAN_FILTER 0
++#define CONFIG_XSTACK_FILTER 0
++#define CONFIG_YADIF_FILTER 0
++#define CONFIG_YADIF_CUDA_FILTER 0
++#define CONFIG_YADIF_VIDEOTOOLBOX_FILTER 0
++#define CONFIG_YAEPBLUR_FILTER 0
++#define CONFIG_ZMQ_FILTER 0
++#define CONFIG_ZOOMPAN_FILTER 0
++#define CONFIG_ZSCALE_FILTER 0
++#define CONFIG_HSTACK_VAAPI_FILTER 0
++#define CONFIG_VSTACK_VAAPI_FILTER 0
++#define CONFIG_XSTACK_VAAPI_FILTER 0
++#define CONFIG_HSTACK_QSV_FILTER 0
++#define CONFIG_VSTACK_QSV_FILTER 0
++#define CONFIG_XSTACK_QSV_FILTER 0
++#define CONFIG_ALLRGB_FILTER 0
++#define CONFIG_ALLYUV_FILTER 0
++#define CONFIG_CELLAUTO_FILTER 0
++#define CONFIG_COLOR_FILTER 0
++#define CONFIG_COLORCHART_FILTER 0
++#define CONFIG_COLORSPECTRUM_FILTER 0
++#define CONFIG_COREIMAGESRC_FILTER 0
++#define CONFIG_DDAGRAB_FILTER 0
++#define CONFIG_FREI0R_SRC_FILTER 0
++#define CONFIG_GRADIENTS_FILTER 0
++#define CONFIG_HALDCLUTSRC_FILTER 0
++#define CONFIG_LIFE_FILTER 0
++#define CONFIG_MANDELBROT_FILTER 0
++#define CONFIG_MPTESTSRC_FILTER 0
++#define CONFIG_NULLSRC_FILTER 0
++#define CONFIG_OPENCLSRC_FILTER 0
++#define CONFIG_PAL75BARS_FILTER 0
++#define CONFIG_PAL100BARS_FILTER 0
++#define CONFIG_RGBTESTSRC_FILTER 0
++#define CONFIG_SIERPINSKI_FILTER 0
++#define CONFIG_SMPTEBARS_FILTER 0
++#define CONFIG_SMPTEHDBARS_FILTER 0
++#define CONFIG_TESTSRC_FILTER 0
++#define CONFIG_TESTSRC2_FILTER 0
++#define CONFIG_YUVTESTSRC_FILTER 0
++#define CONFIG_ZONEPLATE_FILTER 0
++#define CONFIG_NULLSINK_FILTER 0
++#define CONFIG_A3DSCOPE_FILTER 0
++#define CONFIG_ABITSCOPE_FILTER 0
++#define CONFIG_ADRAWGRAPH_FILTER 0
++#define CONFIG_AGRAPHMONITOR_FILTER 0
++#define CONFIG_AHISTOGRAM_FILTER 0
++#define CONFIG_APHASEMETER_FILTER 0
++#define CONFIG_AVECTORSCOPE_FILTER 0
++#define CONFIG_CONCAT_FILTER 0
++#define CONFIG_SHOWCQT_FILTER 0
++#define CONFIG_SHOWCWT_FILTER 0
++#define CONFIG_SHOWFREQS_FILTER 0
++#define CONFIG_SHOWSPATIAL_FILTER 0
++#define CONFIG_SHOWSPECTRUM_FILTER 0
++#define CONFIG_SHOWSPECTRUMPIC_FILTER 0
++#define CONFIG_SHOWVOLUME_FILTER 0
++#define CONFIG_SHOWWAVES_FILTER 0
++#define CONFIG_SHOWWAVESPIC_FILTER 0
++#define CONFIG_SPECTRUMSYNTH_FILTER 0
++#define CONFIG_AVSYNCTEST_FILTER 0
++#define CONFIG_AMOVIE_FILTER 0
++#define CONFIG_MOVIE_FILTER 0
++#define CONFIG_AFIFO_FILTER 0
++#define CONFIG_FIFO_FILTER 0
++#define CONFIG_AA_DEMUXER 0
++#define CONFIG_AAC_DEMUXER 1
++#define CONFIG_AAX_DEMUXER 0
++#define CONFIG_AC3_DEMUXER 0
++#define CONFIG_ACE_DEMUXER 0
++#define CONFIG_ACM_DEMUXER 0
++#define CONFIG_ACT_DEMUXER 0
++#define CONFIG_ADF_DEMUXER 0
++#define CONFIG_ADP_DEMUXER 0
++#define CONFIG_ADS_DEMUXER 0
++#define CONFIG_ADX_DEMUXER 0
++#define CONFIG_AEA_DEMUXER 0
++#define CONFIG_AFC_DEMUXER 0
++#define CONFIG_AIFF_DEMUXER 0
++#define CONFIG_AIX_DEMUXER 0
++#define CONFIG_ALP_DEMUXER 0
++#define CONFIG_AMR_DEMUXER 0
++#define CONFIG_AMRNB_DEMUXER 0
++#define CONFIG_AMRWB_DEMUXER 0
++#define CONFIG_ANM_DEMUXER 0
++#define CONFIG_APAC_DEMUXER 0
++#define CONFIG_APC_DEMUXER 0
++#define CONFIG_APE_DEMUXER 0
++#define CONFIG_APM_DEMUXER 0
++#define CONFIG_APNG_DEMUXER 0
++#define CONFIG_APTX_DEMUXER 0
++#define CONFIG_APTX_HD_DEMUXER 0
++#define CONFIG_AQTITLE_DEMUXER 0
++#define CONFIG_ARGO_ASF_DEMUXER 0
++#define CONFIG_ARGO_BRP_DEMUXER 0
++#define CONFIG_ARGO_CVG_DEMUXER 0
++#define CONFIG_ASF_DEMUXER 0
++#define CONFIG_ASF_O_DEMUXER 0
++#define CONFIG_ASS_DEMUXER 0
++#define CONFIG_AST_DEMUXER 0
++#define CONFIG_AU_DEMUXER 0
++#define CONFIG_AV1_DEMUXER 0
++#define CONFIG_AVI_DEMUXER 1
++#define CONFIG_AVISYNTH_DEMUXER 0
++#define CONFIG_AVR_DEMUXER 0
++#define CONFIG_AVS_DEMUXER 0
++#define CONFIG_AVS2_DEMUXER 0
++#define CONFIG_AVS3_DEMUXER 0
++#define CONFIG_BETHSOFTVID_DEMUXER 0
++#define CONFIG_BFI_DEMUXER 0
++#define CONFIG_BINTEXT_DEMUXER 0
++#define CONFIG_BINK_DEMUXER 0
++#define CONFIG_BINKA_DEMUXER 0
++#define CONFIG_BIT_DEMUXER 0
++#define CONFIG_BITPACKED_DEMUXER 0
++#define CONFIG_BMV_DEMUXER 0
++#define CONFIG_BFSTM_DEMUXER 0
++#define CONFIG_BRSTM_DEMUXER 0
++#define CONFIG_BOA_DEMUXER 0
++#define CONFIG_BONK_DEMUXER 0
++#define CONFIG_C93_DEMUXER 0
++#define CONFIG_CAF_DEMUXER 0
++#define CONFIG_CAVSVIDEO_DEMUXER 0
++#define CONFIG_CDG_DEMUXER 0
++#define CONFIG_CDXL_DEMUXER 0
++#define CONFIG_CINE_DEMUXER 0
++#define CONFIG_CODEC2_DEMUXER 0
++#define CONFIG_CODEC2RAW_DEMUXER 0
++#define CONFIG_CONCAT_DEMUXER 0
++#define CONFIG_DASH_DEMUXER 0
++#define CONFIG_DATA_DEMUXER 0
++#define CONFIG_DAUD_DEMUXER 0
++#define CONFIG_DCSTR_DEMUXER 0
++#define CONFIG_DERF_DEMUXER 0
++#define CONFIG_DFA_DEMUXER 0
++#define CONFIG_DFPWM_DEMUXER 0
++#define CONFIG_DHAV_DEMUXER 0
++#define CONFIG_DIRAC_DEMUXER 0
++#define CONFIG_DNXHD_DEMUXER 0
++#define CONFIG_DSF_DEMUXER 0
++#define CONFIG_DSICIN_DEMUXER 0
++#define CONFIG_DSS_DEMUXER 0
++#define CONFIG_DTS_DEMUXER 0
++#define CONFIG_DTSHD_DEMUXER 0
++#define CONFIG_DV_DEMUXER 0
++#define CONFIG_DVBSUB_DEMUXER 0
++#define CONFIG_DVBTXT_DEMUXER 0
++#define CONFIG_DXA_DEMUXER 0
++#define CONFIG_EA_DEMUXER 0
++#define CONFIG_EA_CDATA_DEMUXER 0
++#define CONFIG_EAC3_DEMUXER 0
++#define CONFIG_EPAF_DEMUXER 0
++#define CONFIG_FFMETADATA_DEMUXER 0
++#define CONFIG_FILMSTRIP_DEMUXER 0
++#define CONFIG_FITS_DEMUXER 0
++#define CONFIG_FLAC_DEMUXER 1
++#define CONFIG_FLIC_DEMUXER 0
++#define CONFIG_FLV_DEMUXER 0
++#define CONFIG_LIVE_FLV_DEMUXER 0
++#define CONFIG_FOURXM_DEMUXER 0
++#define CONFIG_FRM_DEMUXER 0
++#define CONFIG_FSB_DEMUXER 0
++#define CONFIG_FWSE_DEMUXER 0
++#define CONFIG_G722_DEMUXER 0
++#define CONFIG_G723_1_DEMUXER 0
++#define CONFIG_G726_DEMUXER 0
++#define CONFIG_G726LE_DEMUXER 0
++#define CONFIG_G729_DEMUXER 0
++#define CONFIG_GDV_DEMUXER 0
++#define CONFIG_GENH_DEMUXER 0
++#define CONFIG_GIF_DEMUXER 0
++#define CONFIG_GSM_DEMUXER 0
++#define CONFIG_GXF_DEMUXER 0
++#define CONFIG_H261_DEMUXER 0
++#define CONFIG_H263_DEMUXER 0
++#define CONFIG_H264_DEMUXER 0
++#define CONFIG_HCA_DEMUXER 0
++#define CONFIG_HCOM_DEMUXER 0
++#define CONFIG_HEVC_DEMUXER 0
++#define CONFIG_HLS_DEMUXER 0
++#define CONFIG_HNM_DEMUXER 0
++#define CONFIG_ICO_DEMUXER 0
++#define CONFIG_IDCIN_DEMUXER 0
++#define CONFIG_IDF_DEMUXER 0
++#define CONFIG_IFF_DEMUXER 0
++#define CONFIG_IFV_DEMUXER 0
++#define CONFIG_ILBC_DEMUXER 0
++#define CONFIG_IMAGE2_DEMUXER 0
++#define CONFIG_IMAGE2PIPE_DEMUXER 0
++#define CONFIG_IMAGE2_ALIAS_PIX_DEMUXER 0
++#define CONFIG_IMAGE2_BRENDER_PIX_DEMUXER 0
++#define CONFIG_IMF_DEMUXER 0
++#define CONFIG_INGENIENT_DEMUXER 0
++#define CONFIG_IPMOVIE_DEMUXER 0
++#define CONFIG_IPU_DEMUXER 0
++#define CONFIG_IRCAM_DEMUXER 0
++#define CONFIG_ISS_DEMUXER 0
++#define CONFIG_IV8_DEMUXER 0
++#define CONFIG_IVF_DEMUXER 0
++#define CONFIG_IVR_DEMUXER 0
++#define CONFIG_JACOSUB_DEMUXER 0
++#define CONFIG_JV_DEMUXER 0
++#define CONFIG_KUX_DEMUXER 0
++#define CONFIG_KVAG_DEMUXER 0
++#define CONFIG_LAF_DEMUXER 0
++#define CONFIG_LMLM4_DEMUXER 0
++#define CONFIG_LOAS_DEMUXER 0
++#define CONFIG_LUODAT_DEMUXER 0
++#define CONFIG_LRC_DEMUXER 0
++#define CONFIG_LVF_DEMUXER 0
++#define CONFIG_LXF_DEMUXER 0
++#define CONFIG_M4V_DEMUXER 0
++#define CONFIG_MCA_DEMUXER 0
++#define CONFIG_MCC_DEMUXER 0
++#define CONFIG_MATROSKA_DEMUXER 1
++#define CONFIG_MGSTS_DEMUXER 0
++#define CONFIG_MICRODVD_DEMUXER 0
++#define CONFIG_MJPEG_DEMUXER 0
++#define CONFIG_MJPEG_2000_DEMUXER 0
++#define CONFIG_MLP_DEMUXER 0
++#define CONFIG_MLV_DEMUXER 0
++#define CONFIG_MM_DEMUXER 0
++#define CONFIG_MMF_DEMUXER 0
++#define CONFIG_MODS_DEMUXER 0
++#define CONFIG_MOFLEX_DEMUXER 0
++#define CONFIG_MOV_DEMUXER 1
++#define CONFIG_MP3_DEMUXER 1
++#define CONFIG_MPC_DEMUXER 0
++#define CONFIG_MPC8_DEMUXER 0
++#define CONFIG_MPEGPS_DEMUXER 0
++#define CONFIG_MPEGTS_DEMUXER 0
++#define CONFIG_MPEGTSRAW_DEMUXER 0
++#define CONFIG_MPEGVIDEO_DEMUXER 0
++#define CONFIG_MPJPEG_DEMUXER 0
++#define CONFIG_MPL2_DEMUXER 0
++#define CONFIG_MPSUB_DEMUXER 0
++#define CONFIG_MSF_DEMUXER 0
++#define CONFIG_MSNWC_TCP_DEMUXER 0
++#define CONFIG_MSP_DEMUXER 0
++#define CONFIG_MTAF_DEMUXER 0
++#define CONFIG_MTV_DEMUXER 0
++#define CONFIG_MUSX_DEMUXER 0
++#define CONFIG_MV_DEMUXER 0
++#define CONFIG_MVI_DEMUXER 0
++#define CONFIG_MXF_DEMUXER 0
++#define CONFIG_MXG_DEMUXER 0
++#define CONFIG_NC_DEMUXER 0
++#define CONFIG_NISTSPHERE_DEMUXER 0
++#define CONFIG_NSP_DEMUXER 0
++#define CONFIG_NSV_DEMUXER 0
++#define CONFIG_NUT_DEMUXER 0
++#define CONFIG_NUV_DEMUXER 0
++#define CONFIG_OBU_DEMUXER 0
++#define CONFIG_OGG_DEMUXER 1
++#define CONFIG_OMA_DEMUXER 0
++#define CONFIG_PAF_DEMUXER 0
++#define CONFIG_PCM_ALAW_DEMUXER 0
++#define CONFIG_PCM_MULAW_DEMUXER 0
++#define CONFIG_PCM_VIDC_DEMUXER 0
++#define CONFIG_PCM_F64BE_DEMUXER 0
++#define CONFIG_PCM_F64LE_DEMUXER 0
++#define CONFIG_PCM_F32BE_DEMUXER 0
++#define CONFIG_PCM_F32LE_DEMUXER 0
++#define CONFIG_PCM_S32BE_DEMUXER 0
++#define CONFIG_PCM_S32LE_DEMUXER 0
++#define CONFIG_PCM_S24BE_DEMUXER 0
++#define CONFIG_PCM_S24LE_DEMUXER 0
++#define CONFIG_PCM_S16BE_DEMUXER 0
++#define CONFIG_PCM_S16LE_DEMUXER 0
++#define CONFIG_PCM_S8_DEMUXER 0
++#define CONFIG_PCM_U32BE_DEMUXER 0
++#define CONFIG_PCM_U32LE_DEMUXER 0
++#define CONFIG_PCM_U24BE_DEMUXER 0
++#define CONFIG_PCM_U24LE_DEMUXER 0
++#define CONFIG_PCM_U16BE_DEMUXER 0
++#define CONFIG_PCM_U16LE_DEMUXER 0
++#define CONFIG_PCM_U8_DEMUXER 0
++#define CONFIG_PDV_DEMUXER 0
++#define CONFIG_PJS_DEMUXER 0
++#define CONFIG_PMP_DEMUXER 0
++#define CONFIG_PP_BNK_DEMUXER 0
++#define CONFIG_PVA_DEMUXER 0
++#define CONFIG_PVF_DEMUXER 0
++#define CONFIG_QCP_DEMUXER 0
++#define CONFIG_R3D_DEMUXER 0
++#define CONFIG_RAWVIDEO_DEMUXER 0
++#define CONFIG_REALTEXT_DEMUXER 0
++#define CONFIG_REDSPARK_DEMUXER 0
++#define CONFIG_RKA_DEMUXER 0
++#define CONFIG_RL2_DEMUXER 0
++#define CONFIG_RM_DEMUXER 0
++#define CONFIG_ROQ_DEMUXER 0
++#define CONFIG_RPL_DEMUXER 0
++#define CONFIG_RSD_DEMUXER 0
++#define CONFIG_RSO_DEMUXER 0
++#define CONFIG_RTP_DEMUXER 0
++#define CONFIG_RTSP_DEMUXER 0
++#define CONFIG_S337M_DEMUXER 0
++#define CONFIG_SAMI_DEMUXER 0
++#define CONFIG_SAP_DEMUXER 0
++#define CONFIG_SBC_DEMUXER 0
++#define CONFIG_SBG_DEMUXER 0
++#define CONFIG_SCC_DEMUXER 0
++#define CONFIG_SCD_DEMUXER 0
++#define CONFIG_SDNS_DEMUXER 0
++#define CONFIG_SDP_DEMUXER 0
++#define CONFIG_SDR2_DEMUXER 0
++#define CONFIG_SDS_DEMUXER 0
++#define CONFIG_SDX_DEMUXER 0
++#define CONFIG_SEGAFILM_DEMUXER 0
++#define CONFIG_SER_DEMUXER 0
++#define CONFIG_SGA_DEMUXER 0
++#define CONFIG_SHORTEN_DEMUXER 0
++#define CONFIG_SIFF_DEMUXER 0
++#define CONFIG_SIMBIOSIS_IMX_DEMUXER 0
++#define CONFIG_SLN_DEMUXER 0
++#define CONFIG_SMACKER_DEMUXER 0
++#define CONFIG_SMJPEG_DEMUXER 0
++#define CONFIG_SMUSH_DEMUXER 0
++#define CONFIG_SOL_DEMUXER 0
++#define CONFIG_SOX_DEMUXER 0
++#define CONFIG_SPDIF_DEMUXER 0
++#define CONFIG_SRT_DEMUXER 0
++#define CONFIG_STR_DEMUXER 0
++#define CONFIG_STL_DEMUXER 0
++#define CONFIG_SUBVIEWER1_DEMUXER 0
++#define CONFIG_SUBVIEWER_DEMUXER 0
++#define CONFIG_SUP_DEMUXER 0
++#define CONFIG_SVAG_DEMUXER 0
++#define CONFIG_SVS_DEMUXER 0
++#define CONFIG_SWF_DEMUXER 0
++#define CONFIG_TAK_DEMUXER 0
++#define CONFIG_TEDCAPTIONS_DEMUXER 0
++#define CONFIG_THP_DEMUXER 0
++#define CONFIG_THREEDOSTR_DEMUXER 0
++#define CONFIG_TIERTEXSEQ_DEMUXER 0
++#define CONFIG_TMV_DEMUXER 0
++#define CONFIG_TRUEHD_DEMUXER 0
++#define CONFIG_TTA_DEMUXER 0
++#define CONFIG_TXD_DEMUXER 0
++#define CONFIG_TTY_DEMUXER 0
++#define CONFIG_TY_DEMUXER 0
++#define CONFIG_V210_DEMUXER 0
++#define CONFIG_V210X_DEMUXER 0
++#define CONFIG_VAG_DEMUXER 0
++#define CONFIG_VC1_DEMUXER 0
++#define CONFIG_VC1T_DEMUXER 0
++#define CONFIG_VIVIDAS_DEMUXER 0
++#define CONFIG_VIVO_DEMUXER 0
++#define CONFIG_VMD_DEMUXER 0
++#define CONFIG_VOBSUB_DEMUXER 0
++#define CONFIG_VOC_DEMUXER 0
++#define CONFIG_VPK_DEMUXER 0
++#define CONFIG_VPLAYER_DEMUXER 0
++#define CONFIG_VQF_DEMUXER 0
++#define CONFIG_W64_DEMUXER 0
++#define CONFIG_WADY_DEMUXER 0
++#define CONFIG_WAVARC_DEMUXER 0
++#define CONFIG_WAV_DEMUXER 1
++#define CONFIG_WC3_DEMUXER 0
++#define CONFIG_WEBM_DASH_MANIFEST_DEMUXER 0
++#define CONFIG_WEBVTT_DEMUXER 0
++#define CONFIG_WSAUD_DEMUXER 0
++#define CONFIG_WSD_DEMUXER 0
++#define CONFIG_WSVQA_DEMUXER 0
++#define CONFIG_WTV_DEMUXER 0
++#define CONFIG_WVE_DEMUXER 0
++#define CONFIG_WV_DEMUXER 0
++#define CONFIG_XA_DEMUXER 0
++#define CONFIG_XBIN_DEMUXER 0
++#define CONFIG_XMD_DEMUXER 0
++#define CONFIG_XMV_DEMUXER 0
++#define CONFIG_XVAG_DEMUXER 0
++#define CONFIG_XWMA_DEMUXER 0
++#define CONFIG_YOP_DEMUXER 0
++#define CONFIG_YUV4MPEGPIPE_DEMUXER 0
++#define CONFIG_IMAGE_BMP_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_CRI_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_DDS_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_DPX_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_EXR_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_GEM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_GIF_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_HDR_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_J2K_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_JPEG_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_JPEGLS_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_JPEGXL_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PAM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PBM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PCX_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PFM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PGMYUV_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PGM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PGX_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PHM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PHOTOCD_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PICTOR_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PNG_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PPM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PSD_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_QDRAW_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_QOI_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_SGI_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_SVG_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_SUNRAST_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_TIFF_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_VBN_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_WEBP_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_XBM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_XPM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_XWD_PIPE_DEMUXER 0
++#define CONFIG_LIBGME_DEMUXER 0
++#define CONFIG_LIBMODPLUG_DEMUXER 0
++#define CONFIG_LIBOPENMPT_DEMUXER 0
++#define CONFIG_VAPOURSYNTH_DEMUXER 0
++#define CONFIG_A64_MUXER 0
++#define CONFIG_AC3_MUXER 0
++#define CONFIG_ADTS_MUXER 0
++#define CONFIG_ADX_MUXER 0
++#define CONFIG_AIFF_MUXER 0
++#define CONFIG_ALP_MUXER 0
++#define CONFIG_AMR_MUXER 0
++#define CONFIG_AMV_MUXER 0
++#define CONFIG_APM_MUXER 0
++#define CONFIG_APNG_MUXER 0
++#define CONFIG_APTX_MUXER 0
++#define CONFIG_APTX_HD_MUXER 0
++#define CONFIG_ARGO_ASF_MUXER 0
++#define CONFIG_ARGO_CVG_MUXER 0
++#define CONFIG_ASF_MUXER 0
++#define CONFIG_ASS_MUXER 0
++#define CONFIG_AST_MUXER 0
++#define CONFIG_ASF_STREAM_MUXER 0
++#define CONFIG_AU_MUXER 0
++#define CONFIG_AVI_MUXER 0
++#define CONFIG_AVIF_MUXER 0
++#define CONFIG_AVM2_MUXER 0
++#define CONFIG_AVS2_MUXER 0
++#define CONFIG_AVS3_MUXER 0
++#define CONFIG_BIT_MUXER 0
++#define CONFIG_CAF_MUXER 0
++#define CONFIG_CAVSVIDEO_MUXER 0
++#define CONFIG_CODEC2_MUXER 0
++#define CONFIG_CODEC2RAW_MUXER 0
++#define CONFIG_CRC_MUXER 0
++#define CONFIG_DASH_MUXER 0
++#define CONFIG_DATA_MUXER 0
++#define CONFIG_DAUD_MUXER 0
++#define CONFIG_DFPWM_MUXER 0
++#define CONFIG_DIRAC_MUXER 0
++#define CONFIG_DNXHD_MUXER 0
++#define CONFIG_DTS_MUXER 0
++#define CONFIG_DV_MUXER 0
++#define CONFIG_EAC3_MUXER 0
++#define CONFIG_F4V_MUXER 0
++#define CONFIG_FFMETADATA_MUXER 0
++#define CONFIG_FIFO_MUXER 0
++#define CONFIG_FIFO_TEST_MUXER 0
++#define CONFIG_FILMSTRIP_MUXER 0
++#define CONFIG_FITS_MUXER 0
++#define CONFIG_FLAC_MUXER 0
++#define CONFIG_FLV_MUXER 0
++#define CONFIG_FRAMECRC_MUXER 0
++#define CONFIG_FRAMEHASH_MUXER 0
++#define CONFIG_FRAMEMD5_MUXER 0
++#define CONFIG_G722_MUXER 0
++#define CONFIG_G723_1_MUXER 0
++#define CONFIG_G726_MUXER 0
++#define CONFIG_G726LE_MUXER 0
++#define CONFIG_GIF_MUXER 0
++#define CONFIG_GSM_MUXER 0
++#define CONFIG_GXF_MUXER 0
++#define CONFIG_H261_MUXER 0
++#define CONFIG_H263_MUXER 0
++#define CONFIG_H264_MUXER 0
++#define CONFIG_HASH_MUXER 0
++#define CONFIG_HDS_MUXER 0
++#define CONFIG_HEVC_MUXER 0
++#define CONFIG_HLS_MUXER 0
++#define CONFIG_ICO_MUXER 0
++#define CONFIG_ILBC_MUXER 0
++#define CONFIG_IMAGE2_MUXER 0
++#define CONFIG_IMAGE2PIPE_MUXER 0
++#define CONFIG_IPOD_MUXER 0
++#define CONFIG_IRCAM_MUXER 0
++#define CONFIG_ISMV_MUXER 0
++#define CONFIG_IVF_MUXER 0
++#define CONFIG_JACOSUB_MUXER 0
++#define CONFIG_KVAG_MUXER 0
++#define CONFIG_LATM_MUXER 0
++#define CONFIG_LRC_MUXER 0
++#define CONFIG_M4V_MUXER 0
++#define CONFIG_MD5_MUXER 0
++#define CONFIG_MATROSKA_MUXER 0
++#define CONFIG_MATROSKA_AUDIO_MUXER 0
++#define CONFIG_MICRODVD_MUXER 0
++#define CONFIG_MJPEG_MUXER 0
++#define CONFIG_MLP_MUXER 0
++#define CONFIG_MMF_MUXER 0
++#define CONFIG_MOV_MUXER 0
++#define CONFIG_MP2_MUXER 0
++#define CONFIG_MP3_MUXER 0
++#define CONFIG_MP4_MUXER 0
++#define CONFIG_MPEG1SYSTEM_MUXER 0
++#define CONFIG_MPEG1VCD_MUXER 0
++#define CONFIG_MPEG1VIDEO_MUXER 0
++#define CONFIG_MPEG2DVD_MUXER 0
++#define CONFIG_MPEG2SVCD_MUXER 0
++#define CONFIG_MPEG2VIDEO_MUXER 0
++#define CONFIG_MPEG2VOB_MUXER 0
++#define CONFIG_MPEGTS_MUXER 0
++#define CONFIG_MPJPEG_MUXER 0
++#define CONFIG_MXF_MUXER 0
++#define CONFIG_MXF_D10_MUXER 0
++#define CONFIG_MXF_OPATOM_MUXER 0
++#define CONFIG_NULL_MUXER 0
++#define CONFIG_NUT_MUXER 0
++#define CONFIG_OBU_MUXER 0
++#define CONFIG_OGA_MUXER 0
++#define CONFIG_OGG_MUXER 0
++#define CONFIG_OGV_MUXER 0
++#define CONFIG_OMA_MUXER 0
++#define CONFIG_OPUS_MUXER 0
++#define CONFIG_PCM_ALAW_MUXER 0
++#define CONFIG_PCM_MULAW_MUXER 0
++#define CONFIG_PCM_VIDC_MUXER 0
++#define CONFIG_PCM_F64BE_MUXER 0
++#define CONFIG_PCM_F64LE_MUXER 0
++#define CONFIG_PCM_F32BE_MUXER 0
++#define CONFIG_PCM_F32LE_MUXER 0
++#define CONFIG_PCM_S32BE_MUXER 0
++#define CONFIG_PCM_S32LE_MUXER 0
++#define CONFIG_PCM_S24BE_MUXER 0
++#define CONFIG_PCM_S24LE_MUXER 0
++#define CONFIG_PCM_S16BE_MUXER 0
++#define CONFIG_PCM_S16LE_MUXER 0
++#define CONFIG_PCM_S8_MUXER 0
++#define CONFIG_PCM_U32BE_MUXER 0
++#define CONFIG_PCM_U32LE_MUXER 0
++#define CONFIG_PCM_U24BE_MUXER 0
++#define CONFIG_PCM_U24LE_MUXER 0
++#define CONFIG_PCM_U16BE_MUXER 0
++#define CONFIG_PCM_U16LE_MUXER 0
++#define CONFIG_PCM_U8_MUXER 0
++#define CONFIG_PSP_MUXER 0
++#define CONFIG_RAWVIDEO_MUXER 0
++#define CONFIG_RM_MUXER 0
++#define CONFIG_ROQ_MUXER 0
++#define CONFIG_RSO_MUXER 0
++#define CONFIG_RTP_MUXER 0
++#define CONFIG_RTP_MPEGTS_MUXER 0
++#define CONFIG_RTSP_MUXER 0
++#define CONFIG_SAP_MUXER 0
++#define CONFIG_SBC_MUXER 0
++#define CONFIG_SCC_MUXER 0
++#define CONFIG_SEGAFILM_MUXER 0
++#define CONFIG_SEGMENT_MUXER 0
++#define CONFIG_STREAM_SEGMENT_MUXER 0
++#define CONFIG_SMJPEG_MUXER 0
++#define CONFIG_SMOOTHSTREAMING_MUXER 0
++#define CONFIG_SOX_MUXER 0
++#define CONFIG_SPX_MUXER 0
++#define CONFIG_SPDIF_MUXER 0
++#define CONFIG_SRT_MUXER 0
++#define CONFIG_STREAMHASH_MUXER 0
++#define CONFIG_SUP_MUXER 0
++#define CONFIG_SWF_MUXER 0
++#define CONFIG_TEE_MUXER 0
++#define CONFIG_TG2_MUXER 0
++#define CONFIG_TGP_MUXER 0
++#define CONFIG_MKVTIMESTAMP_V2_MUXER 0
++#define CONFIG_TRUEHD_MUXER 0
++#define CONFIG_TTA_MUXER 0
++#define CONFIG_TTML_MUXER 0
++#define CONFIG_UNCODEDFRAMECRC_MUXER 0
++#define CONFIG_VC1_MUXER 0
++#define CONFIG_VC1T_MUXER 0
++#define CONFIG_VOC_MUXER 0
++#define CONFIG_W64_MUXER 0
++#define CONFIG_WAV_MUXER 0
++#define CONFIG_WEBM_MUXER 0
++#define CONFIG_WEBM_DASH_MANIFEST_MUXER 0
++#define CONFIG_WEBM_CHUNK_MUXER 0
++#define CONFIG_WEBP_MUXER 0
++#define CONFIG_WEBVTT_MUXER 0
++#define CONFIG_WSAUD_MUXER 0
++#define CONFIG_WTV_MUXER 0
++#define CONFIG_WV_MUXER 0
++#define CONFIG_YUV4MPEGPIPE_MUXER 0
++#define CONFIG_CHROMAPRINT_MUXER 0
++#define CONFIG_ASYNC_PROTOCOL 0
++#define CONFIG_BLURAY_PROTOCOL 0
++#define CONFIG_CACHE_PROTOCOL 0
++#define CONFIG_CONCAT_PROTOCOL 0
++#define CONFIG_CONCATF_PROTOCOL 0
++#define CONFIG_CRYPTO_PROTOCOL 0
++#define CONFIG_DATA_PROTOCOL 0
++#define CONFIG_FD_PROTOCOL 0
++#define CONFIG_FFRTMPCRYPT_PROTOCOL 0
++#define CONFIG_FFRTMPHTTP_PROTOCOL 0
++#define CONFIG_FILE_PROTOCOL 0
++#define CONFIG_FTP_PROTOCOL 0
++#define CONFIG_GOPHER_PROTOCOL 0
++#define CONFIG_GOPHERS_PROTOCOL 0
++#define CONFIG_HLS_PROTOCOL 0
++#define CONFIG_HTTP_PROTOCOL 0
++#define CONFIG_HTTPPROXY_PROTOCOL 0
++#define CONFIG_HTTPS_PROTOCOL 0
++#define CONFIG_ICECAST_PROTOCOL 0
++#define CONFIG_MMSH_PROTOCOL 0
++#define CONFIG_MMST_PROTOCOL 0
++#define CONFIG_MD5_PROTOCOL 0
++#define CONFIG_PIPE_PROTOCOL 0
++#define CONFIG_PROMPEG_PROTOCOL 0
++#define CONFIG_RTMP_PROTOCOL 0
++#define CONFIG_RTMPE_PROTOCOL 0
++#define CONFIG_RTMPS_PROTOCOL 0
++#define CONFIG_RTMPT_PROTOCOL 0
++#define CONFIG_RTMPTE_PROTOCOL 0
++#define CONFIG_RTMPTS_PROTOCOL 0
++#define CONFIG_RTP_PROTOCOL 0
++#define CONFIG_SCTP_PROTOCOL 0
++#define CONFIG_SRTP_PROTOCOL 0
++#define CONFIG_SUBFILE_PROTOCOL 0
++#define CONFIG_TEE_PROTOCOL 0
++#define CONFIG_TCP_PROTOCOL 0
++#define CONFIG_TLS_PROTOCOL 0
++#define CONFIG_UDP_PROTOCOL 0
++#define CONFIG_UDPLITE_PROTOCOL 0
++#define CONFIG_UNIX_PROTOCOL 0
++#define CONFIG_LIBAMQP_PROTOCOL 0
++#define CONFIG_LIBRIST_PROTOCOL 0
++#define CONFIG_LIBRTMP_PROTOCOL 0
++#define CONFIG_LIBRTMPE_PROTOCOL 0
++#define CONFIG_LIBRTMPS_PROTOCOL 0
++#define CONFIG_LIBRTMPT_PROTOCOL 0
++#define CONFIG_LIBRTMPTE_PROTOCOL 0
++#define CONFIG_LIBSRT_PROTOCOL 0
++#define CONFIG_LIBSSH_PROTOCOL 0
++#define CONFIG_LIBSMBCLIENT_PROTOCOL 0
++#define CONFIG_LIBZMQ_PROTOCOL 0
++#define CONFIG_IPFS_GATEWAY_PROTOCOL 0
++#define CONFIG_IPNS_GATEWAY_PROTOCOL 0
++#endif /* FFMPEG_CONFIG_COMPONENTS_H */
+diff --git a/chromium/config/ChromeOS/linux/x64/libavcodec/bsf_list.c b/chromium/config/ChromeOS/linux/x64/libavcodec/bsf_list.c
+new file mode 100644
+index 0000000000..7ff70c6e2d
+--- /dev/null
++++ b/chromium/config/ChromeOS/linux/x64/libavcodec/bsf_list.c
+@@ -0,0 +1,2 @@
++static const FFBitStreamFilter * const bitstream_filters[] = {
++    NULL };
+diff --git a/chromium/config/ChromeOS/linux/x64/libavcodec/codec_list.c b/chromium/config/ChromeOS/linux/x64/libavcodec/codec_list.c
+new file mode 100644
+index 0000000000..0cc2135452
+--- /dev/null
++++ b/chromium/config/ChromeOS/linux/x64/libavcodec/codec_list.c
+@@ -0,0 +1,22 @@
++static const FFCodec * const codec_list[] = {
++    &ff_h263_decoder,
++    &ff_h264_decoder,
++    &ff_mpeg4_decoder,
++    &ff_theora_decoder,
++    &ff_vp3_decoder,
++    &ff_vp8_decoder,
++    &ff_aac_decoder,
++    &ff_flac_decoder,
++    &ff_mp3_decoder,
++    &ff_vorbis_decoder,
++    &ff_pcm_alaw_decoder,
++    &ff_pcm_f32le_decoder,
++    &ff_pcm_mulaw_decoder,
++    &ff_pcm_s16be_decoder,
++    &ff_pcm_s16le_decoder,
++    &ff_pcm_s24be_decoder,
++    &ff_pcm_s24le_decoder,
++    &ff_pcm_s32le_decoder,
++    &ff_pcm_u8_decoder,
++    &ff_libopus_decoder,
++    NULL };
+diff --git a/chromium/config/ChromeOS/linux/x64/libavcodec/parser_list.c b/chromium/config/ChromeOS/linux/x64/libavcodec/parser_list.c
+new file mode 100644
+index 0000000000..e1652f8b9d
+--- /dev/null
++++ b/chromium/config/ChromeOS/linux/x64/libavcodec/parser_list.c
+@@ -0,0 +1,13 @@
++static const AVCodecParser * const parser_list[] = {
++    &ff_aac_parser,
++    &ff_flac_parser,
++    &ff_h263_parser,
++    &ff_h264_parser,
++    &ff_mpeg4video_parser,
++    &ff_mpegaudio_parser,
++    &ff_opus_parser,
++    &ff_vorbis_parser,
++    &ff_vp3_parser,
++    &ff_vp8_parser,
++    &ff_vp9_parser,
++    NULL };
+diff --git a/chromium/config/ChromeOS/linux/x64/libavformat/demuxer_list.c b/chromium/config/ChromeOS/linux/x64/libavformat/demuxer_list.c
+new file mode 100644
+index 0000000000..74870b99d2
+--- /dev/null
++++ b/chromium/config/ChromeOS/linux/x64/libavformat/demuxer_list.c
+@@ -0,0 +1,10 @@
++static const AVInputFormat * const demuxer_list[] = {
++    &ff_aac_demuxer,
++    &ff_avi_demuxer,
++    &ff_flac_demuxer,
++    &ff_matroska_demuxer,
++    &ff_mov_demuxer,
++    &ff_mp3_demuxer,
++    &ff_ogg_demuxer,
++    &ff_wav_demuxer,
++    NULL };
+diff --git a/chromium/config/ChromeOS/linux/x64/libavformat/muxer_list.c b/chromium/config/ChromeOS/linux/x64/libavformat/muxer_list.c
+new file mode 100644
+index 0000000000..ae54c39f23
+--- /dev/null
++++ b/chromium/config/ChromeOS/linux/x64/libavformat/muxer_list.c
+@@ -0,0 +1,2 @@
++static const FFOutputFormat * const muxer_list[] = {
++    NULL };
+diff --git a/chromium/config/ChromeOS/linux/x64/libavformat/protocol_list.c b/chromium/config/ChromeOS/linux/x64/libavformat/protocol_list.c
+new file mode 100644
+index 0000000000..247e1e4c3a
+--- /dev/null
++++ b/chromium/config/ChromeOS/linux/x64/libavformat/protocol_list.c
+@@ -0,0 +1,2 @@
++static const URLProtocol * const url_protocols[] = {
++    NULL };
+diff --git a/chromium/config/ChromeOS/linux/x64/libavutil/avconfig.h b/chromium/config/ChromeOS/linux/x64/libavutil/avconfig.h
+new file mode 100644
+index 0000000000..c289fbb551
+--- /dev/null
++++ b/chromium/config/ChromeOS/linux/x64/libavutil/avconfig.h
+@@ -0,0 +1,6 @@
++/* Generated by ffmpeg configure */
++#ifndef AVUTIL_AVCONFIG_H
++#define AVUTIL_AVCONFIG_H
++#define AV_HAVE_BIGENDIAN 0
++#define AV_HAVE_FAST_UNALIGNED 1
++#endif /* AVUTIL_AVCONFIG_H */
+diff --git a/chromium/config/ChromeOS/linux/x64/libavutil/ffversion.h b/chromium/config/ChromeOS/linux/x64/libavutil/ffversion.h
+new file mode 100644
+index 0000000000..a29e9ec3ff
+--- /dev/null
++++ b/chromium/config/ChromeOS/linux/x64/libavutil/ffversion.h
+@@ -0,0 +1,5 @@
++/* Automatically generated by version.sh, do not manually edit! */
++#ifndef AVUTIL_FFVERSION_H
++#define AVUTIL_FFVERSION_H
++#define FFMPEG_VERSION "git-2023-06-02-881c5c3f64"
++#endif /* AVUTIL_FFVERSION_H */
+diff --git a/chromium/config/Chromium/linux/riscv64/config.h b/chromium/config/Chromium/linux/riscv64/config.h
+new file mode 100644
+index 0000000000..ede2a13153
+--- /dev/null
++++ b/chromium/config/Chromium/linux/riscv64/config.h
+@@ -0,0 +1,793 @@
++/* Automatically generated by configure - do not modify! */
++#ifndef FFMPEG_CONFIG_H
++#define FFMPEG_CONFIG_H
++/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-iamf --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/home/kxxt/electron-ci/sources/electron/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\"-O2\"' --arch=riscv64 --extra-cflags='-march=rv64gc' --enable-cross-compile --target-os=linux --sysroot=/home/kxxt/electron-ci/sources/electron/src/build/linux/debian_sid_riscv64-sysroot --extra-cflags='--target=riscv64-linux-gnu' --extra-ldflags='--target=riscv64-linux-gnu' --enable-pic --cc=clang --cxx=clang++ --ld=clang --extra-ldflags='-fuse-ld=lld'" -- elide long configuration string from binary */
 +#define FFMPEG_LICENSE "LGPL version 2.1 or later"
 +#define CONFIG_THIS_YEAR 2024
 +#define FFMPEG_DATADIR "/usr/local/share/ffmpeg"
 +#define AVCONV_DATADIR "/usr/local/share/ffmpeg"
-+#define CC_IDENT "clang version 20.0.0git (https://chromium.googlesource.com/a/external/github.com/llvm/llvm-project 3dbd929ea6af134650dd1d91baeb61a4fc1b0eb8)"
++#define CC_IDENT "clang version 20.0.0git (https://chromium.googlesource.com/external/github.com/llvm/llvm-project b81d8e90339a788cc6cb148831612c6b39b93ad5)"
 +#define OS_NAME linux
 +#define EXTERN_PREFIX ""
 +#define EXTERN_ASM 
@@ -4644,6 +10398,8 @@ index 00000000000..f7c0d4639b5
 +#define HAVE_VFP 0
 +#define HAVE_VFPV3 0
 +#define HAVE_SETEND 0
++#define HAVE_SVE 0
++#define HAVE_SVE2 0
 +#define HAVE_ALTIVEC 0
 +#define HAVE_DCBZL 0
 +#define HAVE_LDBRX 0
@@ -4697,6 +10453,8 @@ index 00000000000..f7c0d4639b5
 +#define HAVE_VFP_EXTERNAL 0
 +#define HAVE_VFPV3_EXTERNAL 0
 +#define HAVE_SETEND_EXTERNAL 0
++#define HAVE_SVE_EXTERNAL 0
++#define HAVE_SVE2_EXTERNAL 0
 +#define HAVE_ALTIVEC_EXTERNAL 0
 +#define HAVE_DCBZL_EXTERNAL 0
 +#define HAVE_LDBRX_EXTERNAL 0
@@ -4750,6 +10508,8 @@ index 00000000000..f7c0d4639b5
 +#define HAVE_VFP_INLINE 0
 +#define HAVE_VFPV3_INLINE 0
 +#define HAVE_SETEND_INLINE 0
++#define HAVE_SVE_INLINE 0
++#define HAVE_SVE2_INLINE 0
 +#define HAVE_ALTIVEC_INLINE 0
 +#define HAVE_DCBZL_INLINE 0
 +#define HAVE_LDBRX_INLINE 0
@@ -4802,13 +10562,10 @@ index 00000000000..f7c0d4639b5
 +#define HAVE_SIMD_ALIGN_16 0
 +#define HAVE_SIMD_ALIGN_32 0
 +#define HAVE_SIMD_ALIGN_64 0
-+#define HAVE_ATOMIC_CAS_PTR 0
-+#define HAVE_MACHINE_RW_BARRIER 0
 +#define HAVE_MEMORYBARRIER 0
 +#define HAVE_MM_EMPTY 0
 +#define HAVE_RDTSC 0
 +#define HAVE_SEM_TIMEDWAIT 1
-+#define HAVE_SYNC_VAL_COMPARE_AND_SWAP 1
 +#define HAVE_INLINE_ASM 1
 +#define HAVE_SYMVER 0
 +#define HAVE_X86ASM 0
@@ -4965,6 +10722,8 @@ index 00000000000..f7c0d4639b5
 +#define HAVE_AS_ARCH_DIRECTIVE 0
 +#define HAVE_AS_ARCHEXT_DOTPROD_DIRECTIVE 0
 +#define HAVE_AS_ARCHEXT_I8MM_DIRECTIVE 0
++#define HAVE_AS_ARCHEXT_SVE_DIRECTIVE 0
++#define HAVE_AS_ARCHEXT_SVE2_DIRECTIVE 0
 +#define HAVE_AS_DN_DIRECTIVE 0
 +#define HAVE_AS_FPU_DIRECTIVE 0
 +#define HAVE_AS_FUNC 0
@@ -4991,6 +10750,7 @@ index 00000000000..f7c0d4639b5
 +#define HAVE_KCMVIDEOCODECTYPE_HEVC 0
 +#define HAVE_KCMVIDEOCODECTYPE_HEVCWITHALPHA 0
 +#define HAVE_KCMVIDEOCODECTYPE_VP9 0
++#define HAVE_KCMVIDEOCODECTYPE_AV1 0
 +#define HAVE_KCVPIXELFORMATTYPE_420YPCBCR10BIPLANARVIDEORANGE 0
 +#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR8BIPLANARVIDEORANGE 0
 +#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR10BIPLANARVIDEORANGE 0
@@ -5387,10 +11147,10 @@ index 00000000000..f7c0d4639b5
 +#endif /* FFMPEG_CONFIG_H */
 diff --git a/chromium/config/Chromium/linux/riscv64/config_components.h b/chromium/config/Chromium/linux/riscv64/config_components.h
 new file mode 100644
-index 00000000000..fe3b62f8200
+index 0000000000..f064aeccac
 --- /dev/null
 +++ b/chromium/config/Chromium/linux/riscv64/config_components.h
-@@ -0,0 +1,2231 @@
+@@ -0,0 +1,2234 @@
 +/* Automatically generated by configure - do not modify! */
 +#ifndef FFMPEG_CONFIG_COMPONENTS_H
 +#define FFMPEG_CONFIG_COMPONENTS_H
@@ -6245,6 +12005,7 @@ index 00000000000..fe3b62f8200
 +#define CONFIG_AV1_NVENC_ENCODER 0
 +#define CONFIG_AV1_QSV_ENCODER 0
 +#define CONFIG_AV1_AMF_ENCODER 0
++#define CONFIG_AV1_MF_ENCODER 0
 +#define CONFIG_AV1_VAAPI_ENCODER 0
 +#define CONFIG_LIBOPENH264_ENCODER 0
 +#define CONFIG_H264_AMF_ENCODER 0
@@ -6291,6 +12052,7 @@ index 00000000000..fe3b62f8200
 +#define CONFIG_AV1_NVDEC_HWACCEL 0
 +#define CONFIG_AV1_VAAPI_HWACCEL 0
 +#define CONFIG_AV1_VDPAU_HWACCEL 0
++#define CONFIG_AV1_VIDEOTOOLBOX_HWACCEL 0
 +#define CONFIG_AV1_VULKAN_HWACCEL 0
 +#define CONFIG_H263_VAAPI_HWACCEL 0
 +#define CONFIG_H263_VIDEOTOOLBOX_HWACCEL 0
@@ -6369,6 +12131,7 @@ index 00000000000..fe3b62f8200
 +#define CONFIG_DCA_PARSER 0
 +#define CONFIG_DIRAC_PARSER 0
 +#define CONFIG_DNXHD_PARSER 0
++#define CONFIG_DNXUC_PARSER 0
 +#define CONFIG_DOLBY_E_PARSER 0
 +#define CONFIG_DPX_PARSER 0
 +#define CONFIG_DVAUDIO_PARSER 0
@@ -7624,7 +13387,7 @@ index 00000000000..fe3b62f8200
 +#endif /* FFMPEG_CONFIG_COMPONENTS_H */
 diff --git a/chromium/config/Chromium/linux/riscv64/libavcodec/bsf_list.c b/chromium/config/Chromium/linux/riscv64/libavcodec/bsf_list.c
 new file mode 100644
-index 00000000000..7ff70c6e2d6
+index 0000000000..7ff70c6e2d
 --- /dev/null
 +++ b/chromium/config/Chromium/linux/riscv64/libavcodec/bsf_list.c
 @@ -0,0 +1,2 @@
@@ -7632,7 +13395,7 @@ index 00000000000..7ff70c6e2d6
 +    NULL };
 diff --git a/chromium/config/Chromium/linux/riscv64/libavcodec/codec_list.c b/chromium/config/Chromium/linux/riscv64/libavcodec/codec_list.c
 new file mode 100644
-index 00000000000..7d9debfe612
+index 0000000000..7d9debfe61
 --- /dev/null
 +++ b/chromium/config/Chromium/linux/riscv64/libavcodec/codec_list.c
 @@ -0,0 +1,15 @@
@@ -7653,7 +13416,7 @@ index 00000000000..7d9debfe612
 +    NULL };
 diff --git a/chromium/config/Chromium/linux/riscv64/libavcodec/parser_list.c b/chromium/config/Chromium/linux/riscv64/libavcodec/parser_list.c
 new file mode 100644
-index 00000000000..fdc533b38ff
+index 0000000000..fdc533b38f
 --- /dev/null
 +++ b/chromium/config/Chromium/linux/riscv64/libavcodec/parser_list.c
 @@ -0,0 +1,7 @@
@@ -7666,7 +13429,7 @@ index 00000000000..fdc533b38ff
 +    NULL };
 diff --git a/chromium/config/Chromium/linux/riscv64/libavformat/demuxer_list.c b/chromium/config/Chromium/linux/riscv64/libavformat/demuxer_list.c
 new file mode 100644
-index 00000000000..570a6441d36
+index 0000000000..570a6441d3
 --- /dev/null
 +++ b/chromium/config/Chromium/linux/riscv64/libavformat/demuxer_list.c
 @@ -0,0 +1,8 @@
@@ -7680,7 +13443,7 @@ index 00000000000..570a6441d36
 +    NULL };
 diff --git a/chromium/config/Chromium/linux/riscv64/libavformat/muxer_list.c b/chromium/config/Chromium/linux/riscv64/libavformat/muxer_list.c
 new file mode 100644
-index 00000000000..ae54c39f23d
+index 0000000000..ae54c39f23
 --- /dev/null
 +++ b/chromium/config/Chromium/linux/riscv64/libavformat/muxer_list.c
 @@ -0,0 +1,2 @@
@@ -7688,7 +13451,7 @@ index 00000000000..ae54c39f23d
 +    NULL };
 diff --git a/chromium/config/Chromium/linux/riscv64/libavformat/protocol_list.c b/chromium/config/Chromium/linux/riscv64/libavformat/protocol_list.c
 new file mode 100644
-index 00000000000..247e1e4c3a2
+index 0000000000..247e1e4c3a
 --- /dev/null
 +++ b/chromium/config/Chromium/linux/riscv64/libavformat/protocol_list.c
 @@ -0,0 +1,2 @@
@@ -7696,7 +13459,7 @@ index 00000000000..247e1e4c3a2
 +    NULL };
 diff --git a/chromium/config/Chromium/linux/riscv64/libavutil/avconfig.h b/chromium/config/Chromium/linux/riscv64/libavutil/avconfig.h
 new file mode 100644
-index 00000000000..8558b35027f
+index 0000000000..8558b35027
 --- /dev/null
 +++ b/chromium/config/Chromium/linux/riscv64/libavutil/avconfig.h
 @@ -0,0 +1,6 @@
@@ -7708,20 +13471,20 @@ index 00000000000..8558b35027f
 +#endif /* AVUTIL_AVCONFIG_H */
 diff --git a/chromium/config/Chromium/linux/riscv64/libavutil/ffversion.h b/chromium/config/Chromium/linux/riscv64/libavutil/ffversion.h
 new file mode 100644
-index 00000000000..4303e401160
+index 0000000000..677ca92389
 --- /dev/null
 +++ b/chromium/config/Chromium/linux/riscv64/libavutil/ffversion.h
 @@ -0,0 +1,5 @@
 +/* Automatically generated by version.sh, do not manually edit! */
 +#ifndef AVUTIL_FFVERSION_H
 +#define AVUTIL_FFVERSION_H
-+#define FFMPEG_VERSION "git-2024-10-01-686d6944501"
++#define FFMPEG_VERSION "git-2025-01-10-3d2a884996"
 +#endif /* AVUTIL_FFVERSION_H */
 diff --git a/chromium/config/Chromium/linux/x64/config.asm b/chromium/config/Chromium/linux/x64/config.asm
-index e53a8e2be9d..207a95eb7f8 100644
+index 2fadb1eba9..7f0e14088f 100644
 --- a/chromium/config/Chromium/linux/x64/config.asm
 +++ b/chromium/config/Chromium/linux/x64/config.asm
-@@ -366,7 +366,7 @@
+@@ -371,7 +371,7 @@
  %define HAVE_INLINE_ASM_LABELS 1
  %define HAVE_INLINE_ASM_NONLOCAL_LABELS 1
  %define HAVE_PRAGMA_DEPRECATED 1
@@ -7730,7 +13493,7 @@ index e53a8e2be9d..207a95eb7f8 100644
  %define HAVE_SYMVER_ASM_LABEL 1
  %define HAVE_SYMVER_GNU_ASM 1
  %define HAVE_VFP_ARGS 0
-@@ -421,7 +421,7 @@
+@@ -427,7 +427,7 @@
  %define HAVE_POD2MAN 1
  %define HAVE_POSIX_IOCTL 0
  %define HAVE_TEXI2HTML 0
@@ -7740,25 +13503,25 @@ index e53a8e2be9d..207a95eb7f8 100644
  %define HAVE_OPENVINO2 0
  %define CONFIG_DOC 0
 diff --git a/chromium/config/Chromium/linux/x64/config.h b/chromium/config/Chromium/linux/x64/config.h
-index cf4682f5c09..7917e9eccf9 100644
+index 4a7d85df9b..e00839be88 100644
 --- a/chromium/config/Chromium/linux/x64/config.h
 +++ b/chromium/config/Chromium/linux/x64/config.h
 @@ -1,12 +1,12 @@
  /* Automatically generated by configure - do not modify! */
  #ifndef FFMPEG_CONFIG_H
  #define FFMPEG_CONFIG_H
--/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-iamf --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/usr/local/google/home/sandersd/src/chromium/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\"-O2\"' --enable-lto --arch=x86_64 --target-os=linux --enable-pic --cc=clang --cxx=clang++ --ld=clang --extra-ldflags='-fuse-ld=lld'" -- elide long configuration string from binary */
-+/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-iamf --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/home/kxxt/Workspaces/chromium/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\"-O2\"' --enable-lto --arch=x86_64 --target-os=linux --enable-pic --cc=clang --cxx=clang++ --ld=clang --extra-ldflags='-fuse-ld=lld'" -- elide long configuration string from binary */
+-/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-iamf --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/usr/local/google/home/ezemtsov/projects/chromium/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\"-O2\"' --enable-lto --arch=x86_64 --target-os=linux --enable-pic --cc=clang --cxx=clang++ --ld=clang --extra-ldflags='-fuse-ld=lld'" -- elide long configuration string from binary */
++/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-iamf --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --extra-cflags=-I/home/kxxt/electron-ci/sources/electron/src/third_party/opus/src/include --disable-linux-perf --x86asmexe=nasm --optflags='\"-O2\"' --enable-lto --arch=x86_64 --target-os=linux --enable-pic --cc=clang --cxx=clang++ --ld=clang --extra-ldflags='-fuse-ld=lld'" -- elide long configuration string from binary */
  #define FFMPEG_LICENSE "LGPL version 2.1 or later"
  #define CONFIG_THIS_YEAR 2024
  #define FFMPEG_DATADIR "/usr/local/share/ffmpeg"
  #define AVCONV_DATADIR "/usr/local/share/ffmpeg"
--#define CC_IDENT "clang version 20.0.0git (https://chromium.googlesource.com/a/external/github.com/llvm/llvm-project 6ee7e90a5d21cc0173dc5a0a344d230a80a46fd0)"
-+#define CC_IDENT "clang version 20.0.0git (https://chromium.googlesource.com/a/external/github.com/llvm/llvm-project 3dbd929ea6af134650dd1d91baeb61a4fc1b0eb8)"
+-#define CC_IDENT "clang version 20.0.0git (https://chromium.googlesource.com/a/external/github.com/llvm/llvm-project 923566a67de39a00eb6fc5cabbad307a72aa338e)"
++#define CC_IDENT "clang version 20.0.0git (https://chromium.googlesource.com/external/github.com/llvm/llvm-project b81d8e90339a788cc6cb148831612c6b39b93ad5)"
  #define OS_NAME linux
  #define EXTERN_PREFIX ""
  #define EXTERN_ASM 
-@@ -380,7 +380,7 @@
+@@ -385,7 +385,7 @@
  #define HAVE_INLINE_ASM_LABELS 1
  #define HAVE_INLINE_ASM_NONLOCAL_LABELS 1
  #define HAVE_PRAGMA_DEPRECATED 1
@@ -7767,7 +13530,7 @@ index cf4682f5c09..7917e9eccf9 100644
  #define HAVE_SYMVER_ASM_LABEL 1
  #define HAVE_SYMVER_GNU_ASM 1
  #define HAVE_VFP_ARGS 0
-@@ -435,7 +435,7 @@
+@@ -441,7 +441,7 @@
  #define HAVE_POD2MAN 1
  #define HAVE_POSIX_IOCTL 0
  #define HAVE_TEXI2HTML 0
@@ -7777,18 +13540,18 @@ index cf4682f5c09..7917e9eccf9 100644
  #define HAVE_OPENVINO2 0
  #define CONFIG_DOC 0
 diff --git a/chromium/config/Chromium/linux/x64/libavutil/ffversion.h b/chromium/config/Chromium/linux/x64/libavutil/ffversion.h
-index 71bdf19217c..4303e401160 100644
+index 54c2598a44..677ca92389 100644
 --- a/chromium/config/Chromium/linux/x64/libavutil/ffversion.h
 +++ b/chromium/config/Chromium/linux/x64/libavutil/ffversion.h
 @@ -1,5 +1,5 @@
  /* Automatically generated by version.sh, do not manually edit! */
  #ifndef AVUTIL_FFVERSION_H
  #define AVUTIL_FFVERSION_H
--#define FFMPEG_VERSION "N-118356-gdd11b92cac"
-+#define FFMPEG_VERSION "git-2024-10-01-686d6944501"
+-#define FFMPEG_VERSION "N-118887-g99f17d50d3"
++#define FFMPEG_VERSION "git-2025-01-10-3d2a884996"
  #endif /* AVUTIL_FFVERSION_H */
 diff --git a/chromium/scripts/copy_config.sh b/chromium/scripts/copy_config.sh
-index a18048cf040..0d080211aa2 100755
+index a18048cf04..0d080211aa 100755
 --- a/chromium/scripts/copy_config.sh
 +++ b/chromium/scripts/copy_config.sh
 @@ -10,7 +10,7 @@ for os in android linux linux-noasm mac win; do
@@ -7801,10 +13564,16 @@ index a18048cf040..0d080211aa2 100755
        [ ! -e "build.$arch.$os/$target/config.h" ] && continue
        for f in config.h config_components.h config.asm libavutil/avconfig.h libavutil/ffversion.h libavcodec/bsf_list.c libavcodec/codec_list.c libavcodec/parser_list.c libavformat/demuxer_list.c libavformat/muxer_list.c libavformat/protocol_list.c; do
 diff --git a/ffmpeg_generated.gni b/ffmpeg_generated.gni
-index 35873184358..b5cd6fba09c 100644
+index a392f50cbd..012bc9b784 100644
 --- a/ffmpeg_generated.gni
 +++ b/ffmpeg_generated.gni
-@@ -14,10 +14,8 @@ ffmpeg_asm_sources = []
+@@ -1,4 +1,4 @@
+-# Copyright 2024 The Chromium Authors. All rights reserved.
++# Copyright 2025 The Chromium Authors. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+@@ -14,10 +14,7 @@ ffmpeg_asm_sources = []
  
  use_linux_config = is_linux || is_chromeos || is_fuchsia
  
@@ -7812,12 +13581,11 @@ index 35873184358..b5cd6fba09c 100644
 -    (is_android && current_cpu == "arm" && arm_use_neon) ||
 -    (is_android && current_cpu == "x86") || is_apple || is_win ||
 -    use_linux_config) {
-+if ((use_linux_config && current_cpu == "riscv64") ||
-+    (use_linux_config && current_cpu == "x64")) {
++if ((use_linux_config && current_cpu == "riscv64") || (use_linux_config && current_cpu == "x64")) {
    ffmpeg_c_sources += [
      "libavcodec/ac3_channel_layout_tab.c",
      "libavcodec/ac3_parser.c",
-@@ -211,16 +209,29 @@ if (current_cpu == "arm64" || current_cpu == "x64" ||
+@@ -213,16 +210,27 @@ if (current_cpu == "arm64" || current_cpu == "x64" ||
    ]
  }
  
@@ -7827,9 +13595,7 @@ index 35873184358..b5cd6fba09c 100644
 -    (is_apple && ffmpeg_branding == "Chrome") ||
 -    (is_win && ffmpeg_branding == "Chrome") ||
 -    (use_linux_config && ffmpeg_branding == "Chrome")) {
-+if ((use_linux_config && current_cpu == "riscv64" &&
-+     ffmpeg_branding == "Chrome") ||
-+    (use_linux_config && current_cpu == "x64" && ffmpeg_branding == "Chrome")) {
++if ((use_linux_config && current_cpu == "riscv64" && ffmpeg_branding == "Chrome") || (use_linux_config && current_cpu == "x64" && ffmpeg_branding == "Chrome")) {
    ffmpeg_c_sources += [
 +    "libavcodec/aac/aacdec.c",
 +    "libavcodec/aac/aacdec_ac.c",
@@ -7853,7 +13619,7 @@ index 35873184358..b5cd6fba09c 100644
      "libavcodec/h2645_parse.c",
      "libavcodec/h2645_sei.c",
      "libavcodec/h2645_vui.c",
-@@ -245,46 +256,25 @@ if ((current_cpu == "arm64" && ffmpeg_branding == "Chrome") ||
+@@ -247,46 +255,25 @@ if ((current_cpu == "arm64" && ffmpeg_branding == "Chrome") ||
      "libavcodec/h264pred.c",
      "libavcodec/h264qpel.c",
      "libavcodec/h274.c",
@@ -7911,7 +13677,7 @@ index 35873184358..b5cd6fba09c 100644
    ffmpeg_asm_sources += [
      "libavcodec/x86/aacpsdsp.asm",
      "libavcodec/x86/autorename_libavcodec_x86_videodsp.asm",
-@@ -306,33 +296,19 @@ if ((current_cpu == "x64" && ffmpeg_branding == "Chrome") ||
+@@ -308,33 +295,19 @@ if ((current_cpu == "x64" && ffmpeg_branding == "Chrome") ||
    ]
  }
  
@@ -7956,21 +13722,38 @@ index 35873184358..b5cd6fba09c 100644
    ffmpeg_asm_sources += [
      "libavcodec/x86/dct32.asm",
      "libavcodec/x86/flacdsp.asm",
-@@ -347,133 +323,43 @@ if (current_cpu == "x64" || (is_win && current_cpu == "x86") ||
+@@ -349,134 +322,45 @@ if (current_cpu == "x64" || (is_win && current_cpu == "x86") ||
    ]
  }
  
+-if (current_cpu == "arm64") {
+-  ffmpeg_c_sources += [
+-    "libavcodec/aarch64/autorename_libavcodec_aarch64_vorbisdsp_init.c",
+-    "libavcodec/aarch64/mpegaudiodsp_init.c",
+-    "libavutil/aarch64/autorename_libavutil_aarch64_cpu.c",
+-    "libavutil/aarch64/autorename_libavutil_aarch64_float_dsp_init.c",
+-    "libavutil/aarch64/tx_float_init.c",
+-  ]
+-  ffmpeg_gas_sources += [
+-    "libavcodec/aarch64/autorename_libavcodec_aarch64_vorbisdsp_neon.S",
+-    "libavcodec/aarch64/mpegaudiodsp_neon.S",
+-    "libavutil/aarch64/autorename_libavutil_aarch64_float_dsp_neon.S",
+-    "libavutil/aarch64/cpu_sve.S",
+-    "libavutil/aarch64/tx_float_neon.S",
+-  ]
+-}
+-
 -if (current_cpu == "x64" || (is_android && current_cpu == "x86") ||
 -    (is_win && current_cpu == "x86") ||
 -    (use_linux_config && current_cpu == "x86")) {
 -  ffmpeg_c_sources += [
--    "libavcodec/x86/autorename_libavcodec_x86_vorbisdsp_init.c",
 -    "libavcodec/x86/constants.c",
 -    "libavcodec/x86/flacdsp_init.c",
 -    "libavcodec/x86/mpegaudiodsp.c",
+-    "libavcodec/x86/vorbisdsp_init.c",
 -    "libavutil/x86/autorename_libavutil_x86_cpu.c",
--    "libavutil/x86/autorename_libavutil_x86_float_dsp_init.c",
 -    "libavutil/x86/fixed_dsp_init.c",
+-    "libavutil/x86/float_dsp_init.c",
 -    "libavutil/x86/imgutils_init.c",
 -    "libavutil/x86/lls_init.c",
 -  ]
@@ -7983,7 +13766,7 @@ index 35873184358..b5cd6fba09c 100644
 -    "libavcodec/arm/flacdsp_init_arm.c",
 -    "libavcodec/arm/mpegaudiodsp_init_arm.c",
 -    "libavcodec/arm/vorbisdsp_init_arm.c",
--    "libavutil/arm/autorename_libavutil_arm_cpu.c",
+-    "libavutil/arm/cpu.c",
 -    "libavutil/arm/float_dsp_init_arm.c",
 -    "libavutil/arm/float_dsp_init_vfp.c",
 -  ]
@@ -7994,26 +13777,11 @@ index 35873184358..b5cd6fba09c 100644
 -  ]
 -}
 -
--if (current_cpu == "arm64") {
--  ffmpeg_c_sources += [
--    "libavcodec/aarch64/mpegaudiodsp_init.c",
--    "libavcodec/aarch64/vorbisdsp_init.c",
--    "libavutil/aarch64/cpu.c",
--    "libavutil/aarch64/float_dsp_init.c",
--    "libavutil/aarch64/tx_float_init.c",
--  ]
--  ffmpeg_gas_sources += [
--    "libavcodec/aarch64/autorename_libavcodec_aarch64_vorbisdsp_neon.S",
--    "libavcodec/aarch64/mpegaudiodsp_neon.S",
--    "libavutil/aarch64/autorename_libavutil_aarch64_float_dsp_neon.S",
--    "libavutil/aarch64/tx_float_neon.S",
--  ]
--}
--
 -if ((use_linux_config && current_cpu == "arm" && arm_use_neon &&
 -     ffmpeg_branding == "Chrome") ||
 -    (use_linux_config && current_cpu == "arm" && ffmpeg_branding == "Chrome")) {
--  ffmpeg_c_sources += [
++if (use_linux_config && current_cpu == "riscv64" && ffmpeg_branding == "Chrome") {
+   ffmpeg_c_sources += [
 -    "libavcodec/arm/h264chroma_init_arm.c",
 -    "libavcodec/arm/h264dsp_init_arm.c",
 -    "libavcodec/arm/h264pred_init_arm.c",
@@ -8039,39 +13807,30 @@ index 35873184358..b5cd6fba09c 100644
 -    "libavcodec/x86/h264dsp_init.c",
 -    "libavcodec/x86/sbrdsp_init.c",
 -    "libavcodec/x86/videodsp_init.c",
--  ]
++    "libavcodec/riscv/aacpsdsp_init.c",
++    "libavcodec/riscv/h264_chroma_init_riscv.c",
++    "libavcodec/riscv/h264dsp_init.c",
++    "libavcodec/riscv/h264qpel_init.c",
++    "libavcodec/riscv/sbrdsp_init.c",
++    "libavcodec/riscv/videodsp_init.c",
+   ]
 -}
 -
 -if (use_linux_config && current_cpu == "arm" && arm_use_neon &&
-+if (use_linux_config && current_cpu == "riscv64" &&
-     ffmpeg_branding == "Chrome") {
--  ffmpeg_gas_sources += [
+-    ffmpeg_branding == "Chrome") {
+   ffmpeg_gas_sources += [
 -    "libavcodec/arm/h264cmc_neon.S",
 -    "libavcodec/arm/h264dsp_neon.S",
 -    "libavcodec/arm/h264idct_neon.S",
 -    "libavcodec/arm/h264pred_neon.S",
 -    "libavcodec/arm/h264qpel_neon.S",
 -    "libavcodec/arm/hpeldsp_neon.S",
-+  ffmpeg_c_sources += [
-+    "libavcodec/riscv/aacpsdsp_init.c",
-+    "libavcodec/riscv/h264_chroma_init_riscv.c",
-+    "libavcodec/riscv/h264dsp_init.c",
-+    "libavcodec/riscv/sbrdsp_init.c",
-+    "libavcodec/riscv/videodsp_init.c",
-   ]
--}
--
--if ((is_android && current_cpu == "arm" && arm_use_neon) ||
--    (use_linux_config && current_cpu == "arm" && arm_use_neon)) {
--  ffmpeg_c_sources += [ "libavutil/arm/float_dsp_init_neon.c" ]
-   ffmpeg_gas_sources += [
--    "libavcodec/arm/vorbisdsp_neon.S",
--    "libavutil/arm/float_dsp_neon.S",
 +    "libavcodec/riscv/aacpsdsp_rvv.S",
 +    "libavcodec/riscv/h264_mc_chroma.S",
 +    "libavcodec/riscv/h264addpx_rvv.S",
 +    "libavcodec/riscv/h264dsp_rvv.S",
 +    "libavcodec/riscv/h264idct_rvv.S",
++    "libavcodec/riscv/h264qpel_rvv.S",
 +    "libavcodec/riscv/sbrdsp_rvv.S",
 +    "libavcodec/riscv/startcode_rvb.S",
 +    "libavcodec/riscv/startcode_rvv.S",
@@ -8079,6 +13838,15 @@ index 35873184358..b5cd6fba09c 100644
    ]
  }
  
+-if ((is_android && current_cpu == "arm" && arm_use_neon) ||
+-    (use_linux_config && current_cpu == "arm" && arm_use_neon)) {
+-  ffmpeg_c_sources += [ "libavutil/arm/float_dsp_init_neon.c" ]
+-  ffmpeg_gas_sources += [
+-    "libavcodec/arm/vorbisdsp_neon.S",
+-    "libavutil/arm/float_dsp_neon.S",
+-  ]
+-}
+-
 -if ((is_android && current_cpu == "arm" && arm_use_neon &&
 -     ffmpeg_branding == "Chrome") ||
 -    (use_linux_config && current_cpu == "arm" && arm_use_neon &&
@@ -8112,7 +13880,7 @@ index 35873184358..b5cd6fba09c 100644
 +    "libavutil/riscv/lls_rvv.S",
    ]
  }
--
+ 
 -if ((is_android && current_cpu == "arm" && arm_use_neon) ||
 -    (is_android && current_cpu == "arm64") ||
 -    (is_android && current_cpu == "x64") ||
@@ -8120,244 +13888,252 @@ index 35873184358..b5cd6fba09c 100644
 -  ffmpeg_c_sources += [ "compat/strtod.c" ]
 -}
 diff --git a/libavcodec/autorename_libavcodec_flacdsp.c b/libavcodec/autorename_libavcodec_flacdsp.c
-index ff83e4d5172..6f060652557 100644
+index d0ff2efe35..5e1d7bbac2 100644
 --- a/libavcodec/autorename_libavcodec_flacdsp.c
 +++ b/libavcodec/autorename_libavcodec_flacdsp.c
 @@ -1,2 +1,2 @@
--// Automatically generated on Tue Sep 24 17:20:58 2024. See crbug.com/495833.
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
+-// Automatically generated on Tue Oct 22 17:56:01 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
  #include "flacdsp.c"
 diff --git a/libavcodec/autorename_libavcodec_mpegaudiodsp.c b/libavcodec/autorename_libavcodec_mpegaudiodsp.c
-index 0dd2dd10b75..4555c4e9162 100644
+index 07e52a22fb..5e7fa3ac5b 100644
 --- a/libavcodec/autorename_libavcodec_mpegaudiodsp.c
 +++ b/libavcodec/autorename_libavcodec_mpegaudiodsp.c
 @@ -1,2 +1,2 @@
--// Automatically generated on Tue Sep 24 17:20:58 2024. See crbug.com/495833.
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
+-// Automatically generated on Tue Oct 22 17:56:01 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
  #include "mpegaudiodsp.c"
 diff --git a/libavcodec/autorename_libavcodec_parser.c b/libavcodec/autorename_libavcodec_parser.c
-index a02f14efa31..67fbf18f40c 100644
+index 63c95d8a65..47671d69a4 100644
 --- a/libavcodec/autorename_libavcodec_parser.c
 +++ b/libavcodec/autorename_libavcodec_parser.c
 @@ -1,2 +1,2 @@
--// Automatically generated on Tue Sep 24 17:20:58 2024. See crbug.com/495833.
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
+-// Automatically generated on Tue Oct 22 17:56:01 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
  #include "parser.c"
 diff --git a/libavcodec/autorename_libavcodec_sbrdsp.c b/libavcodec/autorename_libavcodec_sbrdsp.c
-index 7e7329ee292..f78e1e414af 100644
+index 534a55d03e..6138375634 100644
 --- a/libavcodec/autorename_libavcodec_sbrdsp.c
 +++ b/libavcodec/autorename_libavcodec_sbrdsp.c
 @@ -1,2 +1,2 @@
--// Automatically generated on Tue Sep 24 17:20:58 2024. See crbug.com/495833.
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
+-// Automatically generated on Tue Oct 22 17:56:01 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
  #include "sbrdsp.c"
 diff --git a/libavcodec/autorename_libavcodec_videodsp.c b/libavcodec/autorename_libavcodec_videodsp.c
-index 6abf2265ea5..8eea1467ac0 100644
+index 26dca1d497..71a718e312 100644
 --- a/libavcodec/autorename_libavcodec_videodsp.c
 +++ b/libavcodec/autorename_libavcodec_videodsp.c
 @@ -1,2 +1,2 @@
--// Automatically generated on Tue Sep 24 17:20:58 2024. See crbug.com/495833.
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
+-// Automatically generated on Tue Oct 22 17:56:01 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
  #include "videodsp.c"
 diff --git a/libavcodec/autorename_libavcodec_vorbisdsp.c b/libavcodec/autorename_libavcodec_vorbisdsp.c
-index 615245fa4b0..85f131c378c 100644
+index f17bc6d9bb..a57fe858ff 100644
 --- a/libavcodec/autorename_libavcodec_vorbisdsp.c
 +++ b/libavcodec/autorename_libavcodec_vorbisdsp.c
 @@ -1,2 +1,2 @@
--// Automatically generated on Tue Sep 24 17:20:58 2024. See crbug.com/495833.
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
+-// Automatically generated on Tue Oct 22 17:56:01 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
  #include "vorbisdsp.c"
 diff --git a/libavcodec/x86/autorename_libavcodec_x86_aacpsdsp_init.c b/libavcodec/x86/autorename_libavcodec_x86_aacpsdsp_init.c
 new file mode 100644
-index 00000000000..169e3254299
+index 0000000000..65794bcf9e
 --- /dev/null
 +++ b/libavcodec/x86/autorename_libavcodec_x86_aacpsdsp_init.c
 @@ -0,0 +1,2 @@
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
 +#include "aacpsdsp_init.c"
 diff --git a/libavcodec/x86/autorename_libavcodec_x86_flacdsp_init.c b/libavcodec/x86/autorename_libavcodec_x86_flacdsp_init.c
 new file mode 100644
-index 00000000000..b55d63f032a
+index 0000000000..1a84133d88
 --- /dev/null
 +++ b/libavcodec/x86/autorename_libavcodec_x86_flacdsp_init.c
 @@ -0,0 +1,2 @@
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
 +#include "flacdsp_init.c"
 diff --git a/libavcodec/x86/autorename_libavcodec_x86_h264dsp_init.c b/libavcodec/x86/autorename_libavcodec_x86_h264dsp_init.c
 new file mode 100644
-index 00000000000..40a97156593
+index 0000000000..bb21c8e427
 --- /dev/null
 +++ b/libavcodec/x86/autorename_libavcodec_x86_h264dsp_init.c
 @@ -0,0 +1,2 @@
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
 +#include "h264dsp_init.c"
 diff --git a/libavcodec/x86/autorename_libavcodec_x86_sbrdsp_init.c b/libavcodec/x86/autorename_libavcodec_x86_sbrdsp_init.c
 new file mode 100644
-index 00000000000..54260957e1a
+index 0000000000..4832fd4d53
 --- /dev/null
 +++ b/libavcodec/x86/autorename_libavcodec_x86_sbrdsp_init.c
 @@ -0,0 +1,2 @@
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
 +#include "sbrdsp_init.c"
 diff --git a/libavcodec/x86/autorename_libavcodec_x86_videodsp.asm b/libavcodec/x86/autorename_libavcodec_x86_videodsp.asm
-index 5a7e435ea51..8021ff7aad6 100644
+index e0c33e22d2..2c7ab6a5b0 100644
 --- a/libavcodec/x86/autorename_libavcodec_x86_videodsp.asm
 +++ b/libavcodec/x86/autorename_libavcodec_x86_videodsp.asm
 @@ -1,2 +1,2 @@
--; Automatically generated on Tue Sep 24 17:20:58 2024. See crbug.com/495833.
-+; Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
+-; Automatically generated on Tue Oct 22 17:56:01 2024. See crbug.com/495833.
++; Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
  %include "videodsp.asm"
 diff --git a/libavcodec/x86/autorename_libavcodec_x86_videodsp_init.c b/libavcodec/x86/autorename_libavcodec_x86_videodsp_init.c
 new file mode 100644
-index 00000000000..9e6e9a3722f
+index 0000000000..3aca5a481b
 --- /dev/null
 +++ b/libavcodec/x86/autorename_libavcodec_x86_videodsp_init.c
 @@ -0,0 +1,2 @@
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
 +#include "videodsp_init.c"
 diff --git a/libavcodec/x86/autorename_libavcodec_x86_vorbisdsp_init.c b/libavcodec/x86/autorename_libavcodec_x86_vorbisdsp_init.c
-index 190ebbb1e87..a64d2172153 100644
---- a/libavcodec/x86/autorename_libavcodec_x86_vorbisdsp_init.c
+new file mode 100644
+index 0000000000..363c166ed2
+--- /dev/null
 +++ b/libavcodec/x86/autorename_libavcodec_x86_vorbisdsp_init.c
-@@ -1,2 +1,2 @@
--// Automatically generated on Tue Sep 24 17:20:58 2024. See crbug.com/495833.
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
- #include "vorbisdsp_init.c"
+@@ -0,0 +1,2 @@
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
++#include "vorbisdsp_init.c"
 diff --git a/libavformat/autorename_libavformat_aacdec.c b/libavformat/autorename_libavformat_aacdec.c
-index 10783242845..1b28ca7e58f 100644
+index 31bbccdef2..bdf232a1a9 100644
 --- a/libavformat/autorename_libavformat_aacdec.c
 +++ b/libavformat/autorename_libavformat_aacdec.c
 @@ -1,2 +1,2 @@
--// Automatically generated on Tue Sep 24 17:20:58 2024. See crbug.com/495833.
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
+-// Automatically generated on Tue Oct 22 17:56:01 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
  #include "aacdec.c"
 diff --git a/libavformat/autorename_libavformat_flacdec.c b/libavformat/autorename_libavformat_flacdec.c
-index c3182efaaa0..be17d3565e7 100644
+index 1ebeb44780..777767f8d1 100644
 --- a/libavformat/autorename_libavformat_flacdec.c
 +++ b/libavformat/autorename_libavformat_flacdec.c
 @@ -1,2 +1,2 @@
--// Automatically generated on Tue Sep 24 17:20:58 2024. See crbug.com/495833.
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
+-// Automatically generated on Tue Oct 22 17:56:01 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
  #include "flacdec.c"
 diff --git a/libavformat/autorename_libavformat_options.c b/libavformat/autorename_libavformat_options.c
-index f4170795fa1..f663d317a98 100644
+index 4332b6e4ea..ff63a4b96b 100644
 --- a/libavformat/autorename_libavformat_options.c
 +++ b/libavformat/autorename_libavformat_options.c
 @@ -1,2 +1,2 @@
--// Automatically generated on Tue Sep 24 17:20:58 2024. See crbug.com/495833.
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
+-// Automatically generated on Tue Oct 22 17:56:01 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
  #include "options.c"
 diff --git a/libavformat/autorename_libavformat_pcm.c b/libavformat/autorename_libavformat_pcm.c
-index 52bf7231f86..c5b8d5df50f 100644
+index 620b448f10..1fcbb4f63e 100644
 --- a/libavformat/autorename_libavformat_pcm.c
 +++ b/libavformat/autorename_libavformat_pcm.c
 @@ -1,2 +1,2 @@
--// Automatically generated on Tue Sep 24 17:20:58 2024. See crbug.com/495833.
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
+-// Automatically generated on Tue Oct 22 17:56:01 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
  #include "pcm.c"
 diff --git a/libavformat/autorename_libavformat_utils.c b/libavformat/autorename_libavformat_utils.c
-index 4ffd8a131da..875aa06d73a 100644
+index fd4fc594f4..03dfb901ca 100644
 --- a/libavformat/autorename_libavformat_utils.c
 +++ b/libavformat/autorename_libavformat_utils.c
 @@ -1,2 +1,2 @@
--// Automatically generated on Tue Sep 24 17:20:58 2024. See crbug.com/495833.
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
+-// Automatically generated on Tue Oct 22 17:56:01 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
  #include "utils.c"
 diff --git a/libavformat/autorename_libavformat_version.c b/libavformat/autorename_libavformat_version.c
-index 5310985dd2f..cb861468c27 100644
+index 9ba1b0215d..0d8c94604c 100644
 --- a/libavformat/autorename_libavformat_version.c
 +++ b/libavformat/autorename_libavformat_version.c
 @@ -1,2 +1,2 @@
--// Automatically generated on Tue Sep 24 17:20:58 2024. See crbug.com/495833.
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
+-// Automatically generated on Tue Oct 22 17:56:01 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
  #include "version.c"
 diff --git a/libavutil/autorename_libavutil_cpu.c b/libavutil/autorename_libavutil_cpu.c
-index 6db5c5a823c..78634bf62c9 100644
+index 7232f1e4d4..5de73354a6 100644
 --- a/libavutil/autorename_libavutil_cpu.c
 +++ b/libavutil/autorename_libavutil_cpu.c
 @@ -1,2 +1,2 @@
--// Automatically generated on Tue Sep 24 17:20:58 2024. See crbug.com/495833.
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
+-// Automatically generated on Tue Oct 22 17:56:01 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
  #include "cpu.c"
+diff --git a/libavutil/autorename_libavutil_executor.c b/libavutil/autorename_libavutil_executor.c
+index af35d36441..582029f973 100644
+--- a/libavutil/autorename_libavutil_executor.c
++++ b/libavutil/autorename_libavutil_executor.c
+@@ -1,2 +1,2 @@
+-// Automatically generated on Tue Oct 22 17:56:01 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
+ #include "executor.c"
 diff --git a/libavutil/autorename_libavutil_fixed_dsp.c b/libavutil/autorename_libavutil_fixed_dsp.c
-index 5a609e99f28..73692572a97 100644
+index 164dc2dd02..5293f02bd9 100644
 --- a/libavutil/autorename_libavutil_fixed_dsp.c
 +++ b/libavutil/autorename_libavutil_fixed_dsp.c
 @@ -1,2 +1,2 @@
--// Automatically generated on Tue Sep 24 17:20:58 2024. See crbug.com/495833.
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
+-// Automatically generated on Tue Oct 22 17:56:01 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
  #include "fixed_dsp.c"
 diff --git a/libavutil/autorename_libavutil_float_dsp.c b/libavutil/autorename_libavutil_float_dsp.c
-index 0179260e8ab..47059b8b34d 100644
+index 42c04a1f80..45d734c33b 100644
 --- a/libavutil/autorename_libavutil_float_dsp.c
 +++ b/libavutil/autorename_libavutil_float_dsp.c
 @@ -1,2 +1,2 @@
--// Automatically generated on Tue Sep 24 17:20:58 2024. See crbug.com/495833.
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
+-// Automatically generated on Tue Oct 22 17:56:01 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
  #include "float_dsp.c"
 diff --git a/libavutil/autorename_libavutil_imgutils.c b/libavutil/autorename_libavutil_imgutils.c
-index aa19b43350d..1cd7d8a1732 100644
+index 730b011588..51eaffb7db 100644
 --- a/libavutil/autorename_libavutil_imgutils.c
 +++ b/libavutil/autorename_libavutil_imgutils.c
 @@ -1,2 +1,2 @@
--// Automatically generated on Tue Sep 24 17:20:58 2024. See crbug.com/495833.
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
+-// Automatically generated on Tue Oct 22 17:56:01 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
  #include "imgutils.c"
 diff --git a/libavutil/autorename_libavutil_tx_float.c b/libavutil/autorename_libavutil_tx_float.c
-index 179d0975ead..b4fc079639c 100644
+index 27cf41409e..8635efa0be 100644
 --- a/libavutil/autorename_libavutil_tx_float.c
 +++ b/libavutil/autorename_libavutil_tx_float.c
 @@ -1,2 +1,2 @@
--// Automatically generated on Tue Sep 24 17:20:58 2024. See crbug.com/495833.
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
+-// Automatically generated on Tue Oct 22 17:56:01 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
  #include "tx_float.c"
 diff --git a/libavutil/autorename_libavutil_utils.c b/libavutil/autorename_libavutil_utils.c
-index 4ffd8a131da..875aa06d73a 100644
+index fd4fc594f4..03dfb901ca 100644
 --- a/libavutil/autorename_libavutil_utils.c
 +++ b/libavutil/autorename_libavutil_utils.c
 @@ -1,2 +1,2 @@
--// Automatically generated on Tue Sep 24 17:20:58 2024. See crbug.com/495833.
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
+-// Automatically generated on Tue Oct 22 17:56:01 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
  #include "utils.c"
 diff --git a/libavutil/autorename_libavutil_version.c b/libavutil/autorename_libavutil_version.c
-index 5310985dd2f..cb861468c27 100644
+index 9ba1b0215d..0d8c94604c 100644
 --- a/libavutil/autorename_libavutil_version.c
 +++ b/libavutil/autorename_libavutil_version.c
 @@ -1,2 +1,2 @@
--// Automatically generated on Tue Sep 24 17:20:58 2024. See crbug.com/495833.
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
+-// Automatically generated on Tue Oct 22 17:56:01 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
  #include "version.c"
 diff --git a/libavutil/x86/autorename_libavutil_x86_cpu.c b/libavutil/x86/autorename_libavutil_x86_cpu.c
-index 6db5c5a823c..78634bf62c9 100644
+index 7232f1e4d4..5de73354a6 100644
 --- a/libavutil/x86/autorename_libavutil_x86_cpu.c
 +++ b/libavutil/x86/autorename_libavutil_x86_cpu.c
 @@ -1,2 +1,2 @@
--// Automatically generated on Tue Sep 24 17:20:58 2024. See crbug.com/495833.
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
+-// Automatically generated on Tue Oct 22 17:56:01 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
  #include "cpu.c"
 diff --git a/libavutil/x86/autorename_libavutil_x86_fixed_dsp_init.c b/libavutil/x86/autorename_libavutil_x86_fixed_dsp_init.c
 new file mode 100644
-index 00000000000..4472a23a666
+index 0000000000..7bf84af09d
 --- /dev/null
 +++ b/libavutil/x86/autorename_libavutil_x86_fixed_dsp_init.c
 @@ -0,0 +1,2 @@
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
 +#include "fixed_dsp_init.c"
 diff --git a/libavutil/x86/autorename_libavutil_x86_float_dsp_init.c b/libavutil/x86/autorename_libavutil_x86_float_dsp_init.c
-index 3e2cda16e0a..2bb3d09e4d9 100644
---- a/libavutil/x86/autorename_libavutil_x86_float_dsp_init.c
+new file mode 100644
+index 0000000000..164385372c
+--- /dev/null
 +++ b/libavutil/x86/autorename_libavutil_x86_float_dsp_init.c
-@@ -1,2 +1,2 @@
--// Automatically generated on Tue Sep 24 17:20:58 2024. See crbug.com/495833.
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
- #include "float_dsp_init.c"
+@@ -0,0 +1,2 @@
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
++#include "float_dsp_init.c"
 diff --git a/libavutil/x86/autorename_libavutil_x86_lls_init.c b/libavutil/x86/autorename_libavutil_x86_lls_init.c
 new file mode 100644
-index 00000000000..44443e6bab3
+index 0000000000..1229b6a4b5
 --- /dev/null
 +++ b/libavutil/x86/autorename_libavutil_x86_lls_init.c
 @@ -0,0 +1,2 @@
-+// Automatically generated on Wed Nov 13 13:25:52 2024. See crbug.com/495833.
++// Automatically generated on Sat Jan 11 00:53:00 2025. See crbug.com/495833.
 +#include "lls_init.c"
 -- 
 2.39.2

--- a/chromium/riscv64.patch
+++ b/chromium/riscv64.patch
@@ -5,445 +5,31 @@
  makedepends=('python' 'gn' 'ninja' 'clang' 'lld' 'gperf' 'nodejs' 'pipewire'
               'rust' 'rust-bindgen' 'qt5-base' 'qt6-base' 'java-runtime-headless'
 -             'git')
-+             'git' 'python-requests' 'go' 'jq' 'npm' 'rsync')
++             'git' 'jq' 'npm' 'rsync')
  optdepends=('pipewire: WebRTC desktop sharing under Wayland'
              'kdialog: support for native dialogs in Plasma'
              'gtk4: for --gtk-version=4 (GTK4 IME might work better on Wayland)'
-@@ -26,27 +26,362 @@ optdepends=('pipewire: WebRTC desktop sharing under Wayland'
-             'kwallet: support for storing passwords in KWallet on Plasma'
-             'upower: Battery Status API support')
- options=('!lto') # Chromium adds its own flags for ThinLTO
--source=(https://commondatastorage.googleapis.com/chromium-browser-official/chromium-$pkgver.tar.xz
-+source=(chromium-mirror::git+https://github.com/chromium/chromium.git#tag=$pkgver
-         https://github.com/foutrelis/chromium-launcher/archive/v$_launcher_ver/chromium-launcher-$_launcher_ver.tar.gz
-         unbundle-add-enable_freetype.patch
-         unbundle-icu-target.patch
-         const-atomicstring-conversion.patch
-         compiler-rt-adjust-paths.patch
-         increase-fortify-level.patch
--        use-oauth2-client-switches-as-default.patch)
--sha256sums=('c03b6d9c10a2b2db4b1d2cef0657e85ad2e2d836f029655106cebd9a140692e6'
-+        use-oauth2-client-switches-as-default.patch
-+        makepkg-source-roller.py
-+        # BEGIN managed sources
-+        chromium-mirror_third_party_clang-format_script::git+https://chromium.googlesource.com/external/github.com/llvm/llvm-project/clang/tools/clang-format.git#commit=3c0acd2d4e73dd911309d9e970ba09d58bf23a62
-+        chromium-mirror_third_party_libc++_src::git+https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxx.git#commit=6a68fd412b9aecd515a20a7cf84d11b598bfaf96
-+        chromium-mirror_third_party_libc++abi_src::git+https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxxabi.git#commit=9a1d90c3b412d5ebeb97a6e33d98e1d0dd923221
-+        chromium-mirror_third_party_libunwind_src::git+https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libunwind.git#commit=efc3baa2d1ece3630fcfa72bef93ed831bcaec4c
-+        chromium-mirror_chrome_test_data_perf_canvas_bench::git+https://chromium.googlesource.com/chromium/canvas_bench.git#commit=a7b40ea5ae0239517d78845a5fc9b12976bfc732
-+        chromium-mirror_chrome_test_data_perf_frame_rate_content::git+https://chromium.googlesource.com/chromium/frame_rate/content.git#commit=c10272c88463efeef6bb19c9ec07c42bc8fe22b9
-+        chromium-mirror_chrome_test_data_xr_webvr_info::git+https://chromium.googlesource.com/external/github.com/toji/webvr.info.git#commit=c58ae99b9ff9e2aa4c524633519570bf33536248
-+        chromium-mirror_media_cdm_api::git+https://chromium.googlesource.com/chromium/cdm.git#commit=eb21edc44e8e5a82095037be80c8b15c51624293
-+        chromium-mirror_native_client::git+https://chromium.googlesource.com/native_client/src/native_client.git#commit=6944e6b79dbd1b9776681c025bd4f4c281bb4791
-+        chromium-mirror_net_third_party_quiche_src::git+https://quiche.googlesource.com/quiche.git#commit=e0175250977c2b2b95087afc0857883538a1386c
-+        chromium-mirror_testing_libfuzzer_fuzzers_wasm_corpus::git+https://chromium.googlesource.com/v8/fuzzer_wasm_corpus.git#commit=f650ff816f2ef227f61ea2e9f222aa69708ab367
-+        chromium-mirror_third_party_accessibility_test_framework_src::git+https://chromium.googlesource.com/external/github.com/google/Accessibility-Test-Framework-for-Android.git#commit=4a764c690353ea136c82f1a696a70bf38d1ef5fe
-+        chromium-mirror_third_party_angle::git+https://chromium.googlesource.com/angle/angle.git#commit=ac6cda4cbd716102ded6a965f79573b41581898d
-+        chromium-mirror_third_party_anonymous_tokens_src::git+https://chromium.googlesource.com/external/github.com/google/anonymous-tokens.git#commit=6ea6ec78f9e4998d0a7a5677b2aec08f0ac858f8
-+        chromium-mirror_third_party_content_analysis_sdk_src::git+https://chromium.googlesource.com/external/github.com/chromium/content_analysis_sdk.git#commit=9a408736204513e0e95dd2ab3c08de0d95963efc
-+        chromium-mirror_third_party_dav1d_libdav1d::git+https://chromium.googlesource.com/external/github.com/videolan/dav1d.git#commit=389450f61ea0b2057fc9ea393d3065859c4ba7f2
-+        chromium-mirror_third_party_dawn::git+https://dawn.googlesource.com/dawn.git#commit=740d2502dbbd719a76c5a8d3fb4dac1b5363f42e
-+        chromium-mirror_third_party_highway_src::git+https://chromium.googlesource.com/external/github.com/google/highway.git#commit=8295336dd70f1201d42c22ab5b0861de38cf8fbf
-+        chromium-mirror_third_party_google_benchmark_src::git+https://chromium.googlesource.com/external/github.com/google/benchmark.git#commit=344117638c8ff7e239044fd0fa7085839fc03021
-+        chromium-mirror_third_party_boringssl_src::git+https://boringssl.googlesource.com/boringssl.git#commit=cd95210465496ac2337b313cf49f607762abe286
-+        chromium-mirror_third_party_breakpad_breakpad::git+https://chromium.googlesource.com/breakpad/breakpad.git#commit=6b0c5b7ee1988a14a4af94564e8ae8bba8a94374
-+        chromium-mirror_third_party_cast_core_public_src::git+https://chromium.googlesource.com/cast_core/public.git#commit=71f51fd6fa45fac73848f65421081edd723297cd
-+        chromium-mirror_third_party_catapult::git+https://chromium.googlesource.com/catapult.git#commit=44791916611acec1cd74c492c7453e46d9b0dbd2
-+        chromium-mirror_third_party_ced_src::git+https://chromium.googlesource.com/external/github.com/google/compact_enc_det.git#commit=ba412eaaacd3186085babcd901679a48863c7dd5
-+        chromium-mirror_third_party_chromium-variations::git+https://chromium.googlesource.com/chromium-variations.git#commit=7d681838b57a25ca6659b9cc0111f879147c416b
-+        chromium-mirror_third_party_cld_3_src::git+https://chromium.googlesource.com/external/github.com/google/cld_3.git#commit=b48dc46512566f5a2d41118c8c1116c4f96dc661
-+        chromium-mirror_third_party_colorama_src::git+https://chromium.googlesource.com/external/colorama.git#commit=3de9f013df4b470069d03d250224062e8cf15c49
-+        chromium-mirror_third_party_cpu_features_src::git+https://chromium.googlesource.com/external/github.com/google/cpu_features.git#commit=936b9ab5515dead115606559502e3864958f7f6e
-+        chromium-mirror_third_party_cpuinfo_src::git+https://chromium.googlesource.com/external/github.com/pytorch/cpuinfo.git#commit=1e83a2fdd3102f65c6f1fb602c1b320486218a99
-+        chromium-mirror_third_party_crc32c_src::git+https://chromium.googlesource.com/external/github.com/google/crc32c.git#commit=d3d60ac6e0f16780bcfcc825385e1d338801a558
-+        chromium-mirror_third_party_cros_system_api::git+https://chromium.googlesource.com/chromiumos/platform2/system_api.git#commit=b08c5ad457bddea2664ba20fb25beb3d1799fed2
-+        chromium-mirror_third_party_crossbench::git+https://chromium.googlesource.com/crossbench.git#commit=b4d7ae714c548c3e139b95a85582dc15ece1d2f7
-+        chromium-mirror_third_party_depot_tools::git+https://chromium.googlesource.com/chromium/tools/depot_tools.git#commit=20b9bdcace7ed561d6a75728c85373503473cb6b
-+        chromium-mirror_third_party_devtools-frontend_src::git+https://chromium.googlesource.com/devtools/devtools-frontend.git#commit=5284f1c63b2b08c47b8915ce713a1aace991dfe9
-+        chromium-mirror_third_party_dom_distiller_js_dist::git+https://chromium.googlesource.com/chromium/dom-distiller/dist.git#commit=199de96b345ada7c6e7e6ba3d2fa7a6911b8767d
-+        chromium-mirror_third_party_eigen3_src::git+https://chromium.googlesource.com/external/gitlab.com/libeigen/eigen.git#commit=7eea0a9213e801ad9479a6499fd0330ec1db8693
-+        chromium-mirror_third_party_farmhash_src::git+https://chromium.googlesource.com/external/github.com/google/farmhash.git#commit=816a4ae622e964763ca0862d9dbd19324a1eaf45
-+        chromium-mirror_third_party_fast_float_src::git+https://chromium.googlesource.com/external/github.com/fastfloat/fast_float.git#commit=3e57d8dcfb0a04b5a8a26b486b54490a2e9b310f
-+        chromium-mirror_third_party_ffmpeg::git+https://chromium.googlesource.com/chromium/third_party/ffmpeg.git#commit=686d6944501a6ee9c849581e3fe343273d4af3f6
-+        chromium-mirror_third_party_flac::git+https://chromium.googlesource.com/chromium/deps/flac.git#commit=689da3a7ed50af7448c3f1961d1791c7c1d9c85c
-+        chromium-mirror_third_party_flatbuffers_src::git+https://chromium.googlesource.com/external/github.com/google/flatbuffers.git#commit=8db59321d9f02cdffa30126654059c7d02f70c32
-+        chromium-mirror_third_party_fontconfig_src::git+https://chromium.googlesource.com/external/fontconfig.git#commit=14d466b30a8ab4a9d789977ed94f2c30e7209267
-+        chromium-mirror_third_party_fp16_src::git+https://chromium.googlesource.com/external/github.com/Maratyszcza/FP16.git#commit=0a92994d729ff76a58f692d3028ca1b64b145d91
-+        chromium-mirror_third_party_gemmlowp_src::git+https://chromium.googlesource.com/external/github.com/google/gemmlowp.git#commit=13d57703abca3005d97b19df1f2db731607a7dc2
-+        chromium-mirror_third_party_grpc_src::git+https://chromium.googlesource.com/external/github.com/grpc/grpc.git#commit=822dab21d9995c5cf942476b35ca12a1aa9d2737
-+        chromium-mirror_third_party_freetype_src::git+https://chromium.googlesource.com/chromium/src/third_party/freetype2.git#commit=f02bffad0fd57f3acfa835c3f2899c5b71ff8be0
-+        chromium-mirror_third_party_freetype-testing_src::git+https://chromium.googlesource.com/external/github.com/freetype/freetype2-testing.git#commit=7a69b1a2b028476f840ab7d4a2ffdfe4eb2c389f
-+        chromium-mirror_third_party_fxdiv_src::git+https://chromium.googlesource.com/external/github.com/Maratyszcza/FXdiv.git#commit=63058eff77e11aa15bf531df5dd34395ec3017c8
-+        chromium-mirror_third_party_harfbuzz-ng_src::git+https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz.git#commit=1da053e87f0487382404656edca98b85fe51f2fd
-+        chromium-mirror_third_party_ink_src::git+https://chromium.googlesource.com/external/github.com/google/ink.git#commit=4300dc7402a257b85fc5bf2559137edacb050227
-+        chromium-mirror_third_party_ink_stroke_modeler_src::git+https://chromium.googlesource.com/external/github.com/google/ink-stroke-modeler.git#commit=0999e4cf816b42c770d07916698bce943b873048
-+        chromium-mirror_third_party_instrumented_libs::git+https://chromium.googlesource.com/chromium/third_party/instrumented_libraries.git#commit=bb6dbcf2df7a9beb34c3773ef4df161800e3aed9
-+        chromium-mirror_third_party_emoji-segmenter_src::git+https://chromium.googlesource.com/external/github.com/google/emoji-segmenter.git#commit=955936be8b391e00835257059607d7c5b72ce744
-+        chromium-mirror_third_party_ots_src::git+https://chromium.googlesource.com/external/github.com/khaledhosny/ots.git#commit=46bea9879127d0ff1c6601b078e2ce98e83fcd33
-+        chromium-mirror_third_party_libgav1_src::git+https://chromium.googlesource.com/codecs/libgav1.git#commit=a2f139e9123bdb5edf7707ac6f1b73b3aa5038dd
-+        chromium-mirror_third_party_googletest_src::git+https://chromium.googlesource.com/external/github.com/google/googletest.git#commit=62df7bdbc10887e094661e07ec2595b7920376fd
-+        chromium-mirror_third_party_hunspell_dictionaries::git+https://chromium.googlesource.com/chromium/deps/hunspell_dictionaries.git#commit=41cdffd71c9948f63c7ad36e1fb0ff519aa7a37e
-+        chromium-mirror_third_party_icu::git+https://chromium.googlesource.com/chromium/deps/icu.git#commit=ba7ed88cc5ffa428a82a0f787dd61031aa5ef4ca
-+        chromium-mirror_third_party_jsoncpp_source::git+https://chromium.googlesource.com/external/github.com/open-source-parsers/jsoncpp.git#commit=42e892d96e47b1f6e29844cc705e148ec4856448
-+        chromium-mirror_third_party_leveldatabase_src::git+https://chromium.googlesource.com/external/leveldb.git#commit=23e35d792b9154f922b8b575b12596a4d8664c65
-+        chromium-mirror_third_party_libFuzzer_src::git+https://chromium.googlesource.com/external/github.com/llvm/llvm-project/compiler-rt/lib/fuzzer.git#commit=487e79376394754705984c5de7c4ce7f82f2bd7c
-+        chromium-mirror_third_party_fuzztest_src::git+https://chromium.googlesource.com/external/github.com/google/fuzztest.git#commit=0021f30508bc7f73fa5270962d022acb480d242f
-+        chromium-mirror_third_party_domato_src::git+https://chromium.googlesource.com/external/github.com/googleprojectzero/domato.git#commit=053714bccbda79cf76dac3fee48ab2b27f21925e
-+        chromium-mirror_third_party_libaddressinput_src::git+https://chromium.googlesource.com/external/libaddressinput.git#commit=e8712e415627f22d0b00ebee8db99547077f39bd
-+        chromium-mirror_third_party_libaom_source_libaom::git+https://aomedia.googlesource.com/aom.git#commit=840f8797871cc587f7113ea9d2483a1156d57c0e
-+        chromium-mirror_third_party_libavif_src::git+https://chromium.googlesource.com/external/github.com/AOMediaCodec/libavif.git#commit=2c36aed375fff68611641b57d919b191f33431d5
-+        chromium-mirror_third_party_crabbyavif_src::git+https://chromium.googlesource.com/external/github.com/webmproject/CrabbyAvif.git#commit=ffad64ff4e349f926ad5ffcc882e205a94156d77
-+        chromium-mirror_third_party_libavifinfo_src::git+https://aomedia.googlesource.com/libavifinfo.git#commit=8d8b58a3f517ef8d1794baa28ca6ae7d19f65514
-+        chromium-mirror_third_party_nearby_src::git+https://chromium.googlesource.com/external/github.com/google/nearby-connections.git#commit=1b382075dd1bd545655af7ebef949b3090061b74
-+        chromium-mirror_third_party_beto-core_src::git+https://beto-core.googlesource.com/beto-core.git#commit=89563fec14c756482afa08b016eeba9087c8d1e3
-+        chromium-mirror_third_party_securemessage_src::git+https://chromium.googlesource.com/external/github.com/google/securemessage.git#commit=fa07beb12babc3b25e0c5b1f38c16aa8cb6b8f84
-+        chromium-mirror_third_party_speedometer_v3.0::git+https://chromium.googlesource.com/external/github.com/WebKit/Speedometer.git#commit=8d67f28d0281ac4330f283495b7f48286654ad7d
-+        chromium-mirror_third_party_ukey2_src::git+https://chromium.googlesource.com/external/github.com/google/ukey2.git#commit=0275885d8e6038c39b8a8ca55e75d1d4d1727f47
-+        chromium-mirror_third_party_cros-components_src::git+https://chromium.googlesource.com/external/google3/cros_components.git#commit=902e8ca804ae6c05f505e510c16647c32ce4d1cb
-+        chromium-mirror_third_party_libdrm_src::git+https://chromium.googlesource.com/chromiumos/third_party/libdrm.git#commit=ad78bb591d02162d3b90890aa4d0a238b2a37cde
-+        chromium-mirror_third_party_expat_src::git+https://chromium.googlesource.com/external/github.com/libexpat/libexpat.git#commit=624da0f593bb8d7e146b9f42b06d8e6c80d032a3
-+        chromium-mirror_third_party_libipp_libipp::git+https://chromium.googlesource.com/chromiumos/platform2/libipp.git#commit=2209bb84a8e122dab7c02fe66cc61a7b42873d7f
-+        chromium-mirror_third_party_libjpeg_turbo::git+https://chromium.googlesource.com/chromium/deps/libjpeg_turbo.git#commit=927aabfcd26897abb9776ecf2a6c38ea5bb52ab6
-+        chromium-mirror_third_party_liblouis_src::git+https://chromium.googlesource.com/external/liblouis-github.git#commit=9700847afb92cb35969bdfcbbfbbb74b9c7b3376
-+        chromium-mirror_third_party_libphonenumber_dist::git+https://chromium.googlesource.com/external/libphonenumber.git#commit=140dfeb81b753388e8a672900fb7a971e9a0d362
-+        chromium-mirror_third_party_libprotobuf-mutator_src::git+https://chromium.googlesource.com/external/github.com/google/libprotobuf-mutator.git#commit=a304ec48dcf15d942607032151f7e9ee504b5dcf
-+        chromium-mirror_third_party_libsrtp::git+https://chromium.googlesource.com/chromium/deps/libsrtp.git#commit=000edd791434c8738455f10e0dd6b268a4852c0b
-+        chromium-mirror_third_party_libsync_src::git+https://chromium.googlesource.com/aosp/platform/system/core/libsync.git#commit=f4f4387b6bf2387efbcfd1453af4892e8982faf6
-+        chromium-mirror_third_party_libvpx_source_libvpx::git+https://chromium.googlesource.com/webm/libvpx.git#commit=906334ac1de2b0afa666472dce5545b82c1251fb
-+        chromium-mirror_third_party_libwebm_source::git+https://chromium.googlesource.com/webm/libwebm.git#commit=26d9f667170dc75e8d759a997bb61c64dec42dda
-+        chromium-mirror_third_party_libwebp_src::git+https://chromium.googlesource.com/webm/libwebp.git#commit=845d5476a866141ba35ac133f856fa62f0b7445f
-+        chromium-mirror_third_party_libyuv::git+https://chromium.googlesource.com/libyuv/libyuv.git#commit=a8e59d207483f75b87dd5fc670e937672cdf5776
-+        chromium-mirror_third_party_lss::git+https://chromium.googlesource.com/linux-syscall-support.git#commit=ce877209e11aa69dcfffbd53ef90ea1d07136521
-+        chromium-mirror_third_party_material_color_utilities_src::git+https://chromium.googlesource.com/external/github.com/material-foundation/material-color-utilities.git#commit=13434b50dcb64a482cc91191f8cf6151d90f5465
-+        chromium-mirror_third_party_minigbm_src::git+https://chromium.googlesource.com/chromiumos/platform/minigbm.git#commit=3018207f4d89395cc271278fb9a6558b660885f5
-+        chromium-mirror_third_party_nasm::git+https://chromium.googlesource.com/chromium/deps/nasm.git#commit=f477acb1049f5e043904b87b825c5915084a9a29
-+        chromium-mirror_third_party_neon_2_sse_src::git+https://chromium.googlesource.com/external/github.com/intel/ARM_NEON_2_x86_SSE.git#commit=a15b489e1222b2087007546b4912e21293ea86ff
-+        chromium-mirror_third_party_openh264_src::git+https://chromium.googlesource.com/external/github.com/cisco/openh264.git#commit=478e5ab3eca30e600006d5a0a08b176fd34d3bd1
-+        chromium-mirror_third_party_openscreen_src::git+https://chromium.googlesource.com/openscreen.git#commit=4f27c4f1698522dfcea36dca948a13e2eaf4c26c
-+        chromium-mirror_third_party_openxr_src::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/OpenXR-SDK.git#commit=288d3a7ebc1ad959f62d51da75baa3d27438c499
-+        chromium-mirror_third_party_pdfium::git+https://pdfium.googlesource.com/pdfium.git#commit=7a8409531fbb58d7d15ae331e645977b113d7ced
-+        chromium-mirror_third_party_perfetto::git+https://android.googlesource.com/platform/external/perfetto.git#commit=24764a1d9c2fce1e9816ffae691f00353ade330d
-+        chromium-mirror_third_party_protobuf-javascript_src::git+https://chromium.googlesource.com/external/github.com/protocolbuffers/protobuf-javascript.git#commit=e34549db516f8712f678fcd4bc411613b5cc5295
-+        chromium-mirror_third_party_pthreadpool_src::git+https://chromium.googlesource.com/external/github.com/Maratyszcza/pthreadpool.git#commit=560c60d342a76076f0557a3946924c6478470044
-+        chromium-mirror_third_party_pyelftools::git+https://chromium.googlesource.com/chromiumos/third_party/pyelftools.git#commit=19b3e610c86fcadb837d252c794cb5e8008826ae
-+        chromium-mirror_third_party_quic_trace_src::git+https://chromium.googlesource.com/external/github.com/google/quic-trace.git#commit=caa0a6eaba816ecb737f9a70782b7c80b8ac8dbc
-+        chromium-mirror_third_party_pywebsocket3_src::git+https://chromium.googlesource.com/external/github.com/GoogleChromeLabs/pywebsocket3.git#commit=50602a14f1b6da17e0b619833a13addc6ea78bc2
-+        chromium-mirror_third_party_re2_src::git+https://chromium.googlesource.com/external/github.com/google/re2.git#commit=6dcd83d60f7944926bfd308cc13979fc53dd69ca
-+        chromium-mirror_third_party_ruy_src::git+https://chromium.googlesource.com/external/github.com/google/ruy.git#commit=c08ec529fc91722bde519628d9449258082eb847
-+        chromium-mirror_third_party_skia::git+https://skia.googlesource.com/skia.git#commit=f14f6b1ab7cf544c0190074488d17821281cfa4d
-+        chromium-mirror_third_party_smhasher_src::git+https://chromium.googlesource.com/external/smhasher.git#commit=e87738e57558e0ec472b2fc3a643b838e5b6e88f
-+        chromium-mirror_third_party_snappy_src::git+https://chromium.googlesource.com/external/github.com/google/snappy.git#commit=c9f9edf6d75bb065fa47468bf035e051a57bec7c
-+        chromium-mirror_third_party_sqlite_src::git+https://chromium.googlesource.com/chromium/deps/sqlite.git#commit=567495a62a62dc013888500526e82837d727fe01
-+        chromium-mirror_third_party_swiftshader::git+https://swiftshader.googlesource.com/SwiftShader.git#commit=7a9a492a38b7c701f7c96a15a76046aed8f8c0c3
-+        chromium-mirror_third_party_text-fragments-polyfill_src::git+https://chromium.googlesource.com/external/github.com/GoogleChromeLabs/text-fragments-polyfill.git#commit=c036420683f672d685e27415de0a5f5e85bdc23f
-+        chromium-mirror_third_party_tflite_src::git+https://chromium.googlesource.com/external/github.com/tensorflow/tensorflow.git#commit=689e8a82f8070a372981b7476fb673e243330d71
-+        chromium-mirror_third_party_vulkan-deps::git+https://chromium.googlesource.com/vulkan-deps.git#commit=73fd75175922012f21557239b7743a152ea7f1fd
-+        chromium-mirror_third_party_glslang_src::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/glslang.git#commit=2acc4ea0028bc703be2d4e9bc8a4032d015d6516
-+        chromium-mirror_third_party_spirv-cross_src::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Cross.git#commit=b8fcf307f1f347089e3c46eb4451d27f32ebc8d3
-+        chromium-mirror_third_party_spirv-headers_src::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Headers.git#commit=50bc4debdc3eec5045edbeb8ce164090e29b91f3
-+        chromium-mirror_third_party_spirv-tools_src::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/SPIRV-Tools.git#commit=42b315c15b1ff941b46bb3949c105e5386be8717
-+        chromium-mirror_third_party_vulkan-headers_src::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Headers.git#commit=14345dab231912ee9601136e96ca67a6e1f632e7
-+        chromium-mirror_third_party_vulkan-loader_src::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Loader.git#commit=bd1c8ea9c6ac51e4c3a6ddb9d602bb204678eb5f
-+        chromium-mirror_third_party_vulkan-tools_src::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Tools.git#commit=c9a5acda16dc2759457dc856b5d7df00ac5bf4a2
-+        chromium-mirror_third_party_vulkan-utility-libraries_src::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-Utility-Libraries.git#commit=8c907ea21fe0147f791d79051b18e21bc8c4ede0
-+        chromium-mirror_third_party_vulkan-validation-layers_src::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/Vulkan-ValidationLayers.git#commit=cbb4ab171fc7cd0b636a76ee542e238a8734f4be
-+        chromium-mirror_third_party_vulkan_memory_allocator::git+https://chromium.googlesource.com/external/github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git#commit=56300b29fbfcc693ee6609ddad3fdd5b7a449a21
-+        chromium-mirror_third_party_wayland_src::git+https://chromium.googlesource.com/external/anongit.freedesktop.org/git/wayland/wayland.git#commit=a156431ea66fe67d69c9fbba8a8ad34dabbab81c
-+        chromium-mirror_third_party_wayland-protocols_src::git+https://chromium.googlesource.com/external/anongit.freedesktop.org/git/wayland/wayland-protocols.git#commit=7d5a3a8b494ae44cd9651f9505e88a250082765e
-+        chromium-mirror_third_party_wayland-protocols_kde::git+https://chromium.googlesource.com/external/github.com/KDE/plasma-wayland-protocols.git#commit=0b07950714b3a36c9b9f71fc025fc7783e82926e
-+        chromium-mirror_third_party_wayland-protocols_gtk::git+https://chromium.googlesource.com/external/github.com/GNOME/gtk.git#commit=40ebed3a03aef096addc0af09fec4ec529d882a0
-+        chromium-mirror_third_party_webdriver_pylib::git+https://chromium.googlesource.com/external/github.com/SeleniumHQ/selenium/py.git#commit=fc5e7e70c098bfb189a9a74746809ad3c5c34e04
-+        chromium-mirror_third_party_webgl_src::git+https://chromium.googlesource.com/external/khronosgroup/webgl.git#commit=450cceb587613ac1469c5a131fac15935c99e0e7
-+        chromium-mirror_third_party_webgpu-cts_src::git+https://chromium.googlesource.com/external/github.com/gpuweb/cts.git#commit=ae8b3ca40fbeee0bc67ef41a6c5b6dd5af839344
-+        chromium-mirror_third_party_webrtc::git+https://webrtc.googlesource.com/src.git#commit=79aff54b0fa9238ce3518dd9eaf9610cd6f22e82
-+        chromium-mirror_third_party_wuffs_src::git+https://skia.googlesource.com/external/github.com/google/wuffs-mirror-release-c.git#commit=e3f919ccfe3ef542cfc983a82146070258fb57f8
-+        chromium-mirror_third_party_weston_src::git+https://chromium.googlesource.com/external/anongit.freedesktop.org/git/wayland/weston.git#commit=ccf29cb237c3ed09c5f370f35239c93d07abfdd7
-+        chromium-mirror_third_party_xdg-utils::git+https://chromium.googlesource.com/chromium/deps/xdg-utils.git#commit=cb54d9db2e535ee4ef13cc91b65a1e2741a94a44
-+        chromium-mirror_third_party_xnnpack_src::git+https://chromium.googlesource.com/external/github.com/google/XNNPACK.git#commit=3986629de01e518a3f2359bf5629ef2b7ef72330
-+        chromium-mirror_tools_page_cycler_acid3::git+https://chromium.googlesource.com/chromium/deps/acid3.git#commit=a926d0a32e02c4c03ae95bb798e6c780e0e184ba
-+        chromium-mirror_third_party_zstd_src::git+https://chromium.googlesource.com/external/github.com/facebook/zstd.git#commit=20707e3718ee14250fb8a44b3bf023ea36bd88df
-+        chromium-mirror_v8::git+https://chromium.googlesource.com/v8/v8.git#commit=7f72bbed40ca85a6b68ca2f15feca342c9c256d0
-+        chromium-mirror_third_party_angle_third_party_glmark2_src::git+https://chromium.googlesource.com/external/github.com/glmark2/glmark2.git#commit=ca8de51fedb70bace5351c6b002eb952c747e889
-+        chromium-mirror_third_party_angle_third_party_rapidjson_src::git+https://chromium.googlesource.com/external/github.com/Tencent/rapidjson.git#commit=781a4e667d84aeedbeb8184b7b62425ea66ec59f
-+        chromium-mirror_third_party_angle_third_party_VK-GL-CTS_src::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/VK-GL-CTS.git#commit=179dd9f858f0f5b0e52b61aefc621dc82e2ad34a
-+        chromium-mirror_third_party_dawn_buildtools::git+https://chromium.googlesource.com/chromium/src/buildtools.git#commit=9cac81256beb5d4d36c8801afeae38fea34b8486
-+        chromium-mirror_third_party_dawn_build::git+https://chromium.googlesource.com/chromium/src/build.git#commit=a6c1c751fd8c18d9e051b12600aec2753c1712c3
-+        chromium-mirror_third_party_dawn_tools_clang::git+https://chromium.googlesource.com/chromium/src/tools/clang.git#commit=06a29b5bbf392c68d73dc8df9015163cc5a98c40
-+        chromium-mirror_third_party_dawn_testing::git+https://chromium.googlesource.com/chromium/src/testing.git#commit=1bd0da6657e330cf26ed0702b3f456393587ad7c
-+        chromium-mirror_third_party_dawn_third_party_jinja2::git+https://chromium.googlesource.com/chromium/src/third_party/jinja2.git#commit=e2d024354e11cc6b041b0cff032d73f0c7e43a07
-+        chromium-mirror_third_party_dawn_third_party_markupsafe::git+https://chromium.googlesource.com/chromium/src/third_party/markupsafe.git#commit=0bad08bb207bbfc1d6f3bbc82b9242b0c50e5794
-+        chromium-mirror_third_party_dawn_third_party_glfw::git+https://chromium.googlesource.com/external/github.com/glfw/glfw.git#commit=b35641f4a3c62aa86a0b3c983d163bc0fe36026d
-+        chromium-mirror_third_party_dawn_third_party_zlib::git+https://chromium.googlesource.com/chromium/src/third_party/zlib.git#commit=209717dd69cd62f24cbacc4758261ae2dd78cfac
-+        chromium-mirror_third_party_dawn_third_party_abseil-cpp::git+https://chromium.googlesource.com/chromium/src/third_party/abseil-cpp.git#commit=f81f6c011baf9b0132a5594c034fe0060820711d
-+        chromium-mirror_third_party_dawn_third_party_dxc::git+https://chromium.googlesource.com/external/github.com/microsoft/DirectXShaderCompiler.git#commit=080aeb7199e66e4b0a2b6383fd26a9f8d2cccbf5
-+        chromium-mirror_third_party_dawn_third_party_dxheaders::git+https://chromium.googlesource.com/external/github.com/microsoft/DirectX-Headers.git#commit=980971e835876dc0cde415e8f9bc646e64667bf7
-+        chromium-mirror_third_party_dawn_third_party_webgpu-headers::git+https://chromium.googlesource.com/external/github.com/webgpu-native/webgpu-headers.git#commit=8049c324dc7b3c09dc96ea04cb02860f272c8686
-+        chromium-mirror_third_party_dawn_third_party_khronos_OpenGL-Registry::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/OpenGL-Registry.git#commit=5bae8738b23d06968e7c3a41308568120943ae77
-+        chromium-mirror_third_party_dawn_third_party_khronos_EGL-Registry::git+https://chromium.googlesource.com/external/github.com/KhronosGroup/EGL-Registry.git#commit=7dea2ed79187cd13f76183c4b9100159b9e3e071
-+        chromium-mirror_third_party_dawn_third_party_protobuf::git+https://chromium.googlesource.com/chromium/src/third_party/protobuf.git#commit=da2fe725b80ac0ba646fbf77d0ce5b4ac236f823
-+        chromium-mirror_third_party_dawn_tools_protoc_wrapper::git+https://chromium.googlesource.com/chromium/src/tools/protoc_wrapper.git#commit=b5ea227bd88235ab3ccda964d5f3819c4e2d8032
-+        chromium-mirror_third_party_dawn_third_party_jsoncpp::git+https://github.com/open-source-parsers/jsoncpp.git#commit=69098a18b9af0c47549d9a271c054d13ca92b006
-+        chromium-mirror_third_party_dawn_third_party_langsvr::git+https://github.com/google/langsvr.git#commit=303c526231a90049a3e384549720f3fbd453cf66
-+        chromium-mirror_third_party_dawn_third_party_partition_alloc::git+https://chromium.googlesource.com/chromium/src/base/allocator/partition_allocator.git#commit=2e6b2efb6f435aa3dd400cb3bdcead2a601f8f9a
-+        chromium-mirror_third_party_openscreen_src_third_party_tinycbor_src::git+https://chromium.googlesource.com/external/github.com/intel/tinycbor.git#commit=d393c16f3eb30d0c47e6f9d92db62272f0ec4dc7
-+        # END managed sources
-+)
-+sha256sums=('7e430a28181cc6ddb2cd669f47e5517ccd69ba0ae8c3d9011145aea4fae02720'
+@@ -35,7 +35,18 @@ sha256sums=('f98315eacbf3be106feca37f8243d8c4092d4fd832c918aa36dc229eb6ab39e0'
              '213e50f48b67feb4441078d50b0fd431df34323be15be97c55302d3fdac4483a'
-             'f6e05adc80bd2f22b766d41a91739276c62201e47272c561f18a099c4a809e37'
-             '67de7744b92cbfa6fcbf43a71ba531eb5a7b00381d96703d8dc3dfdadaebf67d'
-             'ac0c9e366ca6afe0839f9ecb6bc42614747349da0c3dc46408e5053dcb7ada76'
              'b3de01b7df227478687d7517f61a777450dca765756002c80c4915f271e2d961'
              'd634d2ce1fc63da7ac41f432b1e84c59b7cceabf19d510848a7cff40c8025342'
 -            '6de648d449159dd579e42db304aca0a36243f2ac1538f8d030473afbbc8ff475')
--
--if (( _manual_clone )); then
--  source[0]=fetch-chromium-release
--  makedepends+=('python-httplib2' 'python-pyparsing' 'python-six' 'npm' 'rsync')
--fi
 +            '6de648d449159dd579e42db304aca0a36243f2ac1538f8d030473afbbc8ff475'
-+            'f6f6d939e3979bc2e87820b344ae67b1799c2213258cffc35af0c07591a420cb'
-+            'b7ab26b28122102827dbbefa54a38f9d59729bbdab889dcc6dba672141590717'
-+            '84cee6fc32f8d623349881d1bb3adbb0f4bcabd93f4d975cf76880368bd3823a'
-+            'c2e11cd9701aa91308b3f6b0d9940ea3af0fe08239afbeb386c5c61484c40b40'
-+            '5369afce2d78638f2dae84d2feac377b687fb028cc694ec5d76304f1f6328521'
-+            '5abf726ce9e19c0b0e7818a7ced615a1a6d16f306e7315b9e6db53118c0669b5'
-+            '045eb27642ac8f49b52efec7c52bb6ea3c908552ffadc50449a23b27da7a4737'
-+            '8a8c21768a1f3764e6887cfc907dd857e9fc00a1269dd858e2ba98d70aef889d'
-+            '4d6164564f1fb641cb190966bf525a9d9ed5f30a09ee9d1d37e1d65624b09304'
-+            'b344c098926ab34bb1006f8dfaa8d2ebed9b9b62e77bb42aa689e4bf63093ece'
-+            '5ee08055895487eb8559ce70658d3d66a5820581ab0f6de2fbb226f7fc09743f'
-+            'ece1dee7d933f441230b956458bd3c134f31659cf112c85ec276f085391dd106'
-+            'de6dba1f7c67cb568c5f23e75a994422944ce46c01fc35bddae4ebc023a7145a'
-+            '72d1940d802345cac1abd02e8a2d5b7c06de28df4b1862a29c0e47c47572bf4d'
-+            '0e3ece6abcb4942e0c027294a23d689ff9dce5aacd8e958fdddc0f20d9873765'
-+            '89a368f0652d857d38402d6f3c5cded3c1757230ab7abe01df850a7bf8359119'
-+            'ab4b725f93f0144169d17e48428c12203908dc429a7f8c9ad4c07cc6a65cfc45'
-+            '0ef4b635349f4e80ce8339bc8ad2f0690c0510cf61efb1e0e3a559292c6969d0'
-+            '48bdb7a462a52e890a9b8536d21924d0a4fe3f0dcb9a90a976fcd7a3e2526899'
-+            'bd07cc3f0dfa91629028ed53691eec8e0bf9bed7b3a602f4b8e78a7472e4e6fb'
-+            'd1441f584a5b60bafbed6f3359846f14cef478d189c6a26c42753b2c6e46b2e5'
-+            '1df3cd67ce6f3c2835947ae75e38ff43f1d1f059fa2b8eecdd3b660a3e43860f'
-+            'af24f30b90d5942ecb89b9e5f373de70ec16ce590788a03a8d21f714bbca7337'
-+            'b53d91a216a52e9b5b8a16d813a8fedd6be77af2286563a8b69677851a8f658e'
-+            '8b97c25874c17644300d1cbe6ac1fceb705bf18297e27699ba20497fc47ae239'
-+            '57ba23106318354f6350d97c5737f40085b4cececdcc3fe3f5d82e684c110db8'
-+            'e6a28c25e3d93c9c37414149ff44ac7a1bbb4d8a167061f8ee9679dc065af1bb'
-+            '9e950d9f0bf7f0b52de6744de0922583b4b32281e87f0488c2d1cfc533665aa5'
-+            '6125206b56f365874ba812038dbcd4271f8a73235ab4d211c42b7fd2d636bbc8'
-+            'f8a8c951f2c3e7d7cf3681ea628e5060d414b0ced2f03690c0cf559d00f61367'
-+            '6ae7ae01b3c23f8bf7657a59427aac6f3216e041ebdb983b82c002a949bdb071'
-+            'a313fe6b3c9d3581481efa5f1c7aa82384a58c138b94a13b3f84860ea58fbe20'
-+            'c52f0683f25dfc56c0edea67ef6b456bb6c7055869e71cb68aa7cd9e99a6a9bb'
-+            '5b72d127f022973ee97ae782b6c264a26abb6d161c992c9c8ee7cb1975669a52'
-+            '225174e13413d08a0b7b15309c9fea4d514001a67d99f5d86079ed188e99aa3b'
-+            '47f3f3d044cc0658274833022db1e7695964b1da8f37cb905882d15457212fba'
-+            'bcaa1307331167f0458252b4a27d893dd8929593d02af41a067f0422be2f9cf5'
-+            '6258126c4c354ccacd0ec5f9f82c6970d576359c7aba86e44277b459d1645325'
-+            '64ba2842c41f7f9cffaf13269cb1a6b64211bbb02b65ae0aba0d93caca1627ef'
-+            'b559efcb3ead251b2102029b1b6e21efb9edd2a70e6532d816d9603b860cf409'
-+            'cf96ae84ef29434dd20b0f2daca6013373dd6e47c87cde3aa03abce0500a9f03'
-+            '7df2a26df1b8e69c58692295443e18de9f19bc0107bd5911beed53157a592ad3'
-+            '0db8417b0fd669b95227c266cbc578af1f5e00198fd24f51fee8cfcfccb8b06b'
-+            '5d0c4f261d36707f926fa9ef9a39349f1cccac8ae6443a8f8571c1625eb90c41'
-+            '1a1e2859649a95beef8dba22e8c77735652a212bc88a9bb4dfe1458667dcabbc'
-+            '792d29bbb3fdcfdf21face515e6b9fba1a14ee7bdc82f0cff9620592925425c9'
-+            '884e0bb2a9d96db2afe0fa5b7ee55320636621e1904371ec1f006ca3da31b4d5'
-+            '12081574c11ef21850e9d2cf62580216296a6b7af48f679e6c28e05a376d1f3d'
-+            '0f27ab5434870f31886d7c958ced4ff335a09a1080637fb50afdf95db19e3442'
-+            'd0697f71f188829bcb9e98b229340ea77ee1c5185a02168ac509fbd5c02e7b1b'
-+            '7fbc8404e889753152af9ffe3a5e68a8ae4a598f878bb672b119c745ad5e5078'
-+            'ed1d70be45736383da22f440847d9c256d711a209d85624caba7b16b07a04642'
-+            '753cb94b49f25fd25aa045569722d4780591bf060f17644d9b78e7e83b3fdfc8'
-+            '66004b44318ad7e4329d65b08320136ee8a9f074b7b001107c52377493d28cc0'
-+            'af81f653b73270d4b8f9d1e92ecf39821498c08f4ca5c69872e39bac90b40083'
-+            '6ae17c7b6b1a897550f3b099f4f8f1ca84eb41c3f1d7711d43359040a5450495'
-+            'e4b820457b61971043a9c0bfd6f28e545cb720354b0455b891682b22157164a8'
-+            '92fe0e99dea519a56b80321646b7b2b674564f4e8d036cbbf4d98e8588531720'
-+            '0f219741c90cddba0b442fdbc16c5d1e968bbdf633b8267e132d1a91292cef36'
-+            '9f58ce3d45baf6796965aa79109af62c330f82b97d320bb5d7bbbdea0e579a92'
-+            '739e5654f283ec4d5bf2a54f4d13d4979a92cfb035b407e6736d58203c3a4266'
-+            'ce15a6a958184541728c1cc685c1e4ee07334e9fc8d22c631e446a282c924566'
-+            '59da6a77234770db03204f83967353a58a50e67ebde3b3fed855b54ff3c59294'
-+            'c2eb3aee5d91aa9d80d651d5bc26ae729e9a5bdd2f62985ca394cebac5b8174f'
-+            '63e3cc92fb9b5b9181082eb8ba1574a11e4c36272d10930c4bd7610fed17308a'
-+            'b24992835a1fee39e43b2c39affb5d49a4b937cba6d5a1028dbd3ca6ef147e03'
-+            '55a51c159d1d9ac5c9fa0f3ab15655cd298bffe66eca30f50300c9cdeaf7315e'
-+            '5061150d9d1ed123dba3ecbb69c8d385b35b5b615ad0dd0ce3c9e45a13c17df0'
-+            '46890b0f4deddc446e5ec9de234b78163d43c593f39edc1c4b04b721d49850d7'
-+            '9276f51bb843716df0af91b233e7748241db6bfacd174d211df3339059952d86'
-+            'ac36790b054f2b0fbc5bcb64951ee2f77201d3795d5ccf590adc78b5bc7cb6e2'
-+            '66b8f66432b1325861b5f411c71ec49fa171d9a0063bf958242ddde6ce09c12f'
-+            'f849a0242720e6389140b7d7853e9f56186bac9793aea5e7b9b713d76847c398'
-+            '9c888babaaf59afc855d944e8b26ab573d5e80026dc3bc8dc64720b8f5bb27a2'
-+            'e370a0c442308ee4f93e90f570fd217e77cbf1ecd52f82c6b1c9058c18a74767'
-+            'ae2c189d21dcd056116ee1c3d54b5ae3874e5ac0cc2086c137625b618334cbb1'
-+            'dd3fe1521ff5bc4481bfd447d62322417f069371d107d5df2df8134b0a1bfd79'
-+            'fe2f23319ca61ecb2fac8e586ad71fe36ba340fd4f5c4d0372d0e119d5c264e0'
-+            '3bb4ad9e05483ad8cadd9bf9d7ca0e2e16fd4eb1495ef36f4858be22c2eb31b2'
-+            '4070e77bf7afd9fb949067f63c3580d1f5badacfe4c2ab187129ba20446efd04'
-+            '9c8de69ad47af04565a89920c08f44694f97d7a16f8f23610e5beaf9f38cb71c'
-+            '25906418111df0d29db783092d94148e130592d722393ad4bd76809c6f63f9bd'
-+            '1e7f1fbf8818b35e61f32ed2c6bc0e8808e53ab87f45c8aa6df35daf3f14b720'
-+            '9341676174943fbc5268e023c3e572171289fc4748401723a6dcaef50f793dcd'
-+            '5d3cf0c3beddae9cb08988aff94472c3c9cdd7848cdbab6b921acc01da483eb5'
-+            '77e3ec7142195e044be4662611f6c31407ae8486dcaa7bd1bd03bb1315250cb2'
-+            'c06f2a92cd606654ec565c2fa728e755eaaf7e7a41fb7bd217988274a411c320'
-+            '719b736f7dd6298e0a45b15d9ec14a08d9db56b7b8255946b5056f52638d95f9'
-+            'e475d42b746955422ff9e905354091d0b17cdb2c8989cc6beb6470e76a4aa1dd'
-+            'f2aba031573fc4929d2bd9d03e4b18c4385f399fa0b605eca35898567ebdf7b4'
-+            '9010695b87eef676b62ec429879972c135987dab6eb53b0a4edf1b5a7cb0bb8b'
-+            '3d55fa9e1d628aed3e127b6fb4d3dd47b7ada7b865f683f52e21a51043827479'
-+            'd1c16289a7869f143d72e6d574d4f27f439fd2fd027064dcce1dd6a6aee75d00'
-+            '3cd40fbd2ac25f213a6c26c1e86d9644fce7423368149fb22c71e004ca6c9553'
-+            '1bec23c7e8894fb53e94ee906589c21e1ae677e6872d308cfb033b6eca27c8fd'
-+            '737a2b60713f602b487a67a49c8817d5423218d546943cfe49a57e50c2101d89'
-+            'cf5d7f9bdd280106a7d5e6737db5b1beb6cde4b1d461d8fa2f34baa17c7029a0'
-+            '397d45e6ec567571185ec8d7beb00efd50064ebb51c4c32ac34db76789af9191'
-+            '78f5096d2d425b9663cb289964d994c9a15db7938c5a1a35cc4b286014ca2545'
-+            '00f4fa0ff1741c69c12af0c14a8c60b0b3a28e44c04beee3d61fc7982a6aea5d'
-+            '99995f0ca85ab0e85bd291e5336657df41409a48ca5439dcaf162d8b11ac0ec6'
-+            'dc1206af7485794e1644097b08736e39c8fa50296e514561f8805c6d28b58925'
-+            '599bbbabf9e2dc2006dd9e3e9636c4f648360726173793bf6a5a5414698762c5'
-+            'b7a7a43eae0f41a9e18f54c2334d5797a547238b76d64d59ede26a4d6621de0d'
-+            '39d7dd8b6721a427dae2ca577d5f003459563928850757c519be96cb4064e933'
-+            'f34e477ad80ec4dbb653529d3ea85e52f0061a0d2033d3fcee6c8583d50be859'
-+            '3624b28203c972ea54b490342be74fbd99d4b4748123f9e2837a54ca01c8b392'
-+            'bd724ee01b93651b4ec6ba62ba64d23e153ea7100be760ccaee4a1e6e32787a6'
-+            '1a94dc238b495ea06f98e8876591691eddfc41e3980b84624fd0834add444afb'
-+            'b8f18792ccc1a4b4962278216e04e67f8653f494dc4e224e6d3c915805939a91'
-+            '108a67f21c2bdf2dbc4838f3ba32c992325a29cb62a14b377f8a04a9ad5b2b82'
-+            '9c405e41bed8d82ed309d392b22faeebf64ea75d02dddf6e63ebf4505a573d3b'
-+            'e0da7e95c836d28883f694fbf9e32f68a74e84ca3dc2b36d04c8c43747e18d80'
-+            'd8afe03bbf5561726d403a367275c8e13479de96481dc0152032bff7fc59219d'
-+            '0f18fde832017387600b5ee2ec6a0ae82125c82b97c0f717772f3cd5dfdcd57b'
-+            '5652da8ff7a64af5bcf6bc0360c959e5cb8fc37b4729b7cdc4984eecf6b1f05e'
-+            'c60eaac07b4f1faf3ff4c7d845f5309d59731eeee69748add18855e47ebbfb9f'
-+            '68977011e2e3af5453e227757579f7d44fd68c309cacb849cc6d29a2506e4f3e'
-+            '02e0a810ffe7c6f12ec427d29fa458e9f79098dc984546af51253622e5828b41'
-+            '253338d02b57f6cf8872cffb5435662d5413a7b6f9faf285d8ffe54abcfc2ee8'
-+            '76aaf49fe302f2247cd7c61fd4bbdec5329bb7c1d643084702c028cd2f9d5028'
-+            'c85f36eb1856ae104efb1d681bf89fa0230616f608ccce3343e85598c91b4f9c'
-+            '913fc3a85ae676025bafe63880c6413ffafe42495a04a52527ee914ee9ba3ae5'
-+            '8ee0bade4127e082dc1ae86f0068aa32ea0fbce26069ed2d9dbdef324e1bb980'
-+            '900f9249e65a3bf0189f3e32c6a2d84bd88b9b3a7d7cfba8c12c1be0d78dd31f'
-+            '1da28304d237ba934e76394107e46fed0e4120fd2b257f1c667c2d11b52d959b'
-+            'a9a8839d08232091a0cd381f51380a0a6ebe841f5a8e50a6047aae7b8e34c681'
-+            '02696a90c7831e3fa903df105573c5f10f4934602fb0e90c846fb44213c40b27'
-+            'ac3a122bf70f773c7a7dbc562c5e2d7a7c90c5a2d4b3909f3ad3a9263e56842c'
-+            '9675cba3930d511e02cd8c29af46912d26f9034b1de15842fa6e2c0e12f1259c'
-+            'b5c69e2f9ef90a159c79882ad171cd3cc638f7313048f2a299a57ba06a7f4906'
-+            '0c9106a2bef658f02b2312d081faad6ba8a72bbb5b4ee1cae7d0a95e4ef53f8f'
-+            '04a61e218b3a10ec3cf58e3fe12fb2ea23610f03889d19b31b8ccb3b078efd6e'
-+            '910bc5d9e7523ccd09506bafe3fac586db5106d8cc72d77e8457fdf8b43c225e'
-+            '7606cdbf4d2147cdb89ff43e5e5b3a913c62901481e82815713db5ee024f7d62'
-+            '548c8cd89cf822c790e4703eff53756791450eba73d267a84f3bf3eedf60bef5'
-+            '4518249219bef02aed2859f60f2b3478a42615153d573ee12dec2dca61b145de'
-+            '3417f07eb4a7345e9684c5b093bb09951dc8501c22be67607ea040ae4dcea4a5'
-+            'e67cdb017c07a7ec72a06f1062dc2f124d97527869604575fe48610ff98b581a'
-+            '716cc81139f11a2b438802d37f245f885fc9a0c69ef429a11b156145c903a932'
-+            '1f3f4e54f58245a0b6f68b196aed936a5ad094a2de90b669766deff6b8ef4c3d'
-+            '2a4e7b307dd0c1b88608e60e13a6ae0baf0995765f896f5b622cdc3d067e42d2'
-+            '26abc865fd39a6f65cc1f69383e66820e22fca6e7ab535f5aa8e5c793d81f178'
-+            '6423bbb0a07f8f45cc87d874c0eed1827bb5fc08c361884cb318fa361643024d'
-+            '64633f7373b79cb3e3a7c221f1a8a6033ea6d14fc3234fdb52facc4c1ab2fb24'
-+            'b48490fbcdad8becc160f2dab2ee4a0f67327f1e9d9ddbd96e44150175c68ca9'
-+            '0b95ed21612b4f02e65643f2029d8ce5710f49dbe8b229350bbe643167a4b83b'
-+            '9bd1e05f5128b4715c2d354a6895839d01aae4fc9f56b9d0411afc87fb46daf4'
-+            '3ae63a893b5b585823f04b5a2e604d3df4c7c6e311f5da5b5d5af92a1fd00465'
-+            'd1bea5be4ca41f2e9f29354bc3bdf12d9bba47778eb6fa6b01db053a831f3b42'
-+            'fe4522f5ae297089b0a49ad57e1d695f59810f7fd970615fd1c548a6597794b9'
-+            'f7f5d15365443cbd8137445c3aedf8ccd31c3402f72c0fa7c16e7bf1c7977139'
-+            'b4b2001119694d538dd97c110809503d8ac514caba65f98d11be7ae00c307299'
-+            'f8627f5f3a7c119807afc9dc66ce7cb350f905fd1db7fb6b0077552974a07515'
-+            'ac3f025aa27fec77b24b443df3a69750dc9bb070a40af5180d031b81e66e328c'
-+            '9c09dfbb8ebed025ec8ba34bf95c80fe30dd69eee5a02945c0357ce253d9dcbc'
-+            '8bd1361cf5c6e4e3336cad5b37c79dcc986a46b99e4ad7d679da146dd1fdb7fe'
-+            '868159a9a965cebd40f98f5995d6ac6361869904712c1b62c6b8a67d10dd93b4'
-+            'bde40f830d8edac53f2682acd50bf7db2632cb31c6ddaa1923a8703a58899e11'
-+            '37bd9bc812c1bfc471be2eb003f714e475f8425913c42703b21237f2b1c99e57'
-+            'c23fa31250811a76be900554b9ac127f861ebde09c07ac67cd6b82dd214e5686'
 +            '2ea949ed1d20a1745ce72f760a7d9297dc0002a747c4bd53e243c4d58ba2c7ca'
 +            '5689e9422624c8725509b6fdc277e20c3e8862cf515656faef7507978489bc4e'
-+            '4c9f1f3991459411ca688a185cfab790b13529dd2ee0cce7d7bdc29d89d2f76c'
++            '3c6ab77fdae5771be316d391e3488e5bd8eba967de3faa7295b4ff51acb1de98'
 +            '1713cfc3c73d7f33fd7a9daba9b642869632468bc1068b727827a6b5320a7f88'
 +            '77b62bbe1fd7cc2efc5c19fddba58b41332cc68894e893ce5357f5f75b79f678'
 +            '8fd4c776c44da66133ba3d87506e9a95a08fd461d5d03f53c39cb4af8337448e'
 +            '9b03cd0430c70be9d90705f3d2ebe2d8a982b57bafb419371c0658d76f24f99e'
 +            '3eb5e621757be3f2984acb76d16cf3571bfe5bbbc71ad230b21aa983041ff5ea'
 +            'abc9d2f93d9104de6f6d82c89124cfe0bb5afc291a0b10e0fa8ad827210ae62c'
-+            '53cbad1796b6ef78806b4babef8d29472895d9b23391f4259d092646173b4ccc')
-+
-+_update_sources() {
-+  python makepkg-source-roller.py update "$pkgver" "$pkgname"
-+  updpkgsums
-+}
++            '53cbad1796b6ef78806b4babef8d29472895d9b23391f4259d092646173b4ccc'
++            '68503a4875bf313ef827d9cffb09f8fff102483dcab9ead05ba9bd88924e9f0f')
  
- # Possible replacements are listed in build/linux/unbundle/replace_gn_files.py
- # Keys are the names in the above script; values are the dependencies in Arch
-@@ -89,10 +424,47 @@ depends+=(${_system_libs[@]})
- _google_api_key=AIzaSyDwr302FpOSkGRpLlUpPThNTDPbXcIn_FM
- 
- prepare() {
--  if (( _manual_clone )); then
--    ./fetch-chromium-release $pkgver
--  fi
--  cd chromium-$pkgver
-+  cp -r chromium-mirror_third_party_depot_tools depot_tools
-+  export PATH+=":$PWD/depot_tools" DEPOT_TOOLS_UPDATE=0
-+  # Use a known commit that supports riscv64
-+  git -C depot_tools checkout --detach 2a18f6d3245450d8c96c843a6584aaea561ef873
-+  # Python 3.12 breaks gsutils
-+  # Bundled wheels are not available for riscv64
-+  sed -i '/wheel: </,$d' depot_tools/.vpython3
-+  sed -i '/wheel: </,$d' depot_tools/gsutil.vpython3
-+  # Manually install required wheels
-+  vpython3 -vpython-spec depot_tools/.vpython3 -m pip install httplib2==0.13.1 six==1.10.0 requests==2.31.0
-+
-+  echo "Putting together electron sources"
-+  mv chromium-mirror src
-+  # Generate gclient gn args file and prepare-chromium-source-tree.sh
-+  python makepkg-source-roller.py generate src/DEPS $pkgname
-+  sed -i '/esbuild/d' prepare-chromium-source-tree.sh
-+  rbash prepare-chromium-source-tree.sh "$CARCH"
-+
-+  src/build/util/lastchange.py -o src/build/util/LASTCHANGE
-+  src/build/util/lastchange.py -m GPU_LISTS_VERSION \
-+    --revision-id-only --header src/gpu/config/gpu_lists_version.h
-+  src/build/util/lastchange.py -m SKIA_COMMIT_HASH \
-+    -s src/third_party/skia --header src/skia/ext/skia_commit_hash.h
-+  src/build/util/lastchange.py \
-+    -s src/third_party/dawn --revision src/gpu/webgpu/DAWN_VERSION
-+  # depot_tools/gsutil.py downloads and exec the real gsutil on the fly, not easy to patch
-+  # src/tools/update_pgo_profiles.py --target=linux update \
-+  #   --gs-url-base=chromium-optimization-profiles/pgo_profiles
-+
-+  pushd src/third_party/node
-+  sed -i -e 's/@rollup/rollup/' -e "s/'wasm-node',//" node_modules.py
-+  local _rollup_ver="$(jq -r .dependencies.\"@rollup/wasm-node\" package.json)"
-+  jq ".dependencies.rollup=\"$_rollup_ver\"" package.json > package.json.new
-+  mv package.json{.new,}
-+  popd
-+
-+  # https://gitlab.archlinux.org/archlinux/packaging/packages/electron32/-/issues/1
-+  src/third_party/node/update_npm_deps
-+  GOBIN=$(realpath src/third_party/devtools-frontend/src/third_party/esbuild/) go install "github.com/evanw/esbuild/cmd/esbuild@v0.14.13"
-+
-+  cd src
- 
-   # Allow building against system libraries in official builds
-   sed -i 's/OFFICIAL_BUILD/GOOGLE_CHROME_BUILD/' \
-@@ -105,6 +477,9 @@ prepare() {
-     third_party/blink/renderer/core/xml/parser/xml_document_parser.cc \
-     third_party/libxml/chromium/*.cc
- 
-+  # TODO(riscv): remove once clang >= 19
-+  sed -i 's/std::hardware_destructive_interference_size/64/' components/media_router/common/providers/cast/channel/enum_table.h
-+
-   # Use the --oauth2-client-id= and --oauth2-client-secret= switches for
-   # setting GOOGLE_DEFAULT_CLIENT_ID and GOOGLE_DEFAULT_CLIENT_SECRET at
-   # runtime -- this allows signing into Chromium without baked-in values
-@@ -123,11 +498,27 @@ prepare() {
+ if (( _manual_clone )); then
+   source[0]=fetch-chromium-release
+@@ -111,6 +122,31 @@ prepare() {
    # Increase _FORTIFY_SOURCE level to match Arch's default flags
    patch -Np1 -i ../increase-fortify-level.patch
  
@@ -455,6 +41,7 @@
 +  for rvpatch in riscv-{dav1d,sandbox}.patch; do
 +    patch -Np1 -i ../$rvpatch
 +  done
++  patch -Np1 -d v8 < ../riscv-v8.patch
 +  patch -Np0 -i ../compiler-rt-riscv.patch
 +  patch -Np1 -i ../0001-chrome-runtime_api_delegate-add-riscv64-define.patch
 +  patch -Np1 -i ../0001-extensions-common-api-runtime.json-riscv64-support.patch
@@ -462,26 +49,19 @@
 +  # https://trac.ffmpeg.org/ticket/11302
 +  patch -Np1 -d third_party/ffmpeg < ../0001-Enable-relocate-1-for-ff_h264_weight_funcs_8_rvv.patch
 +
++  pushd third_party/node/
++  sed -i -e 's/@rollup/rollup/' -e "s/'wasm-node',//" node_modules.py
++  local _rollup_ver="$(jq -r .dependencies.\"@rollup/wasm-node\" package.json)"
++  jq ".dependencies.rollup=\"$_rollup_ver\"" package.json > package.json.new
++  mv package.json{.new,}
++  popd
++  third_party/node/update_npm_deps
++
++
    # Fixes for building with libstdc++ instead of libc++
  
    # Link to system tools required by the build
--  rm third_party/node/linux/node-linux-x64/bin/node
-+  mkdir -p third_party/node/linux/node-linux-x64/bin
-   ln -s /usr/bin/node third_party/node/linux/node-linux-x64/bin/
-+  mkdir -p third_party/jdk/current/bin
-   ln -s /usr/bin/java third_party/jdk/current/bin/
- 
-   # test deps are broken for ui/lens with system ICU
-@@ -164,7 +555,7 @@ prepare() {
- build() {
-   make -C chromium-launcher-$_launcher_ver
- 
--  cd chromium-$pkgver
-+  cd src
- 
-   if (( _system_clang )); then
-     export CC=clang
-@@ -198,6 +589,7 @@ build() {
+@@ -181,6 +217,7 @@ build() {
      'enable_widevine=true'
      'enable_nacl=false'
      'use_qt6=true'
@@ -489,16 +69,7 @@
      'moc_qt6_path="/usr/lib/qt6"'
      "google_api_key=\"$_google_api_key\""
    )
-@@ -265,7 +657,7 @@ package() {
-   install -Dm644 LICENSE \
-     "$pkgdir/usr/share/licenses/chromium/LICENSE.launcher"
- 
--  cd ../chromium-$pkgver
-+  cd ../src
- 
-   install -D out/Release/chrome "$pkgdir/usr/lib/chromium/chromium"
-   install -D out/Release/chromedriver.unstripped "$pkgdir/usr/bin/chromedriver"
-@@ -330,4 +722,13 @@ package() {
+@@ -313,4 +350,14 @@ package() {
    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/chromium/LICENSE"
  }
  
@@ -509,6 +80,7 @@
 +         compiler-rt-riscv.patch
 +         Debian-fix-rust-linking.patch
 +         https://github.com/riscv-forks/electron/raw/v32.0.1-riscv/patches/chromium/0001-extensions-common-api-runtime.json-riscv64-support.patch
-+         0001-chrome-runtime_api_delegate-add-riscv64-define.patch)
++         0001-chrome-runtime_api_delegate-add-riscv64-define.patch
++         riscv-v8.patch::https://github.com/riscv-forks/electron/raw/01b9e5d51adecba8cbaeb1de3254cb7d22b76975/patches/v8/0001-riscv-Fix-build-failed-for-native.patch)
 +
  # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
- Switch back to chromium source tarball
- Cherry-pick v8 patch to fix build: https://chromium-review.googlesource.com/c/v8/v8/+/6027486
- Regenerate ffmpeg patch
- Drop a sed hack as we have clang 19 now.
- PGO is enabled by Arch Linux as clang is upgraded to 19. It uses the bundled PGO profile generated for x86_64. Not sure about it's influence on riscv64.
- Tested on centiskorch