### PR TITLE
addpatch: adguardhome 1:0.107.62-1

### DIFF
--- a/adguardhome/riscv64.patch
+++ b/adguardhome/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,7 +12,7 @@ url='https://github.com/AdguardTeam/AdGuardHome'
+ license=(GPL-2.0-only)
+ source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz"
+         $pkgname.service)
+-makedepends=(go nodejs npm git)
++makedepends=(go nodejs-lts-iron npm git)
+ depends=(glibc)
+ b2sums=('2326564d83a010b9302c81d37446dc9fbcdee88930fd537bbefd8ce36f99bf8a7ec86f70b55fa08081055ba1a61e12f22b4d3491280445d744c3aaa5293ca5f5'
+         '161152f91e09fe491db631eb6ed603c0c975453b682467945fdade6091bf427ec932230f3a10e40e2f054dc01567930ecc27343c04882fb0e736b4f6becc96da')


### PR DESCRIPTION
Node.js 24 crashed while building it. I am tracking it at https://github.com/riscv-forks/electron/issues/9.

Temporarily use Node.js 20 as a workaround