### PR TITLE
addpatch: naev

### DIFF
--- a/naev/disable-riscv64-fpu-exception.patch
+++ b/naev/disable-riscv64-fpu-exception.patch
@@ -1,0 +1,13 @@
+diff -Naur naev-0.12.3/meson.build naev-0.12.3_/meson.build
+--- naev-0.12.3/meson.build	2025-02-01 10:29:56.000000000 +0800
++++ naev-0.12.3_/meson.build	2025-02-18 23:25:31.006265834 +0800
+@@ -275,9 +275,7 @@
+    summary('tracy', have_tracy, section: 'Debug', bool_yn: true )
+ 
+    # Standard library feature tests
+-   config_data.set10('HAVE_FEENABLEEXCEPT', cc.has_header_symbol('fenv.h', 'feenableexcept', prefix: '#define _GNU_SOURCE'))
+    config_data.set10('HAVE_ALLOCA_H', cc.has_header('alloca.h'))
+-   config_data.set10('HAVE_FENV_H', cc.has_header('fenv.h'))
+    config_data.set10('HAVE_MALLOC_H', cc.has_header('malloc.h'))
+    # SDL_strndup and SDL_strnstr is in SDL3, so we can remove this once it is released
+    # strndup() detection must work around this bug: https://github.com/mesonbuild/meson/issues/3672

--- a/naev/riscv64.patch
+++ b/naev/riscv64.patch
@@ -1,0 +1,17 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -24,6 +24,7 @@ prepare() {
+ 
+   patch -Np1 -i ../eb11709e3a38da52f93e5415cc7fc9152a081fef.patch
+   patch -Np1 -i ../8cd181e8666e1250f39766dda742f00206f1edbf.patch
++  patch -Np1 -i ../disable-riscv64-fpu-exception.patch
+ }
+ 
+ build() {
+@@ -40,3 +41,6 @@ package() {
+   DESTDIR="$pkgdir" meson install
+   rm -r "$pkgdir"/usr/{include,lib}
+ }
++
++source+=('disable-riscv64-fpu-exception.patch')
++sha512sums+=('6746ff95362eb579e180ee3443a9f7ab1aa670333b5a67d7cdda4400237360c4bcaedc534b25ebe7d908f8914da6d15adba62ecd690a482c9a5ce47e14e173d9')


### PR DESCRIPTION
Same as #4363
But `export CFLAGS="$CFLAGS -DNO_fpu_control"` can not fix this.
So final solution: disable `fpu` related macro definition in `meson.build`.