### PR TITLE
addpatch: apt-swarm 0.5.1-1

### DIFF
--- a/apt-swarm/riscv64.patch
+++ b/apt-swarm/riscv64.patch
@@ -1,0 +1,12 @@
+diff --git PKGBUILD PKGBUILD
+index 0b16b65..3591dae 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -13,6 +13,7 @@ depends=(
+ )
+ makedepends=(
+   'cargo'
++  'cmake'
+ )
+ backup=("etc/$pkgname.conf")
+ options=(!lto)


### PR DESCRIPTION
The compilation of cargo source code of package aws-lc-sys 0.27.1 does not support riscv64 assembly instructions, and only cmake build tool can be selected, so add cmake package.