### PR TITLE
updpatch: postgresql 17.2-3

### DIFF
--- a/postgresql/riscv64.patch
+++ b/postgresql/riscv64.patch
@@ -1,33 +1,6 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -23,7 +23,6 @@ depends=(
-   'libldap'
-   'libxml2'
-   'libxslt'
--  'llvm-libs'
-   'lz4'
-   'openssl'
-   'pam'
-@@ -34,10 +33,8 @@ depends=(
-   'zstd'
- )
- makedepends=(
--  'clang'
-   'docbook-xml'
-   'docbook-xsl'
--  'llvm'
-   'perl'
-   'perl-ipc-run'
-   'python'
-@@ -90,6 +87,7 @@ prepare() {
-   cd postgresql-${pkgver}
-   patch -p1 < ../0001-Set-DEFAULT_PGSOCKET_DIR-to-run-postgresql.patch
-   patch -p1 < ../0002-Force-RPATH-to-be-used-for-the-PL-Perl-plugin.patch
-+  patch -p1 < ../0003-Fix-timezone-test.patch
- }
- 
- build() {
-@@ -107,7 +105,6 @@ build() {
+@@ -112,7 +112,6 @@ build() {
      --with-ldap
      --with-libxml
      --with-libxslt
@@ -35,12 +8,11 @@
      --with-lz4
      --with-openssl
      --with-pam
-@@ -275,3 +272,8 @@ package_postgresql-docs() {
+@@ -279,4 +278,7 @@ package_postgresql-docs() {
+   install -Dm 644 COPYRIGHT -t "${pkgdir}/usr/share/licenses/${pkgname}"
  }
  
++depends=(${depends[@]/llvm-libs})
++makedepends=(${makedepends[@]/clang})
++makedepends=(${makedepends[@]/llvm})
  # vim:set sw=2 sts=-1 et:
-+
-+source+=("0003-Fix-timezone-test.patch::https://github.com/postgres/postgres/commit/8108674f0e5639baebcf03b54b7ccf9e9a8662a2.patch")
-+md5sums+=("86f1ac3c8aab15dbcbfc2d677a25185a")
-+sha256sums+=("60557e29e9001fe1e82aa9c93301bdd6a93075b833518347f2b1cc16e021417c")
-+b2sums+=("41d7b41bd10fb17627e164a607a51240fa0a480a647917e110d85742cdd8f8dd4616a0cdd8f0898a3288fd9906a0ace6dcd60e3b6dcee75b5a9613103ab9d648")


### PR DESCRIPTION
1. Remove `0003-Fix-timezone-test.patch` patch because patch has been appiled.
2. Delete '--with-llvm' still.