### PR TITLE
updpatch: binutils 2.44+r94+gfe459e33c676-1

### DIFF
--- a/binutils/riscv64.patch
+++ b/binutils/riscv64.patch
@@ -1,8 +1,16 @@
-diff --git PKGBUILD PKGBUILD
-index db8ef95..427c387 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -60,7 +60,7 @@
+@@ -46,6 +46,9 @@ prepare() {
+   # Turn off development mode (-Werror, gas run-time checks, date in sonames)
+   sed -i '/^development=/s/true/false/' bfd/development.sh
+ 
++  # https://sourceware.org/bugzilla/show_bug.cgi?id=33029
++  git cherry-pick -n f601ffb52199a883f16df385b73a14e756b3e19a
++
+   # Creds @Fedora
+   # Change the gold configuration script to only warn about
+   # unsupported targets.  This allows the binutils to be built with
+@@ -60,7 +63,7 @@ build() {
      --prefix=/usr \
      --sysconfdir="${pkgdir}"/etc \
      --with-lib-path=/usr/lib:/usr/local/lib \


### PR DESCRIPTION
Backport upstream commit that fixes `as` segfault while building nodejs-lts-jod.

Upstream bug report: https://sourceware.org/bugzilla/show_bug.cgi?id=33029