### PR TITLE
addpatch: mac 11.03-1

### DIFF
--- a/mac/fix-rvv-build.patch
+++ b/mac/fix-rvv-build.patch
@@ -1,0 +1,43 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b025f3d..3f3630b 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -31,8 +31,10 @@ set(archdetect_c_code "
+     #error cmake_ARCH ppc
+ #elif defined __ppc64__
+     #error cmake_ARCH ppc64
+-#elif defined __riscv
+-    #error cmake_ARCH riscv
++#elif defined __riscv && __riscv_xlen == 32
++    #error cmake_ARCH riscv32
++#elif defined __riscv && __riscv_xlen == 64
++    #error cmake_ARCH riscv64
+ #else
+     #error cmake_ARCH unknown
+ #endif
+@@ -204,6 +206,12 @@ if(${ARCHITECTURE} STREQUAL arm OR ${ARCHITECTURE} STREQUAL aarch64)
+         Source/MACLib/NNFilterNeon.cpp)
+ endif()
+ 
++if(${ARCHITECTURE} STREQUAL riscv32 OR ${ARCHITECTURE} STREQUAL riscv64)
++    set(MAC_LIBRARY_SOURCE_FILES
++        ${MAC_LIBRARY_SOURCE_FILES}
++        Source/MACLib/NNFilterRVV.cpp)
++endif()
++
+ #
+ # Define library targets
+ #
+@@ -260,6 +268,12 @@ if(${ARCHITECTURE} STREQUAL x86 OR ${ARCHITECTURE} STREQUAL x86_64)
+     endif()
+ endif()
+ 
++if(${ARCHITECTURE} STREQUAL riscv64)
++    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
++        set_source_files_properties(Source/MACLib/NNFilterRVV.cpp PROPERTIES COMPILE_FLAGS "-march=rv64gcv")
++    endif()
++endif()
++
+ #
+ # Set include folders
+ #

--- a/mac/riscv64.patch
+++ b/mac/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -42,3 +42,12 @@ package() {
+ 
+   install -vDm644 -t "$pkgdir/usr/share/licenses/$pkgname" LICENSE.md
+ }
++
++source+=(fix-rvv-build.patch)
++sha512sums+=('7831b22e068eca5c5f69fd27030cd0693a35fbe990f81a8c39bdd3fcf42967f8ba8c9ac69d03e5fc4d1097ad47d406a2514269fa9c4ae3632ac49ea6c4ff6f4e')
++b2sums+=('9b887c654844c36097aab1daf0aee91296c2ee0c4b266bc1fbdf2f65e6653ea73aa19ca2ef58eeef540936dcb75577583e62201a8d1b162116834f27fc6f1956')
++options+=(!lto)
++
++prepare() {
++  patch -Np1 -i fix-rvv-build.patch
++}


### PR DESCRIPTION
- Fix undefined reference to RVV functions, to be upstreamed via email
- Disable LTO since mixing rv64gc and rv64gcv objects conflicts with it