### PR TITLE
addpatch: brook 20230122-1

### DIFF
--- a/brook/riscv64.patch
+++ b/brook/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,6 +14,12 @@ makedepends=('go' 'git')
+ source=("git+https://github.com/txthinking/brook.git#tag=v$pkgver")
+ sha512sums=('2c9706c81a5869ef7770287414e182d0b38b9294f74113c3e8d1ae22516a8a85e8934ef406f16fd3ade690bef8e5fe6405bbd4b7a14b729b8d21e2dc2adf4333')
+ 
++prepare() {
++  cd brook
++  go mod edit --replace github.com/phuslu/iploc=github.com/phuslu/iploc@561ab243be39d72d4add0439943ae00c61340100
++  go mod tidy
++}
++
+ build() {
+   export CGO_CPPFLAGS="${CPPFLAGS}"
+   export CGO_CFLAGS="${CFLAGS}"


### PR DESCRIPTION
Update `github.com/phuslu/iploc` to support riscv64

Upstreamed: https://github.com/txthinking/brook/issues/1378