### PR TITLE
updpatch: gcc 15.2.1+r22+gc4e96a094636-1

### DIFF
--- a/gcc/riscv64.patch
+++ b/gcc/riscv64.patch
@@ -25,7 +25,17 @@
  prepare() {
    [[ ! -d gcc ]] && ln -s gcc-${pkgver/+/-} gcc
    cd gcc
-@@ -79,7 +82,7 @@ build() {
+@@ -68,6 +71,9 @@ prepare() {
+   # Reproducible gcc-ada
+   patch -Np0 < "$srcdir/gcc-ada-repro.patch"
+ 
++  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=121534
++  git cherry-pick -n f12a272169523823ff27d69f187f73c4211222ae
++
+   mkdir -p "$srcdir/gcc-build"
+   mkdir -p "$srcdir/libgccjit-build"
+ }
+@@ -79,7 +85,7 @@ build() {
        --libexecdir=/usr/lib
        --mandir=/usr/share/man
        --infodir=/usr/share/info
@@ -34,7 +44,7 @@
        --with-build-config=bootstrap-lto
        --with-linker-hash-style=gnu
        --with-system-zlib
-@@ -95,7 +98,7 @@ build() {
+@@ -95,7 +101,7 @@ build() {
        --enable-link-serialization=1
        --enable-linker-build-id
        --enable-lto
@@ -43,7 +53,7 @@
        --enable-plugin
        --enable-shared
        --enable-threads=posix
-@@ -113,7 +116,7 @@ build() {
+@@ -113,7 +119,7 @@ build() {
    CXXFLAGS=${CXXFLAGS/-Werror=format-security/}
  
    "$srcdir/gcc/configure" \
@@ -52,7 +62,7 @@
      --enable-bootstrap \
      "${_confflags[@]:?_confflags unset}"
  
-@@ -161,9 +164,9 @@ check() {
+@@ -161,9 +167,9 @@ check() {
  package_gcc-libs() {
    pkgdesc='Runtime libraries shipped by GCC'
    depends=('glibc>=2.27')
@@ -64,7 +74,7 @@
    replaces=($pkgname-multilib libgphobos)
  
    cd gcc-build
-@@ -176,9 +179,8 @@ package_gcc-libs() {
+@@ -176,9 +182,8 @@ package_gcc-libs() {
               libgomp \
               libitm \
               libquadmath \
@@ -76,7 +86,7 @@
      make -C $CHOST/$lib DESTDIR="$pkgdir" install-toolexeclibLTLIBRARIES
    done
  
-@@ -195,18 +197,17 @@ package_gcc-libs() {
+@@ -195,18 +200,17 @@ package_gcc-libs() {
      make -C $CHOST/$lib DESTDIR="$pkgdir" install-info
    done
  
@@ -98,7 +108,7 @@
    provides=($pkgname-multilib)
    replaces=($pkgname-multilib)
    options=(!emptydirs staticlibs)
-@@ -220,22 +221,18 @@ package_gcc() {
+@@ -220,22 +224,18 @@ package_gcc() {
    install -m755 -t "$pkgdir/${_libdir}/" gcc/{cc1,cc1plus,collect2,lto1}
  
    make -C $CHOST/libgcc DESTDIR="$pkgdir" install
@@ -123,7 +133,7 @@
  
    make DESTDIR="$pkgdir" install-fixincludes
    make -C gcc DESTDIR="$pkgdir" install-mkheaders
-@@ -250,17 +247,12 @@ package_gcc() {
+@@ -250,17 +250,12 @@ package_gcc() {
    make -C $CHOST/libquadmath DESTDIR="$pkgdir" install-nodist_libsubincludeHEADERS
    make -C $CHOST/libsanitizer DESTDIR="$pkgdir" install-nodist_{saninclude,toolexeclib}HEADERS
    make -C $CHOST/libsanitizer/asan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
@@ -142,7 +152,7 @@
  
    make -C libcpp DESTDIR="$pkgdir" install
    make -C gcc DESTDIR="$pkgdir" install-po
-@@ -271,7 +263,7 @@ package_gcc() {
+@@ -271,7 +266,7 @@ package_gcc() {
    # create cc-rs compatible symlinks
    # https://github.com/rust-lang/cc-rs/blob/1.0.73/src/lib.rs#L2578-L2581
    for binary in {c++,g++,gcc,gcc-ar,gcc-nm,gcc-ranlib}; do
@@ -151,7 +161,7 @@
    done
  
    # POSIX conformance launcher scripts for c89 and c99
-@@ -281,9 +273,6 @@ package_gcc() {
+@@ -281,9 +276,6 @@ package_gcc() {
    # install the libstdc++ man pages
    make -C $CHOST/libstdc++-v3/doc DESTDIR="$pkgdir" doc-install-man
  
@@ -161,7 +171,7 @@
    # byte-compile python libraries
    python -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
    python -O -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
-@@ -303,8 +292,6 @@ package_gcc-fortran() {
+@@ -303,8 +295,6 @@ package_gcc-fortran() {
    cd gcc-build
    make -C $CHOST/libgfortran DESTDIR="$pkgdir" install-cafexeclibLTLIBRARIES \
      install-{toolexeclibDATA,nodist_fincludeHEADERS,gfor_cHEADERS}
@@ -170,7 +180,7 @@
    make -C $CHOST/libgomp DESTDIR="$pkgdir" install-nodist_fincludeHEADERS
    make -C gcc DESTDIR="$pkgdir" fortran.install-{common,man,info}
    install -Dm755 gcc/f951 "$pkgdir/${_libdir}/f951"
-@@ -382,7 +369,6 @@ package_gcc-go() {
+@@ -382,7 +372,6 @@ package_gcc-go() {
  
    cd gcc-build
    make -C $CHOST/libgo DESTDIR="$pkgdir" install-exec-am


### PR DESCRIPTION
Cherry-pick the fix for
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=121534, which causes glibc's sinpi/cospi/tanpi functions to be misoptimized.

We can drop #4876 after this, or maybe we can also skip the previous toolchain update and start with this one instead.