### PR TITLE
addpatch: ansible-core 2.18.6-1

### DIFF
--- a/ansible-core/riscv64.patch
+++ b/ansible-core/riscv64.patch
@@ -1,0 +1,14 @@
+diff --git PKGBUILD PKGBUILD
+index 1379f9d..2c8648f 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -79,6 +79,9 @@
+   # EDIT: resolvelib version requirement has been bumped but the related commit is not part of any stable releases yet
+   # See https://github.com/ansible/ansible/commit/771f7ad29ca4d259761eaa88673c2e32f6412bbe
+   patch -Np1 < "${srcdir}/bump_resolvelib_upper_version_bound.patch"
++
++  # We are using setuptools 80.9.0
++  sed -i 's/"setuptools >= 66.1.0, <= 80.7.1"/"setuptools >= 66.1.0"/' pyproject.toml
+ }
+ 
+ build() {


### PR DESCRIPTION
Fixes:

```text
ERROR Missing dependencies:
	setuptools<=80.7.1,>=66.1.0
```

Upstream issue: https://github.com/ansible/ansible/issues/85340