### PR TITLE
sv39-blacklist: add gitea

### DIFF
--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -1,2 +1,3 @@
 argocd
+gitea
 grafana-agent


### PR DESCRIPTION
```
==> Starting build()...
Running webpack...
/build/gitea/src/gitea/node_modules/webpack/lib/util/hash/wasm-hash.js:166                                                                   
                new WebAssembly.Instance(wasmModule),                                                                                        
                ^
                                                                                                                                             
RangeError: WebAssembly.Instance(): Out of memory: Cannot allocate Wasm memory for new instance```