### PR TITLE
updpatch: amdvlk 2025.Q1.3-1

### DIFF
--- a/amdvlk/fix-stb_sprintf.patch
+++ b/amdvlk/fix-stb_sprintf.patch
@@ -1,0 +1,13 @@
+diff --git a/stb_sprintf.h b/stb_sprintf.h
+index ca432a6bca..2add83e2a5 100644
+--- a/stb_sprintf.h
++++ b/stb_sprintf.h
+@@ -230,7 +230,7 @@ STBSP__PUBLICDEC void STB_SPRINTF_DECORATE(set_separators)(char comma, char peri
+ #define stbsp__uint16 unsigned short
+ 
+ #ifndef stbsp__uintptr
+-#if defined(__ppc64__) || defined(__powerpc64__) || defined(__aarch64__) || defined(_M_X64) || defined(__x86_64__) || defined(__x86_64) || defined(__s390x__)
++#if defined(__ppc64__) || defined(__powerpc64__) || defined(__aarch64__) || defined(_M_X64) || defined(__x86_64__) || defined(__x86_64) || defined(__s390x__) || defined(__riscv) && __riscv_xlen == 64
+ #define stbsp__uintptr stbsp__uint64
+ #else
+ #define stbsp__uintptr stbsp__uint32

--- a/amdvlk/riscv64.patch
+++ b/amdvlk/riscv64.patch
@@ -10,9 +10,17 @@
  }
  
  build() {
-@@ -60,3 +63,5 @@ package() {
+@@ -39,6 +42,7 @@ build() {
+   cmake -H. -Bbuilds/Release64 \
+     -DCMAKE_BUILD_TYPE=Release \
+     -DBUILD_WAYLAND_SUPPORT=On \
++    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+     -G Ninja
+     
+   ninja -C builds/Release64
+@@ -60,3 +64,5 @@ package() {
    sed -i "s#/lib64#/lib#g" "${pkgdir}"/usr/share/vulkan/icd.d/amd_icd64.json
    sed -i "s#/lib64#/lib#g" "${pkgdir}"/usr/share/vulkan/implicit_layer.d/amd_icd64.json
  }
 +source+=("fix-stb_sprintf.patch::https://github.com/nothings/stb/pull/1517.diff")
-+sha256sums+=('adaac69864658e8af799cee6272ea6d3504c0021b8ba922e2c867d2cc9c0a62a')
++sha256sums+=('9e97e130813bd058bae57aadc1c451d0ba29db5deff821d050449460f5e2901c')


### PR DESCRIPTION
- Fix patch checksum (and keep it locally)
- Add `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` temporarily and reported to https://github.com/GPUOpen-Drivers/AMDVLK/issues/402