### PR TITLE
fixpatch: gcc14 14.3.1+r25+g42e99e057bd7-1

### DIFF
--- a/gcc14/riscv64.patch
+++ b/gcc14/riscv64.patch
@@ -18,7 +18,7 @@
                86CFFCA918CF3AF47147588051E8B148A9999C34  # foutrelis@archlinux.org
 @@ -44,7 +44,8 @@ validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.
                D3A93CAD751C2AF4F8C7AD516C35B99309B5FA62) # Jakub Jelinek <jakub@redhat.com>
- sha256sums=('33378643f1c72686181f9d3fcd09caf9b06815324467f5dc9b9a3ea41cfba4b4'
+ sha256sums=('36817cc71fad1f13c93dfd2a5de24016accb8b993ef13bdf0465e1ef742f7007'
              '7b09ec947f90b98315397af675369a1e3dfc527fa70013062e6e85c4be0275ab'
 -            '44ea973558842f3f4bd666bdaf6e810fd7b7c7bd36b5cc4c69f93d2cd0124fc7')
 +            '44ea973558842f3f4bd666bdaf6e810fd7b7c7bd36b5cc4c69f93d2cd0124fc7'
@@ -67,15 +67,16 @@
               libubsan.so; do
      ln -s /usr/lib/$lib "$pkgdir/$_libdir/$lib"
    done
-@@ -180,7 +184,6 @@ package_gcc14() {
+@@ -180,7 +184,7 @@ package_gcc14() {
  
    make -C $CHOST/libgcc DESTDIR="$pkgdir" install
    rm -f "${pkgdir}/${_libdir}"/../lib/libgcc_s.so*
 -  rmdir "${pkgdir}/${_libdir}"/../lib
++  rm -f "${pkgdir}/${_libdir}"/libgcc_s.so*
  
    make -C $CHOST/libstdc++-v3/src DESTDIR="$pkgdir" install
    make -C $CHOST/libstdc++-v3/include DESTDIR="$pkgdir" install
-@@ -213,7 +216,7 @@ package_gcc14() {
+@@ -213,7 +217,7 @@ package_gcc14() {
    # create cc-rs compatible symlinks
    # https://github.com/rust-lang/cc-rs/blob/1.0.73/src/lib.rs#L2578-L2581
    for binary in {c++,g++,gcc,gcc-ar,gcc-nm,gcc-ranlib}; do


### PR DESCRIPTION
Remove libgcc_s.so from gcc14 which should belong to gcc14-libs.