### PR TITLE
updpatch: meson 1.7.2-1

### DIFF
--- a/meson/riscv64.patch
+++ b/meson/riscv64.patch
@@ -1,8 +1,6 @@
-diff --git PKGBUILD PKGBUILD
-index 8acfbfd9..371f5b04 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -24,7 +24,6 @@ checkdepends=(
+@@ -28,7 +28,6 @@ checkdepends=(
    boost
    clang
    cmake
@@ -10,7 +8,7 @@ index 8acfbfd9..371f5b04 100644
    cython
    doxygen
    gcc-fortran
-@@ -36,18 +35,15 @@ checkdepends=(
+@@ -42,7 +41,6 @@ checkdepends=(
    graphviz
    gtest
    gtk-doc
@@ -18,10 +16,7 @@ index 8acfbfd9..371f5b04 100644
    gtk3
    gtkmm3
    hotdoc
-   itstool
--  java-environment=8
-   ldc
-   libelf
+@@ -54,7 +52,6 @@ checkdepends=(
    libwmf
    llvm
    mercurial
@@ -29,11 +24,11 @@ index 8acfbfd9..371f5b04 100644
    nasm
    netcdf-fortran
    openmpi
-@@ -61,7 +57,6 @@ checkdepends=(
-   rust-bindgen
+@@ -72,6 +69,7 @@ checkdepends=(
    sdl2
    vala
--  valgrind
+   valgrind
++  vulkan-headers
    vulkan-validation-layers
+   wayland-protocols
    wxgtk3
- )


### PR DESCRIPTION
- Add back java-environment=8
- Enable valgrind tests
- Add missing checkdepends vulkan-headers: https://gitlab.archlinux.org/archlinux/packaging/packages/meson/-/merge_requests/2