### PR TITLE
addpatch: ncnn 20241226-5

### DIFF
--- a/ncnn/riscv64.patch
+++ b/ncnn/riscv64.patch
@@ -1,0 +1,21 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -28,10 +28,11 @@ build() {
+         -DCMAKE_BUILD_TYPE='None' \
+         -DCMAKE_INSTALL_PREFIX=/usr \
+         -DNCNN_SHARED_LIB=ON \
+-        -DNCNN_ENABLE_LTO=ON \
++        -DNCNN_ENABLE_LTO=OFF \
+         -DNCNN_VULKAN=ON \
+         -DNCNN_SYSTEM_GLSLANG=ON \
+         -DNCNN_BUILD_EXAMPLES=OFF \
++        -DNCNN_XTHEADVECTOR=OFF \
+         -DGLSLANG_TARGET_DIR=/usr/lib/cmake \
+         -Wno-dev
+     ninja -C build
+@@ -41,3 +42,5 @@ package() {
+     DESTDIR="$pkgdir" ninja -C build install
+     install -Dm644 "$srcdir"/ncnn/LICENSE.txt -t "$pkgdir"/usr/share/licenses/$pkgname/
+ }
++
++options+=(!lto)


### PR DESCRIPTION
Disable LTO and xtheadvector due to:
- `-march=rv64gcv` conflicts with LTO: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110812
- xtheadvector compilation fails without LTO (fixed in GCC 15 branch): https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116590