### PR TITLE
addpatch: webrtc-audio-processing-0.3 0.3.1-6

### DIFF
--- a/webrtc-audio-processing-0.3/riscv64.patch
+++ b/webrtc-audio-processing-0.3/riscv64.patch
@@ -1,0 +1,22 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -20,14 +20,17 @@ provides=(
+ replaces=(
+   'webrtc-audio-processing<=0.3.1-5'
+ )
+-source=("git+https://gitlab.freedesktop.org/pulseaudio/webrtc-audio-processing.git?signed#tag=v$pkgver")
+-b2sums=('5ebffa25cd06b1ebefb84d05e7698b0f1cd1f25355480953742bd95b13bb6348e6f0fa2aa019ce5017783eec6919debf7a98a5425bfa6e403dc8c0a4c5773b98')
++source=("git+https://gitlab.freedesktop.org/pulseaudio/webrtc-audio-processing.git?signed#tag=v$pkgver"
++        webrtc-riscv64.patch)
++b2sums=('5ebffa25cd06b1ebefb84d05e7698b0f1cd1f25355480953742bd95b13bb6348e6f0fa2aa019ce5017783eec6919debf7a98a5425bfa6e403dc8c0a4c5773b98'
++        'e0b37a781dbedb8893c04710b0eeef5c9c7cc8d62e97a2cd77b871fd94c7930d0f673426ce7bdd0fc0638609bd4b15dfee855686426c8d76c9600ad1229fa1f1')
+ validpgpkeys=(
+   76EFEDBD2EEF4A59DAF0EC53B7A1A30FB2FFCBF3 # Arun Raghavan <arun@arunraghavan.net>
+ )
+ 
+ prepare() {
+   cd webrtc-audio-processing
++  patch -Np1 -i ../webrtc-riscv64.patch
+   NOCONFIGURE=1 ./autogen.sh
+ }
+ 

--- a/webrtc-audio-processing-0.3/webrtc-riscv64.patch
+++ b/webrtc-audio-processing-0.3/webrtc-riscv64.patch
@@ -1,0 +1,14 @@
+diff --git a/webrtc/typedefs.h b/webrtc/typedefs.h
+index d875490..6a96937 100644
+--- a/webrtc/typedefs.h
++++ b/webrtc/typedefs.h
+@@ -47,6 +47,9 @@
+ #elif defined(__pnacl__)
+ #define WEBRTC_ARCH_32_BITS
+ #define WEBRTC_ARCH_LITTLE_ENDIAN
++#elif defined(__riscv) && __riscv_xlen == 64
++#define WEBRTC_ARCH_64_BITS
++#define WEBRTC_ARCH_LITTLE_ENDIAN
+ #else
+ #error Please add support for your architecture in typedefs.h
+ #endif


### PR DESCRIPTION
RISC-V support is present in upstream but not in this legacy version. Port it here.