### PR TITLE
addpatch: vamp-aubio-plugins 0.5.1-6

### DIFF
--- a/vamp-aubio-plugins/riscv-fix.patch
+++ b/vamp-aubio-plugins/riscv-fix.patch
@@ -1,0 +1,21 @@
+--- wscript.orig	2025-02-24 04:39:04.642894481 -0500
++++ wscript	2025-02-24 04:57:45.745046300 -0500
+@@ -47,6 +47,8 @@
+             local_vamp_lib = local_vamp_lib_amd64
+         elif platform.machine() == 'x86_64':
+             local_vamp_lib = local_vamp_lib_i686
++        else:
++            local_vamp_lib = "/non-existent"
+     elif sys.platform == 'darwin':
+         local_vamp_lib = local_vamp_lib_osx
+     elif sys.platform == 'win32':
+@@ -78,8 +80,7 @@
+         conf.env.CXXFLAGS += ['-g', '-Wall', '-Wextra']
+ 
+     if sys.platform.startswith('linux'):
+-        conf.env['CXXFLAGS'] += ['-O3', '-msse', '-msse2', '-mfpmath=sse',
+-                '-ftree-vectorize']
++        conf.env['CXXFLAGS'] += ['-O3', '-ftree-vectorize']
+         if 'mingw' in conf.env.CXX[0]:
+             conf.env.append_value('LINKFLAGS', '-Wl,--enable-auto-import')
+             conf.env.append_value('LINKFLAGS', '-Wl,--retain-symbols-file=../vamp-plugin.list')

--- a/vamp-aubio-plugins/riscv64.patch
+++ b/vamp-aubio-plugins/riscv64.patch
@@ -1,0 +1,17 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -18,6 +18,7 @@ prepare() {
+   cd "${pkgname}-${pkgver}"
+   # don't care aboute outdated waflib
+   rm -rv waflib
++  patch -Np0 -i ../riscv-fix.patch
+ }
+ 
+ build() {
+@@ -32,3 +33,6 @@ package() {
+   # docs
+   install -vDm 644 README.md -t "${pkgdir}/usr/share/doc/${pkgname}/"
+ }
++
++source+=(riscv-fix.patch)
++sha512sums+=(6bac48e9a3a5631082d0f61b556596a73cae9530c817ec9fba6f4e92568979bc10d0603748bfc047273b3afe706bdd415993b47441f7b4be0e26b7cf3dd5e431)


### PR DESCRIPTION
- Add an else branch to set fallback value of local_vamp_lib to `/non-existent`. This variable is not used as we are using system vamp-plugin-sdk.
- Drop '-msse', '-msse2' compiler flags

Closes: https://archriscv.felixc.at/.status/log.htm?url=logs/vamp-aubio-plugins/vamp-aubio-plugins-0.5.1-6.log