### PR TITLE
addpatch: libkrunfw 4.9.0-2

### DIFF
--- a/libkrunfw/riscv64.patch
+++ b/libkrunfw/riscv64.patch
@@ -1,0 +1,25 @@
+diff --git PKGBUILD PKGBUILD
+index a19bc74..32e44f4 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -10,7 +10,7 @@
+ arch=('x86_64')
+ license=('GPL-2.0-only' 'LGPL-2.1-only')
+ depends=('glibc')
+-makedepends=('bc' 'python-pyelftools')
++makedepends=('bc' 'python-pyelftools' 'cpio')
+ source=("https://github.com/containers/libkrunfw/archive/refs/tags/v$pkgver/$pkgname-$pkgver.tar.gz"
+         "https://cdn.kernel.org/pub/linux/kernel/v${_kver%%.*}.x/linux-${_kver}.tar.xz")
+ noextract=("linux-${_kver}.tar.xz")
+@@ -35,3 +35,11 @@
+   install -Dm644 LICENSE-GPL-2.0-only "$pkgdir"/usr/share/licenses/$pkgname/LICENSE-GPL-2.0-only
+   install -Dm644 LICENSE-LGPL-2.1-only "$pkgdir"/usr/share/licenses/$pkgname/LICENSE-LGPL-2.1-only
+ }
++
++source+=("$pkgname-riscv64.patch::https://github.com/Xeonacid/libkrunfw/commit/ee0c441758ae583bff7d36db364be3c8ac2e58f0.diff")
++sha256sums+=('d8792adb64117c99315c11628090bde2128d99cfbe309f1bcdbc0f69658be5e1')
++
++prepare() {
++  cd "$pkgname-$pkgver"
++  patch -Np1 -i ../"$pkgname-riscv64.patch"
++}


### PR DESCRIPTION
`cpio` makedepends is added to build `arch/riscv/boot/Image`

https://github.com/containers/libkrunfw/pull/94