### PR TITLE
addpatch: ruby-pycall 1.5.2-4

### DIFF
--- a/ruby-pycall/init-return-test.patch
+++ b/ruby-pycall/init-return-test.patch
@@ -1,0 +1,13 @@
+diff --git a/pycall.rb/spec/pycall_spec.rb b/pycall.rb/spec/pycall_spec.rb
+index 536438b..3089cdd 100644
+--- a/pycall.rb/spec/pycall_spec.rb
++++ b/pycall.rb/spec/pycall_spec.rb
+@@ -152,7 +152,7 @@ require 'pycall'
+ puts(PyCall.init ? 'true' : 'false')
+ RUBY
+       expect(status).to be_success
+-      expect(out.chomp).to eq('true')
++      expect(out.lines.last.chomp).to eq('true')
+     end
+ 
+     it 'returns false if already initialized' do

--- a/ruby-pycall/riscv64.patch
+++ b/ruby-pycall/riscv64.patch
@@ -1,0 +1,20 @@
+diff --git PKGBUILD PKGBUILD
+index 001dd0c..50fa715 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -27,10 +27,13 @@ checkdepends=(
+   ruby-test-unit
+ )
+ options=(!emptydirs)
+-source=("git+${url}.git#tag=v${pkgver}")
+-sha512sums=('SKIP')
++source=("git+${url}.git#tag=v${pkgver}"
++        init-return-test.patch)
++sha512sums=('SKIP'
++            '4abb802b714e7279381a554e94ad484d6d51319754f64fbc3518e8d75c3838813b543c838df6734ef4ff0ececf6396c5791003bd04c98665b261ff5624d2d21e')
+ 
+ prepare() {
++  patch -Np1 -i ./init-return-test.patch
+   cd pycall.rb
+   sed -r -e '/rake-compiler-dock/d' -e '/launchy/d' -i pycall.gemspec
+ }


### PR DESCRIPTION
fix 'Failure/Error: expect(out.chomp).to eq('true')' in riscv64 for Bundler/gem analysis.