### PR TITLE
updpatch: transmission 4.0.6-9

### DIFF
--- a/transmission/riscv64.patch
+++ b/transmission/riscv64.patch
@@ -1,14 +1,6 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -19,7 +19,6 @@ makedepends=(cmake
-              gtkmm-4.0
-              intltool
-              libayatana-indicator
--             libb64
-              libdeflate
-              libevent
-              libnatpmp
-@@ -63,7 +62,7 @@ build() {
+@@ -62,7 +62,7 @@ build() {
  		-D ENABLE_UTILS=ON \
  		-D ENABLE_UTP=ON \
  		-D INSTALL_LIB=ON \
@@ -17,3 +9,9 @@
  		-D USE_SYSTEM_DEFLATE=ON \
  		-D USE_SYSTEM_DHT=ON \
  		-D USE_SYSTEM_EVENT2=ON \
+@@ -145,3 +145,5 @@ package_transmission-qt() {
+ 	_install_component qt
+ 	install -Dm644 COPYING "$pkgdir/usr/share/licenses/transmission-qt/COPYING"
+ }
++
++makedepends=(${makedepends[@]/libb64})


### PR DESCRIPTION
Now we don't need to remove `libb64` from makedepends.
This is because makedepends changes frequently and thus cannot be patched.