### PR TITLE
addpatch: binutils 2.44-1

### DIFF
--- a/binutils/riscv64.patch
+++ b/binutils/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index db8ef95..427c387 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -60,7 +60,7 @@
+     --prefix=/usr \
+     --sysconfdir="${pkgdir}"/etc \
+     --with-lib-path=/usr/lib:/usr/local/lib \
+-    --with-bugurl=https://gitlab.archlinux.org/archlinux/packaging/packages/binutils/-/issues \
++    --with-bugurl=https://github.com/felixonmars/archriscv-packages/issues \
+     --enable-cet \
+     --enable-colored-disassembly \
+     --enable-default-execstack=no \


### PR DESCRIPTION
Set bugurl to our repo so user facing bug won't distrub Arch Linux.