### PR TITLE
sv39-blacklist: add prometheus

### DIFF
--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -3,4 +3,5 @@ forgejo
 gitea
 grafana-agent
 prettier
+prometheus
 vue-language-tools


### PR DESCRIPTION
```
/build/prometheus/src/prometheus-3.5.0/web/ui/react-app/node_modules/react-scripts/scripts/build.js:19
  throw err;
  ^

RangeError: WebAssembly.instantiate(): Out of memory: Cannot allocate Wasm memory for new instance
    at lazyllhttp (node:internal/deps/undici/undici:6342:32)

Node.js v24.2.0
make: *** [Makefile:64: ui-build] Error 1
```