### PR TITLE
fixpatch: glibc 2.42+r3+gbc13db739377-1

### DIFF
--- a/glibc/riscv64.patch
+++ b/glibc/riscv64.patch
@@ -52,7 +52,7 @@
        --enable-stack-protector=strong
        --enable-systemtap
        --disable-nscd
-@@ -62,6 +62,12 @@ build() {
+@@ -62,6 +62,14 @@ build() {
    # _FORTIFY_SOURCE=3 causes testsuite build failure and is unnecessary during
    # actual builds (support is built-in via --enable-fortify-source).
    CFLAGS=${CFLAGS/-Wp,-D_FORTIFY_SOURCE=3/}
@@ -62,10 +62,12 @@
 +  # the old happy path of generating R_RISCV_CALL_PLT for such memset calls and
 +  # then optimizing them away.
 +  CFLAGS=${CFLAGS/-fno-plt/}
++  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=121534
++  CFLAGS+=" -fno-builtin-round"
  
    (
      cd glibc-build
-@@ -75,7 +81,6 @@ build() {
+@@ -75,7 +83,6 @@ build() {
          --libdir=/usr/lib \
          --libexecdir=/usr/lib \
          --enable-cet \
@@ -73,7 +75,7 @@
          "${_configure_flags[@]}"
  
      make -O
-@@ -84,29 +89,6 @@ build() {
+@@ -84,29 +91,6 @@ build() {
      make info
    )
  
@@ -103,7 +105,7 @@
    # pregenerate locales here instead of in package
    # functions because localedef does not like fakeroot
    make -C "${srcdir}"/glibc/localedata objdir="${srcdir}"/glibc-build \
-@@ -141,7 +123,7 @@ check() (
+@@ -141,7 +125,7 @@ check() (
    _skip_test tst-shstk-legacy-1g     sysdeps/x86_64/Makefile
    _skip_test tst-adjtime             time/Makefile
  
@@ -112,7 +114,7 @@
  )
  
  package_glibc() {
-@@ -190,31 +172,6 @@ package_glibc() {
+@@ -190,31 +174,6 @@ package_glibc() {
    install -Dm644 "${srcdir}"/sdt-config.h "${pkgdir}"/usr/include/sys/sdt-config.h
  }
  
@@ -144,7 +146,7 @@
  package_glibc-locales() {
    pkgdesc='Pregenerated locales for GNU C Library'
    depends=("glibc=$pkgver")
-@@ -225,3 +182,9 @@ package_glibc-locales() {
+@@ -225,3 +184,9 @@ package_glibc-locales() {
    # deduplicate locale data
    hardlink -c "${pkgdir}"/usr/lib/locale
  }


### PR DESCRIPTION
Add `-fno-builtin-round` to `CFLAGS` because GCC 15 misoptimizes C23 {sin,cos,tan}pi functions using this builtin, which causes the following 9 tests to fail:

    FAIL: math/test-double-cospi
    FAIL: math/test-double-sinpi
    FAIL: math/test-double-tanpi
    FAIL: math/test-float32x-cospi
    FAIL: math/test-float32x-sinpi
    FAIL: math/test-float32x-tanpi
    FAIL: math/test-float64-cospi
    FAIL: math/test-float64-sinpi
    FAIL: math/test-float64-tanpi

with Failure: sinpi (qNaN): Exception "Invalid operation" set

The "inline"-ed round builtin uses signaling comparision code `flt.d`, which raises NV exception bit even for quiet NaN. It does not save/restore fflags (at least after optimization), thus causes the above test failure.

This bug only affects riscv64 and gcc 15.

Additional details are available in my bug report: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=121534