### PR TITLE
updpatch: qemu 9.2.3-1.1

### DIFF
--- a/qemu/riscv64.patch
+++ b/qemu/riscv64.patch
@@ -16,6 +16,15 @@
  source=(
    https://download.qemu.org/qemu-$pkgver.tar.xz{,.sig}
    bridge.conf
+@@ -209,7 +209,7 @@ _qemu_desktop_optdepends=(
+   'qemu-system-mips: for MIPS system emulator'
+   'qemu-system-or1k: for OpenRisc32 system emulator'
+   'qemu-system-ppc: for PPC system emulator'
+-  'qemu-system-riscv: for RISC-V system emulator'
++  'qemu-system-x86: for x86 system emulator'
+   'qemu-system-rx: for RX system emulator'
+   'qemu-system-s390x: for S390 system emulator'
+   'qemu-system-sh4: for SH4 system emulator'
 @@ -435,13 +435,6 @@ package_qemu-common() {
    # remove unneeded files
    find "$pkgdir" -name .buildinfo -delete
@@ -99,6 +108,15 @@
    mv -v $pkgname/* "$pkgdir"
    _install_licenses
  }
+@@ -1178,7 +1183,7 @@ package_qemu-base() {
+   depends=(
+     qemu-common=$pkgver-$pkgrel
+     qemu-img=$pkgver-$pkgrel
+-    qemu-system-x86=$pkgver-$pkgrel
++    qemu-system-riscv=$pkgver-$pkgrel
+     virtiofsd
+   )
+   optdepends=("${_qemu_base_optdepends[@]}")
 @@ -1227,7 +1232,6 @@ package_qemu-full() {
      qemu-tests=$pkgver-$pkgrel
      qemu-tools=$pkgver-$pkgrel


### PR DESCRIPTION
Change depends of qemu-base to qemu-system-riscv and move qemu-system-x86 to optdepends.