### PR TITLE
addpatch: python-graph-tool 2.86-2

### DIFF
--- a/python-graph-tool/riscv64.patch
+++ b/python-graph-tool/riscv64.patch
@@ -1,0 +1,16 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -41,6 +41,13 @@ b2sums=('03d5e5c47ba157652e2b1d63e5b0a5cc8f873472e79fc1ccd3f1c0e64dfb56e9a03c581
+ # (due to unwanted mixture of optimization flags during link time).
+ options=(!lto)
+ 
++prepare() {
++  cd graph-tool-$pkgver
++
++  sed -i 's/ppc64le/ppc64le|riscv64/' m4/ax_boost_base.m4
++  autoreconf
++}
++
+ build() {
+   cd graph-tool-$pkgver
+ 


### PR DESCRIPTION
Add riscv64 to 64 bit arches to fix https://archriscv.felixc.at/.status/logs/python-graph-tool/python-graph-tool-2.86-1.log

Upstream PR: https://git.skewed.de/count0/graph-tool/-/merge_requests/73