### PR TITLE
updpatch: nodejs 24.2.0-1

### DIFF
--- a/nodejs/riscv64.patch
+++ b/nodejs/riscv64.patch
@@ -1,6 +1,6 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -51,6 +51,15 @@ _set_flags() {
+@@ -51,6 +51,17 @@ _set_flags() {
    # /usr/lib/libnode.so uses malloc_usable_size, which is incompatible with fortification level 3
    CFLAGS="${CFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
    CXXFLAGS="${CXXFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
@@ -13,17 +13,23 @@
 +  cd node
 +  patch -Np1 -i ../fix-trap-handler.patch
 +  patch -Np1 -i ../hwy-broken-rvv.diff
++  patch -Np1 -i ../v8-riscv-fix-trampoline.patch
++  patch -Np1 -i ../v8-riscv-fix-trampoline-release.patch
  }
  
  build() {
-@@ -95,4 +104,10 @@ package() {
+@@ -95,4 +106,14 @@ package() {
    install -Dm644 LICENSE -t "$pkgdir"/usr/share/licenses/nodejs/
  }
  
 +
 +makedepends+=(clang)
 +source+=("fix-trap-handler.patch"
-+         "hwy-broken-rvv.diff")
++         "hwy-broken-rvv.diff"
++         "v8-riscv-fix-trampoline.patch"
++         "v8-riscv-fix-trampoline-release.patch")
 +sha512sums+=('f2ff6da8cf5dcc994a7a20342e2928dc1821fbbf42891009a6234b6051277e0200d7e3fbba63b9a2773887591d0ad5ceb1bb3d25e5efeb557f6d00109a80253c'
-+             'de07b0d9c3481036ee97a22941ff444fee86c78abbc26afef36f17508bb479ce3ab83ca160109fbf4f0b9b3266dcce30860873dc8ffbcac1a70e98d17638ca55')
++             'de07b0d9c3481036ee97a22941ff444fee86c78abbc26afef36f17508bb479ce3ab83ca160109fbf4f0b9b3266dcce30860873dc8ffbcac1a70e98d17638ca55'
++             '625507d38eb6c14e9a502aa85d6a265bf14444987b6a62da40cf63cdbb027ef530adafbae55e89266f2077715a3c94f77f32037c793340dd2b192c99ebd5abed'
++             'fcb6226fae37958d3b0566a6e30e1ef6d8a434baa1d0850133c4c2aedf98108c6033de6a81858a5e84b04d8524c7d09080a965b00a9f6f9e13fc7825cb348ea5')
  # vim:set ts=2 sw=2 et:

--- a/nodejs/v8-riscv-fix-trampoline-release.patch
+++ b/nodejs/v8-riscv-fix-trampoline-release.patch
@@ -1,0 +1,50 @@
+From 35e479a4ea840e72a286bf0519c76151b42c539e Mon Sep 17 00:00:00 2001
+From: Lu Yahan <yahan@iscas.ac.cn>
+Date: Wed, 18 Jun 2025 09:02:36 +0800
+Subject: [PATCH] deps: V8: cherry-pick 7f436a0b44a1
+
+Original commit message:
+
+    [riscv] Check trampoline before Constant pool in Release mode
+
+    Change-Id: I9645cded9328dabb2c11c7859b998c838b95f97b
+
+Refs: https://github.com/v8/v8/commit/7f436a0b44a15f2f8536e3d208d1e2f99592f803
+---
+ common.gypi                                        | 2 +-
+ deps/v8/src/codegen/riscv/macro-assembler-riscv.cc | 5 ++---
+ 2 files changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/common.gypi b/common.gypi
+index 90f48604f3..f9fe11388d 100644
+--- a/common.gypi
++++ b/common.gypi
+@@ -38,7 +38,7 @@
+ 
+     # Reset this number to 0 on major V8 upgrades.
+     # Increment by one for each non-official patch applied to deps/v8.
+-    'v8_embedder_string': '-node.18',
++    'v8_embedder_string': '-node.19',
+ 
+     ##### V8 defaults for Node.js #####
+ 
+diff --git a/deps/v8/src/codegen/riscv/macro-assembler-riscv.cc b/deps/v8/src/codegen/riscv/macro-assembler-riscv.cc
+index 71a1866246..04ffd05c0b 100644
+--- a/deps/v8/src/codegen/riscv/macro-assembler-riscv.cc
++++ b/deps/v8/src/codegen/riscv/macro-assembler-riscv.cc
+@@ -4941,10 +4941,9 @@ void MacroAssembler::Jump(Register target, Condition cond, Register rs,
+     jr(target);
+     DEBUG_PRINTF("\tCheckTrampolinePool pc_offset:%d %d\n", pc_offset(),
+                  next_buffer_check() - ConstpoolComputesize());
+-    if (!is_trampoline_emitted() && v8_flags.debug_code &&
++    if (!is_trampoline_emitted() &&
+         pc_offset() >= (next_buffer_check() - ConstpoolComputesize())) {
+-      // Debug mode will emit more instrs than Release mode.
+-      // so we need to check trampoline pool before Constant pool.
++      // We need to check trampoline pool before Constant pool.
+       // Here need to emit trampoline first.
+       // Jump(ra, al) will block trampoline pool for 1 instr.
+       nop();
+-- 
+2.47.2
+

--- a/nodejs/v8-riscv-fix-trampoline.patch
+++ b/nodejs/v8-riscv-fix-trampoline.patch
@@ -1,0 +1,180 @@
+From fcf3c056959c4fa5ad477d253db926796614225d Mon Sep 17 00:00:00 2001
+From: Lu Yahan <yahan@iscas.ac.cn>
+Date: Tue, 10 Jun 2025 15:41:56 +0800
+Subject: [PATCH] deps: V8: backport bbaae8e36164
+
+Original commit message:
+
+    Reland "[riscv] Fix Check failed in bind_to"
+
+    This is a reland of commit fdb5de2c741658e94944f2ec1218530e98601c23
+
+    Original change's description:
+    > [riscv] Fix Check failed in bind_to
+    >
+    > The trampoline should be emitted before the constant pool.
+    >
+    > Bug: 420232092
+    >
+    > Change-Id: I3a909b122607e37aca9d8765f28810ec74d5dc0b
+    > Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6578135
+    > Auto-Submit: Yahan Lu (LuYahan) <yahan@iscas.ac.cn>
+    > Reviewed-by: Ji Qiu <qiuji@iscas.ac.cn>
+    > Commit-Queue: Ji Qiu <qiuji@iscas.ac.cn>
+    > Cr-Commit-Position: refs/heads/main@{#100480}
+
+    Bug: 420232092
+    Change-Id: I1fac1ed8c349383ef4510abea338b3d695ed57ab
+    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6595668
+    Commit-Queue: Ji Qiu <qiuji@iscas.ac.cn>
+    Reviewed-by: Ji Qiu <qiuji@iscas.ac.cn>
+    Cr-Commit-Position: refs/heads/main@{#100745}
+
+Refs: https://github.com/v8/v8/commit/bbaae8e36164b02b678966c7612bf3d23644b22c
+Co-authored-by: kxxt <rsworktech@outlook.com>
+---
+ common.gypi                                      |  2 +-
+ deps/v8/src/codegen/riscv/assembler-riscv.cc     |  4 ++--
+ deps/v8/src/codegen/riscv/assembler-riscv.h      | 15 +++++++++++++--
+ .../src/codegen/riscv/macro-assembler-riscv.cc   | 16 ++++++++++++----
+ 4 files changed, 28 insertions(+), 9 deletions(-)
+
+diff --git a/common.gypi b/common.gypi
+index 96ec81cd81..9904ad4ce3 100644
+--- a/common.gypi
++++ b/common.gypi
+@@ -38,7 +38,7 @@
+ 
+     # Reset this number to 0 on major V8 upgrades.
+     # Increment by one for each non-official patch applied to deps/v8.
+-    'v8_embedder_string': '-node.17',
++    'v8_embedder_string': '-node.18',
+ 
+     ##### V8 defaults for Node.js #####
+ 
+diff --git a/deps/v8/src/codegen/riscv/assembler-riscv.cc b/deps/v8/src/codegen/riscv/assembler-riscv.cc
+index a9093ed331..6cc3724b25 100644
+--- a/deps/v8/src/codegen/riscv/assembler-riscv.cc
++++ b/deps/v8/src/codegen/riscv/assembler-riscv.cc
+@@ -720,8 +720,8 @@ void Assembler::bind_to(Label* L, int pos) {
+             trampoline_pos = get_trampoline_entry(fixup_pos);
+             CHECK_NE(trampoline_pos, kInvalidSlotPos);
+           }
+-          CHECK((trampoline_pos - fixup_pos) <= kMaxBranchOffset);
+           DEBUG_PRINTF("\t\ttrampolining: %d\n", trampoline_pos);
++          CHECK((trampoline_pos - fixup_pos) <= kMaxBranchOffset);
+           target_at_put(fixup_pos, trampoline_pos, false);
+           fixup_pos = trampoline_pos;
+         }
+@@ -1486,6 +1486,7 @@ void Assembler::BlockTrampolinePoolFor(int instructions) {
+ }
+ 
+ void Assembler::CheckTrampolinePool() {
++  if (trampoline_emitted_) return;
+   // Some small sequences of instructions must not be broken up by the
+   // insertion of a trampoline pool; such sequences are protected by setting
+   // either trampoline_pool_blocked_nesting_ or no_trampoline_pool_before_,
+@@ -1507,7 +1508,6 @@ void Assembler::CheckTrampolinePool() {
+     return;
+   }
+ 
+-  DCHECK(!trampoline_emitted_);
+   DCHECK_GE(unbound_labels_count_, 0);
+   if (unbound_labels_count_ > 0) {
+     // First we emit jump, then we emit trampoline pool.
+diff --git a/deps/v8/src/codegen/riscv/assembler-riscv.h b/deps/v8/src/codegen/riscv/assembler-riscv.h
+index 2577e12a5d..5c408bfd2e 100644
+--- a/deps/v8/src/codegen/riscv/assembler-riscv.h
++++ b/deps/v8/src/codegen/riscv/assembler-riscv.h
+@@ -303,6 +303,8 @@ class V8_EXPORT_PRIVATE Assembler : public AssemblerBase,
+   // See Assembler::CheckConstPool for more info.
+   void EmitPoolGuard();
+ 
++  void FinishCode() { ForceConstantPoolEmissionWithoutJump(); }
++
+ #if defined(V8_TARGET_ARCH_RISCV64)
+   static void set_target_value_at(
+       Address pc, uint64_t target,
+@@ -617,6 +619,8 @@ class V8_EXPORT_PRIVATE Assembler : public AssemblerBase,
+     }
+   }
+ 
++  inline int next_buffer_check() { return next_buffer_check_; }
++
+   friend class VectorUnit;
+   class VectorUnit {
+    public:
+@@ -728,16 +732,19 @@ class V8_EXPORT_PRIVATE Assembler : public AssemblerBase,
+ 
+   // Block the emission of the trampoline pool before pc_offset.
+   void BlockTrampolinePoolBefore(int pc_offset) {
+-    if (no_trampoline_pool_before_ < pc_offset)
++    if (no_trampoline_pool_before_ < pc_offset) {
++      DEBUG_PRINTF("\tBlockTrampolinePoolBefore %d\n", pc_offset);
+       no_trampoline_pool_before_ = pc_offset;
++    }
+   }
+ 
+   void StartBlockTrampolinePool() {
+-    DEBUG_PRINTF("\tStartBlockTrampolinePool\n");
++    DEBUG_PRINTF("\tStartBlockTrampolinePool %d\n", pc_offset());
+     trampoline_pool_blocked_nesting_++;
+   }
+ 
+   void EndBlockTrampolinePool() {
++    DEBUG_PRINTF("\tEndBlockTrampolinePool\n");
+     trampoline_pool_blocked_nesting_--;
+     DEBUG_PRINTF("\ttrampoline_pool_blocked_nesting:%d\n",
+                  trampoline_pool_blocked_nesting_);
+@@ -767,6 +774,10 @@ class V8_EXPORT_PRIVATE Assembler : public AssemblerBase,
+ 
+   bool is_buffer_growth_blocked() const { return block_buffer_growth_; }
+ 
++  inline int ConstpoolComputesize() {
++    return constpool_.ComputeSize(Jump::kOmitted, Alignment::kOmitted);
++  }
++
+  private:
+   // Avoid overflows for displacements etc.
+   static const int kMaximalBufferSize = 512 * MB;
+diff --git a/deps/v8/src/codegen/riscv/macro-assembler-riscv.cc b/deps/v8/src/codegen/riscv/macro-assembler-riscv.cc
+index 9ac7746ad1..28e648fb0c 100644
+--- a/deps/v8/src/codegen/riscv/macro-assembler-riscv.cc
++++ b/deps/v8/src/codegen/riscv/macro-assembler-riscv.cc
+@@ -4926,11 +4926,22 @@ void MacroAssembler::LoadRootRegisterOffset(Register destination,
+ 
+ void MacroAssembler::Jump(Register target, Condition cond, Register rs,
+                           const Operand& rt) {
+-  BlockTrampolinePoolScope block_trampoline_pool(this);
+   if (cond == cc_always) {
+     jr(target);
++    DEBUG_PRINTF("\tCheckTrampolinePool pc_offset:%d %d\n", pc_offset(),
++                 next_buffer_check() - ConstpoolComputesize());
++    if (!is_trampoline_emitted() && v8_flags.debug_code &&
++        pc_offset() >= (next_buffer_check() - ConstpoolComputesize())) {
++      // Debug mode will emit more instrs than Release mode.
++      // so we need to check trampoline pool before Constant pool.
++      // Here need to emit trampoline first.
++      // Jump(ra, al) will block trampoline pool for 1 instr.
++      nop();
++      CheckTrampolinePool();
++    }
+     ForceConstantPoolEmissionWithoutJump();
+   } else {
++    BlockTrampolinePoolScope block_trampoline_pool(this);
+     BRANCH_ARGS_CHECK(cond, rs, rt);
+     Branch(kInstrSize * 2, NegateCondition(cond), rs, rt);
+     jr(target);
+@@ -5342,9 +5353,6 @@ void MacroAssembler::StoreReturnAddressAndCall(Register target) {
+ 
+ void MacroAssembler::Ret(Condition cond, Register rs, const Operand& rt) {
+   Jump(ra, cond, rs, rt);
+-  if (cond == al) {
+-    ForceConstantPoolEmissionWithoutJump();
+-  }
+ }
+ 
+ void MacroAssembler::BranchLong(Label* L) {
+-- 
+2.47.2
+


### PR DESCRIPTION
Backport two V8 CL to fix
https://github.com/riscv-forks/electron/issues/9, upstreamed: https://github.com/nodejs/node/pull/58746