### PR TITLE
addpatch: calcmysky 0.3.5-1

### DIFF
--- a/calcmysky/riscv64.patch
+++ b/calcmysky/riscv64.patch
@@ -1,0 +1,12 @@
+diff --git PKGBUILD PKGBUILD
+index f40a7a2..14705b4 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -32,6 +32,6 @@ check() {
+ }
+ 
+ package() {
+-  DESTDIR="$pkgdir" cmake --build build --target install
++  DESTDIR="$pkgdir" cmake --build build --target install -- -j1
+   install -vDm 644 CalcMySky/COPYING -t "$pkgdir/usr/share/licenses/$pkgname"
+ }


### PR DESCRIPTION
The package can be packaged normally in the container, but the parallel compilation is stuck under qemu-user simulation.  run it with a single thread.