### PR TITLE
updpatch: bazel7 7.5.0-1

### DIFF
--- a/bazel7/bazel7-riscv.diff
+++ b/bazel7/bazel7-riscv.diff
@@ -1,5 +1,37 @@
+From de6ccce03afdf2e96e38ed7c4343607690bc1e65 Mon Sep 17 00:00:00 2001
+Message-ID: <de6ccce03afdf2e96e38ed7c4343607690bc1e65.1743169249.git.rsworktech@outlook.com>
+From: Levi Zim <rsworktech@outlook.com>
+Date: Wed, 26 Mar 2025 07:51:42 +0800
+Subject: [PATCH] Add support for riscv64 linux
+
+This patch brings enough support for bootstraping bazel itself on
+riscv64 linux platform.
+
+Changes:
+
+* Bump rules_java for bazelbuild/rules_java#282
+  bazelbuild/rules_java#198
+* Bump stardoc to 0.7.1 and rules_jvm_external to 6.1 to fix CI failure
+* Use portable `uname -m` in mininize_jdk.sh
+* Add prebuilt jdk for riscv64
+* Bump abseil-cpp for abseil/abseil-cpp#1644
+
+Tested on riscv 64 linux by `bazel build //src:bazel --compilation_mode=opt`
+---
+ BUILD                                         |    2 +-
+ MODULE.bazel                                  |   21 +-
+ MODULE.bazel.lock                             | 5094 ++++++++++++-----
+ distdir_deps.bzl                              |   10 +
+ repositories.bzl                              |    6 +
+ src/BUILD                                     |    3 +
+ src/MODULE.tools                              |    2 +-
+ src/minimize_jdk.sh                           |    4 +-
+ ...6.0.patch => rules_jvm_external_6.1.patch} |  106 +-
+ 9 files changed, 3773 insertions(+), 1475 deletions(-)
+ rename third_party/{rules_jvm_external_6.0.patch => rules_jvm_external_6.1.patch} (66%)
+
 diff --git a/BUILD b/BUILD
