### PR TITLE
addpatch: electron37 37.2.6-2

### DIFF
--- a/electron37/Debian-fix-rust-linking.patch
+++ b/electron37/Debian-fix-rust-linking.patch
@@ -1,0 +1,47 @@
+--- build/toolchain/gcc_toolchain.gni.orig	2024-08-19 14:13:35.233954725 +0200
++++ build/toolchain/gcc_toolchain.gni	2024-08-22 00:56:01.438433033 +0200
+@@ -441,7 +441,13 @@
+         # -soname flag is not available on aix ld
+         soname_flag = "-Wl,-soname=\"$soname\""
+       }
+-      link_command = "$ld -shared $soname_flag {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" @\"$rspfile\" {{rlibs}}"
++      if (target_cpu == "riscv64") {
++        # Work around linker failures due to Rust libraries and the use of whole-archive
++        link_command = "$ld -shared $soname_flag -Wl,--start-group {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" @\"$rspfile\" {{rlibs}} -Wl,--end-group"
++      }
++      else {
++        link_command = "$ld -shared $soname_flag {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" @\"$rspfile\" {{rlibs}}"
++      }
+ 
+       # Generate a map file to be used for binary size analysis.
+       # Map file adds ~10% to the link time on a z620.
+@@ -553,7 +559,13 @@
+         whole_archive_flag = "-Wl,--whole-archive"
+         no_whole_archive_flag = "-Wl,--no-whole-archive"
+       }
+-      command = "$ld -shared {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" $soname_flag @\"$rspfile\""
++      if (target_cpu == "riscv64") {
++        # Work around linker failures due to Rust libraries and the use of whole-archive
++        command = "$ld -shared -Wl,--start-group {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" $soname_flag @\"$rspfile\" -Wl,--end-group"
++      }
++      else {
++        command = "$ld -shared {{ldflags}}${extra_ldflags} -o \"$unstripped_sofile\" $soname_flag @\"$rspfile\""
++      }
+ 
+       if (defined(invoker.strip)) {
+         strip_command = "${invoker.strip} -o \"$sofile\" \"$unstripped_sofile\""
+@@ -617,8 +629,12 @@
+       # We need to specify link groups, at least, for single pass linkers. I.e.
+       # Rust libraries are alpha-sorted instead of by dependencies so they fail
+       # to link if not properly ordered or grouped.
+-      link_command = "$ld {{ldflags}}${extra_ldflags} -o \"$unstripped_outfile\" $start_group_flag @\"$rspfile\" $end_group_flag {{solibs}} {{libs}} $start_group_flag {{rlibs}} $end_group_flag"
+-
++      if (target_cpu == "riscv64") {
++        link_command = "$ld -Wl,--start-group {{ldflags}}${extra_ldflags} -o \"$unstripped_outfile\" @\"$rspfile\" {{solibs}} {{libs}} {{rlibs}} -Wl,--end-group"
++      }
++      else {
++        link_command = "$ld {{ldflags}}${extra_ldflags} -o \"$unstripped_outfile\" $start_group_flag @\"$rspfile\" $end_group_flag {{solibs}} {{libs}} $start_group_flag {{rlibs}} $end_group_flag"
++      }
+       # Generate a map file to be used for binary size analysis.
+       # Map file adds ~10% to the link time on a z620.
+       # With target_os="android", libchrome.so.map.gz is ~20MB.

--- a/electron37/riscv64.patch
+++ b/electron37/riscv64.patch
@@ -1,0 +1,209 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -29,9 +29,11 @@ depends=(c-ares
+ makedepends=(clang
+              git
+              gn
++             go
+              gperf
+              # harfbuzz-icu # disabled because ICU 76 not supported yet
+              java-runtime-headless
++             jq
+              libnotify
+              libva
+              lld
+@@ -59,7 +61,7 @@ optdepends=('kde-cli-tools: file deletion support (kioclient5)'
+             'trash-cli: file deletion support (trash-put)'
+             'xdg-utils: open URLs with desktop’s default (xdg-email, xdg-open)')
+ options=('!lto') # Electron adds its own flags for ThinLTO
+-source=("git+https://github.com/electron/electron.git#tag=v$pkgver"
++source=("git+https://github.com/riscv-forks/electron.git#branch=v$pkgver-riscv"
+         https://gitlab.com/Matt.Jolly/chromium-patches/-/archive/$_gcc_patches/chromium-patches-$_gcc_patches.tar.bz2
+         # Chromium
+         compiler-rt-adjust-paths.patch
+@@ -72,6 +74,7 @@ source=("git+https://github.com/electron/electron.git#tag=v$pkgver"
+         electron.desktop
+         jinja-python-3.10.patch
+         use-system-libraries-in-node.patch
++        Debian-fix-rust-linking.patch
+         makepkg-source-roller.py
+         # BEGIN managed sources
+         chromium-mirror::git+https://github.com/chromium/chromium.git#tag=138.0.7204.185
+@@ -229,7 +232,7 @@ source=("git+https://github.com/electron/electron.git#tag=v$pkgver"
+         )
+ sha256sums=('1ea134da21add1fc95a4d49ad2dff806115aa2f2ffdcb91dca1fd01e1f54d71c'
+             '6f5067e5f87ac0591295fc3ec0f7e722d0f5eb94ade2fb3e73ae8abcbb674f8a'
+-            '750fa28c0cbe464a45bab5a1021434e296ad83fef78b927eaec0f82df3aac26c'
++            '5015488f61d19f990aa609d09052db939f795d930034faa383fb186898caf17c'
+             '11a96ffa21448ec4c63dd5c8d6795a1998d8e5cd5a689d91aea4d2bdd13fb06e'
+             '2d98a7a6a553fb5c17c4bfe36f011410f377afa12a6a818ba36543dc9a258f4a'
+             'de3222b13d3a49628a00fd74acae633912b830f78c2de452d3bdff3d0e42026d'
+@@ -238,6 +241,7 @@ sha256sums=('1ea134da21add1fc95a4d49ad2dff806115aa2f2ffdcb91dca1fd01e1f54d71c'
+             '4484200d90b76830b69eea3a471c103999a3ce86bb2c29e6c14c945bf4102bae'
+             '55dbe71dbc1f3ab60bf1fa79f7aea7ef1fe76436b1d7df48728a1f8227d2134e'
+             '991e54f4490cdbb5e52c9a4a4f6e0e32f2fc95979f18a4736016d065da229c2e'
++            '3eb5e621757be3f2984acb76d16cf3571bfe5bbbc71ad230b21aa983041ff5ea'
+             '0e75444d1620a932294375f3372100334e2aadfec9cc2e6a1c7c8f1f0c2f252b'
+             '15df7339b9129e9677f2f8570949973b749feae334583db4b80c7caaf5c38c0e'
+             '0b7a546ee6913c49519c10c293ac530ff381641a8a465fa2e184d6dbe0fb784d'
+@@ -437,12 +441,22 @@ prepare() {
+   cp -r chromium-mirror_third_party_depot_tools depot_tools
+   export PATH+=":$PWD/depot_tools" DEPOT_TOOLS_UPDATE=0
+   #export VPYTHON_BYPASS='manually managed python not supported by chrome operations'
++  # Use a known commit that supports riscv64
++  git -C depot_tools checkout --detach 2a18f6d3245450d8c96c843a6584aaea561ef873
++  # Python 3.12 breaks gsutils
++  # Bundled wheels are not available for riscv64
++  sed -i '/wheel: </,$d' depot_tools/.vpython3
++  sed -i '/wheel: </,$d' depot_tools/gsutil.vpython3
++  # Manually install required wheels
++  vpython3 -m pip install httplib2==0.13.1 six==1.10.0 requests==2.31.0
+ 
+   echo "Putting together electron sources"
+   # Generate gclient gn args file and prepare-electron-source-tree.sh
+   python makepkg-source-roller.py generate electron/DEPS $pkgname
++  sed -i '/esbuild/d' prepare-electron-source-tree.sh
+   rbash prepare-electron-source-tree.sh "$CARCH"
+   mv electron src/electron
++  GOBIN=$(realpath src/third_party/devtools-frontend/src/third_party/esbuild/) go install "github.com/evanw/esbuild/cmd/esbuild@v0.25.1"
+ 
+   echo "Running hooks..."
+   # depot_tools/gclient.py runhooks
+@@ -454,11 +468,44 @@ prepare() {
+     -s src/third_party/skia --header src/skia/ext/skia_commit_hash.h
+   src/build/util/lastchange.py \
+     -s src/third_party/dawn --revision src/gpu/webgpu/DAWN_VERSION
+-  src/tools/update_pgo_profiles.py --target=linux update \
+-    --gs-url-base=chromium-optimization-profiles/pgo_profiles
++  #src/tools/update_pgo_profiles.py --target=linux update \
++  #  --gs-url-base=chromium-optimization-profiles/pgo_profiles
+ 
++  # Link to system tools required by the build
++  pushd src
++  mkdir -p third_party/node/linux/node-linux-x64/bin
++  ln -sfn /usr/bin/node third_party/node/linux/node-linux-x64/bin/
++  mkdir -p third_party/jdk/current/bin
++  ln -sfn /usr/bin/java third_party/jdk/current/bin/
++  ln -sfn /usr/bin/clang-format buildtools/linux64
++  popd
++
++  pushd src/third_party/node/
++  sed -i -e 's/@rollup/rollup/' -e "s/'wasm-node',//" node_modules.py
++  local _rollup_ver="$(jq -r .dependencies.\"@rollup/wasm-node\" package.json)"
++  jq ".dependencies.rollup=\"$_rollup_ver\"" package.json > package.json.new
++  mv package.json{.new,}
++  popd
+   # https://gitlab.archlinux.org/archlinux/packaging/packages/electron32/-/issues/1
+   src/third_party/node/update_npm_deps
++  pushd src/third_party/devtools-frontend/src
++  sed -i -e 's/@rollup/rollup/' -e "s/'wasm-node',//" scripts/devtools_paths.py
++  local _rollup_ver="$(jq -r .devDependencies.\"@rollup/wasm-node\" package.json)"
++  jq ".devDependencies.rollup=\"$_rollup_ver\" | .devDependencies.\"@rollup/rollup-linux-riscv64-gnu\"=\"$_rollup_ver\""  package.json > package.json.new
++  mv package.json{.new,}
++  # Chromium hosts a custom registry at https://npm.skia.org/chrome-devtools/
++  # and rejects some packages:
++  # Package fs-extra with version 11.3.0 was created 108h0m0s time ago. This is less than 1 week and so failed the audit.
++  sed -i /registry/d .npmrc
++  # Replace direct invocation of wasm rollup
++  sed -i 's\@rollup/wasm-node\rollup\' \
++    inspector_overlay/BUILD.gn \
++    front_end/models/live-metrics/web-vitals-injected/BUILD.gn \
++    front_end/Images/BUILD.gn \
++    front_end/panels/recorder/injected/BUILD.gn \
++    scripts/build/ninja/bundle.gni
++  popd
++  python src/third_party/devtools-frontend/src/scripts/deps/manage_node_deps.py
+ 
+   src/electron/script/apply_all_patches.py \
+       src/electron/patches/config.json
+@@ -480,6 +527,8 @@ prepare() {
+     third_party/blink/renderer/core/xml/parser/xml_document_parser.cc \
+     third_party/libxml/chromium/*.cc
+ 
++  patch -Np0 -i ../Debian-fix-rust-linking.patch
++
+   # Upstream fixes
+   # patch -Np1 -i ../disable-clang-fextend-variable-liveness.patch
+   # patch -d third_party/pdfium -Np1 < ../pdfium-fix-build-with-system-libpng.patch
+@@ -553,6 +602,8 @@ build() {
+     'enable_hangout_services_extension=true'
+     'enable_widevine=false'
+     'enable_nacl=false'
++    'is_clang=true'
++    "override_electron_version=\"$pkgver\""
+   )
+ 
+   if [[ -n ${_system_libs[icu]+set} ]]; then
+@@ -566,7 +617,7 @@ build() {
+     'clang_base_path="/usr"'
+     'clang_use_chrome_plugins=false'
+     "clang_version=\"$_clang_version\""
+-    'chrome_pgo_phase=2'
++    'chrome_pgo_phase=0'
+   )
+ 
+   # Allow the use of nightly features with stable Rust compiler
+@@ -588,6 +639,10 @@ build() {
+   CFLAGS+='   -Wno-unknown-warning-option'
+   CXXFLAGS+=' -Wno-unknown-warning-option'
+ 
++  # Remove flags that are causing weird bugs on riscv64
++  CFLAGS=${CFLAGS/-Wp,-D_FORTIFY_SOURCE=2}
++  CXXFLAGS=${CXXFLAGS/-Wp,-D_FORTIFY_SOURCE=2}
++
+   # Let Chromium set its own symbol level
+   CFLAGS=${CFLAGS/-g }
+   CXXFLAGS=${CXXFLAGS/-g }
+@@ -603,6 +658,11 @@ build() {
+   CFLAGS=${CFLAGS/-fstack-clash-protection}
+   CXXFLAGS=${CXXFLAGS/-fstack-clash-protection}
+ 
++  # Chromium already targets rv64gc. Manually setting it in CFLAGS overrides some objects
++  # that should be complied with rv64gcv
++  CFLAGS=${CFLAGS/-march=rv64gc }
++  CXXFLAGS=${CXXFLAGS/-march=rv64gc }
++
+   # https://crbug.com/957519#c122
+   CXXFLAGS=${CXXFLAGS/-Wp,-D_GLIBCXX_ASSERTIONS}
+ 
+@@ -635,3 +695,5 @@ package() {
+   install -Dm644 src/electron/default_app/icon.png \
+           "${pkgdir}/usr/share/pixmaps/${pkgname}.png"  # hicolor has no 1024x1024
+ }
++
++sha256sums[0]=SKIP
+diff --git compiler-rt-adjust-paths.patch compiler-rt-adjust-paths.patch
+index 96c06c5..c0b48df 100644
+--- compiler-rt-adjust-paths.patch
++++ compiler-rt-adjust-paths.patch
+@@ -1,8 +1,8 @@
+ diff --git a/build/config/clang/BUILD.gn b/build/config/clang/BUILD.gn
+-index 8c03235f5d14..6c9afd9e1b5b 100644
++index 8c03235f5d141..3e77418fe5414 100644
+ --- a/build/config/clang/BUILD.gn
+ +++ b/build/config/clang/BUILD.gn
+-@@ -210,12 +210,15 @@ template("clang_lib") {
++@@ -210,12 +210,18 @@ template("clang_lib") {
+        } else if (is_linux || is_chromeos) {
+          if (current_cpu == "x64") {
+            _dir = "x86_64-unknown-linux-gnu"
+@@ -15,10 +15,13 @@ index 8c03235f5d14..6c9afd9e1b5b 100644
+          } else if (current_cpu == "arm64") {
+            _dir = "aarch64-unknown-linux-gnu"
+ +          _suffix = "-aarch64"
+++        } else if (current_cpu == "riscv64") {
+++           _dir = "riscv64-unknown-linux-gnu"
+++           _suffix = "-riscv64"
+          } else if (current_cpu == "loong64") {
+            _dir = "loongarch64-unknown-linux-gnu"
+          } else {
+-@@ -248,6 +251,11 @@ template("clang_lib") {
++@@ -248,6 +254,11 @@ template("clang_lib") {
+          assert(false)  # Unhandled target platform
+        }
+  
+@@ -30,4 +33,3 @@ index 8c03235f5d14..6c9afd9e1b5b 100644
+        _lib_file = "${_prefix}clang_rt.${_libname}${_suffix}.${_ext}"
+        libs = [ "$_clang_lib_dir/$_dir/$_lib_file" ]
+  
+-


### PR DESCRIPTION
Based on electron36 patches.

Changes at riscv-forks/electron: https://github.com/riscv-forks/electron/compare/4869844bf258f1d73345d1fb4efb59f2f9646ffd..v37.2.6-riscv/