### PR TITLE
addpatch: certbot-dns-google 4.1.1-1

### DIFF
--- a/certbot-dns-google/riscv64.patch
+++ b/certbot-dns-google/riscv64.patch
@@ -1,0 +1,16 @@
+diff --git PKGBUILD PKGBUILD
+index 802b2f3..7f3b0ec 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -40,7 +40,10 @@ check() {
+   cd "$_repo/$pkgname"
+ 
+   # https://github.com/certbot/certbot/issues/9606
+-  pytest -v -W ignore::DeprecationWarning
++  pytest -v \
++  -W ignore::DeprecationWarning \
++  -W ignore::UserWarning
++
+ }
+ 
+ package() {


### PR DESCRIPTION
As of setuptools 81, pkg_resources.declare_namespace has been marked as deprecated.I temporarily changed the pytest call to ignore UserWarning to prevent errors from interrupting the test. I submitted a PR upstream to delete `__import__('pkg_resources').declare_namespace(__name__)`[upstream](https://github.com/protocolbuffers/protobuf/pull/22442)