### PR TITLE
addpatch: libpeas 1.36.0-6

### DIFF
--- a/libpeas/riscv64.patch
+++ b/libpeas/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -55,7 +55,7 @@ build() {
+ 
+ check() {
+   xvfb-run -s '-nolisten local' \
+-    meson test -C build --print-errorlogs
++    meson test -C build --print-errorlogs --timeout-multiplier 600
+ }
+ 
+ _pick() {


### PR DESCRIPTION
The test costs around 100s on both qemu-user and SG2042

Additionally, meson itself has a default timeout for test that is 30s, and the upstream source is not hard encoding any timeout value, just keep it as meson's default. The timeout could be passed by args while building, so we may not need to report it upstream.