### PR TITLE
addpatch: gcc14 14.2.1+r753+g1cd744a6828f-3

### DIFF
--- a/gcc14/riscv64.patch
+++ b/gcc14/riscv64.patch
@@ -1,0 +1,86 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -18,7 +18,6 @@ url='https://gcc.gnu.org'
+ makedepends=(
+   binutils
+   doxygen
+-  gcc-ada
+   gcc-d
+   git
+   libisl
+@@ -37,6 +36,7 @@ options=(!emptydirs !lto)
+ _libdir=usr/lib/gcc/$CHOST/${pkgver%%+*}
+ source=(gcc14::git+https://sourceware.org/git/gcc.git#commit=${_commit}
+         c89 c99
++        unfilter-default-library-path.patch
+ )
+ validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
+               86CFFCA918CF3AF47147588051E8B148A9999C34  # foutrelis@archlinux.org
+@@ -44,7 +44,8 @@ validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.
+               D3A93CAD751C2AF4F8C7AD516C35B99309B5FA62) # Jakub Jelinek <jakub@redhat.com>
+ sha256sums=('33378643f1c72686181f9d3fcd09caf9b06815324467f5dc9b9a3ea41cfba4b4'
+             '7b09ec947f90b98315397af675369a1e3dfc527fa70013062e6e85c4be0275ab'
+-            '44ea973558842f3f4bd666bdaf6e810fd7b7c7bd36b5cc4c69f93d2cd0124fc7')
++            '44ea973558842f3f4bd666bdaf6e810fd7b7c7bd36b5cc4c69f93d2cd0124fc7'
++            '7183fdeea8fd148cf9dd03b0932f9d439b818a5ab3bc9a5e20d8e0b41c9e0efd')
+ 
+ pkgver() {
+   cd gcc14
+@@ -60,6 +61,12 @@ prepare() {
+   # Arch Linux installs x86_64 libraries /lib
+   sed -i '/m64=/s/lib64/lib/' gcc/config/i386/t-linux64
+ 
++  # Remove codes filtering default library paths to make mold work correctly
++  patch -Np1 < ../unfilter-default-library-path.patch
++
++  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=119012
++  git revert -n 3228df20cfa3581015dc32657eb17d6f24af3104
++
+   mkdir -p "$srcdir/gcc-build"
+ }
+ 
+@@ -70,8 +77,8 @@ build() {
+       --libexecdir=/usr/lib
+       --mandir=/usr/share/man
+       --infodir=/usr/share/info
+-      --with-bugurl=https://gitlab.archlinux.org/archlinux/packaging/packages/gcc14/-/issues
+-      --with-build-config=bootstrap-lto
++      --with-bugurl=https://github.com/felixonmars/archriscv-packages/issues
++      --with-build-config=bootstrap-lto-lean
+       --with-linker-hash-style=gnu
+       --with-system-zlib
+       --enable-__cxa_atexit
+@@ -136,8 +143,6 @@ package_gcc14-libs() {
+ 
+   cd gcc-build
+   make -C $CHOST/libgcc DESTDIR="$pkgdir" install-shared
+-  mv "${pkgdir}/${_libdir}"/../lib/* "${pkgdir}/${_libdir}"
+-  rmdir "${pkgdir}/${_libdir}"/../lib
+   rm -f "$pkgdir/$_libdir/libgcc_eh.a"
+ 
+   for lib in libasan.so \
+@@ -148,7 +153,6 @@ package_gcc14-libs() {
+              liblsan.so \
+              libquadmath.so \
+              libstdc++.so \
+-             libtsan.so \
+              libubsan.so; do
+     ln -s /usr/lib/$lib "$pkgdir/$_libdir/$lib"
+   done
+@@ -180,7 +184,6 @@ package_gcc14() {
+ 
+   make -C $CHOST/libgcc DESTDIR="$pkgdir" install
+   rm -f "${pkgdir}/${_libdir}"/../lib/libgcc_s.so*
+-  rmdir "${pkgdir}/${_libdir}"/../lib
+ 
+   make -C $CHOST/libstdc++-v3/src DESTDIR="$pkgdir" install
+   make -C $CHOST/libstdc++-v3/include DESTDIR="$pkgdir" install
+@@ -213,7 +216,7 @@ package_gcc14() {
+   # create cc-rs compatible symlinks
+   # https://github.com/rust-lang/cc-rs/blob/1.0.73/src/lib.rs#L2578-L2581
+   for binary in {c++,g++,gcc,gcc-ar,gcc-nm,gcc-ranlib}; do
+-    ln -s /usr/bin/${binary} "${pkgdir}"/usr/bin/x86_64-linux-gnu-${binary}-14
++    ln -s /usr/bin/${binary} "${pkgdir}"/usr/bin/riscv64-linux-gnu-${binary}-14
+   done
+ 
+   # POSIX conformance launcher scripts for c89 and c99

--- a/gcc14/unfilter-default-library-path.patch
+++ b/gcc14/unfilter-default-library-path.patch
@@ -1,0 +1,22 @@
+diff --git a/gcc/gcc.cc b/gcc/gcc.cc
+index 16bb07f2cdc..1beb23ba279 100644
+--- a/gcc/gcc.cc
++++ b/gcc/gcc.cc
+@@ -7904,17 +7904,6 @@ is_directory (const char *path1, bool linker)
+   *cp++ = '.';
+   *cp = '\0';
+ 
+-  /* Exclude directories that the linker is known to search.  */
+-  if (linker
+-      && IS_DIR_SEPARATOR (path[0])
+-      && ((cp - path == 6
+-	   && filename_ncmp (path + 1, "lib", 3) == 0)
+-	  || (cp - path == 10
+-	      && filename_ncmp (path + 1, "usr", 3) == 0
+-	      && IS_DIR_SEPARATOR (path[4])
+-	      && filename_ncmp (path + 5, "lib", 3) == 0)))
+-    return 0;
+-
+   return (stat (path, &st) >= 0 && S_ISDIR (st.st_mode));
+ }
+ 


### PR DESCRIPTION
- Initialize patch for gcc14 based on gcc and gcc13 patches.
- Use `bootstrap-lto-lean` build config to workaround gcc self-miscompliation bug (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=119012).
  - Previously reverting a commit could work around it, but now it is no longer the case.