### PR TITLE
updpatch: chromium 136.0.7103.59-1

### DIFF
--- a/chromium/riscv64.patch
+++ b/chromium/riscv64.patch
@@ -9,17 +9,18 @@
  optdepends=('pipewire: WebRTC desktop sharing under Wayland'
              'kdialog: support for native dialogs in Plasma'
              'gtk4: for --gtk-version=4 (GTK4 IME might work better on Wayland)'
-@@ -41,7 +41,17 @@ sha256sums=('bc07d4b8f8377a218a2f5b5c5ae8276535650b2a524706d4959ed54322874950'
-             'd3dd9b4132c9748b824f3dcf730ec998c0087438db902bc358b3c391658bebf5'
-             'b3de01b7df227478687d7517f61a777450dca765756002c80c4915f271e2d961'
+@@ -41,7 +41,18 @@ sha256sums=('a124a9bc3f6f3e24fa97c5ec59d94a040b774a8fbca2e1196bf39b240f0d42f2'
+             'cc8a71a312e9314743c289b7b8fddcc80350a31445d335f726bb2e68edf916d1'
              'd634d2ce1fc63da7ac41f432b1e84c59b7cceabf19d510848a7cff40c8025342'
+             'd6f3914c6adadaf061e7e2b1430c96d32b0cad05244b5cfaf58cf5344006a169'
 -            'e6da901e4d0860058dc2f90c6bbcdc38a0cf4b0a69122000f62204f24fa7e374')
 +            'e6da901e4d0860058dc2f90c6bbcdc38a0cf4b0a69122000f62204f24fa7e374'
 +            '2ea949ed1d20a1745ce72f760a7d9297dc0002a747c4bd53e243c4d58ba2c7ca'
 +            '5689e9422624c8725509b6fdc277e20c3e8862cf515656faef7507978489bc4e'
 +            '407f3b7fc060565b77ef836ea9ea3a338ad160353d6d0ea25971098b075ecb24'
-+            'f9268dfef93ec49ef39f8e51b3b76cf7b0b2a513ecd329f17b19bf51a48653f1'
++            '0b2f0442ac109669959c342df20afdff61b50231c8541d4c1a1f5262b4751de0'
 +            'e670453e11b1b6dea17e1a9bd8fd0f81b7c98e35d750599ba082bd4f8f15c026'
++            '5b2a0a43f4d9eb3515a24930d27981b3019c5a27cedb6ee05b7974805580d5d1'
 +            '35a710ee8b7047ff4976281ea127fe33c58861f2b94d0d979798478baa7130ab'
 +            '9b03cd0430c70be9d90705f3d2ebe2d8a982b57bafb419371c0658d76f24f99e'
 +            '3eb5e621757be3f2984acb76d16cf3571bfe5bbbc71ad230b21aa983041ff5ea'
@@ -28,25 +29,26 @@
  
  if (( _manual_clone )); then
    source[0]=fetch-chromium-release
-@@ -120,6 +130,30 @@ prepare() {
-   # Increase _FORTIFY_SOURCE level to match Arch's default flags
-   patch -Np1 -i ../increase-fortify-level.patch
+@@ -124,6 +135,31 @@ prepare() {
+   # Disable usage of --warning-suppression-mappings flag which needs clang 20
+   patch -Np1 -i ../disable-clang-warning-suppression-flag.patch
  
 +  # RISC-V
 +  patch -Np1 -i ../riscv-chromium-variations-133.patch
 +  patch -Np0 -i ../swiftshader-use-llvm16.patch
 +  patch -Np0 -i ../Debian-fix-rust-linking.patch
 +  patch -Np1 -i ../highway-disable-rvv.patch
-+  # pushd v8
-+  # popd
++  pushd v8
++  patch -Np1 -i "${srcdir}"/0001-riscv-Fix-the-RISC-V-build.patch
++  popd
 +
-+  for rvpatch in riscv-{dav1d,sandbox-135}.patch; do
++  for rvpatch in riscv-{dav1d,sandbox-136}.patch; do
 +    patch -Np1 -i ../$rvpatch
 +  done
 +  patch -Np0 -i ../compiler-rt-riscv.patch
 +  patch -Np1 -i ../0001-chrome-runtime_api_delegate-add-riscv64-define.patch
 +  patch -Np1 -i ../0001-extensions-common-api-runtime.json-riscv64-support.patch
-+  patch -Np1 -d third_party/ffmpeg < ../riscv-ffmpeg-135.patch
++  patch -Np1 -d third_party/ffmpeg < ../riscv-ffmpeg-136.patch
 +
 +  pushd third_party/node/
 +  sed -i -e 's/@rollup/rollup/' -e "s/'wasm-node',//" node_modules.py
@@ -59,8 +61,8 @@
    # Fixes for building with libstdc++ instead of libc++
  
    # Link to system tools required by the build
-@@ -140,6 +174,25 @@ prepare() {
-     sed -i 's/adler2/adler/' build/rust/std/BUILD.gn
+@@ -140,6 +176,25 @@ prepare() {
+     ./tools/clang/scripts/update.py
    fi
  
 +  pushd third_party/devtools-frontend/src
@@ -85,7 +87,7 @@
    # Remove bundled libraries for which we will use the system copies; this
    # *should* do what the remove_bundled_libraries.py script does, with the
    # added benefit of not having to list all the remaining libraries
-@@ -195,6 +248,7 @@ build() {
+@@ -195,6 +250,7 @@ build() {
      'enable_nacl=false'
      'use_qt5=true'
      'use_qt6=true'
@@ -93,17 +95,17 @@
      'moc_qt6_path="/usr/lib/qt6"'
      "google_api_key=\"$_google_api_key\""
    )
-@@ -328,4 +382,17 @@ package() {
+@@ -328,4 +384,17 @@ package() {
    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/chromium/LICENSE"
  }
  
-+_riscv_fork_patches='https://github.com/riscv-forks/electron/raw/7ebbb543e0bb538b5c1b9f0e4b9add718dbbdfbc/patches/'
++_riscv_fork_patches='https://github.com/riscv-forks/electron/raw/abf9343fc68bf384126837e72da9fa9670784690/patches/'
 +source+=(swiftshader-use-llvm16.patch
 +         riscv-dav1d.patch
-+         riscv-sandbox-135.patch::${_riscv_fork_patches}/chromium/0002-Add-support-for-riscv64-linux.patch
-+         riscv-ffmpeg-135.patch::${_riscv_fork_patches}/ffmpeg/0001-ffmpeg-generate-riscv64-changes.patch
++         riscv-sandbox-136.patch::${_riscv_fork_patches}/chromium/0002-Add-support-for-riscv64-linux.patch
++         riscv-ffmpeg-136.patch::${_riscv_fork_patches}/ffmpeg/0001-ffmpeg-generate-riscv64-changes.patch
 +         highway-disable-rvv.patch::${_riscv_fork_patches}/chromium/0001-disable-rvv-in-highway-due-to-broken-runtime-dispatc.patch
-+         #${_riscv_fork_patches}/v8/0001-riscv-leaptiering-Enable-leaptiering-support.patch
++         ${_riscv_fork_patches}/v8/0001-riscv-Fix-the-RISC-V-build.patch
 +         riscv-chromium-variations-133.patch
 +         compiler-rt-riscv.patch
 +         Debian-fix-rust-linking.patch


### PR DESCRIPTION
- Update chromium riscv patchset for 136. See https://github.com/riscv-forks/electron/commit/abf9343fc68bf384126837e72da9fa9670784690 for more details
- Tested on centiskorch