### PR TITLE
qemu-user-blacklist: add libvirt

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -71,6 +71,7 @@ liborcus
 libseccomp
 libsecret
 libuv
+libvirt
 lmdb
 m4
 mdbook


### PR DESCRIPTION
The test `libvirt:script / qemu replies check` timeout 30s on qemu-user but finished in 5s on SG2042