### PR TITLE
updpatch: ghc 9.4.8-1.3

### DIFF
--- a/ghc/riscv64.patch
+++ b/ghc/riscv64.patch
@@ -1,8 +1,8 @@
-diff --git a/PKGBUILD b/PKGBUILD
-index c7828b0..1028d32 100644
+diff --git PKGBUILD PKGBUILD
+index c7828b0..24f2c71 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -19,17 +19,21 @@ url='https://www.haskell.org/ghc/'
+@@ -19,17 +19,24 @@ url='https://www.haskell.org/ghc/'
  license=('custom')
  makedepends=('ghc-static' 'perl' 'libxslt' 'docbook-xsl' 'python-sphinx' 'haskell-hadrian'
               'haskell-hscolour' 'texlive-fontsrecommended' 'texlive-latexextra' 'texlive-xetex'
@@ -11,23 +11,26 @@ index c7828b0..1028d32 100644
  source=("https://downloads.haskell.org/~ghc/$pkgver/$pkgbase-${pkgver}-src.tar.xz"
 -        ghc-rebuild-doc-index.hook ghc-register.hook ghc-unregister.hook)
 +        ghc-rebuild-doc-index.hook ghc-register.hook ghc-unregister.hook
-+        0001-rts-posix-OSMem-Shrinking-allocation-size-when-it-s-.patch)
++        0001-rts-posix-OSMem-Shrinking-allocation-size-when-it-s-.patch
++        $pkgbase-fix-c-output-for-modern-c-initiative.patch::https://gitlab.haskell.org/ghc/ghc/-/commit/a5a7a0cead6de89648d3a7323c2dc64c59a830fc.patch)
  sha512sums=('e5cfb30adc73dc0054f5db2921e5f255c8a980e005798882a2e9daa8df2409ddbe1ec6403e1f6862efc9e4700db4b68d5cae36999d77c7d3fd2fe0ab51cb9923'
              'd69e5222d1169c4224a2b69a13e57fdd574cb1b5932b15f4bc6c7d269a9658dd87acb1be81f52fbcf3cb64f96978b9943d10cee2c21bff0565aaa93a5d35fcae'
              '5f659651d8e562a4dcaae0f821d272d6e9c648b645b1d6ab1af61e4dd690dc5a4b9c6846753b7f935963f001bb1ae1f40cd77731b71ef5a8dbc079a360aa3f8f'
 -            '3bdbd05c4a2c4fce4adf6802ff99b1088bdfad63da9ebfc470af9e271c3dd796f86fba1cf319d8f4078054d85c6d9e6a01f79994559f24cc77ee1a25724af2e6')
 +            '3bdbd05c4a2c4fce4adf6802ff99b1088bdfad63da9ebfc470af9e271c3dd796f86fba1cf319d8f4078054d85c6d9e6a01f79994559f24cc77ee1a25724af2e6'
-+            '5000bda406e1c5bf66d29f39b61f2334b197ed631b06792f5547d4249200ceba04c4b809483f2bb7549d5bf876ab2ef885fb688eff084c89822c9d62823c1ca0')
++            '5000bda406e1c5bf66d29f39b61f2334b197ed631b06792f5547d4249200ceba04c4b809483f2bb7549d5bf876ab2ef885fb688eff084c89822c9d62823c1ca0'
++            'a85c11a75bcf4c6eca9cae7d850cdab9b6424633ff6744f0a9b233daced5e71a9ecaf30cd6789da0b7b189fd85048365427e636d9f04a3a3097f8532af80d13c')
  
  prepare() {
    cd ghc-$pkgver
  
-+  patch -p1 < 0001-rts-posix-OSMem-Shrinking-allocation-size-when-it-s-.patch
++  patch -p1 < ../0001-rts-posix-OSMem-Shrinking-allocation-size-when-it-s-.patch
++  patch compiler/GHC/HsToCore/Foreign/Decl.hs ../$pkgbase-fix-c-output-for-modern-c-initiative.patch
 +
    # devendor rtd-theme for sphinx compatibility
    rm -r docs/users_guide/rtd-theme
    sed -i 's/rtd-theme/sphinx_rtd_theme/' docs/users_guide/conf.py
-@@ -75,7 +79,7 @@ package_ghc-static() {
+@@ -75,7 +82,7 @@ package_ghc-static() {
  
  package_ghc() {
    pkgdesc='The Glasgow Haskell Compiler'


### PR DESCRIPTION
- Apply patch to fix build of gi-glib.
- Fix path for previous patch.