### PR TITLE
sv39-blacklist: initialize list

### DIFF
--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -1,0 +1,2 @@
+argocd
+grafana-agent


### PR DESCRIPTION
Basically anything running WASM during build needs to be added here. I am only adding these two because they have been failing too much. Please add more if you encounter.

See
https://github.com/riscv-forks/electron/issues/3#issuecomment-2391689815 for the underlying issue.