### PR TITLE
sv39-blacklist: add phpldapadmin

### DIFF
--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -3,6 +3,7 @@ forgejo
 gitea
 grafana-agent
 navidrome
+phpldapadmin
 prettier
 prometheus
 vue-language-tools


### PR DESCRIPTION
```
/build/phpldapadmin/src/phpLDAPadmin-2.2.2/node_modules/webpack/lib/util/hash/wasm-hash.js:168                                                                                                                                                                                             
                new WebAssembly.Instance(wasmModule),                                                                                                                                                                                                                                      
                ^                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                           
RangeError: WebAssembly.Instance(): Out of memory: Cannot allocate Wasm memory for new instance
```