### PR TITLE
qemu-user-blacklist: add darkhttpd

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -17,6 +17,7 @@ chezmoi
 cloud-init
 coreutils
 ctags
+darkhttpd
 datovka
 dbus
 diffutils


### PR DESCRIPTION
darkhttpd's test uses lsan which doesn't work without ptrace:

```
===> test_make_safe_uri
==2547==LeakSanitizer has encountered a fatal error.
==2547==HINT: For debugging, try setting environment variable LSAN_OPTIONS=verbosity=1:log_threads=1
==2547==HINT: LeakSanitizer does not work under ptrace (strace, gdb, etc)
```

In addition, the test may need more beefy machine to pass. On Unmatched the tests' HTTP client will send requests before server starts to listen to socket and fails:

```
======================================================================
ERROR: test_forward_relative (__main__.TestForward.test_forward_relative)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/var/lib/archbuild/extra-riscv64/hacker/build/darkhttpd/src/darkhttpd/devel/test_forward.py", line 16, in test_forward_relative
    resp = self.get('/foo/bar', req_hdrs={'Host': 'secure.example.com'})
  File "/var/lib/archbuild/extra-riscv64/hacker/build/darkhttpd/src/darkhttpd/devel/test.py", line 109, in get
    c = Conn()
  File "/var/lib/archbuild/extra-riscv64/hacker/build/darkhttpd/src/darkhttpd/devel/test.py", line 30, in __init__
    self.s.connect(("0.0.0.0", self.port))
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
ConnectionRefusedError: [Errno 111] Connection refused
```

Timeout could be added but that would be an extra patch to maintain.