### PR TITLE
updpatch: gcc 15.2.1+r22+gc4e96a094636-1

### DIFF
--- a/gcc/riscv64.patch
+++ b/gcc/riscv64.patch
@@ -12,7 +12,23 @@
    libisl
    libmpc
    python
-@@ -55,6 +52,12 @@ pkgver() {
+@@ -41,6 +38,7 @@ _libdir=usr/lib/gcc/$CHOST/${pkgver%%+*}
+ source=(git+https://sourceware.org/git/gcc.git#commit=${_commit}
+         c89 c99
+         gcc-ada-repro.patch
++        round-builtin-fix.patch
+ )
+ validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
+               86CFFCA918CF3AF47147588051E8B148A9999C34  # foutrelis@archlinux.org
+@@ -49,12 +47,19 @@ validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.
+ sha256sums=('d1d0263f7595e2189110dbe5d12608e144637a6a29a247e41c6926915caab8de'
+             '7b09ec947f90b98315397af675369a1e3dfc527fa70013062e6e85c4be0275ab'
+             '44ea973558842f3f4bd666bdaf6e810fd7b7c7bd36b5cc4c69f93d2cd0124fc7'
+-            '1773f5137f08ac1f48f0f7297e324d5d868d55201c03068670ee4602babdef2f')
++            '1773f5137f08ac1f48f0f7297e324d5d868d55201c03068670ee4602babdef2f'
++            '1e8ab4229f8a18dc6a620c78c895e4ff6bdae78d78de89b5d194ca1590a5dfdb')
+ pkgver() {
+   cd gcc
    echo "$(cat gcc/BASE-VER)+$(git describe --abbrev=12 --tags | sed 's/[^-]*-[^-]*-//;s/[^-]*-/r&/;s/-/+/g;s/_/./')"
  }
  
