### PR TITLE
updpatch: diffoscope 294-1

### DIFF
--- a/diffoscope/riscv64.patch
+++ b/diffoscope/riscv64.patch
@@ -1,13 +1,13 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -63,8 +63,8 @@ optdepends=(
- makedepends=('help2man' 'python-docutils' 'git' 'python-setuptools')
+@@ -79,8 +79,8 @@ makedepends=(
+ )
  checkdepends=(
-   'python-pytest' 'python-jsbeautifier' 'python-h5py' 'acl' 'binutils' 'bzip2' 'cdrtools' 'cpio' 'diffutils' 'e2fsprogs' 'enjarify'
+   'python-pytest' 'python-jsbeautifier' 'python-h5py' 'acl' 'binutils' 'bzip2' 'cdrtools' 'cpio' 'e2fsprogs' 'enjarify'
 -  'hdf5' 'imagemagick' 'java-environment=11' 'fontforge' 'gettext' 'ghc' 'gnupg' 'mono' 'pgpdump' 'poppler' 'sqlite' 'squashfs-tools'
 -  'libxmlb' 'lz4' 'unzip' 'gzip' 'tar' 'tcpdump' 'vim' 'xz' 'llvm' 'colord' 'fpc' 'openssh' 'openssl' 'odt2txt' 'docx2txt' 'r' 'dtc'
 +  'hdf5' 'imagemagick' 'java-environment=11' 'fontforge' 'gettext' 'ghc' 'gnupg' 'pgpdump' 'poppler' 'sqlite' 'squashfs-tools'
 +  'libxmlb' 'lz4' 'unzip' 'gzip' 'tar' 'tcpdump' 'vim' 'xz' 'llvm' 'colord' 'openssh' 'openssl' 'odt2txt' 'docx2txt' 'r' 'dtc'
-   'giflib' 'gnumeric' 'python-progressbar' 'binwalk' 'python-argcomplete' 'zstd' 'uboot-tools')
+   'giflib' 'gnumeric' 'python-progressbar' 'binwalk' 'python-argcomplete' 'zstd' 'uboot-tools' 'asar')
  source=(https://diffoscope.org/archive/diffoscope-${pkgver}.tar.bz2{,.asc})
- sha512sums=('ebe3a40dd0a0325948ba44e8d67799229c2a868f8f1a7dfad2a138a254cfd144eb2890292d2b8c381edc7ca7ea92fb7f804f67f92aa16e6e90c2cf2231c3491e'
+ sha512sums=('6333edd3143760302156da80672bdabdf2f9f3d4fe9e5d7f5d7d070c34069ed00b0aec44aa6e9104f1880b647219778be410fdb7e34a3a90fdb823f21d6d2ad1'


### PR DESCRIPTION
- Fix rotten
- check() fails due to missing libxml2.so.2. `--nocheck` is needed or just wait for libxml2 rebuild to be finished.