### PR TITLE
addpatch: xournalpp 1.2.6-1

### DIFF
--- a/xournalpp/riscv64.patch
+++ b/xournalpp/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -13,7 +13,7 @@ makedepends=('git' 'cmake' 'doxygen' 'graphviz')
+ depends=('gtk3' 'poppler-glib' 'libxml2' 'portaudio' 'libsndfile' 'lua'
+          'libzip')
+ source=("git+https://github.com/xournalpp/xournalpp.git#tag=v${pkgver}")
+-sha256sums=('9319ef38831414f3e3e4b2e36e86f910700d40772c654d5309ef759eff52337e')
++sha256sums=('3f1dc11be2c1eea36cc9dbc1a972cb5d9ae383d8296251f96beeffafa339611d')
+ 
+ replaces=('xournal')
+ 


### PR DESCRIPTION
Upstream hash mismatch

Link: https://gitlab.archlinux.org/archlinux/packaging/packages/xournalpp/-/merge_requests/1