### PR TITLE
addpatch: boost 1.87.0-2

### DIFF
--- a/boost/boost-fix-missing-cstdint.patch
+++ b/boost/boost-fix-missing-cstdint.patch
@@ -1,0 +1,24 @@
+diff --git a/include/boost/lockfree/detail/freelist.hpp b/include/boost/lockfree/detail/freelist.hpp
+index 31c8c98..2ac6019 100644
+--- a/include/boost/lockfree/detail/freelist.hpp
++++ b/include/boost/lockfree/detail/freelist.hpp
+@@ -10,6 +10,7 @@
+ #define BOOST_LOCKFREE_FREELIST_HPP_INCLUDED
+ 
+ #include <array>
++#include <cstdint>
+ #include <cstring>
+ #include <limits>
+ #include <memory>
+diff --git a/include/boost/lockfree/stack.hpp b/include/boost/lockfree/stack.hpp
+index 19d5e7d..d6646e3 100644
+--- a/include/boost/lockfree/stack.hpp
++++ b/include/boost/lockfree/stack.hpp
+@@ -29,6 +29,7 @@
+ #include <boost/lockfree/detail/uses_optional.hpp>
+ #include <boost/lockfree/lockfree_forward.hpp>
+ 
++#include <cstdint>
+ #include <tuple>
+ #include <type_traits>
+ 

--- a/boost/riscv64.patch
+++ b/boost/riscv64.patch
@@ -1,0 +1,22 @@
+diff --git PKGBUILD PKGBUILD
+index a316ffb..777b117 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -30,6 +30,9 @@
+   # fix the smartpointer prints (https://github.com/boostorg/smart_ptr/issues/115)
+   # also see https://github.com/luceneplusplus/LucenePlusPlus/issues/208
+   patch -Np4 -d boost/smart_ptr < ../$pkgname-fix-smart-pointer-output.patch
++
++  # fix missing <cstdint> (https://github.com/boostorg/lockfree/pull/109)
++  patch -Np2 < ../$pkgname-fix-missing-cstdint.patch
+ }
+ 
+ build() {
+@@ -159,4 +162,7 @@
+   cp fakeinstall/lib/boost-python*/mpi.so "$pkgdir"$site_packages/boost/mpi.so
+ }
+ 
++source+=($pkgname-fix-missing-cstdint.patch)
++sha256sums+=('450fbb4f0d42a4fb098ea5ab72ea87e5b4a0921fc80618cded24ebd4b17c9c4a')
++
+ # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
Backport https://github.com/boostorg/lockfree/pull/109, adding missing `<cstdint>` include, to fix `libuhd` compile error.

Build `libuhd` after this bump.