### PR TITLE
addpatch: chewing-editor 0.1.2-1

### DIFF
--- a/chewing-editor/riscv64.patch
+++ b/chewing-editor/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index 3e6620d..2c39610 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -29,7 +29,7 @@ build() {
+ check() {
+     cd build
+ 
+-    make test
++    make test ARGS="-E valgrind"
+ }
+ 
+ package() {


### PR DESCRIPTION
On riscv64, Valgrind fails to start after failing to redirect dynamic linker symbols.  [upstreamed](https://bugs.kde.org/show_bug.cgi?id=510193)