### PR TITLE
updpatch: python-executing 2.2.0-1

### DIFF
--- a/python-executing/riscv64.patch
+++ b/python-executing/riscv64.patch
@@ -1,25 +1,21 @@
-diff --git PKGBUILD PKGBUILD
-index 851b7fa..f2f0e85 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -24,15 +24,18 @@ checkdepends=(
- )
- source=("git+$url.git#tag=v$pkgver"
- 	"handle-changed-positions-for-exit.patch"
--	"backwards-compat-fix-3.13.patch")
-+	"backwards-compat-fix-3.13.patch"
-+  "fix-test-many-source-for-filename-calls-timeout.patch")
- b2sums=('e1279b1e4ca0bfc080cf119bfc043d59e19c410194c775312d511a928394b37aabedcb222179f97208464bdad9a3837e186a980ef578397b648095f8449735a1'
-         '24ded153604e65d1804405814a3ab75f92908c973b5ec6d9c4bb8f501070cfaeb16802110e1d9e7b2518c330d5cc519b185429b2b89beb41b3e6750e2d1fb00e'
--        '0ffae66e218505b783f36153053822228f0b18ff3e4ecc40e9483b3e7cc0fbecad42223824e975724a91ef38dfd0ff015c8590d638417743848d34b06d6ca75d')
-+        '0ffae66e218505b783f36153053822228f0b18ff3e4ecc40e9483b3e7cc0fbecad42223824e975724a91ef38dfd0ff015c8590d638417743848d34b06d6ca75d'
-+        '152545e095b4ed4401a199a22196f97ee7f7cca220063c4734ea33d70e0640f234e95f0a52cbf3aa8c15a8cc940e03f97ed636193b33db4892d4b73e55071c52')
+@@ -25,6 +25,11 @@ checkdepends=(
+ source=("git+$url.git#tag=v$pkgver")
+ b2sums=('38dfe34190ff9296b95d992cbe2d55cc481b05dd6b39c5ee4400e04fdf6c86d181304035f6b5b822936a74ce250089d23d5f82431f903244649235167ac18486')
  
- prepare() {
-   cd "$_name"
-   patch -Np1 -i "$srcdir/backwards-compat-fix-3.13.patch"
-   patch -Np1 -i "$srcdir/handle-changed-positions-for-exit.patch"
++prepare() {
++  cd "$_name"
 +  patch -Np1 -i "$srcdir/fix-test-many-source-for-filename-calls-timeout.patch"
- }
- 
++}
++
  build() {
+   cd "$_name"
+   python -m build --wheel --skip-dependency-check --no-isolation
+@@ -44,3 +49,6 @@ package() {
+   cd "$_name"
+   python -m installer --destdir="$pkgdir" dist/*.whl
+ }
++
++source+=(fix-test-many-source-for-filename-calls-timeout.patch)
++b2sums+=('152545e095b4ed4401a199a22196f97ee7f7cca220063c4734ea33d70e0640f234e95f0a52cbf3aa8c15a8cc940e03f97ed636193b33db4892d4b73e55071c52')


### PR DESCRIPTION
Fix rotten and make it less likely to rot