-index bc013c953d9675..6adf02be09bdb3 100644
+index bc013c953d..6adf02be09 100644
 --- a/BUILD
 +++ b/BUILD
 @@ -104,7 +104,7 @@ genrule(
@@ -12,10 +44,10 @@ index bc013c953d9675..6adf02be09bdb3 100644
          "//third_party/upb:01_remove_werror.patch",
          "//third_party/grpc:BUILD",
 diff --git a/MODULE.bazel b/MODULE.bazel
-index 883b22d845be2a..ad2cdce3097d7d 100644
+index 883b22d845..3c779e131f 100644
 --- a/MODULE.bazel
 +++ b/MODULE.bazel
-@@ -13,20 +13,20 @@ module(
+@@ -13,23 +13,23 @@ module(
  # =========================================
  
  bazel_dep(name = "rules_license", version = "0.0.7")
@@ -41,7 +73,11 @@ index 883b22d845be2a..ad2cdce3097d7d 100644
 +bazel_dep(name = "rules_jvm_external", version = "6.1")
  bazel_dep(name = "rules_python", version = "0.33.2")
  bazel_dep(name = "rules_testing", version = "0.6.0")
- bazel_dep(name = "googletest", version = "1.14.0", repo_name = "com_google_googletest")
+-bazel_dep(name = "googletest", version = "1.14.0", repo_name = "com_google_googletest")
++bazel_dep(name = "googletest", version = "1.15.2", repo_name = "com_google_googletest")
+ bazel_dep(name = "with_cfg.bzl", version = "0.2.4")
+ 
+ # TODO(pcloudy): Add remoteapis and googleapis as Bazel modules in the BCR.
 @@ -39,7 +39,7 @@ bazel_dep(name = "googleapis", version = "")
  single_version_override(
      module_name = "rules_jvm_external",
@@ -51,12 +87,14 @@ index 883b22d845be2a..ad2cdce3097d7d 100644
  )
  
  local_path_override(
-@@ -63,7 +63,7 @@ single_version_override(
+@@ -62,8 +62,8 @@ single_version_override(
+ 
  # The following Bazel modules are not direct dependencies for building Bazel,
  # but are required for visibility from DIST_ARCHIVE_REPOS in repositories.bzl
- bazel_dep(name = "apple_support", version = "1.8.1")
+-bazel_dep(name = "apple_support", version = "1.8.1")
 -bazel_dep(name = "abseil-cpp", version = "20230125.1")
-+bazel_dep(name = "abseil-cpp", version = "20230802.1")
++bazel_dep(name = "apple_support", version = "1.15.1")
++bazel_dep(name = "abseil-cpp", version = "20240722.1")
  bazel_dep(name = "c-ares", version = "1.15.0")
  bazel_dep(name = "rules_go", version = "0.39.1")
  bazel_dep(name = "rules_kotlin", version = "1.9.0")
@@ -69,7 +107,7 @@ index 883b22d845be2a..ad2cdce3097d7d 100644
      "openjdk_linux_vanilla",
      "openjdk_macos_aarch64_vanilla",
 diff --git a/distdir_deps.bzl b/distdir_deps.bzl
-index fabaf84a3113bb..1c202bb8030e02 100644
+index fabaf84a31..1c202bb803 100644
 --- a/distdir_deps.bzl
 +++ b/distdir_deps.bzl
 @@ -488,6 +488,16 @@ DIST_DEPS = {
@@ -90,7 +128,7 @@ index fabaf84a3113bb..1c202bb8030e02 100644
          "archive": "zulu21.28.85-ca-jdk21.0.0-macosx_x64.tar.gz",
          "sha256": "9639b87db586d0c89f7a9892ae47f421e442c64b97baebdff31788fbe23265bd",
 diff --git a/repositories.bzl b/repositories.bzl
-index dffa917d93c0ba..62c2db2cca4069 100644
+index dffa917d93..62c2db2cca 100644
 --- a/repositories.bzl
 +++ b/repositories.bzl
 @@ -93,6 +93,12 @@ def embedded_jdk_repositories():
@@ -107,7 +145,7 @@ index dffa917d93c0ba..62c2db2cca4069 100644
          name = "openjdk_macos_x86_64_vanilla",
          integrity = "sha256-zXTl63OMkUWdS45eEOrJGK4qBdIan8fKXcLaZOZbzr0=",
 diff --git a/src/BUILD b/src/BUILD
-index abded2708a30ba..9ecb09cc885465 100644
+index abded2708a..9ecb09cc88 100644
 --- a/src/BUILD
 +++ b/src/BUILD
 @@ -168,6 +168,9 @@ filegroup(
@@ -121,7 +159,7 @@ index abded2708a30ba..9ecb09cc885465 100644
              "@openjdk_linux_s390x_vanilla//file",
          ],
 diff --git a/src/MODULE.tools b/src/MODULE.tools
-index 51e51ac5e5f8e1..42ce4eb5ed718d 100644
+index 51e51ac5e5..42ce4eb5ed 100644
 --- a/src/MODULE.tools
 +++ b/src/MODULE.tools
 @@ -5,7 +5,7 @@
@@ -134,7 +172,7 @@ index 51e51ac5e5f8e1..42ce4eb5ed718d 100644
  bazel_dep(name = "rules_proto", version = "4.0.0")
  bazel_dep(name = "rules_python", version = "0.22.1")
 diff --git a/src/minimize_jdk.sh b/src/minimize_jdk.sh
-index afeeb65a1c64fb..732896c471decb 100755
+index afeeb65a1c..732896c471 100755
 --- a/src/minimize_jdk.sh
 +++ b/src/minimize_jdk.sh
 @@ -30,8 +30,8 @@ else
@@ -152,7 +190,7 @@ diff --git a/third_party/rules_jvm_external_6.0.patch b/third_party/rules_jvm_ex
 similarity index 66%
 rename from third_party/rules_jvm_external_6.0.patch
 rename to third_party/rules_jvm_external_6.1.patch
-index 17c8d82205a15f..cb63b1f56b74e6 100644
+index 17c8d82205..cb63b1f56b 100644
 --- a/third_party/rules_jvm_external_6.0.patch
 +++ b/third_party/rules_jvm_external_6.1.patch
 @@ -1,34 +1,39 @@
@@ -220,7 +258,7 @@ index 17c8d82205a15f..cb63b1f56b74e6 100644
  +_BUILD_VENDOR = """
  +load("@rules_jvm_external//private/rules:jvm_import.bzl", "jvm_import")
  +
-@@ -36,21 +41,21 @@ index c60c590..7b16164 100644
+@@ -36,21 +41,21 @@
  +"""
  +
   DEFAULT_AAR_IMPORT_LABEL = "@build_bazel_rules_android//android:rules.bzl"
@@ -247,7 +285,7 @@ index 17c8d82205a15f..cb63b1f56b74e6 100644
  +    repository_ctx.file(
  +        "BUILD.vendor",
  +        (_BUILD_VENDOR).format(
-@@ -60,11 +65,11 @@ index c60c590..7b16164 100644
+@@ -60,11 +65,11 @@
  +    )
  +
       _add_outdated_files(repository_ctx, artifacts, repositories)
@@ -262,7 +300,7 @@ index 17c8d82205a15f..cb63b1f56b74e6 100644
       repository_ctx.report_progress("Generating BUILD targets..")
  -    (generated_imports, jar_versionless_target_labels) = parser.generate_imports(
  +    (generated_imports, jar_versionless_target_labels, _) = parser.generate_imports(
-@@ -72,7 +77,7 @@ index c60c590..7b16164 100644
+@@ -72,7 +77,7 @@
           dependencies = v2_lock_file.get_artifacts(lock_file_contents),
           explicit_artifacts = {
  diff --git a/private/dependency_tree_parser.bzl b/private/dependency_tree_parser.bzl
@@ -271,7 +309,7 @@ index 17c8d82205a15f..cb63b1f56b74e6 100644
  --- a/private/dependency_tree_parser.bzl
  +++ b/private/dependency_tree_parser.bzl
  @@ -76,7 +76,8 @@ def _generate_target(
-@@ -85,43 +90,43 @@ index 103fe5e..21159ed 100644
+@@ -85,43 +90,43 @@
       to_return = []
       simple_coord = strip_packaging_and_classifier_and_version(artifact["coordinates"])
       target_label = escape(simple_coord)
@@ -327,7 +365,7 @@ index 17c8d82205a15f..cb63b1f56b74e6 100644
                   testonly_artifacts,
                   default_visibilities,
                   artifact,
-@@ -131,15 +136,18 @@ index 103fe5e..21159ed 100644
+@@ -131,15 +136,18 @@
           else:  # artifact_path == None:
               # Special case for certain artifacts that only come with a POM file.
               # Such artifacts "aggregate" their dependencies, so they don't have
@@ -349,3 +387,6 @@ index 17c8d82205a15f..cb63b1f56b74e6 100644
 +-- 
 +2.49.0
 +
+-- 
+2.49.0
+

--- a/bazel7/riscv64.patch
+++ b/bazel7/riscv64.patch
@@ -1,15 +1,7 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -16,11 +16,17 @@ makedepends=('git' 'protobuf' 'python')
- options=('!debug' '!strip')
- source=(
-   "https://github.com/bazelbuild/bazel/releases/download/${pkgver}/bazel-${pkgver}-dist.zip"{,.sig}
-+  bazel7-riscv.diff
- )
- b2sums=('e8eaa780f5f985419db81124a9d36470443e5c70eb6f8dc1d850c40c739cb0a957c1a7102d7e9c465e75d7cc03c1effe8d0373338ee45a67ba623871f8bfd54d'
--        'SKIP')
-+        'SKIP'
-+        '66208f6013787f1fb1386f2f4d12291bfb10d8ee473dc99274f13e27c0512432bc08ccfae4945ae68bac45261137bb52303f7887a2b7cfbbb9581b828cc85632')
+@@ -21,6 +21,10 @@ b2sums=('e8eaa780f5f985419db81124a9d36470443e5c70eb6f8dc1d850c40c739cb0a957c1a71
+         'SKIP')
  validpgpkeys=('71A1D0EFCFEB6281FD0437C93D5919B448457EE0')
  
 +prepare() {
@@ -19,3 +11,11 @@
  build() {
    EMBED_LABEL=$pkgver EXTRA_BAZEL_ARGS="--tool_java_runtime_version=local_jdk" ./compile.sh
    ./output/bazel build scripts:bazel-complete.bash
+@@ -38,4 +42,7 @@ package() {
+     cp -r "${srcdir}/${d}" "${pkgdir}/usr/share/bazel/"
+   done
+ }
++
++source+=(bazel7-riscv.diff)
++b2sums+=('d65de7c58096d588be5964f52accbd65ee0f0c4e53c2021e4665089fed3f8a3a58e5d9fed5fa8c201ad391482a94a463eb8d33be53aa699f30cbfbc4afa3051c')
+ # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
- Bump abseil-cpp for https://github.com/abseil/abseil-cpp/pull/1644 , which fixes RDCYCLE SIGILL on linux >= 6.6.
- Make the patch less likely to rot as we might keep it for a while.