### PR TITLE
updpatch: dioxus-cli 0.6.1-1

### DIFF
--- a/dioxus-cli/riscv64.patch
+++ b/dioxus-cli/riscv64.patch
@@ -1,20 +1,26 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -9,7 +9,8 @@ url="https://github.com/DioxusLabs/dioxus"
- license=('MIT' 'Apache-2.0')
- arch=("x86_64")
- depends=('gcc-libs' 'bzip2' 'zlib' 'openssl' 'xz')
--makedepends=('cargo')
-+makedepends=('cargo' 'cmake' 'clang')
-+checkdepends=('libunwind')
- provides=('dx')
- source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
- b2sums=('fe9594ad831e7c715c38b8f900326d56c58d774fab189584130e251bbf1f6d6f6021a46f961bed0e7e34f4dc4af90ede82893897cb4abf891e90fb85c1b426d5')
-@@ -27,6 +28,7 @@ build() {
+@@ -17,11 +17,14 @@ options=('!lto')
  
- check() {
+ prepare() {
    cd "${pkgname%-cli}-$pkgver"
-+  CFLAGS=${CFLAGS/-Wp,-D_FORTIFY_SOURCE=3/}
-   cargo test -p "$pkgname" --frozen
++  patch -Np1 -i ../test-cfg.patch
+   cargo fetch --target "$(rustc -vV | sed -n 's/host: //p')" # --locked
  }
  
+ build() {
+   cd "${pkgname%-cli}-$pkgver"
++  export CFLAGS=${CFLAGS/-Wp,-D_FORTIFY_SOURCE=3/}
++  export CXXFLAGS=${CFLAGS/-Wp,-D_FORTIFY_SOURCE=3/}
+   cargo build -p "$pkgname" --release --frozen
+ }
+ 
+@@ -37,4 +40,8 @@ package() {
+   install -Dm 644 LICENSE-MIT -t "$pkgdir/usr/share/licenses/$pkgname"
+ }
+ 
++source+=("test-cfg.patch::https://github.com/DioxusLabs/dioxus/pull/3624.diff")
++b2sums+=('80c8b565762e4fc68cdb2213f193b55acdc211851b15ca3482fddecfa001b21e323dc83dedd9b78714e0cec2492889287472cd4f2ed9d04269757a19f14f81da')
++makedepends+=('clang' 'cmake')
++
+ # vim: ts=2 sw=2 et:


### PR DESCRIPTION
Skip test using prebuilt binaries on unsupported platforms. Upstreamed to https://github.com/DioxusLabs/dioxus/pull/3624.