### PR TITLE
addpatch: libpng 1.6.49-1

### DIFF
--- a/libpng/riscv64.patch
+++ b/libpng/riscv64.patch
@@ -1,0 +1,27 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,6 +12,7 @@ arch=('x86_64')
+ url='http://www.libpng.org/pub/png/libpng.html'
+ license=('custom')
+ depends=('zlib' 'sh')
++options=(!lto)
+ makedepends=('git')
+ provides=('libpng16.so')
+ source=("git+https://github.com/pnggroup/libpng.git?signed#tag=v${pkgver}")
+@@ -28,8 +29,15 @@ prepare() {
+ 
+ build() {
+   cd $pkgname
+-
++  # Enable RVV runtime dispatch using HWCAPS
++  # https://github.com/pnggroup/libpng/blob/libpng16/contrib/riscv-rvv/linux.c#L30
++  # Some objects needs to be built with rv64gv but our rv64gc always overrides it,
++  # so removing ours as a compromise.
++  # LTO is disabled due to a gcc bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110812
++  CFLAGS="${CFLAGS/-march=rv64gc/}"
++  CXXFLAGS="${CXXFLAGS/-march=rv64gc/}"
+   ./configure \
++    --enable-riscv-rvv=check \
+     --prefix=/usr \
+     --disable-static
+   make


### PR DESCRIPTION
- An ICE happens when not applying any patch. I have reported it to gcc: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=120674
- Enable RVV runtime dispatch.
- Remove our `-march=rv64gc` flag because some objects needs to be built with `-march=rv64gv` and our flags always overide it because our flags are appended to the commandline.
- Disable LTO due to another bug in GCC compiler: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110812