### PR TITLE
addpatch: opensearch-sql-plugin 3.1.0.0-1

### DIFF
--- a/opensearch-sql-plugin/riscv64.patch
+++ b/opensearch-sql-plugin/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -29,6 +29,7 @@ build() {
+     --exclude-task ":doctest:doctest" \
+     --exclude-task ":jacocoTestReport" \
+     --exclude-task ":sql:build" \
++    --exclude-task ":integ-test:yamlRestTest" \
+     --exclude-task ":integ-test:integTest"
+ }
+ 


### PR DESCRIPTION
Skip `:integ-test:yamlRestTest` as it requires downloading an official release binary tarball, which does not exist for riscv64.

(OpenSearch now supports riscv64 only in source but not in binary releases)