### PR TITLE
addpatch: cargo-msrv 0.18.3-1

### DIFF
--- a/cargo-msrv/riscv64.patch
+++ b/cargo-msrv/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index 2d8583c..735d064 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -8,7 +8,7 @@
+ url="https://github.com/foresterre/cargo-msrv"
+ license=('MIT' 'Apache-2.0')
+ depends=('gcc-libs' 'openssl' 'rustup')
+-makedepends=('cargo')
++makedepends=('cargo' 'cmake' 'clang')
+ source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
+ sha256sums=('5ebe6dd493cd9641d31cf736458ea0ef61a74d162ca0364b56c91239efc88ee6')
+ options=('!lto')


### PR DESCRIPTION
Extra makedepends to build aws-lc-sys without pre-generated binding.