### PR TITLE
addpatch: kirigami 6.16.0-2

### DIFF
--- a/kirigami/riscv64.patch
+++ b/kirigami/riscv64.patch
@@ -1,0 +1,17 @@
+diff --git PKGBUILD PKGBUILD
+index 2bf889e..de2c083 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -23,9 +23,9 @@ source=(https://download.kde.org/stable/frameworks/${pkgver%.*}/$pkgname-$pkgver
+         https://invent.kde.org/frameworks/kirigami/-/commit/140067bb.patch)
+ sha256sums=('16d1142aacd8514f95cf9bdb44b2a720f3397b5ee68a489a54c86a560af55516'
+             'SKIP'
+-            '830fcf415a50f86a88ad785654c1437b19f524e27c339904f54042b88a86377d'
+-            'b9a2525c0683bc01c1f81f6bde44bbe9df25bb773e6e3f74e1b0ac104585cb96'
+-            'da07315df607f39809d46e347678e661d4a9ea4a6fd118b70895ec6c3b8bb394')
++            '0116f483e0905978ab5434e4eb740507e89d504ae789d2bcdc581eef665180e8'
++            '1e7b5d0f7fc3f5718ca4ae519b8697dc513441a57431b428f45dfc0f8394c421'
++            'f406ae53fec7164d1877eed0e8bd2364fbcc5525f26eb130441db7af77a574e2')
+ validpgpkeys=(53E6B47B45CEA3E0D5B7457758D0EE648A48B3BB # David Faure <faure@kde.org>
+               E0A3EB202F8E57528E13E72FD7574483BB57B18D # Jonathan Esk-Riddell <jr@jriddell.org>
+               90A968ACA84537CC27B99EAF2C8DF587A6D4AAC1 # Nicolas Fella <nicolas.fella@kde.org>


### PR DESCRIPTION
Update checksum. Reported at
https://gitlab.archlinux.org/archlinux/packaging/packages/kirigami/-/issues/3