@@ -25,17 +41,18 @@
  prepare() {
    [[ ! -d gcc ]] && ln -s gcc-${pkgver/+/-} gcc
    cd gcc
-@@ -68,6 +71,9 @@ prepare() {
+@@ -68,6 +73,10 @@ prepare() {
    # Reproducible gcc-ada
    patch -Np0 < "$srcdir/gcc-ada-repro.patch"
  
 +  # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=121534
 +  git cherry-pick -n f12a272169523823ff27d69f187f73c4211222ae
++  patch -Np1 < "$srcdir/round-builtin-fix.patch"
 +
    mkdir -p "$srcdir/gcc-build"
    mkdir -p "$srcdir/libgccjit-build"
  }
-@@ -79,7 +85,7 @@ build() {
+@@ -79,7 +88,7 @@ build() {
        --libexecdir=/usr/lib
        --mandir=/usr/share/man
        --infodir=/usr/share/info
@@ -44,7 +61,7 @@
        --with-build-config=bootstrap-lto
        --with-linker-hash-style=gnu
        --with-system-zlib
-@@ -95,7 +101,7 @@ build() {
+@@ -95,7 +104,7 @@ build() {
        --enable-link-serialization=1
        --enable-linker-build-id
        --enable-lto
@@ -53,7 +70,7 @@
        --enable-plugin
        --enable-shared
        --enable-threads=posix
-@@ -113,7 +119,7 @@ build() {
+@@ -113,7 +122,7 @@ build() {
    CXXFLAGS=${CXXFLAGS/-Werror=format-security/}
  
    "$srcdir/gcc/configure" \
@@ -62,7 +79,7 @@
      --enable-bootstrap \
      "${_confflags[@]:?_confflags unset}"
  
-@@ -161,9 +167,9 @@ check() {
+@@ -161,9 +170,9 @@ check() {
  package_gcc-libs() {
    pkgdesc='Runtime libraries shipped by GCC'
    depends=('glibc>=2.27')
@@ -74,7 +91,7 @@
    replaces=($pkgname-multilib libgphobos)
  
    cd gcc-build
-@@ -176,9 +182,8 @@ package_gcc-libs() {
+@@ -176,9 +185,8 @@ package_gcc-libs() {
               libgomp \
               libitm \
               libquadmath \
@@ -86,7 +103,7 @@
      make -C $CHOST/$lib DESTDIR="$pkgdir" install-toolexeclibLTLIBRARIES
    done
  
-@@ -195,18 +200,17 @@ package_gcc-libs() {
+@@ -195,18 +203,17 @@ package_gcc-libs() {
      make -C $CHOST/$lib DESTDIR="$pkgdir" install-info
    done
  
@@ -108,7 +125,7 @@
    provides=($pkgname-multilib)
    replaces=($pkgname-multilib)
    options=(!emptydirs staticlibs)
-@@ -220,22 +224,18 @@ package_gcc() {
+@@ -220,22 +227,18 @@ package_gcc() {
    install -m755 -t "$pkgdir/${_libdir}/" gcc/{cc1,cc1plus,collect2,lto1}
  
    make -C $CHOST/libgcc DESTDIR="$pkgdir" install
@@ -133,7 +150,7 @@
  
    make DESTDIR="$pkgdir" install-fixincludes
    make -C gcc DESTDIR="$pkgdir" install-mkheaders
-@@ -250,17 +250,12 @@ package_gcc() {
+@@ -250,17 +253,12 @@ package_gcc() {
    make -C $CHOST/libquadmath DESTDIR="$pkgdir" install-nodist_libsubincludeHEADERS
    make -C $CHOST/libsanitizer DESTDIR="$pkgdir" install-nodist_{saninclude,toolexeclib}HEADERS
    make -C $CHOST/libsanitizer/asan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
@@ -152,7 +169,7 @@
  
    make -C libcpp DESTDIR="$pkgdir" install
    make -C gcc DESTDIR="$pkgdir" install-po
-@@ -271,7 +266,7 @@ package_gcc() {
+@@ -271,7 +269,7 @@ package_gcc() {
    # create cc-rs compatible symlinks
    # https://github.com/rust-lang/cc-rs/blob/1.0.73/src/lib.rs#L2578-L2581
    for binary in {c++,g++,gcc,gcc-ar,gcc-nm,gcc-ranlib}; do
@@ -161,7 +178,7 @@
    done
  
    # POSIX conformance launcher scripts for c89 and c99
-@@ -281,9 +276,6 @@ package_gcc() {
+@@ -281,9 +279,6 @@ package_gcc() {
    # install the libstdc++ man pages
    make -C $CHOST/libstdc++-v3/doc DESTDIR="$pkgdir" doc-install-man
  
@@ -171,7 +188,7 @@
    # byte-compile python libraries
    python -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
    python -O -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
-@@ -303,8 +295,6 @@ package_gcc-fortran() {
+@@ -303,8 +298,6 @@ package_gcc-fortran() {
    cd gcc-build
    make -C $CHOST/libgfortran DESTDIR="$pkgdir" install-cafexeclibLTLIBRARIES \
      install-{toolexeclibDATA,nodist_fincludeHEADERS,gfor_cHEADERS}
@@ -180,7 +197,7 @@
    make -C $CHOST/libgomp DESTDIR="$pkgdir" install-nodist_fincludeHEADERS
    make -C gcc DESTDIR="$pkgdir" fortran.install-{common,man,info}
    install -Dm755 gcc/f951 "$pkgdir/${_libdir}/f951"
-@@ -382,7 +372,6 @@ package_gcc-go() {
+@@ -382,7 +375,6 @@ package_gcc-go() {
  
    cd gcc-build
    make -C $CHOST/libgo DESTDIR="$pkgdir" install-exec-am

--- a/gcc/round-builtin-fix.patch
+++ b/gcc/round-builtin-fix.patch
@@ -1,0 +1,147 @@
+__builtin_round() fails to correctly generate invalid exceptions for NaN
+inputs when -ftrapping-math is used (which is the default). According to
+the specification, an invalid exception should be raised for sNaN, but
+not for qNaN.
+
+Commit f12a27216952 ("RISC-V: fix __builtin_round clobbering FP...")
+attempted to avoid raising an invalid exception for qNaN by saving and
+restoring the FP exception flags. However this inadvertently suppressed
+the invalid exception for sNaN as well.
+
+Instead of saving/restoring fflags, this patch uses the same approach
+than the well tested GLIBC round implementation. When flag_trapping_math
+is enabled, it first checks whether the input is a NaN using feq.s/d. In
+that case it adds the input value with itself to possibly convert sNaN
+into qNaN. With this change, the glibc testsuite passes again.
+
+The generated code with -ftrapping-math now looks like:
+
+convert_float_to_float_round
+  feq.s       a5,fa0,fa0
+  beqz        a5,.L6
+  auipc       a5,0x0
+  flw         fa4,42(a5)
+  fabs.s      fa5,fa0
+  flt.s       a5,fa5,fa4
+  beqz        a5,.L5
+  fcvt.w.s    a5,fa0,rmm
+  fcvt.s.w    fa5,a5
+  fsgnj.s     fa0,fa5,fa0
+  ret
+.L6:
+  fadd.s      fa0,fa0,fa0
+.L5:
+  ret
+
+With -fno-trapping-math, the additional checks are omitted so the
+resulting code is unchanged.
+
+Fixes: f652a35877e3 ("This is almost exclusively Jivan's work....")
+Fixes: f12a27216952 ("RISC-V: fix __builtin_round clobbering FP...")
+
+        PR target/161652
+
+gcc/ChangeLog:
+
+	* config/riscv/riscv.md (round_pattern): special case NaN input
+	instead of saving/restoring fflags.
+
+gcc/testsuite/ChangeLog:
+
+        * gcc.target/riscv/rvv/autovec/vls/math-nearbyint-1.c: Adjust
+        scan pattern for fewer instances of frflags/fsrflags.
+
+Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>
+---
+ gcc/config/riscv/riscv.md                     | 38 ++++++++++++-------
+ .../riscv/rvv/autovec/vls/math-nearbyint-1.c  |  4 +-
+ 2 files changed, 27 insertions(+), 15 deletions(-)
+
+diff --git a/gcc/config/riscv/riscv.md b/gcc/config/riscv/riscv.md
+index 843a048e9d8..e6246e120f1 100644
+--- a/gcc/config/riscv/riscv.md
++++ b/gcc/config/riscv/riscv.md
+@@ -2322,27 +2322,37 @@
+   else
+     {
+       rtx reg;
+-      rtx label = gen_label_rtx ();
++      rtx label1 = gen_label_rtx ();
++      rtx label2 = gen_label_rtx ();
++      rtx label3 = gen_label_rtx ();
+       rtx end_label = gen_label_rtx ();
+       rtx abs_reg = gen_reg_rtx (<ANYF:MODE>mode);
+       rtx coeff_reg = gen_reg_rtx (<ANYF:MODE>mode);
+       rtx tmp_reg = gen_reg_rtx (<ANYF:MODE>mode);
+-      rtx fflags = gen_reg_rtx (SImode);
+ 
+       riscv_emit_move (tmp_reg, operands[1]);
++
++      if (flag_trapping_math)
++	{
++	  /* Check if the input is a NaN */
++	  riscv_expand_conditional_branch (label1, EQ, operands[1], operands[1]);
++
++	  emit_jump_insn (gen_jump (label3));
++	  emit_barrier ();
++
++	  emit_label (label1);
++	}
++
+       riscv_emit_move (coeff_reg,
+ 		       riscv_vector::get_fp_rounding_coefficient (<ANYF:MODE>mode));
+       emit_insn (gen_abs<ANYF:mode>2 (abs_reg, operands[1]));
+ 
+-      /* fp compare can set invalid flag for NaN, so backup fflags.  */
+-      if (flag_trapping_math)
+-        emit_insn (gen_riscv_frflags (fflags));
+-      riscv_expand_conditional_branch (label, LT, abs_reg, coeff_reg);
++      riscv_expand_conditional_branch (label2, LT, abs_reg, coeff_reg);
+ 
+       emit_jump_insn (gen_jump (end_label));
+       emit_barrier ();
+ 
+-      emit_label (label);
++      emit_label (label2);
+       switch (<ANYF:MODE>mode)
+ 	{
+ 	case SFmode:
+@@ -2361,15 +2371,17 @@
+ 
+       emit_insn (gen_copysign<ANYF:mode>3 (tmp_reg, abs_reg, operands[1]));
+ 
+-      emit_label (end_label);
++      emit_jump_insn (gen_jump (end_label));
++      emit_barrier ();
+ 
+-      /* Restore fflags, but after label.  This is slightly different
+-         than glibc implementation which only needs to restore under
+-         the label, since it checks for NaN first, meaning following fp
+-         compare can't raise fp exceptons and thus not clobber fflags.  */
+       if (flag_trapping_math)
+-        emit_insn (gen_riscv_fsflags (fflags));
++	{
++	  emit_label (label3);
++	  /* Generate a qNaN from an sNaN if needed */
++	  emit_insn (gen_add<ANYF:mode>3 (tmp_reg, operands[1], operands[1]));
++	}
+ 
++      emit_label (end_label);
+       riscv_emit_move (operands[0], tmp_reg);
+     }
+ 
+diff --git a/gcc/testsuite/gcc.target/riscv/rvv/autovec/vls/math-nearbyint-1.c b/gcc/testsuite/gcc.target/riscv/rvv/autovec/vls/math-nearbyint-1.c
+index 89af160112c..bb62ce2ef8a 100644
+--- a/gcc/testsuite/gcc.target/riscv/rvv/autovec/vls/math-nearbyint-1.c
++++ b/gcc/testsuite/gcc.target/riscv/rvv/autovec/vls/math-nearbyint-1.c
+@@ -54,5 +54,5 @@ DEF_OP_V (nearbyint, 512, double, __builtin_nearbyint)
+ /* { dg-final { scan-tree-dump-not "4096,4096" "optimized" } } */
+ /* { dg-final { scan-assembler-times {vfcvt\.x\.f\.v\s+v[0-9]+,\s*v[0-9]+,\s*v0\.t} 30 } } */
+ /* { dg-final { scan-assembler-times {vfcvt\.f\.x\.v\s+v[0-9]+,\s*v[0-9]+,\s*v0\.t} 30 } } */
+-/* { dg-final { scan-assembler-times {frflags\s+[atx][0-9]+} 32 } } */
+-/* { dg-final { scan-assembler-times {fsflags\s+[atx][0-9]+} 32 } } */
++/* { dg-final { scan-assembler-times {frflags\s+[atx][0-9]+} 30 } } */
++/* { dg-final { scan-assembler-times {fsflags\s+[atx][0-9]+} 30 } } */
+-- 
+2.47.2
+


### PR DESCRIPTION
Pick up fix for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=121652 from https://gcc.gnu.org/pipermail/gcc-patches/2025-September/696217.html