### PR TITLE
qemu-user-blacklist: add hwloc

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -53,6 +53,7 @@ gupnp-igd
 gxplugins.lv2
 haskell-pandoc
 haxe
+hwloc
 hyperfine
 iaito
 ihaskell


### PR DESCRIPTION
Seems lstopo and hwloc-gather-topology returns slightly different information on qemu-user:

```
# tests/hwloc/linux/gather/test-suite.log
Extracting tarball...
Saving tarball topology to XML...
Comparing XML outputs...
--- save1.xml   2025-05-23 04:07:24.771914250 +0000
+++ save2.xml   2025-05-23 04:11:10.844166135 +0000
@@ -21,7 +21,6 @@
     <info name="hwlocVersion" value="2.12.1"/>
     <info name="ProcessName" value="lstopo-no-graphics"/>
     <object type="Package" os_index="0" cpuset="0xffffffff" complete_cpuset="0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="3">
-      <info name="CPUModel" value="AMD Ryzen 9 5950X 16-Core Processor"/>
       <object type="NUMANode" os_index="0" cpuset="0xffffffff" complete_cpuset="0xffffffff" nodeset="0x00000001" complete_nodeset="0x00000001" gp_index="118" local_memory="134968868864">
         <page_type size="4096" count="32951384"/>
         <page_type size="2097152" count="0"/>
FAIL test-gather-topology.sh (exit status: 1)
```