### PR TITLE
addpatch: basis-universal 1.60-1

### DIFF
--- a/basis-universal/riscv64.patch
+++ b/basis-universal/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index e8917f7..c8aa47d 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -38,7 +38,7 @@ build() {
+     -G Ninja
+     -D CMAKE_BUILD_TYPE=Release
+     -D CMAKE_INSTALL_PREFIX=/usr
+-    -D SSE=ON
++    # -D SSE=ON
+     -W no-dev
+   )
+ 


### PR DESCRIPTION
SSE isn't available in riscv64