### PR TITLE
addpatch: wild 0.6.0-1

### DIFF
--- a/wild/riscv64.patch
+++ b/wild/riscv64.patch
@@ -1,0 +1,19 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -33,6 +33,7 @@ b2sums=('02d33e93d594429a6999fcc9ac4ba9b8e6107d4a160260d83f0f5da288f7b2583581a14
+ prepare() {
+   cd "${pkgname}-${pkgver}"
+   cp "${srcdir}/test-config.toml" .
++  patch -Np1 -i ../fix-riscv64-build.patch
+   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+ }
+ 
+@@ -53,4 +54,8 @@ package() {
+   install -Dm 644 LICENSE-* -t "${pkgdir}/usr/share/licenses/${pkgname}"
+ }
+ 
++source+=(fix-riscv64-build.patch::https://github.com/davidlattimore/wild/commit/faee8336979722f08bef470923e0af2549840105.diff)
++sha256sums+=('10bd1f1da65b6908f52db72bc3c86d0ac1cc07abf2c637be2c671d53ad1fc11b')
++b2sums+=('58b95e8620e5552ff4a87b34c8dc0fe86a4c7da952a5e611ace6782d0a09646aea9e044bcd38bb81892f9848f308eff0e690bc5f0f5bef5717539ddbd1f299d2')
++
+ # vim: ts=2 sw=2 et:


### PR DESCRIPTION
Upstream supports RISC-V now. Backporting one compilation fix to make it work on our side.