### PR TITLE
addpatch: telepathy-salut 0.8.1-10

### DIFF
--- a/telepathy-salut/riscv64.patch
+++ b/telepathy-salut/riscv64.patch
@@ -1,0 +1,16 @@
+diff --git PKGBUILD PKGBUILD
+index dca2c3d..e72fea1 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -31,7 +31,10 @@ prepare() {
+ 
+ build() {
+     cd "$pkgname-$pkgver"
+-    ./configure --prefix=/usr \
++    ./configure \
++        --build=riscv64-unknown-linux-gnu \
++        --host=riscv64-unknown-linux-gnu \
++        --prefix=/usr \
+         --libexecdir=/usr/lib/telepathy \
+         --disable-plugins --disable-Werror \
+         --with-tls=gnutls \


### PR DESCRIPTION
The config.guess / config.sub included in the package is too old and does not recognize riscv64.