### PR TITLE
rmvpatch: apache-orc 2.0.3-6

### DIFF
--- a/apache-orc/riscv64.patch
+++ b/apache-orc/riscv64.patch
@@ -1,8 +1,0 @@
---- PKGBUILD
-+++ PKGBUILD
-@@ -55,3 +55,5 @@ check(){
- package(){
-   make DESTDIR="${pkgdir}" -C build install
- }
-+
-+source=(https://archive.apache.org/dist/${_pkg}/${_pkg}-${pkgver}/${_pkg}-${pkgver}.tar.gz{,.asc})


### PR DESCRIPTION
No longer needed.