### PR TITLE
sv39-blacklist: add navidrome

### DIFF
--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -2,6 +2,7 @@ argocd
 forgejo
 gitea
 grafana-agent
+navidrome
 prettier
 prometheus
 vue-language-tools


### PR DESCRIPTION
```
✗ Build failed in 1m 4s
error during build:
[vite-plugin-pwa:build] WebAssembly.instantiate(): Out of memory: Cannot allocate Wasm memory for new instance
RangeError: WebAssembly.instantiate(): Out of memory: Cannot allocate Wasm memory for new instance
```