### PR TITLE
addpatch: spotify-player 0.24.0-2

### DIFF
--- a/spotify-player/riscv64.patch
+++ b/spotify-player/riscv64.patch
@@ -1,0 +1,17 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -21,6 +21,7 @@ prepare() {
+ 
+ build() {
+ 	cd "${pkgname}-${pkgver}"
++	export CFLAGS=${CFLAGS/-Wp,-D_FORTIFY_SOURCE=3/}
+ 	cargo build --frozen --release --bin spotify_player --no-default-features
+ }
+ 
+@@ -37,4 +38,6 @@ package() {
+ 	install -Dm644 README.md "$pkgdir/usr/share/doc/$pkgname/README.md"
+ }
+ 
++makedepends+=('clang' 'cmake')
++
+ # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
Add clang and cmake to makedepends until aws-lc-rs' pregenerated riscv64 binding is ready.

The code builds with -O0 and conflicts with _FORTIFY_SOURCE.