### PR TITLE
sv39-blacklist: add python-esphome-dashboard

### DIFF
--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -6,4 +6,5 @@ navidrome
 phpldapadmin
 prettier
 prometheus
+python-esphome-dashboard
 vue-language-tools


### PR DESCRIPTION
```
src/index.ts → esphome_dashboard/static/js/esphome/...
[!] (plugin monaco) RangeError: WebAssembly.instantiate(): Out of memory: Cannot allocate Wasm memory for new instance
RangeError: WebAssembly.instantiate(): Out of memory: Cannot allocate Wasm memory for new instance
```