### PR TITLE
updpatch: ghc 9.4.8-1

### DIFF
--- a/ghc/0001-rts-posix-OSMem-Shrinking-allocation-size-when-it-s-.patch
+++ b/ghc/0001-rts-posix-OSMem-Shrinking-allocation-size-when-it-s-.patch
@@ -1,0 +1,106 @@
+From 96a3727f4a26844b0081861e426e5a66e44fe279 Mon Sep 17 00:00:00 2001
+From: Yao Zi <ziyao@disroot.org>
+Date: Sat, 17 May 2025 08:02:08 -0400
+Subject: [PATCH] rts: posix: OSMem: Shrinking allocation size when it's
+ unresonable
+
+On architectures with a small virtual address spaces like RISC-V systems
+utilizing SV39 configuration, osReserveHeapMemory() may successfully
+mmap a memory chunk whose size just fits in the whole userspace address
+space, in which case the hint isn't respected.
+
+If the randomized address layout occasionally allows the allocated
+memory to start below minimumAddress (typically 8GiB),
+osReserveHeapMemory() will adjust the mmap hint towards high-end without
+shrinking the desired allocated size.
+
+Since the only possible region covers almost the whole address space,
+subsequent trials of allocation with only hint increased and size left
+unchanged will always result in the same memory region, never
+satisifying the requirement of minimumAddress, and finally leading to a
+dead loop.
+
+This patch improves the logic when mmapping succeeds but minimumAddress
+isn't satisified. In this case, we first check whether the combination
+of hint and size is reasonable on the system by requesting a page at the
+end of the desired allocated region with MAP_FIXED_NO_REPLACE.
+
+If the checking request fails with an errno other than EEXIST, we could
+know that the system isn't able to handle the desired allocation. This
+patch will decrease the size a little and retry, avoiding the dead loop
+of allocate -> requirements not satisified -> increase hint -> allocate
+and get the same memory region again.
+
+Signed-off-by: Yao Zi <ziyao@disroot.org>
+---
+ rts/posix/OSMem.c | 34 ++++++++++++++++++++++++++++++++--
+ 1 file changed, 32 insertions(+), 2 deletions(-)
+
+diff --git a/rts/posix/OSMem.c b/rts/posix/OSMem.c
+index 822546d..a1c94ca 100644
+--- a/rts/posix/OSMem.c
++++ b/rts/posix/OSMem.c
+@@ -508,8 +508,30 @@ osTryReserveHeapMemory (W_ len, void *hint)
+     return start;
+ }
+ 
++static int check_allocation_reasonable(W_ start, size_t size, size_t pageSize)
++{
++    /*
++     * Allocate only one page with MAP_FIXED_NOREPLACE. Failures with errnos
++     * different from EEXIST suggests the allocation isn't reasonable on the
++     * system.
++     */
++    void *addr = (void *)(start + size);
++    void *ptr = mmap(addr, pageSize, PROT_READ,
++                     MAP_PRIVATE | MAP_FIXED_NOREPLACE | MAP_ANONYMOUS, -1, 0);
++    if (ptr == MAP_FAILED && errno != EEXIST) {
++        return 0;
++    }
++
++    if (munmap(ptr, pageSize) < 0) {
++        sysErrorBelch("unable to release mapped page");
++    }
++
++    return 1;
++}
++
+ void *osReserveHeapMemory(void *startAddressPtr, W_ *len)
+ {
++    size_t pageSize = getPageSize();
+     int attempt;
+     void *at;
+ 
+@@ -580,7 +602,6 @@ void *osReserveHeapMemory(void *startAddressPtr, W_ *len)
+             stg_exit(EXIT_FAILURE);
+         }
+ 
+-        size_t pageSize = getPageSize();
+         // 2/3rds of limit, round down to multiple of PAGE_SIZE
+         *len = (W_) (asLimit.rlim_cur * 0.666) & ~(pageSize - 1);
+ 
+@@ -630,11 +651,20 @@ void *osReserveHeapMemory(void *startAddressPtr, W_ *len)
+             break;
+         } else {
+             // We got addressing space but it wasn't above the 8GB mark.
+-            // Try again.
+             if (munmap(at, *len) < 0) {
+                 sysErrorBelch("unable to release reserved heap");
+             }
++
++            // If we're performing an allocation with unreasonble size, shrink
++            // the size instead of moving the base address up.
++            if (!check_allocation_reasonable((W_)hint, *len, pageSize)) {
++                *len -= *len / 8;
++                continue;
++            }
++
++            // Otherwise, try again with hint adjusted.
+         }
++
+         attempt++;
+     }
+ 
+-- 
+2.49.0
+

