### PR TITLE
addpatch: rustup 1.28.1-1

### DIFF
--- a/rustup/riscv64.patch
+++ b/rustup/riscv64.patch
@@ -1,0 +1,9 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -57,4 +57,6 @@ package() {
+   install -Dm644 LICENSE-APACHE "${pkgdir}"/usr/share/licenses/$pkgname/LICENSE-APACHE
+ }
+ 
++makedepends+=('clang' 'cmake')
++
+ # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
Add clang and cmake to makedepends until aws-lc-rs' pregenerated riscv64 binding is ready.