### PR TITLE
addpatch: pgbackrest 2.55.1-1

### DIFF
--- a/pgbackrest/riscv64.patch
+++ b/pgbackrest/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -19,8 +19,6 @@ backup=(etc/$pkgname/$pkgname.conf)
+ prepare() {
+   echo '# Placeholder config. See https://pgbackrest.org/configuration.html for more info.' > example.conf
+ 
+-  export CFLAGS="$CFLAGS -fcf-protection"
+-  export CXXFLAGS="$CXXFLAGS -fcf-protection"
+   export LDFLAGS="$LDFLAGS -Wl,-z,relro -Wl,-z,now -Wl,-z,shstk"
+ 
+   arch-meson $pkgname-release-$pkgver build


### PR DESCRIPTION
`-fcf-protection` is not supported on RISC-V.