### PR TITLE
addpatch: vlc 3.0.21-28

### DIFF
--- a/vlc/riscv64.patch
+++ b/vlc/riscv64.patch
@@ -1,0 +1,45 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -9,7 +9,7 @@ pkgname=(
+   libvlc
+   vlc-cli
+   vlc-gui-{ncurses,qt,skins2}
+-  vlc-plugin-{a52dec,aalib,alsa,aom,archive,aribb24,aribb25,ass,avahi,bluray,caca,cddb,chromecast,dav1d,dbus,dbus-screensaver,dca,dvb,dvd,faad2,ffmpeg,firewire,flac,fluidsynth,freetype,gme,gnutls,gstreamer,inflate,jack,journal,jpeg,kate,kwallet,libsecret,lirc,live555,lua,mad,matroska,mdns,modplug,mpeg2,mpg123,mtp,musepack,nfs,notify,ogg,opus,png,pulse,quicksync,samplerate,sdl,sftp,shout,smb,soxr,speex,srt,svg,tag,theora,twolame,udev,upnp,vorbis,vpx,x264,x265,xml,zvbi}
++  vlc-plugin-{a52dec,aalib,alsa,aom,archive,aribb24,aribb25,ass,avahi,bluray,caca,cddb,chromecast,dav1d,dbus,dbus-screensaver,dca,dvb,dvd,faad2,ffmpeg,firewire,flac,fluidsynth,freetype,gme,gnutls,gstreamer,inflate,jack,journal,jpeg,kate,kwallet,libsecret,lirc,live555,lua,mad,matroska,mdns,modplug,mpeg2,mpg123,mtp,musepack,nfs,notify,ogg,opus,png,pulse,samplerate,sdl,sftp,shout,smb,soxr,speex,srt,svg,tag,theora,twolame,udev,upnp,vorbis,vpx,x264,x265,xml,zvbi}
+   vlc-plugins-{all,base,extra,video-output,visualization}
+ )
+ _vlcver=3.0.21
+@@ -509,8 +509,6 @@ package_vlc() {
+     _pick $pkgname-plugin-pulse usr/lib/vlc/plugins/audio_output/libpulse_plugin.so
+     _pick $pkgname-plugin-pulse usr/lib/vlc/plugins/services_discovery/libpulselist_plugin.so
+ 
+-    _pick $pkgname-plugin-quicksync usr/lib/vlc/plugins/codec/libqsv_plugin.so
+-
+     _pick $pkgname-plugin-samplerate usr/lib/vlc/plugins/audio_filter/libsamplerate_plugin.so
+ 
+     _pick $pkgname-plugin-sdl usr/lib/vlc/plugins/codec/libsdl_image_plugin.so
+@@ -790,16 +788,10 @@ package_vlc() {
+     _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libgrey_yuv_plugin.so
+     _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi420_10_p010_plugin.so
+     _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi420_nv12_plugin.so
+-    _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi420_rgb_mmx_plugin.so
+     _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi420_rgb_plugin.so
+-    _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi420_rgb_sse2_plugin.so
+-    _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi420_yuy2_mmx_plugin.so
+     _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi420_yuy2_plugin.so
+-    _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi420_yuy2_sse2_plugin.so
+     _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi422_i420_plugin.so
+-    _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi422_yuy2_mmx_plugin.so
+     _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi422_yuy2_plugin.so
+-    _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi422_yuy2_sse2_plugin.so
+     _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/librv32_plugin.so
+     _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libyuvp_plugin.so
+     _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libyuy2_i420_plugin.so
+@@ -1964,7 +1956,6 @@ package_vlc-plugins-extra() {
+     vlc-plugin-mtp
+     vlc-plugin-musepack
+     vlc-plugin-nfs
+-    vlc-plugin-quicksync
+     vlc-plugin-samplerate
+     vlc-plugin-sdl
+     vlc-plugin-sftp


### PR DESCRIPTION
- Drop vlc-plugin-quicksync because it depends on libmfx which we haven't packaged yet.
- Drop x86 specific plugins in vlc-plugins-base.
- There are no riscv specific plugins for us to pick in this version. But we will need to pick up libdeinterlace_rvv_plugin, libtransform_rvv_plugin and libvolume_rvv_plugin in future releases.