### PR TITLE
sv39-blacklist: add forgejo

### DIFF
--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -1,3 +1,4 @@
 argocd
+forgejo
 gitea
 grafana-agent


### PR DESCRIPTION
```
/build/forgejo/src/forgejo/node_modules/webpack/lib/util/hash/wasm-hash.js:166                                                               
                new WebAssembly.Instance(wasmModule),                                                                                        
                ^

RangeError: WebAssembly.Instance(): Out of memory: Cannot allocate Wasm memory for new instance
```