### PR TITLE
updpatch: vaultwarden-web 2025.5.1.1-1 

### DIFF
--- a/sg2042-blacklist.txt
+++ b/sg2042-blacklist.txt
@@ -7,3 +7,4 @@ qt6-webengine
 typescript
 grafana
 vault
+vaultwarden-web

--- a/vaultwarden-web/riscv64.patch
+++ b/vaultwarden-web/riscv64.patch
@@ -1,20 +1,10 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -15,7 +15,7 @@ license=(GPL-3.0-only)
- depends=(vaultwarden)
- makedepends=(
+@@ -14,6 +14,7 @@ makedepends=(
    git
--  nodejs
-+  nodejs-lts-iron
+   nodejs-lts-iron
    npm
++  python
  )
  install=$pkgname.install
-@@ -35,6 +35,8 @@ pkgver() {
- prepare() {
-   cd bitwarden-clients
- 
-+  export ELECTRON_SKIP_BINARY_DOWNLOAD=1
-+
-   # Copy Vaultwarden images
-   cp -vr ../bw_web_builds/resources/src/images/{logo-{dark,white}@2x,icon-white}.png \
-     apps/web/src/images
+ source=("$pkgname::git+$url#tag=v$pkgver")


### PR DESCRIPTION
- Add python to makedepends because some dependencies needs to be built
  from source for riscv64.
- Drop other changes that has already been upstreamed to Arch.
- npm install busy spins indefinitely on sg2042, which does not occur in qemu-user. So add to sg2042 blacklist. (Might worth further investigation).