### PR TITLE
addpatch: aom

### DIFF
--- a/aom/riscv64.patch
+++ b/aom/riscv64.patch
@@ -1,0 +1,9 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -72,4 +72,6 @@ package_aom-docs() {
+   install -Dt "$pkgdir/usr/share/licenses/$pkgname" -m644 libaom-$pkgver/{LICENSE,PATENTS}
+ }
+ 
++options=(!lto)
++
+ # vim:set sw=2 sts=-1 et:


### PR DESCRIPTION
Disable `lto` to fix `lto1: fatal error: target specific builtin not available`