### PR TITLE
addpatch: suitesparse

### DIFF
--- a/suitesparse/riscv64.patch
+++ b/suitesparse/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -8,6 +8,7 @@ pkgver=7.11.0
+ pkgrel=1
+ pkgdesc='A collection of sparse matrix libraries'
+ url='http://faculty.cse.tamu.edu/davis/suitesparse.html'
++options=(!debug !lto)
+ arch=(x86_64)
+ depends=(blas
+          gcc-libs


### PR DESCRIPTION
- Upstream uses Google's cpu_features package to implement RVV runtime detection so we can keep RVV enabled.
- Disable LTO because of `lto1: fatal error: target specific builtin not available`
- Disable debug because we hit my previously reported gcc bug again in a different senario: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=120674
  - I have reduced the ICE testcase using cvise and added it to the bug report.