### PR TITLE
sv39-blacklist: add prettier

### DIFF
--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -2,4 +2,5 @@ argocd
 forgejo
 gitea
 grafana-agent
+prettier
 vue-language-tools


### PR DESCRIPTION
```
➤ YN0001: │ RangeError: WebAssembly.Instance(): Out of memory: Cannot allocate Wasm memory for new instance                                  
    at Y ([worker eval]:1:284192)
    at [worker eval]:1:287198
    at I ([worker eval]:1:287215)
    at [worker eval]:1:320275
    at getInstance ([worker eval]:1:112099)
    at new ZipFS ([worker eval]:1:296450)
    at convertToZipWorker ([worker eval]:1:409038)
    at MessagePort.<anonymous> ([worker eval]:1:410963)
    at [nodejs.internal.kHybridDispatch] (node:internal/event_target:827:20)
    at MessagePort.<anonymous> (node:internal/per_context/messageport:23:28)
➤ YN0000: └ Completed in 38s 684ms
➤ YN0000: · Failed with errors in 41s 8ms
```