### PR TITLE
addpatch: kmod 34.2-1

### DIFF
--- a/kmod/fix-riscv64-tests.patch
+++ b/kmod/fix-riscv64-tests.patch
@@ -1,0 +1,25 @@
+Description: wrap riscv_hwprobe(2)
+Author: Aurelien Jarno <aurel32@debian.org>
+
+--- a/testsuite/init_module.c
++++ b/testsuite/init_module.c
+@@ -364,6 +364,19 @@ TS_EXPORT long int syscall(long int __sy
+ 		return nextlib_syscall(__NR_gettid);
+ 	}
+ 
++#ifdef __NR_riscv_hwprobe
++	if (__sysno == __NR_riscv_hwprobe) {
++		/*
++		 * RISC-V Hardware Probing Interface. This might be used by
++		 * some libraries (e.g. openssl) to probe the hardware
++		 * capabilities. Just pretend the syscall doesn't exist, this
++		 * will just fallback to less optimized code.
++		 */
++		errno = ENOSYS;
++		return -1;
++	}
++#endif
++
+ 	/*
+ 	 * FIXME: no way to call the libc function due since this is a
+ 	 * variadic argument function and we don't have a vsyscall() variant

--- a/kmod/riscv64.patch
+++ b/kmod/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -57,3 +57,12 @@ package() {
+   install -Dm0644 "${srcdir}/depmod.hook" "${pkgdir}/usr/share/libalpm/hooks/60-depmod.hook"
+   install -Dm0755 "${srcdir}/depmod.script" "${pkgdir}/usr/share/libalpm/scripts/depmod"
+ }
++
++source+=(fix-riscv64-tests.patch)
++sha256sums+=('3319d0e398276d0a5c8ada91e327ed2014041f5eb08d1ea890615dabd29b572a')
++
++prepare() {
++  cd kmod
++  # https://salsa.debian.org/md/kmod/-/blob/627679a9d9cbb8549cb84934ed7d7423d802f7a6/debian/patches/fix_riscv64_tests
++  patch -Np1 -i ../fix-riscv64-tests.patch
++}


### PR DESCRIPTION
Wrap riscv_hwprobe in test mockup to fix failure. Patch taken from Debian: https://salsa.debian.org/md/kmod/-/blob/627679a9d9cbb8549cb84934ed7d7423d802f7a6/debian/patches/fix_riscv64_tests