### PR TITLE
addpatch: libsrtp 1:2.7.0-1

### DIFF
--- a/libsrtp/riscv64.patch
+++ b/libsrtp/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index 561f187..56e67f2 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -46,7 +46,7 @@ build() {
+ }
+ 
+ check() {
+-  meson test -C build --print-errorlogs
++  meson test -C build --timeout-multiplier=120 --print-errorlogs
+ }
+ 
+ package_libsrtp() {


### PR DESCRIPTION
The source code has hundreds of thousands of function calls and some division operations that are not optimized. The riscv64 is significantly slower than the x86_64, resulting in a timeout error.