### PR TITLE
updpkg: x86_64-linux-gnu-binutils 2.44-1

### DIFF
--- a/x86_64-linux-gnu-binutils/PKGBUILD
+++ b/x86_64-linux-gnu-binutils/PKGBUILD
@@ -3,17 +3,22 @@
 
 _target=x86_64-linux-gnu
 pkgname=$_target-binutils
-pkgver=2.43
+pkgver=2.44
 pkgrel=1
 pkgdesc='A set of programs to assemble and manipulate binary and object files for the x86_64 target'
 arch=(riscv64)
 url='https://www.gnu.org/software/binutils/'
 license=(GPL)
-depends=(zlib libelf)
-source=(https://ftp.gnu.org/gnu/binutils/binutils-$pkgver.tar.bz2{,.sig})
-sha1sums=('9b0b465bf52fdbb677bd67ba64424842e297ebcd'
+depends=(
+  glibc
+  libelf
+  zlib libz.so
+  zstd libzstd.so
+)
+source=(https://ftpmirror.gnu.org/gnu/binutils/binutils-$pkgver.tar.bz2{,.sig})
+sha1sums=('8657069418bb4b198dddca6ff38cd355c2d5a04c'
           'SKIP')
-sha256sums=('fed3c3077f0df7a4a1aa47b080b8c53277593ccbb4e5e78b73ffb4e3f265e750'
+sha256sums=('f66390a661faa117d00fab2e79cf2dc9d097b42cc296bf3f8677d1e7b452dc3a'
             'SKIP')
 validpgpkeys=('3A24BC1E8FB409FA9F14371813FCEF89DD9E3C4F') # Nick Clifton (Chief Binutils Maintainer) <nickc@redhat.com>
 
@@ -28,12 +33,14 @@ build() {
   ./configure --target=$_target \
               --with-sysroot=/usr/$_target \
               --prefix=/usr \
+              --disable-gprofng \
               --enable-multilib \
               --with-gnu-as \
               --with-gnu-ld \
               --disable-nls \
               --enable-ld=default \
               --enable-gold \
+              --enable-new-dtags \
               --enable-plugins \
               --enable-deterministic-archives
 
@@ -56,10 +63,6 @@ package() {
   # Remove file conflicting with host binutils and manpages for MS Windows tools
   rm "$pkgdir"/usr/share/man/man1/$_target-{dlltool,windres,windmc}*
   rm "$pkgdir"/usr/lib/bfd-plugins/libdep.so
-  rm "$pkgdir"/usr/etc/gprofng.rc
-  rm "$pkgdir"/usr/lib/libgprofng.a
-  rm -r "$pkgdir"/usr/include
-  rm -r "$pkgdir"/usr/lib/gprofng/
 
   # Remove info documents that conflict with host version
   rm -r "$pkgdir"/usr/share/info


### PR DESCRIPTION
- Update to match https://gitlab.archlinux.org/archlinux/packaging/packages/aarch64-linux-gnu-binutils/-/commit/c7df57a632b6c4bb69a74969717fa5cb70f20554
- Use ftpmirror.gnu.org as ftp.gnu.org is **extremely** slow right now