### PR TITLE
updpatch: libseccomp 2.5.6-1

### DIFF
--- a/libseccomp/riscv64.patch
+++ b/libseccomp/riscv64.patch
@@ -1,12 +1,12 @@
-Index: PKGBUILD
-===================================================================
---- PKGBUILD	(revision 405399)
-+++ PKGBUILD	(working copy)
-@@ -12,7 +12,6 @@
- license=('LGPL2.1')
+--- PKGBUILD
++++ PKGBUILD
+@@ -11,9 +11,6 @@ pkgdesc='Enhanced seccomp library'
+ arch=(x86_64)
+ license=(LGPL-2.1-only)
  url="https://github.com/seccomp/libseccomp"
- depends=('glibc')
--checkdepends=('valgrind')
- makedepends=('gperf' 'cython' 'python-setuptools')
- source=(https://github.com/seccomp/${pkgname}/releases/download/v${pkgver}/${pkgname}-${pkgver}.tar.gz{,.asc})
- sha256sums=('ee307e383c77aa7995abc5ada544d51c9723ae399768a97667d4cdb3c3a30d55'
+-checkdepends=(
+-  valgrind
+-)
+ makedepends=(
+   cython
+   glibc


### PR DESCRIPTION
- Fix rotten patch
- We still need this patch even if we have valgrind now. Because running those valgrind tests need debug info, or we ship an unstripped dyld.

```
Test 02-sim-basic%%012-00001 valgrind output                                                                                                                                                                                                
==154369== Memcheck, a memory error detector                                                                                                                                                                                                
==154369== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.                                                                                                                                                                  
==154369== Using Valgrind-3.24.0.GIT and LibVEX; rerun with -h for copyright info                                                                                                                                                           
==154369== Command: ./02-sim-basic -b                                                                                                                                                                                                       
==154369==                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                            
valgrind:  Fatal error at startup: a function redirection                                                                                                                                                                                   
valgrind:  which is mandatory for this platform-tool combination                                                                                                                                                                            
valgrind:  cannot be set up.  Details of the redirection are:                                                                                                                                                                               
valgrind:                                                                                                                                                                                                                                   
valgrind:  A must-be-redirected function                                                                                                                                                                                                    
valgrind:  whose name matches the pattern:      index                                                                                                                                                                                       
valgrind:  in an object with soname matching:   ld-linux-riscv64-lp64d.so.1                                                                                                                                                                 
valgrind:  was not found whilst processing                                                                                                                                                                                                  
valgrind:  symbols from the object with soname: ld-linux-riscv64-lp64d.so.1                                                                                                                                                                 
valgrind:                                                                                                                                                                                                                                   
valgrind:  Possible fixes: (1, short term): install glibc's debuginfo                                                                                                                                                                       
valgrind:  package on this machine.  (2, longer term): ask the packagers                                                                                                                                                                    
valgrind:  for your Linux distribution to please in future ship a non-                                                                                                                                                                      
valgrind:  stripped ld.so (or whatever the dynamic linker .so is called)                                                                                                                                                                    
valgrind:  that exports the above-named function using the standard                                                                                                                                                                         
valgrind:  calling conventions for this platform.  The package you need                                                                                                                                                                     
valgrind:  to install for fix (1) is called                                                                                                                                                                                                 
valgrind:                                                                                                                                                                                                                                   
valgrind:    On Debian, Ubuntu:                 libc6-dbg                                                                                                                                                                                   
valgrind:    On SuSE, openSuSE, Fedora, RHEL:   glibc-debuginfo                                                                                                                                                                             
valgrind:                                                                                                                                                                                                                                   
valgrind:  Note that if you are debugging a 32 bit process on a                                                                                                                                                                             
valgrind:  64 bit system, you will need a corresponding 32 bit debuginfo                                                                                                                                                                    
valgrind:  package (e.g. libc6-dbg:i386).                                                                                                                                                                                                   
valgrind:                                                                                                                                                                                                                                   
valgrind:  Cannot continue -- exiting now.  Sorry.   
```