### PR TITLE
qemu-user-blacklist: add lksctp-tools

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -70,6 +70,7 @@ libseccomp
 libsecret
 libuv
 libvirt
+lksctp-tools
 lmdb
 m4
 mdbook


### PR DESCRIPTION
qemu-user does not support SCTP protocol:

```
==> Starting check()...
./test_assoc_abort
test_assoc_abort.c  1 BROK : setsockopt(11): Protocol not available
DUMP_CORE ./sctputil.h: 257
test_assoc_abort fails
make: *** [Makefile:1770: v4test] Error 1
```