### PR TITLE
updpatch: libpng 1.6.50-1

### DIFF
--- a/libpng/riscv64.patch
+++ b/libpng/riscv64.patch
@@ -1,14 +1,16 @@
+diff --git PKGBUILD PKGBUILD
+index 620a620..db1994a 100644
 --- PKGBUILD
 +++ PKGBUILD
 @@ -12,6 +12,7 @@ arch=('x86_64')
  url='http://www.libpng.org/pub/png/libpng.html'
- license=('custom')
+ license=('libpng-2.0')
  depends=('zlib' 'sh')
 +options=(!lto)
  makedepends=('git')
  provides=('libpng16.so')
  source=("git+https://github.com/pnggroup/libpng.git?signed#tag=v${pkgver}")
-@@ -28,8 +29,15 @@ prepare() {
+@@ -28,7 +29,13 @@ prepare() {
  
  build() {
    cd $pkgname
@@ -21,7 +23,5 @@
 +  CFLAGS="${CFLAGS/-march=rv64gc/}"
 +  CXXFLAGS="${CXXFLAGS/-march=rv64gc/}"
    ./configure \
-+    --enable-riscv-rvv=check \
      --prefix=/usr \
      --disable-static
-   make


### PR DESCRIPTION
Runtime check is the default in
https://github.com/pnggroup/libpng/commit/f451a4de09eac5533f6da3cbc194e0416984713b

Note that we may need to stay on this version or revert https://github.com/pnggroup/libpng/commit/7916eb7ba08e97ac97c71784e15f78e3ffcd838c so we can keep runtime detection of RVV.