### PR TITLE
addpatch: openshadinglanguage

### DIFF
--- a/openshadinglanguage/riscv64.patch
+++ b/openshadinglanguage/riscv64.patch
@@ -1,0 +1,9 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -40,4 +40,6 @@ package() {
+   install -Dm644 LICENSE.md "$pkgdir"/usr/share/licenses/$pkgname/LICENSE.md
+ }
+ 
++depends+=('fmt')
++
+ # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
Add missing `fmt` dependency.
Fix `OpenImageIO could not be found because dependency fmt could not be found`.