### PR TITLE
updpatch: firefox-developer-edition 142.0b9-1

### DIFF
--- a/firefox-developer-edition/riscv64.patch
+++ b/firefox-developer-edition/riscv64.patch
@@ -1,30 +1,22 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -152,7 +152,7 @@ ac_add_options --with-system-nss
+@@ -151,10 +151,18 @@ ac_add_options --with-system-nss
  # Features
  ac_add_options --enable-alsa
  ac_add_options --enable-jack
 -ac_add_options --enable-crashreporter
-+ac_add_options --disable-crashreporter
  ac_add_options --disable-updater
  ac_add_options --disable-tests
  END
-@@ -174,6 +174,10 @@ build() {
-   CFLAGS="${CFLAGS/-fexceptions/}"
-   CXXFLAGS="${CXXFLAGS/-fexceptions/}"
- 
-+  cat >.mozconfig ../mozconfig
-+  ./mach build --priority normal
 +
-+: <<COMMENT
-   # LTO needs more open files
-   ulimit -n 4096
- 
-@@ -208,6 +212,7 @@ ac_add_options --with-pgo-profile-path=${PWD@Q}/merged.profdata
- ac_add_options --with-pgo-jarlog=${PWD@Q}/jarlog
- END
-   ./mach build --priority normal
-+COMMENT
++  case "$CARCH" in
++    x86_64 | i*86 | arm* | aarch64)
++      echo 'ac_add_options --enable-crashreporter' >>../mozconfig
++      ;;
++    *)
++      echo 'ac_add_options --disable-crashreporter' >>../mozconfig
++      ;;
++  esac
  }
  
- package() {
+ build() {


### PR DESCRIPTION
- Upstreamed disabling of crash reporter: https://gitlab.archlinux.org/archlinux/packaging/packages/firefox-developer-edition/-/merge_requests/2
- Enable PGO as Firefox builds fine with it