### PR TITLE
sv39-blacklist: add vue-language-tools

### DIFF
--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -2,3 +2,4 @@ argocd
 forgejo
 gitea
 grafana-agent
+vue-language-tools


### PR DESCRIPTION
```
RangeError: WebAssembly.instantiate(): Out of memory: Cannot allocate Wasm memory for new instance                                           
```