### PR TITLE
addpatch: onetbb 2022.2.0-1

### DIFF
--- a/onetbb/riscv64.patch
+++ b/onetbb/riscv64.patch
@@ -1,0 +1,25 @@
+diff --git PKGBUILD PKGBUILD
+index 40b401a..06b8a45 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -28,14 +28,18 @@ conflicts=('intel-tbb' 'tbb')
+ provides=("intel-tbb=${pkgver}" "tbb=${pkgver}")
+ replaces=('intel-tbb' 'tbb')
+ source=("https://github.com/uxlfoundation/oneTBB/archive/v${pkgver}/${pkgname}-${pkgver}.tar.gz"
+-        '010-onetbb-fix-linkage-of-test-malloc-pure-c.patch')
++        '010-onetbb-fix-linkage-of-test-malloc-pure-c.patch'
++        onetbb-enable-fcf-protection-on-x86-only.patch::https://github.com/uxlfoundation/oneTBB/commit/65d46656f56200a7e89168824c4dbe4943421ff9.patch)
+ sha512sums=('d87c67514ca17c9769910194a8fac912e183952ad5c408dbceb48edc8aef13375df3d4c9120a7366206c8ab72699ed953df65c11c261e19d8e9d273c73d073f3'
+-            'e94bcdfb6fd6d9d4ee9a16f4dc21c57bd24d78143899239afcf708aea0c8daf94a34490ccea1e9b2308036bdeb143eea2d3d8d02274f0806e47d83a7e9696ba5')
++            'e94bcdfb6fd6d9d4ee9a16f4dc21c57bd24d78143899239afcf708aea0c8daf94a34490ccea1e9b2308036bdeb143eea2d3d8d02274f0806e47d83a7e9696ba5'
++            '55c8b2fed32d501d1450c60ada29a93f138560d7da214ee80b13aad6d47657be72dc84974f3c5ff893c5439d8cf132702fa044738f402fb393ec8e5d0a708249')
+ 
+ prepare() {
+     # https://github.com/uxlfoundation/oneTBB/issues/1735
+     # https://gitlab.archlinux.org/archlinux/packaging/packages/onetbb/-/merge_requests/2
+     patch -d "oneTBB-${pkgver}" -Np1 -i "${srcdir}/010-onetbb-fix-linkage-of-test-malloc-pure-c.patch"
++    # https://github.com/uxlfoundation/oneTBB/pull/1768
++    patch -d "oneTBB-${pkgver}" -Np1 -i "${srcdir}/onetbb-enable-fcf-protection-on-x86-only.patch"
+ }
+ 
+ build() {


### PR DESCRIPTION
Backport a patch to fix build on non-x86 architectures.