### PR TITLE
addpatch: grilo-plugins 0.3.18-1

### DIFF
--- a/grilo-plugins/riscv64.patch
+++ b/grilo-plugins/riscv64.patch
@@ -1,0 +1,15 @@
+diff --git PKGBUILD PKGBUILD
+index 427088d..65a0887 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -79,7 +79,9 @@ build() {
+ }
+ 
+ check() {
+-  dbus-run-session meson test -C build --print-errorlogs
++  local skip_tests='test_lua_theaudiodb|test_chromaprint_resolve'
++  local tests_to_run=$(meson test --list -C build | grep -E -v "$skip_tests")
++  dbus-run-session meson test -C build --print-errorlogs  ${tests_to_run}
+ }
+ 
+ package() {


### PR DESCRIPTION
skip two test.
test_lua_theaudiodb is an old issue to  the upstream that havn't be solved.[upstreamed](https://gitlab.gnome.org/GNOME/grilo-plugins/-/issues/56)Used to get data from TheAudioDB website, non-critical function.
test_chromaprint_resolve,the root cause of the failure is not in the grilo-plugins we are building. The gst-plugins-bad package required by the check depends on the old version of x265 when compiled. However, the arch repository in riscv later updated x265 but did not recompile gst-plugins-bad(?), resulting in ABI problem.and i skip this.