### PR TITLE
updpatch: bazel 8.1.1-1

### DIFF
--- a/bazel/riscv64.patch
+++ b/bazel/riscv64.patch
@@ -6,7 +6,7 @@
    "https://github.com/bazelbuild/bazel/releases/download/${pkgver}/bazel-${pkgver}-dist.zip"{,.sig}
 +  bazel-riscv.diff
  )
- b2sums=('76da69aa2ee53db5c2151d02cfc165489207883245b3e5b16a44020babac8eb8441beceef47f970e27b9897a1add3f4954e3ca5d3b2bed18b8493fe9ab036775'
+ b2sums=('8c8d98498d8ccbfd28e6fec91e4aff785be446393c2be408b4c9ff4135fba6b41cabfa7ca9f56b37acefe37c092d22c10374b3b35f46d79f417dd6fc6bac2756'
 -        'SKIP')
 +        'SKIP'
 +        '5434f4013aeb112ea2bcb0dc6620ad7539b2f7953d899e71129bdf00b3ce5c6d3cc10a96f294338dcda5232d2389c6da46c44cd2160f49a1f5827081cd5dddac')


### PR DESCRIPTION
- Fix rotten
- Upstreamed (8.x backport): https://github.com/bazelbuild/bazel/pull/25732