### PR TITLE
updpatch: gcc 14.2.1+r753+g1cd744a6828f-1

### DIFF
--- a/gcc/riscv64.patch
+++ b/gcc/riscv64.patch
@@ -1,5 +1,3 @@
-diff --git PKGBUILD PKGBUILD
-index 0f91e47..b1b00cf 100644
 --- PKGBUILD
 +++ PKGBUILD
 @@ -18,11 +18,8 @@ url='https://gcc.gnu.org'
@@ -22,13 +20,14 @@ index 0f91e47..b1b00cf 100644
  )
  validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
                86CFFCA918CF3AF47147588051E8B148A9999C34  # foutrelis@archlinux.org
-@@ -49,12 +47,19 @@ validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.
- sha256sums=('82b674a17bbac14acbf16b10e9d61e928e5630cd56635eb97acfeda849d4ebbf'
-             'de48736f6e4153f03d0a5d38ceb6c6fdb7f054e8f47ddd6af0a3dbf14f27b931'
-             '2513c6d9984dd0a2058557bf00f06d8d5181734e41dcfe07be7ed86f2959622a'
+@@ -49,12 +47,20 @@ validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.
+ sha256sums=('33378643f1c72686181f9d3fcd09caf9b06815324467f5dc9b9a3ea41cfba4b4'
+             '7b09ec947f90b98315397af675369a1e3dfc527fa70013062e6e85c4be0275ab'
+             '44ea973558842f3f4bd666bdaf6e810fd7b7c7bd36b5cc4c69f93d2cd0124fc7'
 -            '1773f5137f08ac1f48f0f7297e324d5d868d55201c03068670ee4602babdef2f')
 +            '1773f5137f08ac1f48f0f7297e324d5d868d55201c03068670ee4602babdef2f'
 +            '7183fdeea8fd148cf9dd03b0932f9d439b818a5ab3bc9a5e20d8e0b41c9e0efd')
