### PR TITLE
fixpatch: gcc13 13.3.1+r432+gfc8bd63119c0-3

### DIFF
--- a/gcc13/riscv64.patch
+++ b/gcc13/riscv64.patch
@@ -59,11 +59,13 @@
               libubsan.so; do
      ln -s /usr/lib/$lib "$pkgdir/$_libdir/$lib"
    done
-@@ -189,7 +196,7 @@ package_gcc13() {
+@@ -188,8 +195,8 @@ package_gcc13() {
+   install -m755 -t "$pkgdir/${_libdir}/" gcc/{cc1,cc1plus,collect2,lto1,gcov{,-tool}}
  
    make -C $CHOST/libgcc DESTDIR="$pkgdir" install
-   rm -f "${pkgdir}/${_libdir}"/../lib/libgcc_s.so*
+-  rm -f "${pkgdir}/${_libdir}"/../lib/libgcc_s.so*
 -  rmdir "${pkgdir}/${_libdir}"/../lib
++  rm -f "${pkgdir}/${_libdir}"/libgcc_s.so*
 +  rm -rf "${pkgdir}/${_libdir}"/../lib
  
    make -C $CHOST/libstdc++-v3/src DESTDIR="$pkgdir" install


### PR DESCRIPTION
Remove libgcc_s.so accidentally included in `gcc13`.