### PR TITLE
updpatch: glibc 2.42+r17+gd7274d718e6f-1

### DIFF
--- a/glibc/riscv64.patch
+++ b/glibc/riscv64.patch
@@ -1,32 +1,5 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -14,22 +14,22 @@ pkgrel=1
- arch=(x86_64)
- url='https://www.gnu.org/software/libc'
- license=(GPL-2.0-or-later LGPL-2.1-or-later)
--makedepends=(git gd lib32-gcc-libs python)
-+makedepends=(git gd python)
- options=(staticlibs !lto)
- source=("git+https://sourceware.org/git/glibc.git#commit=${_commit}"
-         locale.gen.txt
-         locale-gen
--        lib32-glibc.conf
-         sdt.h sdt-config.h
-+        "mremap-fix-test.patch::https://inbox.sourceware.org/libc-alpha/20250208-fix-mremap-tst-v1-1-ad7ee617ec65@coelacanthus.name/raw"
- )
- validpgpkeys=(7273542B39962DF7B299931416792B4EA25340F8 # Carlos O'Donell
-               BC7C7372637EC10C57D7AA6579C43DFBF1CF2187) # Siddhesh Poyarekar
- b2sums=('e3b06cd0f8d34a3f9d5d7c01cd87aec1b14eaaa0d501c242c7a54f63299bf10afa7d9ddc4a071c2295c500af4e750fe62107d0570ddaffccfeb216675a8b913e'
-         'c859bf2dfd361754c9e3bbd89f10de31f8e81fd95dc67b77d10cb44e23834b096ba3caa65fbc1bd655a8696c6450dfd5a096c476b3abf5c7e125123f97ae1a72'
-         '04fbb3b0b28705f41ccc6c15ed5532faf0105370f22133a2b49867e790df0491f5a1255220ff6ebab91a462f088d0cf299491b3eb8ea53534cb8638a213e46e3'
--        '7c265e6d36a5c0dff127093580827d15519b6c7205c2e1300e82f0fb5b9dd00b6accb40c56581f18179c4fbbc95bd2bf1b900ace867a83accde0969f7b609f8a'
-         'a6a5e2f2a627cc0d13d11a82458cfd0aa75ec1c5a3c7647e5d5a3bb1d4c0770887a3909bfda1236803d5bc9801bfd6251e13483e9adf797e4725332cd0d91a0e'
--        '214e995e84b342fe7b2a7704ce011b7c7fc74c2971f98eeb3b4e677b99c860addc0a7d91b8dc0f0b8be7537782ee331999e02ba48f4ccc1c331b60f27d715678')
-+        '214e995e84b342fe7b2a7704ce011b7c7fc74c2971f98eeb3b4e677b99c860addc0a7d91b8dc0f0b8be7537782ee331999e02ba48f4ccc1c331b60f27d715678'
-+        '3ba09c775c0d58bf9e5b08985ea5fa73509433df7ff284f035f7f73357e8f35a79c8e7f3a0fecfe4b8759831e9f0d38e8524dcf2b8132066a47cb7e234880a6e')
- 
- pkgver() {
-   cd glibc
 @@ -37,21 +37,21 @@ pkgver() {
  }
  
@@ -144,13 +117,12 @@
  package_glibc-locales() {
    pkgdesc='Pregenerated locales for GNU C Library'
    depends=("glibc=$pkgver")
-@@ -225,3 +182,9 @@ package_glibc-locales() {
+@@ -225,3 +182,8 @@ package_glibc-locales() {
    # deduplicate locale data
    hardlink -c "${pkgdir}"/usr/lib/locale
  }
 +
-+for i in "${!pkgname[@]}"; do
-+  if [[ ${pkgname[i]} = "lib32-glibc" ]]; then
-+    unset 'pkgname[i]'
-+  fi
-+done
++pkgname=(${pkgname[@]/lib32-glibc})
++makedepends=(${makedepends[@]/lib32-gcc-libs})
++source+=("mremap-fix-test.patch::https://inbox.sourceware.org/libc-alpha/20250208-fix-mremap-tst-v1-1-ad7ee617ec65@coelacanthus.name/raw")
++b2sums+=('3ba09c775c0d58bf9e5b08985ea5fa73509433df7ff284f035f7f73357e8f35a79c8e7f3a0fecfe4b8759831e9f0d38e8524dcf2b8132066a47cb7e234880a6e')


### PR DESCRIPTION
Refresh patch. math/test-nearbyint-except still fails under GCC 15.2.1: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=121652