### PR TITLE
addpatch: cmake 3.31.5-1

### DIFF
--- a/cmake/riscv64.patch
+++ b/cmake/riscv64.patch
@@ -1,0 +1,16 @@
+diff --git PKGBUILD PKGBUILD
+index 3f1c730..5cee830 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -57,3 +57,11 @@
+   emacs -batch -f batch-byte-compile "${pkgdir}"/usr/share/emacs/site-lisp/cmake-mode.el
+   install -Dm644 Copyright.txt "${pkgdir}"/usr/share/licenses/${pkgname}/LICENSE
+ }
++
++source+=(cmake-numofphysicalcpu-riscv64.patch::https://gitlab.kitware.com/utils/kwsys/-/commit/2f65474577fe71be4383ff2c82ea5cdeccda832e.diff)
++sha512sums+=('efe549b99d754665d4915ca2f8fe7df24a5ba831bc66727c3d5f7acdf2439273a9c239454032256d4aeecfa5f72eafb8f9be4c85b04dc11caff2afe6f829223e')
++
++prepare() {
++  cd ${pkgname}
++  patch -d Source/kwsys -Np1 < ../cmake-numofphysicalcpu-riscv64.patch
++}


### PR DESCRIPTION
Backport https://gitlab.kitware.com/utils/kwsys/-/merge_requests/328 to fix `MPIEXEC_MAX_NUMPROCS` enforced to `1`, which causes build error on `ginkgo-hpc`.