### PR TITLE
updpatch: nzbget 24.7-1

### DIFF
--- a/nzbget/riscv64.patch
+++ b/nzbget/riscv64.patch
@@ -1,8 +1,12 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -63,3 +63,5 @@ package() {
+@@ -63,3 +63,9 @@ package() {
    DESTDIR="$pkgdir" cmake --install build
    install -vDm644 -t "$pkgdir/usr/share/doc/$pkgname" ./*.md
  }
 +
 +options=(!lto)
++checkdepends+=(
++  'unrar'
++  '7zip'
++)


### PR DESCRIPTION
Fix following errors:
```log
which: no 7z in (/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl)
which: no unrar in (/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl)
```
and test error
```log
7/8 Test #7: SystemTests ......................***Failed    6.44 sec
```