### PR TITLE
addpatch: electron34 34.0.0-3

### DIFF
--- a/electron34/Debian-fix-rust-linking.patch
+++ b/electron34/Debian-fix-rust-linking.patch
@@ -1,0 +1,47 @@
+--- build/toolchain/gcc_toolchain.gni.orig	2024-08-19 14:13:35.233954725 +0200
++++ build/toolchain/gcc_toolchain.gni	2024-08-22 00:56:01.438433033 +0200
+@@ -441,7 +441,13 @@
+         # -soname flag is not available on aix ld
+         soname_flag = "-Wl,-soname=\"$soname\""
+       }
+-      link_command = "$ld -shared $soname_flag {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" @\"$rspfile\" {{rlibs}}"
++      if (target_cpu == "riscv64") {
++        # Work around linker failures due to Rust libraries and the use of whole-archive
++        link_command = "$ld -shared $soname_flag -Wl,--start-group {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" @\"$rspfile\" {{rlibs}} -Wl,--end-group"
++      }
++      else {
++        link_command = "$ld -shared $soname_flag {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" @\"$rspfile\" {{rlibs}}"
++      }
+ 
+       # Generate a map file to be used for binary size analysis.
+       # Map file adds ~10% to the link time on a z620.
+@@ -553,7 +559,13 @@
+         whole_archive_flag = "-Wl,--whole-archive"
+         no_whole_archive_flag = "-Wl,--no-whole-archive"
+       }
+-      command = "$ld -shared {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" $soname_flag @\"$rspfile\""
++      if (target_cpu == "riscv64") {
++        # Work around linker failures due to Rust libraries and the use of whole-archive
++        command = "$ld -shared -Wl,--start-group {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" $soname_flag @\"$rspfile\" -Wl,--end-group"
++      }
++      else {
++        command = "$ld -shared {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" $soname_flag @\"$rspfile\""
++      }
+ 
+       if (defined(invoker.strip)) {
+         strip_command = "${invoker.strip} -o \"$sofile\" \"$unstripped_sofile\""
+@@ -617,8 +629,12 @@
+       # We need to specify link groups, at least, for single pass linkers. I.e.
+       # Rust libraries are alpha-sorted instead of by dependencies so they fail
+       # to link if not properly ordered or grouped.
+-      link_command = "$ld {{ldflags}}${extra_ldflags} -o \"$unstripped_outfile\" $start_group_flag @\"$rspfile\" $end_group_flag {{solibs}} {{libs}} $start_group_flag {{rlibs}} $end_group_flag"
+-
++      if (target_cpu == "riscv64") {
++        link_command = "$ld -Wl,--start-group {{ldflags}}${extra_ldflags} -o \"$unstripped_outfile\" @\"$rspfile\" {{solibs}} {{libs}} {{rlibs}} -Wl,--end-group"
++      }
++      else {
++        link_command = "$ld {{ldflags}}${extra_ldflags} -o \"$unstripped_outfile\" $start_group_flag @\"$rspfile\" $end_group_flag {{solibs}} {{libs}} $start_group_flag {{rlibs}} $end_group_flag"
++      }
+       # Generate a map file to be used for binary size analysis.
+       # Map file adds ~10% to the link time on a z620.
+       # With target_os="android", libchrome.so.map.gz is ~20MB.

--- a/electron34/riscv64.patch
+++ b/electron34/riscv64.patch
@@ -1,0 +1,207 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -29,10 +29,12 @@ depends=(c-ares
+ makedepends=(clang
+              git
+              gn
++             go
+              gperf
+              harfbuzz-icu
+              http-parser
+              java-runtime-headless
++             jq
+              libnotify
+              libva
+              lld
+@@ -60,7 +62,7 @@ optdepends=('kde-cli-tools: file deletion support (kioclient5)'
+             'trash-cli: file deletion support (trash-put)'
+             'xdg-utils: open URLs with desktop’s default (xdg-email, xdg-open)')
+ options=('!lto') # Electron adds its own flags for ThinLTO
+-source=("git+https://github.com/electron/electron.git#tag=v$pkgver"
++source=("git+https://github.com/riscv-forks/electron.git#branch=v$pkgver-riscv"
+         https://gitlab.com/Matt.Jolly/chromium-patches/-/archive/$_gcc_patches/chromium-patches-$_gcc_patches.tar.bz2
+         # Chromium
+         compiler-rt-adjust-paths.patch
+@@ -71,6 +73,7 @@ source=("git+https://github.com/electron/electron.git#tag=v$pkgver"
+         electron.desktop
+         jinja-python-3.10.patch
+         use-system-libraries-in-node.patch
++        Debian-fix-rust-linking.patch
+         makepkg-source-roller.py
+         # BEGIN managed sources
+         chromium-mirror::git+https://github.com/chromium/chromium.git#tag=132.0.6834.83
+@@ -241,13 +244,14 @@ source=("git+https://github.com/electron/electron.git#tag=v$pkgver"
+         )
+ sha256sums=('b3620e57fb5dca017015d89e1b3a737d20d682432ad8d10fa969f9081eedef9f'
+             '40cd0f3cc33adf19c7413a35d4a48c24f1b2507e9c12f1b29cf6573ad1b9148d'
+-            'b3de01b7df227478687d7517f61a777450dca765756002c80c4915f271e2d961'
++            '8e128dec0d9416029ea8124e14963c9e0caf897bf60d347a070e393edebdff1c'
+             'a4a822e135b253c93089a80c679842cc470c6936742767ae09d952646889abd6'
+             'dd2d248831dd4944d385ebf008426e66efe61d6fdf66f8932c963a12167947b4'
+             '13fcf26193f4417fd5dfbc82a3f24e5c7a1cce82f729f6a73f1b1d3a7b580b34'
+             '4484200d90b76830b69eea3a471c103999a3ce86bb2c29e6c14c945bf4102bae'
+             '55dbe71dbc1f3ab60bf1fa79f7aea7ef1fe76436b1d7df48728a1f8227d2134e'
+             'ff588a8a4fd2f79eb8a4f11cf1aa151298ffb895be566c57cc355d47f161f53f'
++            '3eb5e621757be3f2984acb76d16cf3571bfe5bbbc71ad230b21aa983041ff5ea'
+             '2c8cd28cee0e1df1862e801794f210d2b7cac652f943cf94f43c2abe26f2a2f4'
+             '7a313802c44a16c3ce1b503946335c211a800a94262209028bf794f116fc0fbe'
+             '0b7a546ee6913c49519c10c293ac530ff381641a8a465fa2e184d6dbe0fb784d'
+@@ -460,12 +464,22 @@ prepare() {
+   cp -r chromium-mirror_third_party_depot_tools depot_tools
+   export PATH+=":$PWD/depot_tools" DEPOT_TOOLS_UPDATE=0
+   #export VPYTHON_BYPASS='manually managed python not supported by chrome operations'
++  # Use a known commit that supports riscv64
++  git -C depot_tools checkout --detach 2a18f6d3245450d8c96c843a6584aaea561ef873
++  # Python 3.12 breaks gsutils
++  # Bundled wheels are not available for riscv64
++  sed -i '/wheel: </,$d' depot_tools/.vpython3
++  sed -i '/wheel: </,$d' depot_tools/gsutil.vpython3
++  # Manually install required wheels
++  vpython3 -m pip install httplib2==0.13.1 six==1.10.0 requests==2.31.0
+ 
+   echo "Putting together electron sources"
+   # Generate gclient gn args file and prepare-electron-source-tree.sh
+   python makepkg-source-roller.py generate electron/DEPS $pkgname
++  sed -i '/esbuild/d' prepare-electron-source-tree.sh
+   rbash prepare-electron-source-tree.sh "$CARCH"
+   mv electron src/electron
++  GOBIN=$(realpath src/third_party/devtools-frontend/src/third_party/esbuild/) go install "github.com/evanw/esbuild/cmd/esbuild@v0.14.13"
+ 
+   echo "Running hooks..."
+   # depot_tools/gclient.py runhooks
+@@ -477,11 +491,44 @@ prepare() {
+     -s src/third_party/skia --header src/skia/ext/skia_commit_hash.h
+   src/build/util/lastchange.py \
+     -s src/third_party/dawn --revision src/gpu/webgpu/DAWN_VERSION
+-  src/tools/update_pgo_profiles.py --target=linux update \
+-    --gs-url-base=chromium-optimization-profiles/pgo_profiles
++  #src/tools/update_pgo_profiles.py --target=linux update \
++  #  --gs-url-base=chromium-optimization-profiles/pgo_profiles
+ 
++  # Link to system tools required by the build
++  pushd src
++  mkdir -p third_party/node/linux/node-linux-x64/bin
++  ln -sfn /usr/bin/node third_party/node/linux/node-linux-x64/bin/
++  mkdir -p third_party/jdk/current/bin
++  ln -sfn /usr/bin/java third_party/jdk/current/bin/
++  ln -sfn /usr/bin/clang-format buildtools/linux64
++  popd
++
++  pushd src/third_party/node/
++  sed -i -e 's/@rollup/rollup/' -e "s/'wasm-node',//" node_modules.py
++  local _rollup_ver="$(jq -r .dependencies.\"@rollup/wasm-node\" package.json)"
++  jq ".dependencies.rollup=\"$_rollup_ver\"" package.json > package.json.new
++  mv package.json{.new,}
++  popd
+   # https://gitlab.archlinux.org/archlinux/packaging/packages/electron32/-/issues/1
+   src/third_party/node/update_npm_deps
++  pushd src/third_party/devtools-frontend/src
++  sed -i -e 's/@rollup/rollup/' -e "s/'wasm-node',//" scripts/devtools_paths.py
++  local _rollup_ver="$(jq -r .devDependencies.\"@rollup/wasm-node\" package.json)"
++  jq ".devDependencies.rollup=\"$_rollup_ver\" | .devDependencies.\"@rollup/rollup-linux-riscv64-gnu\"=\"$_rollup_ver\""  package.json > package.json.new
++  mv package.json{.new,}
++  # Chromium hosts a custom registry at https://npm.skia.org/chrome-devtools/
++  # and rejects some packages:
++  # Package fs-extra with version 11.3.0 was created 108h0m0s time ago. This is less than 1 week and so failed the audit.
++  sed -i /registry/d .npmrc
++  # Replace direct invocation of wasm rollup
++  sed -i 's\@rollup/wasm-node\rollup\' \
++    inspector_overlay/BUILD.gn \
++    front_end/models/live-metrics/web-vitals-injected/BUILD.gn \
++    front_end/Images/BUILD.gn \
++    front_end/panels/recorder/injected/BUILD.gn \
++    scripts/build/ninja/bundle.gni
++  popd
++  python src/third_party/devtools-frontend/src/scripts/deps/manage_node_deps.py
+ 
+   src/electron/script/apply_all_patches.py \
+       src/electron/patches/config.json
+@@ -505,6 +552,8 @@ prepare() {
+ 
+   patch -Np0 -i ../blink-fix-missing-stdlib-include.patch
+ 
++  patch -Np0 -i ../Debian-fix-rust-linking.patch
++
+   ## Upstream fixes
+ 
+   # Allow libclang_rt.builtins from compiler-rt >= 16 to be used
+@@ -514,13 +563,6 @@ prepare() {
+   patch -Np1 -i ../chromium-patches-*/chromium-130-interference-size.patch
+   patch -Np1 -i ../chromium-patches-*/chromium-132-compiler.patch
+ 
+-  # Link to system tools required by the build
+-  mkdir -p third_party/node/linux/node-linux-x64/bin
+-  ln -sfn /usr/bin/node third_party/node/linux/node-linux-x64/bin/
+-  mkdir -p third_party/jdk/current/bin
+-  ln -sfn /usr/bin/java third_party/jdk/current/bin/
+-  ln -sfn /usr/bin/clang-format buildtools/linux64
+-
+   # Electron specific fixes
+   patch -Np1 -i "${srcdir}/jinja-python-3.10.patch" -d "third_party/electron_node/tools/inspector_protocol/jinja2"
+   patch -Np1 -i "${srcdir}/use-system-libraries-in-node.patch"
+@@ -573,6 +615,8 @@ build() {
+     'enable_hangout_services_extension=true'
+     'enable_widevine=false'
+     'enable_nacl=false'
++    'is_clang=true'
++    "override_electron_version=\"$pkgver\""
+   )
+ 
+   if [[ -n ${_system_libs[icu]+set} ]]; then
+@@ -586,7 +630,7 @@ build() {
+     'clang_base_path="/usr"'
+     'clang_use_chrome_plugins=false'
+     "clang_version=\"$_clang_version\""
+-    'chrome_pgo_phase=2'
++    'chrome_pgo_phase=0'
+   )
+ 
+   # Allow the use of nightly features with stable Rust compiler
+@@ -608,6 +652,10 @@ build() {
+   CFLAGS+='   -Wno-unknown-warning-option'
+   CXXFLAGS+=' -Wno-unknown-warning-option'
+ 
++  # Remove flags that are causing weird bugs on riscv64
++  CFLAGS=${CFLAGS/-Wp,-D_FORTIFY_SOURCE=2}
++  CXXFLAGS=${CXXFLAGS/-Wp,-D_FORTIFY_SOURCE=2}
++
+   # Let Chromium set its own symbol level
+   CFLAGS=${CFLAGS/-g }
+   CXXFLAGS=${CXXFLAGS/-g }
+@@ -655,3 +703,5 @@ package() {
+   install -Dm644 src/electron/default_app/icon.png \
+           "${pkgdir}/usr/share/pixmaps/${pkgname}.png"  # hicolor has no 1024x1024
+ }
++
++sha256sums[0]=SKIP
+diff --git compiler-rt-adjust-paths.patch compiler-rt-adjust-paths.patch
+index 0469220..8ee7f55 100644
+--- compiler-rt-adjust-paths.patch
++++ compiler-rt-adjust-paths.patch
+@@ -1,8 +1,6 @@
+-diff --git a/build/config/clang/BUILD.gn b/build/config/clang/BUILD.gn
+-index d4de2e0cca0..57359c32121 100644
+---- a/build/config/clang/BUILD.gn
+-+++ b/build/config/clang/BUILD.gn
+-@@ -130,12 +130,15 @@ template("clang_lib") {
++--- a/build/config/clang/BUILD.gn	2024-03-09 04:32:07.577338262 +0100
+++++ b/build/config/clang/BUILD.gn	2024-03-09 04:55:29.376410067 +0100
++@@ -124,14 +124,18 @@
+        } else if (is_linux || is_chromeos) {
+          if (current_cpu == "x64") {
+            _dir = "x86_64-unknown-linux-gnu"
+@@ -15,10 +13,13 @@ index d4de2e0cca0..57359c32121 100644
+          } else if (current_cpu == "arm64") {
+            _dir = "aarch64-unknown-linux-gnu"
+ +          _suffix = "-aarch64"
++         } else if (current_cpu == "riscv64") {
++           _dir = "riscv64-unknown-linux-gnu"
+++          _suffix = "-riscv64"
+          } else {
+            assert(false)  # Unhandled cpu type
+          }
+-@@ -166,6 +169,11 @@ template("clang_lib") {
++@@ -162,6 +166,11 @@
+          assert(false)  # Unhandled target platform
+        }
+  


### PR DESCRIPTION
Changes at riscv-forks/electron: https://github.com/riscv-forks/electron/commit/6f565472cb0509728311228041feb2b60db758c7

- Fix rotten patches
- Regenerate ffmpeg patch
- Pick V8 build fix patch
- ffmpeg: enable relocate for ff_h264_weight_funcs_8_rvv
- Add patch that adds riscv64 to `Study::CpuArchitecture` in chromium variations

Packaging changes compared to electron33:

- Replace rollup wasm module with native rollup at more places to workaround more issues as mentioned in https://github.com/felixonmars/archriscv-packages/pull/4252
- Disable the download of PGO profile and thus PGO beause it is hard to patch gsutil which is downloaded on the fly and a py3.8 vpython env is also created on the fly.