### PR TITLE
addpatch: python-rpy2 3.5.17-2

### DIFF
--- a/python-rpy2/riscv64.patch
+++ b/python-rpy2/riscv64.patch
@@ -1,0 +1,17 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -30,6 +30,7 @@ sha256sums=('7945658af4478d744b5d8e4afa60ef7f791fe16055070e5604cebec7f4c80c2c')
+ prepare() {
+   cd rpy2
+   git cherry-pick -n c31ec06cb913ae2bebf46753a2751ca1a1b5660b # Fix tests with numpy 2.0
++  patch -Np1 -i ../rpy2-fix-Rcomplex.diff
+ }
+ 
+ build() {
+@@ -48,3 +49,6 @@ package() {
+ 
+   python -m installer --destdir="$pkgdir" dist/*.whl
+ }
++
++source+=(rpy2-fix-Rcomplex.diff)
++sha256sums+=(303f40e56c6f5b06ef3fd53307ad25a51c4547679681945d9b6176a506626638)

--- a/python-rpy2/rpy2-fix-Rcomplex.diff
+++ b/python-rpy2/rpy2-fix-Rcomplex.diff
@@ -1,0 +1,44 @@
+diff --git a/rpy2/rinterface.py b/rpy2/rinterface.py
+index cbe24cc2..ac8a7c9e 100644
+--- a/rpy2/rinterface.py
++++ b/rpy2/rinterface.py
+@@ -662,10 +662,10 @@ class ComplexSexpVector(SexpVector):
+     @staticmethod
+     def _CAST_IN(x):
+         if isinstance(x, complex):
+-            res = (x.real, x.imag)
++            res = { "r": x.real, "i": x.imag }
+         else:
+             try:
+-                res = (x.r, x.i)
++                res = { "r": x.r, "i": x.i }
+             except AttributeError:
+                 raise TypeError(
+                     'Unable to turn value into an R complex number.'
+@@ -1228,7 +1228,7 @@ def _post_initr_setup() -> None:
+     na_values.NA_Complex = sexp.NAComplexType(
+         _rinterface.ffi.new(
+             'Rcomplex *',
+-            [openrlib.rlib.R_NaReal, openrlib.rlib.R_NaReal])
++            { "r": openrlib.rlib.R_NaReal, "i": openrlib.rlib.R_NaReal })
+     )
+     NA_Complex = na_values.NA_Complex
+ 
+diff --git a/rpy2/rinterface_lib/R_API.h b/rpy2/rinterface_lib/R_API.h
+index f703bcec..bf08ae5d 100644
+--- a/rpy2/rinterface_lib/R_API.h
++++ b/rpy2/rinterface_lib/R_API.h
+@@ -31,9 +31,12 @@ const unsigned int FREESXP    = 31;
+ const unsigned int FUNSXP     = 99;
+ 
+ /* include/R_exts/Complex.h */
+-typedef struct {
++typedef union {
++    struct {
+     double r;
+     double i;
++    };
++    double _Complex private_data_c;
+ } Rcomplex;
+ 
+ /* include/Rinternals.h */


### PR DESCRIPTION
Fix Rcomplex definition, upstreamed https://github.com/rpy2/rpy2/pull/1147

The upstream PR doesn't apply to this release so store a patch here.