### PR TITLE
updpatch: ldc 3:1.41.0-1

### DIFF
--- a/ldc/riscv64.patch
+++ b/ldc/riscv64.patch
@@ -1,9 +1,20 @@
+diff --git PKGBUILD PKGBUILD
+index 2865a35..fc96c4d 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -35,6 +35,11 @@ prepare() {
+@@ -13,7 +13,7 @@ pkgdesc="A D Compiler based on the LLVM Compiler Infrastructure including D runt
+ arch=('x86_64')
+ url="https://github.com/ldc-developers/ldc"
+ license=('BSD-3-Clause AND BSL-1.0 AND Apache-2.0 WITH LLVM-exception')
+-makedepends=('git' 'cmake' 'llvm' 'lld' 'ldc' 'ninja')
++makedepends=('git' 'cmake' 'llvm' 'lld' 'ldc' 'ninja' 'llvm19-libs')
+ # Disable lto as linking the ldc2 binary fails
+ options=(!lto)
  
-     # Set version used for path construction in getRelativeClangCompilerRTLibPath()
-     sed -i "s/ldc::llvm_version_base/\"$_clangversion\"/" driver/linker-gcc.cpp
+@@ -34,6 +34,11 @@ prepare() {
+ 
+     # LLVMDebuginfod required curl
+     sed -i "s/-lLLVMDebuginfod/-lLLVMDebuginfod -lcurl/" tools/CMakeLists.txt
 +
 +    patch -Np1 -d runtime/phobos -i "$srcdir/disable-static-NaN-tests.patch"
 +
@@ -12,7 +23,7 @@
  }
  
  build() {
-@@ -50,7 +55,7 @@ build() {
+@@ -49,7 +54,7 @@ build() {
      -DBUILD_SHARED_LIBS=BOTH \
      -DBUILD_LTO_LIBS=ON \
      -DLDC_WITH_LLD=OFF \
@@ -21,7 +32,7 @@
      -DADDITIONAL_DEFAULT_LDC_SWITCHES="\"-link-defaultlib-shared\"," \
      ..
      ninja
-@@ -102,3 +107,6 @@ package_liblphobos() {
+@@ -101,3 +106,6 @@ package_liblphobos() {
      # licenses
      install -D -m644 "$srcdir/ldc/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
  }


### PR DESCRIPTION
Refresh patch. Also add llvm19-libs for bootstrapping.