### PR TITLE
addpatch: telepathy-gabble 0.18.4

### DIFF
--- a/telepathy-gabble/riscv64.patch
+++ b/telepathy-gabble/riscv64.patch
@@ -1,0 +1,16 @@
+diff --git PKGBUILD PKGBUILD
+index 27837cf..9401a24 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -43,7 +43,10 @@ prepare() {
+ 
+ build() {
+   cd $pkgname-$pkgver
+-  ./configure --prefix=/usr \
++  ./configure \
++    --build=riscv64-unknown-linux-gnu \
++    --host=riscv64-unknown-linux-gnu \
++    --prefix=/usr \
+     --libexecdir=/usr/lib/telepathy \
+     --disable-Werror --enable-gtk-doc
+   sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool


### PR DESCRIPTION
The config.guess / config.sub included in the package is too old and does not recognize riscv64.According to the original PKGBUILD, autoreconf was used in the prepare stage, but it didn't work.