### PR TITLE
addpatch: palette 3.0.0-1

### DIFF
--- a/palette/riscv64.patch
+++ b/palette/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index 84606fc..22a9932 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -39,6 +39,8 @@ prepare() {
+ 
+ build() {
+   arch-meson $pkgname build
++  ninja -C build src/palette.ui
++  cp build/src/palette.ui palette/src/palette.ui
+   meson compile -C build
+ }
+ 


### PR DESCRIPTION
On x86_64, ninja executes Generating src/palette.ui before building src/palette.vala . On riscv64, the generator does not generate the ui file when compiling palette.vala . upstream failed ,because my registration for a gnome account failed inexplicably, I have sent an email to gnome to report this .