### PR TITLE
addpatch: python-zope-annotation 5.1-1

### DIFF
--- a/python-zope-annotation/riscv64.patch
+++ b/python-zope-annotation/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -32,6 +32,7 @@ sha512sums=('7477cfa0d8c35511025d1dba9469b0a66dbbbeeeaa951b8b57ac2cf7c2c4d0caf4b
+ 
+ build() {
+   cd $_pkgname-$pkgver
++  sed -i -E 's/(setuptools)\s<=\s[0-9]+\.[0-9]+\.[0-9]+/\1/' pyproject.toml
+   python -m build --wheel --no-isolation
+ }
+ 


### PR DESCRIPTION
Allow building with arbitary setuptools version to fix building with our packaged setuptools 80.x.

I have opened an issue to ask about the setuptools version constraint: https://github.com/zopefoundation/zope.annotation/issues/28