### PR TITLE
addpatch: hashcat 7.1.0-1

### DIFF
--- a/hashcat/riscv64.patch
+++ b/hashcat/riscv64.patch
@@ -1,0 +1,20 @@
+diff --git PKGBUILD PKGBUILD
+index cbda150..86c2c15 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -25,6 +25,7 @@
+   make \
+     PREFIX=/usr \
+     SHARED=1 \
++    MAINTAINER_MODE=1 \
+     USE_SYSTEM_XXHASH=1 \
+     USE_SYSTEM_OPENCL=1 \
+     USE_SYSTEM_ZLIB=1
+@@ -36,6 +37,7 @@
+     DESTDIR="${pkgdir}" \
+     PREFIX=/usr \
+     SHARED=1 \
++    MAINTAINER_MODE=1 \
+     USE_SYSTEM_XXHASH=1 \
+     USE_SYSTEM_OPENCL=1 \
+     USE_SYSTEM_ZLIB=1 \


### PR DESCRIPTION
Set `MAINTAINER_MODE=1` to disable `-march=native` and `-mavx2`.

https://gitlab.archlinux.org/archlinux/packaging/packages/hashcat/-/merge_requests/2