### PR TITLE
updpatch: glibc 2.41+r9+ga900dbaf70f0-1

### DIFF
--- a/glibc/riscv64.patch
+++ b/glibc/riscv64.patch
@@ -1,6 +1,6 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -14,12 +14,11 @@ pkgrel=2
+@@ -14,22 +14,22 @@ pkgrel=1
  arch=(x86_64)
  url='https://www.gnu.org/software/libc'
  license=(GPL-2.0-or-later LGPL-2.1-or-later)
@@ -12,17 +12,22 @@
          locale-gen
 -        lib32-glibc.conf
          sdt.h sdt-config.h
++	"mremap-fix-test.patch::https://inbox.sourceware.org/libc-alpha/20250208-fix-mremap-tst-v1-1-ad7ee617ec65@coelacanthus.name/raw"
  )
  validpgpkeys=(7273542B39962DF7B299931416792B4EA25340F8 # Carlos O'Donell
-@@ -27,7 +26,6 @@ validpgpkeys=(7273542B39962DF7B299931416792B4EA25340F8 # Carlos O'Donell
- b2sums=('74c4f1e1231834579d19c96cc60fc370c9c4468e254fe069aad6102c8678d163ab6e58ebf0a11de680483105ba02d362842a817d698e134731f70c2d5b383eed'
+               BC7C7372637EC10C57D7AA6579C43DFBF1CF2187) # Siddhesh Poyarekar
+ b2sums=('c1b5cc81db71ce62c14864c74c0df39f7f5b2db503a179da79fc5a40a434051f8fc25754f9937a056228e92cf2857c98a98432dc145c0ef646d22c7cb59fd256'
          'c859bf2dfd361754c9e3bbd89f10de31f8e81fd95dc67b77d10cb44e23834b096ba3caa65fbc1bd655a8696c6450dfd5a096c476b3abf5c7e125123f97ae1a72'
          '04fbb3b0b28705f41ccc6c15ed5532faf0105370f22133a2b49867e790df0491f5a1255220ff6ebab91a462f088d0cf299491b3eb8ea53534cb8638a213e46e3'
 -        '7c265e6d36a5c0dff127093580827d15519b6c7205c2e1300e82f0fb5b9dd00b6accb40c56581f18179c4fbbc95bd2bf1b900ace867a83accde0969f7b609f8a'
          'a6a5e2f2a627cc0d13d11a82458cfd0aa75ec1c5a3c7647e5d5a3bb1d4c0770887a3909bfda1236803d5bc9801bfd6251e13483e9adf797e4725332cd0d91a0e'
-         '214e995e84b342fe7b2a7704ce011b7c7fc74c2971f98eeb3b4e677b99c860addc0a7d91b8dc0f0b8be7537782ee331999e02ba48f4ccc1c331b60f27d715678')
+-        '214e995e84b342fe7b2a7704ce011b7c7fc74c2971f98eeb3b4e677b99c860addc0a7d91b8dc0f0b8be7537782ee331999e02ba48f4ccc1c331b60f27d715678')
++        '214e995e84b342fe7b2a7704ce011b7c7fc74c2971f98eeb3b4e677b99c860addc0a7d91b8dc0f0b8be7537782ee331999e02ba48f4ccc1c331b60f27d715678'
++        '3ba09c775c0d58bf9e5b08985ea5fa73509433df7ff284f035f7f73357e8f35a79c8e7f3a0fecfe4b8759831e9f0d38e8524dcf2b8132066a47cb7e234880a6e')
  
-@@ -37,7 +35,7 @@ pkgver() {
+ pkgver() {
+   cd glibc
+@@ -37,10 +37,13 @@ pkgver() {
  }
  
  prepare() {
@@ -31,7 +36,13 @@
  
    [[ -d glibc-$pkgver ]] && ln -s glibc-$pkgver glibc
    cd glibc
-@@ -51,7 +49,6 @@ build() {
++  # RISC-V: Fix IFUNC resolver cannot access gp pointer
++  git cherry-pick -n 30992cb5e9d713ab0f4135dd8776a201f7a53f24
++  patch -Np1 -i ../mremap-fix-test.patch
+ }
+ 
+ build() {
+@@ -51,7 +54,6 @@ build() {
        --enable-bind-now
        --enable-fortify-source
        --enable-kernel=4.4
@@ -39,7 +50,7 @@
        --enable-stack-protector=strong
        --enable-systemtap
        --disable-nscd
-@@ -83,29 +80,6 @@ build() {
+@@ -83,29 +85,6 @@ build() {
      make info
    )
  
@@ -69,7 +80,7 @@
    # pregenerate locales here instead of in package
    # functions because localedef does not like fakeroot
    make -C "${srcdir}"/glibc/localedata objdir="${srcdir}"/glibc-build \
-@@ -140,7 +114,7 @@ check() (
+@@ -140,7 +119,7 @@ check() (
    _skip_test tst-shstk-legacy-1g     sysdeps/x86_64/Makefile
    _skip_test tst-adjtime             time/Makefile
  
@@ -78,7 +89,7 @@
  )
  
  package_glibc() {
-@@ -189,31 +163,6 @@ package_glibc() {
+@@ -189,31 +168,6 @@ package_glibc() {
    install -Dm644 "${srcdir}"/sdt-config.h "${pkgdir}"/usr/include/sys/sdt-config.h
  }
  
@@ -110,7 +121,7 @@
  package_glibc-locales() {
    pkgdesc='Pregenerated locales for GNU C Library'
    depends=("glibc=$pkgver")
-@@ -224,3 +173,10 @@ package_glibc-locales() {
+@@ -224,3 +178,10 @@ package_glibc-locales() {
    # deduplicate locale data
    hardlink -c "${pkgdir}"/usr/lib/locale
  }


### PR DESCRIPTION
Cherry-pick two patches:

- RISC-V: Fix IFUNC resolver cannot access gp pointer by cyy
- linux: prevent kernel choose addr by itself in mremap test by c10s