### PR TITLE
fixpkg: dotnet-core-bootstrap 9.0.7.sdk108-1

### DIFF
--- a/dotnet-core-bootstrap/PKGBUILD
+++ b/dotnet-core-bootstrap/PKGBUILD
@@ -44,6 +44,7 @@ optdepends=('bash-completion: Bash completion support')
 options=(
   !lto
   staticlibs
+  !strip
 )
 _tag=2d8506e0fc69ec3d8e92eb3090e18fdb5f8636f5
 source=(git+https://github.com/dotnet/dotnet.git#tag=${_tag}


### PR DESCRIPTION
Add `!strip` to workaround stripped ELF machine field with strip on x86_64:

```text
$ file /usr/share/dotnet/dotnet
/usr/share/dotnet/dotnet: ELF 64-bit LSB pie executable, no machine, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-riscv64-lp64d.so.1, BuildID[sha1]=a5dbda059f3f3c459aff89a04c728a2ac02fc81c, for GNU/Linux 4.15.0, stripped
```

This should be reported to binutils as a bug, but still doing tests like a `git bisect`.