### PR TITLE
addpatch: libguestfs 1.54.1-3

### DIFF
--- a/libguestfs/fix-char-signedness.patch
+++ b/libguestfs/fix-char-signedness.patch
@@ -1,0 +1,27 @@
+From d7d5264ce8240fdbb712c110580b28b4913e38d2 Mon Sep 17 00:00:00 2001
+From: Jacob Reger <regerjacob@gmail.com>
+Date: Tue, 25 Feb 2025 09:00:40 -0800
+Subject: [PATCH] libguestfs: Rust binding build error and warning fixes
+
+Fixed break in Rust bindings where callback registering expected a
+*const i8, but were provided with a *const c_char. Changed to be both
+*const c_char in alignment with the libguestfs documentation.
+
+Signed-off-by: Jacob Reger <regerjacob@gmail.com>
+---
+ rust/src/event.rs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/rust/src/event.rs b/rust/src/event.rs
+index 72afd3cf67..156968a69d 100644
+--- a/rust/src/event.rs
++++ b/rust/src/event.rs
+@@ -29,7 +29,7 @@ type GuestfsEventCallback = extern "C" fn(
+     u64,
+     i32,
+     i32,
+-    *const i8,
++    *const c_char,
+     usize,
+     *const u64,
+     usize,

--- a/libguestfs/riscv64.patch
+++ b/libguestfs/riscv64.patch
@@ -1,0 +1,27 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -46,7 +46,6 @@ _appliancedeps=(
+   rsync
+   squashfs-tools
+   strace
+-  syslinux
+   systemd-sysvcompat
+   vim
+   xfsprogs
+@@ -132,6 +131,8 @@ prepare() {
+   # disable php tests, as missing arginfo definition makes them fail: https://github.com/libguestfs/libguestfs/issues/78
+   patch -Np1 -d $pkgname-$pkgver -i ../$pkgname-1.48.1-disable_php_tests.patch
+ 
++  patch -Np1 -d $pkgname-$pkgver -i ../fix-char-signedness.patch
++
+   cd $pkgname-$pkgver
+   autoreconf -fiv
+ }
+@@ -162,3 +163,7 @@ check() {
+ package() {
+   make INSTALLDIRS=vendor DESTDIR="$pkgdir" install -C $pkgname-$pkgver
+ }
++
++source+=(fix-char-signedness.patch)
++sha512sums+=('04df21407ab6c0b2415674f99cea4c2f17b3f62e563acd6b7201ea24f6c30369b118cca308b5b3a772cc0504d35ed558058f0a945c203290c907378a7b23b969')
++b2sums+=('4fedc82af6190e9478478d6ef9705d6e7c06a9dbfe06b5c7645edd0e66409b382248fb0efed585218ce1b241255f0cf107422f9a1bb6ca84d400d380303cd68b')


### PR DESCRIPTION
- Remove syslinux dependency, only available on x86
- Backport https://github.com/libguestfs/libguestfs/commit/d7d5264ce8240fdbb712c110580b28b4913e38d2
- Should be built after linux-lts and qemu, possibly with nocheck since tests run qemu-system-riscv64, too slow for machines without H extension