### PR TITLE
addpkg: dotnet-core-bootstrap 9.0.7.sdk108

### DIFF
--- a/dotnet-core-bootstrap/PKGBUILD
+++ b/dotnet-core-bootstrap/PKGBUILD
@@ -1,0 +1,233 @@
+# Maintainer: Maxime Gauduin <alucryd@archlinux.org>
+# Contributor: Kristian Mosegaard <kristian@mosen.me>
+# Contributor: Max Liebkies <mail@maxliebkies.de>
+# Contributor: Krzysztof Bogacki <krzysztof.bogacki@leancode.pl>
+
+pkgbase=dotnet-core-bootstrap
+pkgname=(
+ dotnet-host
+ dotnet-runtime
+ aspnet-runtime
+ dotnet-sdk
+ netstandard-targeting-pack
+ dotnet-targeting-pack
+ aspnet-targeting-pack
+ dotnet-source-built-artifacts
+)
+pkgver=9.0.7.sdk108
+pkgrel=1
+arch=(any)
+url=https://dotnet.microsoft.com
+license=(MIT)
+makedepends=(
+  bash
+  clang18
+  cmake
+  dotnet-sdk
+  dotnet-source-built-artifacts
+  git
+  icu
+  krb5
+  libgit2
+  libunwind
+  libxml2
+  lldb
+  llvm18
+  lttng-ust2.12
+  nodejs
+  openssl
+  systemd
+  zlib
+  riscv64-linux-gnu-gcc
+)
+optdepends=('bash-completion: Bash completion support')
+options=(
+  !lto
+  staticlibs
+)
+_tag=2d8506e0fc69ec3d8e92eb3090e18fdb5f8636f5
+source=(git+https://github.com/dotnet/dotnet.git#tag=${_tag}
+        dotnet-core-arch-riscv64.patch
+        dotnet-core-disable-AOT-riscv64.patch::https://github.com/dotnet/sdk/pull/42158.diff
+        dotnet-core-bootstrap-rootfs-riscv64.tar.zst)
+b2sums=('3ecabb9005f89e966091d08da850fbdcd1f30aa4a565c02d6a3a3b3d62059fc38cb8f6febdfd3656eb320e05aed75a04c9e1cad9bed838deaf2c035e36c2c888'
+        'faa570916e372835063b8cfb85dc982bb166fa298ae3d8d067adca268b214f898da6d2ef23757ecc1798823f78995bcc577e04f67ec619001e2c6612338724e8'
+        'e2d4e2dddd753ddc894317f2d3be560a9b14343aaee5432913e4f51659b950e5aa8e5cb60621a99a05be2ab57431566783f772a35df4a711a0ae71b2a0846edb'
+        'SKIP')
+noextract=(dotnet-core-bootstrap-rootfs-riscv64.tar.zst)
+
+prepare() {
+  mkdir rootfs
+  bsdtar -xf dotnet-core-bootstrap-rootfs-riscv64.tar.zst -C rootfs
+
+  cd dotnet
+
+  # fix bootstrap
+  git remote set-url origin https://github.com/dotnet/dotnet.git
+
+  patch -Np1 -i ../dotnet-core-arch-riscv64.patch
+  # Re-enable AOT when https://github.com/dotnet/runtime/pull/110688 released
+  patch -d src/sdk -Np1 -i "$srcdir/dotnet-core-disable-AOT-riscv64.patch"
+
+  ./prep-source-build.sh
+}
+
+pkgver() {
+  cd dotnet
+
+  if [[ $(git describe --tags) != v9.0.* ]]; then
+    msg "Invalid SDK version"
+    exit 1
+  fi
+
+  local _standardver=$(xmllint --xpath "//*[local-name()='NETStandardLibraryRefPackageVersion']/text()" src/sdk/eng/Versions.props)
+
+  if [[ $_standardver != 2.1.0 ]]; then
+    msg "Invalid Standard version"
+    exit 1
+  fi
+
+  local _sdkver=$(xmllint --xpath "//*[local-name()='VersionSDKMinor']/text()" src/sdk/eng/Versions.props)$(xmllint --xpath "//*[local-name()='VersionFeature']/text()" src/sdk/eng/Versions.props)
+  local _runtimever=$(xmllint --xpath "//*[local-name()='ProductVersion']/text()" src/runtime/eng/Versions.props)
+
+  echo "${_runtimever}.sdk${_sdkver}"
+}
+
+build() {
+  cd dotnet
+
+  export COMPlus_LTTng=0
+  export VERBOSE=1
+  export OPENSSL_ENABLE_SHA1_SIGNATURES=1
+
+  export PATH="/usr/lib/llvm18/bin:$PATH"
+
+  # this uses malloc_usable_size, which is incompatible with fortification level 3
+  CFLAGS="${CFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
+  CXXFLAGS="${CXXFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
+
+  CFLAGS=$(echo $CFLAGS  | sed -e 's/-fstack-clash-protection//' )
+  CXXFLAGS=$(echo $CXXFLAGS  | sed -e 's/-fstack-clash-protection//' )
+  export EXTRA_CFLAGS="$CFLAGS"
+  export EXTRA_CXXFLAGS="$CXXFLAGS"
+  export EXTRA_LDFLAGS="$LDFLAGS"
+  unset CFLAGS
+  unset CXXFLAGS
+  unset LDFLAGS
+
+  export ROOTFS_DIR="$srcdir/rootfs"
+
+  # Crossgen does not work on crossbuild
+  export DISABLE_CROSSGEN=1
+
+  ./build.sh --clean-while-building --source-build /p:TargetArchitecture=riscv64 /p:Crossbuild=true
+}
+
+package_dotnet-host() {
+  pkgdesc='A generic driver for the .NET Core Command Line Interface'
+  depends=(
+    gcc-libs
+    glibc
+  )
+  optdepends=('bash-completion: Bash completion support')
+
+  install -dm 755 "${pkgdir}"/usr/{bin,lib,share/{dotnet,licenses/dotnet-host}}
+  bsdtar -xf dotnet/artifacts/assets/Release/dotnet-sdk-${pkgver%.*.sdk*}.${pkgver#*sdk}-linux-riscv64.tar.gz -C "${pkgdir}"/usr/share/dotnet/ --no-same-owner dotnet host
+  bsdtar -xf dotnet/artifacts/assets/Release/dotnet-sdk-${pkgver%.*.sdk*}.${pkgver#*sdk}-linux-riscv64.tar.gz -C "${pkgdir}"/usr/share/licenses/dotnet-host/ --no-same-owner LICENSE.txt ThirdPartyNotices.txt
+  ln -s /usr/share/dotnet/dotnet "${pkgdir}"/usr/bin/dotnet
+  ln -s /usr/share/dotnet/host/fxr/${pkgver%.sdk*}/libhostfxr.so "${pkgdir}"/usr/lib/libhostfxr.so
+  install -Dm 644 dotnet/src/sdk/scripts/register-completions.bash "${pkgdir}"/usr/share/bash-completion/completions/dotnet
+  install -Dm 644 dotnet/src/sdk/scripts/register-completions.zsh "${pkgdir}"/usr/share/zsh/site-functions/_dotnet
+}
+
+package_dotnet-runtime() {
+  pkgdesc='The .NET Core runtime'
+  depends=(
+    dotnet-host
+    gcc-libs
+    glibc
+    icu
+    krb5
+    libunwind
+    zlib
+    openssl
+  )
+  optdepends=('lttng-ust2.12: CoreCLR tracing')
+  provides=(dotnet-runtime-${pkgver%.*.sdk*})
+  conflicts=(dotnet-runtime-${pkgver%.*.sdk*})
+
+  install -dm 755 "${pkgdir}"/usr/share/{dotnet,licenses}
+  bsdtar -xf dotnet/artifacts/assets/Release/dotnet-sdk-${pkgver%.*.sdk*}.${pkgver#*sdk}-linux-riscv64.tar.gz -C "${pkgdir}"/usr/share/dotnet/ --no-same-owner shared/Microsoft.NETCore.App
+  ln -s dotnet-host "${pkgdir}"/usr/share/licenses/dotnet-runtime
+}
+
+package_aspnet-runtime() {
+  pkgdesc='The ASP.NET Core runtime'
+  depends=(dotnet-runtime)
+  provides=(aspnet-runtime-${pkgver%.*.sdk*})
+  conflicts=(aspnet-runtime-${pkgver%.*.sdk*})
+
+  install -dm 755 "${pkgdir}"/usr/share/{dotnet,licenses}
+  bsdtar -xf dotnet/artifacts/assets/Release/dotnet-sdk-${pkgver%.*.sdk*}.${pkgver#*sdk}-linux-riscv64.tar.gz -C "${pkgdir}"/usr/share/dotnet/ --no-same-owner shared/Microsoft.AspNetCore.App
+  ln -s dotnet-host "${pkgdir}"/usr/share/licenses/aspnet-runtime
+}
+
+package_dotnet-sdk() {
+  pkgdesc='The .NET Core SDK'
+  depends=(
+    dotnet-runtime
+    dotnet-targeting-pack
+    glibc
+    gcc-libs
+    netstandard-targeting-pack
+  )
+  optdepends=('aspnet-targeting-pack: Build ASP.NET Core applications')
+  provides=(dotnet-sdk-${pkgver%.*.sdk*})
+  conflicts=(dotnet-sdk-${pkgver%.*.sdk*})
+
+  install -dm 755 "${pkgdir}"/usr/share/{dotnet,licenses}
+  bsdtar -xf dotnet/artifacts/assets/Release/dotnet-sdk-${pkgver%.*.sdk*}.${pkgver#*sdk}-linux-riscv64.tar.gz -C "${pkgdir}"/usr/share/dotnet/ --no-same-owner sdk sdk-manifests templates
+  ln -s dotnet-host "${pkgdir}"/usr/share/licenses/dotnet-sdk
+}
+
+package_netstandard-targeting-pack() {
+  pkgdesc='The .NET Standard targeting pack'
+  provides=(netstandard-targeting-pack-2.1)
+  conflicts=(netstandard-targeting-pack-2.1)
+
+  install -dm 755 "${pkgdir}"/usr/share/{dotnet,licenses}
+  bsdtar -xf dotnet/artifacts/assets/Release/dotnet-sdk-${pkgver%.*.sdk*}.${pkgver#*sdk}-linux-riscv64.tar.gz -C "${pkgdir}"/usr/share/dotnet/ --no-same-owner packs/NETStandard.Library.Ref
+  ln -s dotnet-host "${pkgdir}"/usr/share/licenses/netstandard-targeting-pack
+}
+
+package_dotnet-targeting-pack() {
+  pkgdesc='The .NET Core targeting pack'
+  depends=(netstandard-targeting-pack)
+  provides=(dotnet-targeting-pack-${pkgver%.*.sdk*})
+  conflicts=(dotnet-targeting-pack-${pkgver%.*.sdk*})
+
+  install -dm 755 "${pkgdir}"/usr/share/{dotnet,licenses}
+  bsdtar -xf dotnet/artifacts/assets/Release/dotnet-sdk-${pkgver%.*.sdk*}.${pkgver#*sdk}-linux-riscv64.tar.gz -C "${pkgdir}"/usr/share/dotnet/ --no-same-owner packs/Microsoft.NETCore.App.{Host.linux-riscv64,Ref}
+  ln -s dotnet-host "${pkgdir}"/usr/share/licenses/dotnet-targeting-pack
+}
+
+package_aspnet-targeting-pack() {
+  pkgdesc='The ASP.NET Core targeting pack'
+  depends=(dotnet-targeting-pack)
+  provides=(aspnet-targeting-pack-${pkgver%.*.sdk*})
+  conflicts=(aspnet-targeting-pack-${pkgver%.*.sdk*})
+
+  install -dm 755 "${pkgdir}"/usr/share/{dotnet,licenses}
+  bsdtar -xf dotnet/artifacts/assets/Release/dotnet-sdk-${pkgver%.*.sdk*}.${pkgver#*sdk}-linux-riscv64.tar.gz -C "${pkgdir}"/usr/share/dotnet/ --no-same-owner packs/Microsoft.AspNetCore.App.Ref
+  ln -s dotnet-host "${pkgdir}"/usr/share/licenses/aspnet-targeting-pack
+}
+
+package_dotnet-source-built-artifacts() {
+  pkgdesc='Internal package for building the .NET Core SDK'
+  provides=(dotnet-source-built-artifacts-${pkgver%.*.sdk*})
+  conflicts=(dotnet-source-built-artifacts-${pkgver%.*.sdk*})
+
+  install -Dm 644 dotnet/artifacts/assets/Release/Private.SourceBuilt.Artifacts.*.tar.gz -t "${pkgdir}"/usr/share/dotnet/source-built-artifacts/
+}
+
+# vim: ts=2 sw=2 et:

--- a/dotnet-core-bootstrap/build_rootfs.sh
+++ b/dotnet-core-bootstrap/build_rootfs.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+. PKGBUILD
+makedepends=( ${makedepends[*]/dotnet-sdk} )
+makedepends=( ${makedepends[*]/dotnet-source-built-artifacts} )
+makedepends=( ${makedepends[*]/riscv64-linux-gnu-gcc} )
+
+mkdir rootfs
+sudo pacstrap -C /usr/share/devtools/pacman.conf.d/extra-riscv64.conf -M rootfs base-devel ${makedepends[*]}
+echo -e "y\ny" | sudo pacman --sysroot rootfs -Scc
+
+# dotnet will try to find file in /. A permission denied will lead to failure...
+sudo rm -rf rootfs/var/lib/tpm2-tss/system/keystore
+
+sudo bsdtar --acls --xattrs -C rootfs -caf dotnet-core-bootstrap-rootfs-riscv64.tar.zst .

--- a/dotnet-core-bootstrap/dotnet-core-arch-riscv64.patch
+++ b/dotnet-core-bootstrap/dotnet-core-arch-riscv64.patch
@@ -1,0 +1,46 @@
+diff --git a/src/runtime/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json b/src/runtime/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json
+index 64e7c5546b..2aeb362e0e 100644
+--- a/src/runtime/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json
++++ b/src/runtime/src/libraries/Microsoft.NETCore.Platforms/src/runtime.json
+@@ -1050,6 +1050,12 @@
+         "linux"
+       ]
+     },
++    "arch-riscv64": {
++      "#import": [
++        "arch",
++        "linux-riscv64"
++      ]
++    },
+     "arch-x64": {
+       "#import": [
+         "arch",
+diff --git a/src/sdk/Directory.Build.props b/src/sdk/Directory.Build.props
+index 90b657484e..dadc793612 100644
+--- a/src/sdk/Directory.Build.props
++++ b/src/sdk/Directory.Build.props
+@@ -8,6 +8,7 @@
+     <Architecture Condition="'$(Architecture)' == '' AND '$(BuildArchitecture)' == 's390x'">$(BuildArchitecture)</Architecture>
+     <Architecture Condition="'$(Architecture)' == '' AND '$(BuildArchitecture)' == 'ppc64le'">$(BuildArchitecture)</Architecture>
+     <Architecture Condition="'$(Architecture)' == '' AND '$(BuildArchitecture)' == 'loongarch64'">$(BuildArchitecture)</Architecture>
++    <Architecture Condition="'$(Architecture)' == '' AND '$(BuildArchitecture)' == 'riscv64'">$(BuildArchitecture)</Architecture>
+     <Architecture Condition="'$(Architecture)' == ''">x64</Architecture>
+ 
+     <!--
+diff --git a/src/source-build-reference-packages/src/textOnlyPackages/src/microsoft.netcore.platforms/5.0.0/runtime.json b/src/source-build-reference-packages/src/textOnlyPackages/src/microsoft.netcore.platforms/5.0.0/runtime.json
+index 026b236c7d..8e14d28c8b 100755
+--- a/src/source-build-reference-packages/src/textOnlyPackages/src/microsoft.netcore.platforms/5.0.0/runtime.json
++++ b/src/source-build-reference-packages/src/textOnlyPackages/src/microsoft.netcore.platforms/5.0.0/runtime.json
+@@ -489,6 +489,12 @@
+         "linux"
+       ]
+     },
++    "arch-riscv64": {
++      "#import": [
++        "arch",
++        "linux-riscv64"
++      ]
++    },
+     "arch-x64": {
+       "#import": [
+         "arch",


### PR DESCRIPTION
Cross build on x86_64 with the following steps:
- Run `sudo ./build_rootfs.sh` to build a riscv64 rootfs
- Build the package with `pkgctl build` as usual

NativeAOT and Crossgen2 are disabled, so the performance may not be ideal. NativeAOT should be available in dotnet 10.

Diff with the original `dotnet-core` PKGBUILD:

```diff
diff --git PKGBUILD PKGBUILD
index 3780660..c8f24ce 100644
--- PKGBUILD
+++ PKGBUILD
@@ -3,7 +3,7 @@
 # Contributor: Max Liebkies <mail@maxliebkies.de>
 # Contributor: Krzysztof Bogacki <krzysztof.bogacki@leancode.pl>

-pkgbase=dotnet-core
+pkgbase=dotnet-core-bootstrap
 pkgname=(
  dotnet-host
  dotnet-runtime
@@ -16,7 +16,7 @@
 )
 pkgver=9.0.7.sdk108
 pkgrel=1
-arch=(x86_64)
+arch=(any)
 url=https://dotnet.microsoft.com
 license=(MIT)
 makedepends=(
@@ -38,6 +38,7 @@
   openssl
   systemd
   zlib
+  riscv64-linux-gnu-gcc
 )
 optdepends=('bash-completion: Bash completion support')
 options=(
@@ -45,23 +46,29 @@
   staticlibs
 )
 _tag=2d8506e0fc69ec3d8e92eb3090e18fdb5f8636f5
-source=(git+https://github.com/dotnet/dotnet.git#tag=${_tag})
-b2sums=('3ecabb9005f89e966091d08da850fbdcd1f30aa4a565c02d6a3a3b3d62059fc38cb8f6febdfd3656eb320e05aed75a04c9e1cad9bed838deaf2c035e36c2c888')
+source=(git+https://github.com/dotnet/dotnet.git#tag=${_tag}
+        dotnet-core-arch-riscv64.patch
+        dotnet-core-disable-AOT-riscv64.patch::https://github.com/dotnet/sdk/pull/42158.diff
+        dotnet-core-bootstrap-rootfs-riscv64.tar.zst)
+b2sums=('3ecabb9005f89e966091d08da850fbdcd1f30aa4a565c02d6a3a3b3d62059fc38cb8f6febdfd3656eb320e05aed75a04c9e1cad9bed838deaf2c035e36c2c888'
+        'faa570916e372835063b8cfb85dc982bb166fa298ae3d8d067adca268b214f898da6d2ef23757ecc1798823f78995bcc577e04f67ec619001e2c6612338724e8'
+        'e2d4e2dddd753ddc894317f2d3be560a9b14343aaee5432913e4f51659b950e5aa8e5cb60621a99a05be2ab57431566783f772a35df4a711a0ae71b2a0846edb'
+        'SKIP')
+noextract=(dotnet-core-bootstrap-rootfs-riscv64.tar.zst)

 prepare() {
+  mkdir rootfs
+  bsdtar -xf dotnet-core-bootstrap-rootfs-riscv64.tar.zst -C rootfs
+
   cd dotnet

   # fix bootstrap
   git remote set-url origin https://github.com/dotnet/dotnet.git

-  local _bootstrapver=$(xmllint --xpath "//*[local-name()='PrivateSourceBuiltSdkVersion']/text()" eng/Versions.props)
-  local _previousver=$(pacman -Q dotnet-source-built-artifacts | sed -r 's/.*([0-9]+\.[0-9]+)\.[0-9]+\.sdk([0-9]+)-.*/\1.\2/')
+  patch -Np1 -i ../dotnet-core-arch-riscv64.patch
+  # Re-enable AOT when https://github.com/dotnet/runtime/pull/110688 released
+  patch -d src/sdk -Np1 -i "$srcdir/dotnet-core-disable-AOT-riscv64.patch"

-  if [[ $_bootstrapver == $_previousver ]]; then
-    cp -r /usr/share/dotnet .dotnet
-    ln -sf /usr/share/dotnet/source-built-artifacts/Private.SourceBuilt.Artifacts.*.tar.gz prereqs/packages/archive/
-#    ln -sf /usr/share/dotnet/source-built-artifacts/Private.SourceBuilt.Prebuilts.*.tar.gz prereqs/packages/archive/
-  fi
   ./prep-source-build.sh
 }

@@ -108,7 +115,12 @@
   unset CXXFLAGS
   unset LDFLAGS

-  ./build.sh --clean-while-building --online --source-build
+  export ROOTFS_DIR="$srcdir/rootfs"
+
+  # Crossgen does not work on crossbuild
+  export DISABLE_CROSSGEN=1
+
+  ./build.sh --clean-while-building --source-build /p:TargetArchitecture=riscv64 /p:Crossbuild=true
 }

 package_dotnet-host() {
@@ -120,8 +132,8 @@
   optdepends=('bash-completion: Bash completion support')

   install -dm 755 "${pkgdir}"/usr/{bin,lib,share/{dotnet,licenses/dotnet-host}}
-  bsdtar -xf dotnet/artifacts/assets/Release/dotnet-sdk-${pkgver%.*.sdk*}.${pkgver#*sdk}-arch-x64.tar.gz -C "${pkgdir}"/usr/share/dotnet/ --no-same-owner dotnet host
-  bsdtar -xf dotnet/artifacts/assets/Release/dotnet-sdk-${pkgver%.*.sdk*}.${pkgver#*sdk}-arch-x64.tar.gz -C "${pkgdir}"/usr/share/licenses/dotnet-host/ --no-same-owner LICENSE.txt ThirdPartyNotices.txt
+  bsdtar -xf dotnet/artifacts/assets/Release/dotnet-sdk-${pkgver%.*.sdk*}.${pkgver#*sdk}-linux-riscv64.tar.gz -C "${pkgdir}"/usr/share/dotnet/ --no-same-owner dotnet host
+  bsdtar -xf dotnet/artifacts/assets/Release/dotnet-sdk-${pkgver%.*.sdk*}.${pkgver#*sdk}-linux-riscv64.tar.gz -C "${pkgdir}"/usr/share/licenses/dotnet-host/ --no-same-owner LICENSE.txt ThirdPartyNotices.txt
   ln -s /usr/share/dotnet/dotnet "${pkgdir}"/usr/bin/dotnet
   ln -s /usr/share/dotnet/host/fxr/${pkgver%.sdk*}/libhostfxr.so "${pkgdir}"/usr/lib/libhostfxr.so
   install -Dm 644 dotnet/src/sdk/scripts/register-completions.bash "${pkgdir}"/usr/share/bash-completion/completions/dotnet
@@ -145,7 +157,7 @@
   conflicts=(dotnet-runtime-${pkgver%.*.sdk*})

   install -dm 755 "${pkgdir}"/usr/share/{dotnet,licenses}
-  bsdtar -xf dotnet/artifacts/assets/Release/dotnet-sdk-${pkgver%.*.sdk*}.${pkgver#*sdk}-arch-x64.tar.gz -C "${pkgdir}"/usr/share/dotnet/ --no-same-owner shared/Microsoft.NETCore.App
+  bsdtar -xf dotnet/artifacts/assets/Release/dotnet-sdk-${pkgver%.*.sdk*}.${pkgver#*sdk}-linux-riscv64.tar.gz -C "${pkgdir}"/usr/share/dotnet/ --no-same-owner shared/Microsoft.NETCore.App
   ln -s dotnet-host "${pkgdir}"/usr/share/licenses/dotnet-runtime
 }

@@ -156,7 +168,7 @@
   conflicts=(aspnet-runtime-${pkgver%.*.sdk*})

   install -dm 755 "${pkgdir}"/usr/share/{dotnet,licenses}
-  bsdtar -xf dotnet/artifacts/assets/Release/dotnet-sdk-${pkgver%.*.sdk*}.${pkgver#*sdk}-arch-x64.tar.gz -C "${pkgdir}"/usr/share/dotnet/ --no-same-owner shared/Microsoft.AspNetCore.App
+  bsdtar -xf dotnet/artifacts/assets/Release/dotnet-sdk-${pkgver%.*.sdk*}.${pkgver#*sdk}-linux-riscv64.tar.gz -C "${pkgdir}"/usr/share/dotnet/ --no-same-owner shared/Microsoft.AspNetCore.App
   ln -s dotnet-host "${pkgdir}"/usr/share/licenses/aspnet-runtime
 }

@@ -174,7 +186,7 @@
   conflicts=(dotnet-sdk-${pkgver%.*.sdk*})

   install -dm 755 "${pkgdir}"/usr/share/{dotnet,licenses}
-  bsdtar -xf dotnet/artifacts/assets/Release/dotnet-sdk-${pkgver%.*.sdk*}.${pkgver#*sdk}-arch-x64.tar.gz -C "${pkgdir}"/usr/share/dotnet/ --no-same-owner sdk sdk-manifests templates
+  bsdtar -xf dotnet/artifacts/assets/Release/dotnet-sdk-${pkgver%.*.sdk*}.${pkgver#*sdk}-linux-riscv64.tar.gz -C "${pkgdir}"/usr/share/dotnet/ --no-same-owner sdk sdk-manifests templates
   ln -s dotnet-host "${pkgdir}"/usr/share/licenses/dotnet-sdk
 }

@@ -184,7 +196,7 @@
   conflicts=(netstandard-targeting-pack-2.1)

   install -dm 755 "${pkgdir}"/usr/share/{dotnet,licenses}
-  bsdtar -xf dotnet/artifacts/assets/Release/dotnet-sdk-${pkgver%.*.sdk*}.${pkgver#*sdk}-arch-x64.tar.gz -C "${pkgdir}"/usr/share/dotnet/ --no-same-owner packs/NETStandard.Library.Ref
+  bsdtar -xf dotnet/artifacts/assets/Release/dotnet-sdk-${pkgver%.*.sdk*}.${pkgver#*sdk}-linux-riscv64.tar.gz -C "${pkgdir}"/usr/share/dotnet/ --no-same-owner packs/NETStandard.Library.Ref
   ln -s dotnet-host "${pkgdir}"/usr/share/licenses/netstandard-targeting-pack
 }

@@ -195,7 +207,7 @@
   conflicts=(dotnet-targeting-pack-${pkgver%.*.sdk*})

   install -dm 755 "${pkgdir}"/usr/share/{dotnet,licenses}
-  bsdtar -xf dotnet/artifacts/assets/Release/dotnet-sdk-${pkgver%.*.sdk*}.${pkgver#*sdk}-arch-x64.tar.gz -C "${pkgdir}"/usr/share/dotnet/ --no-same-owner packs/Microsoft.NETCore.App.{Host.arch-x64,Ref}
+  bsdtar -xf dotnet/artifacts/assets/Release/dotnet-sdk-${pkgver%.*.sdk*}.${pkgver#*sdk}-linux-riscv64.tar.gz -C "${pkgdir}"/usr/share/dotnet/ --no-same-owner packs/Microsoft.NETCore.App.{Host.linux-riscv64,Ref}
   ln -s dotnet-host "${pkgdir}"/usr/share/licenses/dotnet-targeting-pack
 }

@@ -206,7 +218,7 @@
   conflicts=(aspnet-targeting-pack-${pkgver%.*.sdk*})

   install -dm 755 "${pkgdir}"/usr/share/{dotnet,licenses}
-  bsdtar -xf dotnet/artifacts/assets/Release/dotnet-sdk-${pkgver%.*.sdk*}.${pkgver#*sdk}-arch-x64.tar.gz -C "${pkgdir}"/usr/share/dotnet/ --no-same-owner packs/Microsoft.AspNetCore.App.Ref
+  bsdtar -xf dotnet/artifacts/assets/Release/dotnet-sdk-${pkgver%.*.sdk*}.${pkgver#*sdk}-linux-riscv64.tar.gz -C "${pkgdir}"/usr/share/dotnet/ --no-same-owner packs/Microsoft.AspNetCore.App.Ref
   ln -s dotnet-host "${pkgdir}"/usr/share/licenses/aspnet-targeting-pack
 }
```