### PR TITLE
qemu-user-blacklist: add valkey

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -134,6 +134,7 @@ tpm2-tss
 tracexec
 upower
 uutils-coreutils
+valkey
 vim
 wanderlust
 wayland


### PR DESCRIPTION
`check()` fails in qemu-user:

```text
!!! WARNING The following tests failed:

*** [err]: Process title set as expected in tests/unit/other.tcl
Expected 'TEST' to be equal to '/usr/bin/qemu-riscv64-staticsrc/valkey-server./tests/tmp/valkey.conf.18802.252' (context: type eval line 10 cmd {assert_equal "TEST" [lindex $cmdline 0]} proc ::test)
*** [err]: Test child sending info in tests/integration/rdb.tcl
Expected '1' to be more than or equal to '2' (context: type eval line 99 cmd {assert_morethan_equal $iteration 2} proc ::test)
```