### PR TITLE
rmvpatch: rustup

### DIFF
--- a/rustup/riscv64.patch
+++ b/rustup/riscv64.patch
@@ -1,9 +1,0 @@
---- PKGBUILD
-+++ PKGBUILD
-@@ -57,4 +57,6 @@ package() {
-   install -Dm644 LICENSE-APACHE "${pkgdir}"/usr/share/licenses/$pkgname/LICENSE-APACHE
- }
- 
-+makedepends+=('clang' 'cmake')
-+
- # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
aws-lc-sys has been upgraded upstream so prebuilt bindings are available for riscv64 now.