++
  pkgver() {
    cd gcc
    echo "$(cat gcc/BASE-VER)+$(git describe --abbrev=12 --tags | sed 's/[^-]*-[^-]*-//;s/[^-]*-/r&/;s/-/+/g;s/_/./')"
@@ -43,7 +42,7 @@ index 0f91e47..b1b00cf 100644
  prepare() {
    [[ ! -d gcc ]] && ln -s gcc-${pkgver/+/-} gcc
    cd gcc
-@@ -68,6 +73,15 @@ prepare() {
+@@ -68,6 +74,18 @@ prepare() {
    # Reproducible gcc-ada
    patch -Np0 < "$srcdir/gcc-ada-repro.patch"
  
@@ -56,10 +55,13 @@ index 0f91e47..b1b00cf 100644
 +  # https://github.com/golang/go/issues/57691
 +  git cherry-pick -n 21a07620f4bfe38f12e6d5be8b1eeecc29fa6852
 +
++  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=119012
++  git revert -n 3228df20cfa3581015dc32657eb17d6f24af3104
++
    mkdir -p "$srcdir/gcc-build"
    mkdir -p "$srcdir/libgccjit-build"
  }
-@@ -95,7 +109,7 @@ build() {
+@@ -95,7 +113,7 @@ build() {
        --enable-link-serialization=1
        --enable-linker-build-id
        --enable-lto
@@ -68,7 +70,7 @@ index 0f91e47..b1b00cf 100644
        --enable-plugin
        --enable-shared
        --enable-threads=posix
-@@ -113,7 +127,7 @@ build() {
+@@ -113,7 +131,7 @@ build() {
    CXXFLAGS=${CXXFLAGS/-Werror=format-security/}
  
    "$srcdir/gcc/configure" \
@@ -77,7 +79,7 @@ index 0f91e47..b1b00cf 100644
      --enable-bootstrap \
      "${_confflags[@]:?_confflags unset}"
  
-@@ -161,9 +175,9 @@ check() {
+@@ -161,9 +179,9 @@ check() {
  package_gcc-libs() {
    pkgdesc='Runtime libraries shipped by GCC'
    depends=('glibc>=2.27')
@@ -89,7 +91,7 @@ index 0f91e47..b1b00cf 100644
    replaces=($pkgname-multilib libgphobos)
  
    cd gcc-build
-@@ -176,9 +190,8 @@ package_gcc-libs() {
+@@ -176,9 +194,8 @@ package_gcc-libs() {
               libgomp \
               libitm \
               libquadmath \
@@ -101,7 +103,7 @@ index 0f91e47..b1b00cf 100644
      make -C $CHOST/$lib DESTDIR="$pkgdir" install-toolexeclibLTLIBRARIES
    done
  
-@@ -195,18 +208,17 @@ package_gcc-libs() {
+@@ -195,18 +212,17 @@ package_gcc-libs() {
      make -C $CHOST/$lib DESTDIR="$pkgdir" install-info
    done
  
@@ -123,7 +125,7 @@ index 0f91e47..b1b00cf 100644
    provides=($pkgname-multilib)
    replaces=($pkgname-multilib)
    options=(!emptydirs staticlibs)
-@@ -220,22 +232,18 @@ package_gcc() {
+@@ -220,22 +236,18 @@ package_gcc() {
    install -m755 -t "$pkgdir/${_libdir}/" gcc/{cc1,cc1plus,collect2,lto1}
  
    make -C $CHOST/libgcc DESTDIR="$pkgdir" install
@@ -148,7 +150,7 @@ index 0f91e47..b1b00cf 100644
  
    make DESTDIR="$pkgdir" install-fixincludes
    make -C gcc DESTDIR="$pkgdir" install-mkheaders
-@@ -250,16 +258,11 @@ package_gcc() {
+@@ -250,16 +262,11 @@ package_gcc() {
    make -C $CHOST/libquadmath DESTDIR="$pkgdir" install-nodist_libsubincludeHEADERS
    make -C $CHOST/libsanitizer DESTDIR="$pkgdir" install-nodist_{saninclude,toolexeclib}HEADERS
    make -C $CHOST/libsanitizer/asan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
@@ -166,7 +168,7 @@ index 0f91e47..b1b00cf 100644
  
    make -C libcpp DESTDIR="$pkgdir" install
    make -C gcc DESTDIR="$pkgdir" install-po
-@@ -270,7 +273,7 @@ package_gcc() {
+@@ -270,7 +277,7 @@ package_gcc() {
    # create cc-rs compatible symlinks
    # https://github.com/rust-lang/cc-rs/blob/1.0.73/src/lib.rs#L2578-L2581
    for binary in {c++,g++,gcc,gcc-ar,gcc-nm,gcc-ranlib}; do
@@ -175,7 +177,7 @@ index 0f91e47..b1b00cf 100644
    done
  
    # POSIX conformance launcher scripts for c89 and c99
-@@ -280,9 +283,6 @@ package_gcc() {
+@@ -280,9 +287,6 @@ package_gcc() {
    # install the libstdc++ man pages
    make -C $CHOST/libstdc++-v3/doc DESTDIR="$pkgdir" doc-install-man
  
@@ -185,7 +187,7 @@ index 0f91e47..b1b00cf 100644
    # byte-compile python libraries
    python -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
    python -O -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
-@@ -302,8 +302,6 @@ package_gcc-fortran() {
+@@ -302,8 +306,6 @@ package_gcc-fortran() {
    cd gcc-build
    make -C $CHOST/libgfortran DESTDIR="$pkgdir" install-cafexeclibLTLIBRARIES \
      install-{toolexeclibDATA,nodist_fincludeHEADERS,gfor_cHEADERS}
@@ -194,7 +196,7 @@ index 0f91e47..b1b00cf 100644
    make -C $CHOST/libgomp DESTDIR="$pkgdir" install-nodist_fincludeHEADERS
    make -C gcc DESTDIR="$pkgdir" fortran.install-{common,man,info}
    install -Dm755 gcc/f951 "$pkgdir/${_libdir}/f951"
-@@ -381,7 +379,6 @@ package_gcc-go() {
+@@ -381,7 +383,6 @@ package_gcc-go() {
  
    cd gcc-build
    make -C $CHOST/libgo DESTDIR="$pkgdir" install-exec-am


### PR DESCRIPTION
Fix rotten patch and revert a commit that causes bootstrap failure.

Bug reports:
- https://github.com/Rust-GCC/gccrs/issues/3424
- https://gcc.gnu.org/bugzilla/show_bug.cgi?id=119012

Reverted commit: https://patchwork.ozlabs.org/project/gcc/patch/mptzfk45brm.fsf@arm.com/

During bisection, the failure messages are mostly:

    Comparing stages 2 and 3
    Bootstrap comparison failure!
    gcc/rust/rust-lex.o differs

or

    Comparing stages 2 and 3
    Bootstrap comparison failure!
    gcc/builtins.o differs

or crash in RTL pass like:

    *** stack smashing detected ***: terminated
    during RTL pass: combine
    /usr/src/debug/gcc/gcc/gcc/config/riscv/corev.md: In function ‘recog_84.isra’:
    /usr/src/debug/gcc/gcc/gcc/config/riscv/corev.md:2557:1: internal compiler error: Aborted
    0x9c9f05 crash_signal
            /usr/src/debug/gcc/gcc/gcc/toplev.cc:319
    0x1690b13 try_combine
            /usr/src/debug/gcc/gcc/gcc/combine.cc:4772
    0x16926e3 combine_instructions
            /usr/src/debug/gcc/gcc/gcc/combine.cc:1285
    0x16926e3 rest_of_handle_combine
            /usr/src/debug/gcc/gcc/gcc/combine.cc:15116
    0x16926e3 execute
            /usr/src/debug/gcc/gcc/gcc/combine.cc:15160

Upstream hasn't responded since I reported the bad commit. I think we can revert it here temporarily to restart our long delayed gcc toolchain update. The bad commit seems to be a fix for a 25 year old bug.