### PR TITLE
addpatch: audacity 3.7.3-2

### DIFF
--- a/audacity/riscv64.patch
+++ b/audacity/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -97,8 +97,10 @@ build() {
+   )
+ 
+   export VST3SDK='/usr/src/vst3sdk'
+-  export CFLAGS+=" -DNDEBUG"
+-  export CXXFLAGS+=" -DNDEBUG"
++  # https://github.com/audacity/audacity/issues/8726 (-std=gnu17)
++  # https://github.com/audacity/audacity/issues/8872 (-ffp-contract=off)
++  export CFLAGS+=" -DNDEBUG -std=gnu17 -ffp-contract=off"
++  export CXXFLAGS+=" -DNDEBUG -ffp-contract=off"
+   cmake "${cmake_options[@]}"
+   cmake --build build --verbose
+ }


### PR DESCRIPTION
New added options explanations:

- `-std=gnu17`: audacity/audacity#8726
  - [Upstreamed to Arch repo](https://gitlab.archlinux.org/archlinux/packaging/packages/audacity/-/merge_requests/2)
- `-ffp-contract=off`: audacity/audacity#8872
  - Not sure of the upstream preferred solution, we can disable FMA for RISC-V 64-bit for now to make floating point results consistent with x86_64.