### PR TITLE
addpatch: gdl 3.40.0-2

### DIFF
--- a/gdl/riscv64.patch
+++ b/gdl/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index 8298bb5..10429fe 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -31,7 +31,7 @@
+   # Fix build with libxml2 2.12
+   git cherry-pick -n 414f83eb4ad9e5576ee3d089594bf1301ff24091
+ 
+-  autoreconf -fvi
++  autoreconf -fvi -I /usr/share/gettext/m4
+ }
+ 
+ build() {


### PR DESCRIPTION
In gettext 0.24.1-1 the m4 files have moved from /usr/share/aclocal/ to /usr/share/gettext/m4.

https://gitlab.archlinux.org/archlinux/packaging/packages/gdl/-/merge_requests/1