--- a/ghc/riscv64.patch
+++ b/ghc/riscv64.patch
@@ -1,17 +1,33 @@
-diff --git PKGBUILD PKGBUILD
-index c7828b0..d763b43 100644
+diff --git a/PKGBUILD b/PKGBUILD
+index c7828b0..1028d32 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -19,7 +19,7 @@ url='https://www.haskell.org/ghc/'
+@@ -19,17 +19,21 @@ url='https://www.haskell.org/ghc/'
  license=('custom')
  makedepends=('ghc-static' 'perl' 'libxslt' 'docbook-xsl' 'python-sphinx' 'haskell-hadrian'
               'haskell-hscolour' 'texlive-fontsrecommended' 'texlive-latexextra' 'texlive-xetex'
 -             'ttf-dejavu' 'alex' 'happy' 'time' 'numactl' 'python-sphinx_rtd_theme')
 +             'ttf-dejavu' 'alex' 'happy' 'time' 'numactl' 'python-sphinx_rtd_theme' 'llvm14')
  source=("https://downloads.haskell.org/~ghc/$pkgver/$pkgbase-${pkgver}-src.tar.xz"
-         ghc-rebuild-doc-index.hook ghc-register.hook ghc-unregister.hook)
+-        ghc-rebuild-doc-index.hook ghc-register.hook ghc-unregister.hook)
++        ghc-rebuild-doc-index.hook ghc-register.hook ghc-unregister.hook
++        0001-rts-posix-OSMem-Shrinking-allocation-size-when-it-s-.patch)
  sha512sums=('e5cfb30adc73dc0054f5db2921e5f255c8a980e005798882a2e9daa8df2409ddbe1ec6403e1f6862efc9e4700db4b68d5cae36999d77c7d3fd2fe0ab51cb9923'
-@@ -75,7 +75,7 @@ package_ghc-static() {
+             'd69e5222d1169c4224a2b69a13e57fdd574cb1b5932b15f4bc6c7d269a9658dd87acb1be81f52fbcf3cb64f96978b9943d10cee2c21bff0565aaa93a5d35fcae'
+             '5f659651d8e562a4dcaae0f821d272d6e9c648b645b1d6ab1af61e4dd690dc5a4b9c6846753b7f935963f001bb1ae1f40cd77731b71ef5a8dbc079a360aa3f8f'
+-            '3bdbd05c4a2c4fce4adf6802ff99b1088bdfad63da9ebfc470af9e271c3dd796f86fba1cf319d8f4078054d85c6d9e6a01f79994559f24cc77ee1a25724af2e6')
++            '3bdbd05c4a2c4fce4adf6802ff99b1088bdfad63da9ebfc470af9e271c3dd796f86fba1cf319d8f4078054d85c6d9e6a01f79994559f24cc77ee1a25724af2e6'
++            '5000bda406e1c5bf66d29f39b61f2334b197ed631b06792f5547d4249200ceba04c4b809483f2bb7549d5bf876ab2ef885fb688eff084c89822c9d62823c1ca0')
+ 
+ prepare() {
+   cd ghc-$pkgver
+ 
++  patch -p1 < 0001-rts-posix-OSMem-Shrinking-allocation-size-when-it-s-.patch
++
+   # devendor rtd-theme for sphinx compatibility
+   rm -r docs/users_guide/rtd-theme
+   sed -i 's/rtd-theme/sphinx_rtd_theme/' docs/users_guide/conf.py
+@@ -75,7 +79,7 @@ package_ghc-static() {
  
  package_ghc() {
    pkgdesc='The Glasgow Haskell Compiler'


### PR DESCRIPTION
This should solve random hangs in RTS when running GHC-compiled programs with newer Linux kernels. The RTS patch should be upstreamed after cleaning up.