### PR TITLE
updpatch: opensearch 3.2.0-1

### DIFF
--- a/opensearch/riscv64.patch
+++ b/opensearch/riscv64.patch
@@ -8,8 +8,8 @@
  arch=('x86_64')
  url="https://opensearch.org/docs/opensearch/index/"
  license=('Apache-2.0')
--makedepends=("java-environment-openjdk=${_jdkver}" 'unzip')
-+makedepends=("java-environment-openjdk=${_jdkver}" 'unzip' 'cmake' 'abseil-cpp')
+-makedepends=("java-environment-openjdk=${_jdkver}" "java-environment-openjdk=11" "java-environment-openjdk=17" 'unzip')
++makedepends=("java-environment-openjdk=${_jdkver}" "java-environment-openjdk=11" "java-environment-openjdk=17" 'unzip' 'cmake' 'abseil-cpp')
  source=(
    "OpenSearch-${pkgver}.tar.gz::https://github.com/opensearch-project/OpenSearch/archive/${pkgver}.tar.gz"
    opensearch.service
@@ -19,9 +19,9 @@
    opensearch.default
 +  "protobuf-${_protobuf_ver}.tar.gz::https://github.com/protocolbuffers/protobuf/archive/v${_protobuf_ver}.tar.gz"
  )
- sha256sums=('7f682d85fb82c2caa9fe6dff0a0c1769df0b5ed96b993ac8cdd6485f3d103fda'
+ sha256sums=('1f791778b8c86c1072181c810022f904613b9061568698ac014224ac71e12419'
              'b59d064ce8e348f22b969cc2b7522a1c7b64d4b4e3fd98d9ad1f01d842e94d46'
-@@ -52,7 +54,18 @@ sha256sums=('7f682d85fb82c2caa9fe6dff0a0c1769df0b5ed96b993ac8cdd6485f3d103fda'
+@@ -52,7 +54,18 @@ sha256sums=('1f791778b8c86c1072181c810022f904613b9061568698ac014224ac71e12419'
              'a133b8944d57d81224caf03f8d0e5b127f2570123b2a1e2d2f6eb199446448ae'
              '515e509f811a367cfd0a6cbafb3f8f472276410d53df7957aa878d8047a3cfc6'
              'eb1ea6146d2bd16eeb63061dfcdb7ebed55da556397c7d6c924941b1564f1f72'
@@ -41,7 +41,7 @@
  
  build() {
    cd "OpenSearch-${pkgver}"
-@@ -64,7 +77,7 @@ build() {
+@@ -66,7 +79,7 @@ build() {
  
    # OpenSearch
    ./gradlew :distribution:buildSystemdModule
@@ -50,7 +50,7 @@
  
    # Plugins
    for p in \
-@@ -149,7 +162,7 @@ package_opensearch() {
+@@ -151,7 +164,7 @@ package_opensearch() {
    install -dm755 "${pkgdir}"/{usr/share,var/lib,var/log}/opensearch
    install -dm755 "${pkgdir}/usr/bin"
  


### PR DESCRIPTION
- Refresh patch
- One test might fail with the following error on dual-processor SG2042, but works fine elsewhere.

      > `node{:plugins:analysis-icu:yamlRestTest-0}` failed to wait for ports files after 150000 MILLISECONDS