### PR TITLE
addpatch: python-pexpect 4.9.0-4

### DIFF
--- a/python-pexpect/riscv64.patch
+++ b/python-pexpect/riscv64.patch
@@ -1,0 +1,22 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -30,15 +30,18 @@ source=(
+   "git+$url#tag=$_tag"
+   "$pkgname-python-3.13-compatibility.patch::https://src.fedoraproject.org/rpms/python-pexpect/raw/rawhide/f/794.patch"
+   "$pkgname-fix-test.patch"
++  "https://github.com/pexpect/pexpect/pull/813/commits/3cc22a6648e550daf37be4cdfe8955931f64a522.diff"
+ )
+ sha512sums=('cb0243b856fe56d7d86f055a002579bfa69a6842fddbd58680377ac4ffa390fbbc1867f42441dd80db9bae2fd8435ebf625ad8903afdf16e11436c9350cb6155'
+             'ac8f16a04943f279bd76accac79d74c95d620bc777a3f93807f1d0394dd02b238036868749086364257d3473adacd978e2498686ef22b2bbb20b0cff8ae5da57'
+-            'b634e07ea0972f0fe9909db6dc366b29a05bd8beff148e6408ee63b894dd3d487680ad4eec291a8e85e911301041ab1323807b61964a36c45e2aac714f582349')
++            'b634e07ea0972f0fe9909db6dc366b29a05bd8beff148e6408ee63b894dd3d487680ad4eec291a8e85e911301041ab1323807b61964a36c45e2aac714f582349'
++            'b8eb98d17b2d9f655369fef3c47aa1d8edede5a74b05c7a2da4b24def88d18fe6ea81e7f5fddaa696542cda7d912a5797642740be21c1e0f055fde05c3dbff32')
+ 
+ prepare() {
+   cd ${pkgname#python-}
+   patch -Np1 -i ../$pkgname-python-3.13-compatibility.patch
+   patch -Np1 -i ../$pkgname-fix-test.patch
++  patch -Np1 -i ../3cc22a6648e550daf37be4cdfe8955931f64a522.diff
+ }
+ 
+ build() {


### PR DESCRIPTION
Fix test failure, upstreamed: pexpect/pexpect#813