### PR TITLE
addpatch: libgcrypt 1.11.2-1

### DIFF
--- a/libgcrypt/riscv64.patch
+++ b/libgcrypt/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -21,7 +21,7 @@ license=(
+     'LicenseRef-OCB1'
+ )
+ depends=('libgpg-error' 'glibc')
+-options=('!emptydirs')
++options=('!emptydirs' '!lto')
+ # https://www.gnupg.org/download/integrity_check.html
+ source=(https://gnupg.org/ftp/gcrypt/${pkgname}/${pkgname}-${pkgver}.tar.bz2{,.sig})
+ sha256sums=('6ba59dd192270e8c1d22ddb41a07d95dcdbc1f0fb02d03c4b54b235814330aac'


### PR DESCRIPTION
- Disable LTO due to RVV related LTO errors. This is tracked upstream in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=110812#c7
- libgcrypt has runtime dispatch support for RVV.