### PR TITLE
addpkg: bazel7 7.5.0-2

### DIFF
--- a/bazel7/PKGBUILD
+++ b/bazel7/PKGBUILD
@@ -1,0 +1,48 @@
+# Contributor: kpcyrd <kpcyrd[at]archlinux[dot]org>
+# Contributor: Sven-Hendrik Haase <svenstaro@archlinux.org>
+# Contributor: Konstantin Gizdov <arch@kge.pw>
+# Contributor: Frederik Schwan <frederik dot schwan at linux dot com>
+# Contributor: Simon Legner <Simon.Legner@gmail.com>
+
+pkgname=bazel7
+pkgver=7.5.0
+pkgrel=2
+pkgdesc='Correct, reproducible, and fast builds for everyone'
+arch=('riscv64')
+license=('Apache-2.0')
+url='https://bazel.build/'
+depends=('java-environment=21' 'libarchive' 'zip' 'unzip' 'which')
+makedepends=('git' 'protobuf' 'python')
+options=('!debug' '!strip')
+source=(
+  "https://github.com/bazelbuild/bazel/releases/download/${pkgver}/bazel-${pkgver}-dist.zip"{,.sig}
+)
+b2sums=('e8eaa780f5f985419db81124a9d36470443e5c70eb6f8dc1d850c40c739cb0a957c1a7102d7e9c465e75d7cc03c1effe8d0373338ee45a67ba623871f8bfd54d'
+        'SKIP'
+        '92e5ab752ef4fd71eae0c3ed07c37b510d70516779114a20a01bac9889ba6a90a1212e9ee8b89bdabcdbb6b74d424d18bb2f8d2b92024702d4dac19c2c7efaa4')
+validpgpkeys=('71A1D0EFCFEB6281FD0437C93D5919B448457EE0')
+
+prepare() {
+  patch -Np1 -i bazel7-riscv.diff
+}
+
+build() {
+  EMBED_LABEL=$pkgver EXTRA_BAZEL_ARGS="--tool_java_runtime_version=local_jdk" ./compile.sh
+  ./output/bazel build scripts:bazel-complete.bash
+  cd output
+  ./bazel shutdown
+}
+
+package() {
+  install -Dm755 "${srcdir}/scripts/packages/bazel.sh" "${pkgdir}/usr/bin/bazel"
+  install -Dm755 "${srcdir}/output/bazel" "${pkgdir}/usr/bin/bazel-real"
+  install -Dm644 "${srcdir}/bazel-bin/scripts/bazel-complete.bash" "${pkgdir}/usr/share/bash-completion/completions/bazel"
+  install -Dm644 "${srcdir}/scripts/zsh_completion/_bazel" "${pkgdir}/usr/share/zsh/site-functions/_bazel"
+  mkdir -p "${pkgdir}/usr/share/bazel"
+  for d in examples third_party tools; do
+    cp -r "${srcdir}/${d}" "${pkgdir}/usr/share/bazel/"
+  done
+}
+
+source+=(bazel7-riscv.diff)
+# vim:set ts=2 sw=2 et:

--- a/bazel7/bazel7-riscv.diff
+++ b/bazel7/bazel7-riscv.diff
@@ -1,0 +1,416 @@
+From bdd0715797b2f10a20a1c47994d2ba214ee6d4b8 Mon Sep 17 00:00:00 2001
+From: Levi Zim <rsworktech@outlook.com>
+Date: Wed, 26 Mar 2025 07:51:42 +0800
+Subject: [PATCH] Add support for riscv64 linux
+
+This patch brings enough support for bootstraping bazel itself on
+riscv64 linux platform.
+
+Changes:
+
+* Bump rules_java for bazelbuild/rules_java#282
+  bazelbuild/rules_java#198
+* Bump stardoc to 0.7.1 and rules_jvm_external to 6.1 to fix CI failure
+* Use portable `uname -m` in mininize_jdk.sh
+* Add prebuilt jdk for riscv64
+* Bump abseil-cpp for abseil/abseil-cpp#1644
+
+Tested on riscv 64 linux by `bazel build //src:bazel --compilation_mode=opt`
+---
+ BUILD                                         |   2 +-
+ MODULE.bazel                                  |  21 ++--
+ distdir_deps.bzl                              |  10 ++
+ repositories.bzl                              |   6 +
+ src/BUILD                                     |   3 +
+ src/MODULE.tools                              |   2 +-
+ src/main/cpp/archive_utils.h                  |   1 +
+ src/main/cpp/blaze.h                          |   1 +
+ src/minimize_jdk.sh                           |   4 +-
+ ...6.0.patch => rules_jvm_external_6.1.patch} | 106 ++++++++++--------
+ 10 files changed, 93 insertions(+), 63 deletions(-)
+ rename third_party/{rules_jvm_external_6.0.patch => rules_jvm_external_6.1.patch} (66%)
+
+diff --git a/BUILD b/BUILD
+index bc013c953d..6adf02be09 100644
+--- a/BUILD
++++ b/BUILD
+@@ -104,7 +104,7 @@ genrule(
+         "//third_party/googleapis:MODULE.bazel",
+         "//third_party/remoteapis:MODULE.bazel",
+         "//third_party:BUILD",
+-        "//third_party:rules_jvm_external_6.0.patch",
++        "//third_party:rules_jvm_external_6.1.patch",
+         "//third_party/upb:BUILD",
+         "//third_party/upb:01_remove_werror.patch",
+         "//third_party/grpc:BUILD",
+diff --git a/MODULE.bazel b/MODULE.bazel
+index 84e08db938..b6ab1b0ffd 100644
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -13,23 +13,23 @@ module(
+ # =========================================
+ 
+ bazel_dep(name = "rules_license", version = "0.0.7")
+-bazel_dep(name = "bazel_skylib", version = "1.6.1")
++bazel_dep(name = "bazel_skylib", version = "1.7.1")
+ bazel_dep(name = "protobuf", version = "21.7", repo_name = "com_google_protobuf")
+ bazel_dep(name = "grpc", version = "1.48.1.bcr.1", repo_name = "com_github_grpc_grpc")
+ bazel_dep(name = "platforms", version = "0.0.10")
+ bazel_dep(name = "rules_pkg", version = "0.9.1")
+-bazel_dep(name = "stardoc", version = "0.5.6", repo_name = "io_bazel_skydoc")
++bazel_dep(name = "stardoc", version = "0.7.1", repo_name = "io_bazel_skydoc")
+ bazel_dep(name = "zstd-jni", version = "1.5.2-3.bcr.1")
+ bazel_dep(name = "blake3", version = "1.5.1.bcr.1")
+ bazel_dep(name = "zlib", version = "1.3.1.bcr.3")
+-bazel_dep(name = "rules_cc", version = "0.0.9")
+-bazel_dep(name = "rules_java", version = "7.6.5")
++bazel_dep(name = "rules_cc", version = "0.0.10")
++bazel_dep(name = "rules_java", version = "7.12.5")
+ bazel_dep(name = "rules_graalvm", version = "0.11.1")
+-bazel_dep(name = "rules_proto", version = "6.0.0")
+-bazel_dep(name = "rules_jvm_external", version = "6.0")
++bazel_dep(name = "rules_proto", version = "6.0.2")
++bazel_dep(name = "rules_jvm_external", version = "6.1")
+ bazel_dep(name = "rules_python", version = "0.33.2")
+ bazel_dep(name = "rules_testing", version = "0.6.0")
+-bazel_dep(name = "googletest", version = "1.14.0", repo_name = "com_google_googletest")
++bazel_dep(name = "googletest", version = "1.15.2", repo_name = "com_google_googletest")
+ bazel_dep(name = "with_cfg.bzl", version = "0.2.4")
+ 
+ # TODO(pcloudy): Add remoteapis and googleapis as Bazel modules in the BCR.
+@@ -39,7 +39,7 @@ bazel_dep(name = "googleapis", version = "")
+ single_version_override(
+     module_name = "rules_jvm_external",
+     patch_strip = 1,
+-    patches = ["//third_party:rules_jvm_external_6.0.patch"],
++    patches = ["//third_party:rules_jvm_external_6.1.patch"],
+ )
+ 
+ local_path_override(
+@@ -62,8 +62,8 @@ single_version_override(
+ 
+ # The following Bazel modules are not direct dependencies for building Bazel,
+ # but are required for visibility from DIST_ARCHIVE_REPOS in repositories.bzl
+-bazel_dep(name = "apple_support", version = "1.8.1")
+-bazel_dep(name = "abseil-cpp", version = "20230125.1")
++bazel_dep(name = "apple_support", version = "1.15.1")
++bazel_dep(name = "abseil-cpp", version = "20240722.1")
+ bazel_dep(name = "c-ares", version = "1.15.0")
+ bazel_dep(name = "rules_go", version = "0.39.1")
+ bazel_dep(name = "rules_kotlin", version = "1.9.0")
+@@ -286,6 +286,7 @@ use_repo(
+     "debian_proto_deps",
+     "openjdk_linux_aarch64_vanilla",
+     "openjdk_linux_ppc64le_vanilla",
++    "openjdk_linux_riscv64_vanilla",
+     "openjdk_linux_s390x_vanilla",
+     "openjdk_linux_vanilla",
+     "openjdk_macos_aarch64_vanilla",
+diff --git a/distdir_deps.bzl b/distdir_deps.bzl
+index fabaf84a31..1c202bb803 100644
+--- a/distdir_deps.bzl
++++ b/distdir_deps.bzl
+@@ -488,6 +488,16 @@ DIST_DEPS = {
+         ],
+         "used_in": [],
+     },
++    "openjdk_linux_riscv64_vanilla": {
++        "archive": "OpenJDK21U-jdk_riscv64_linux_hotspot_21.0.6_7.tar.gz",
++        "sha256": "203796e4ba2689aa921b5e0cdc9e02984d88622f80fcb9acb05a118b05007be8",
++        "strip_prefix": "jdk-21.0.6+7",
++        "urls": [
++            "https://mirror.bazel.build/github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.6%2B7/OpenJDK21U-jdk_riscv64_linux_hotspot_21.0.6_7.tar.gz",
++            "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.6%2B7/OpenJDK21U-jdk_riscv64_linux_hotspot_21.0.6_7.tar.gz",
++        ],
++        "used_in": [],
++    },
+     "openjdk_macos_x86_64_vanilla": {
+         "archive": "zulu21.28.85-ca-jdk21.0.0-macosx_x64.tar.gz",
+         "sha256": "9639b87db586d0c89f7a9892ae47f421e442c64b97baebdff31788fbe23265bd",
+diff --git a/repositories.bzl b/repositories.bzl
+index dffa917d93..62c2db2cca 100644
+--- a/repositories.bzl
++++ b/repositories.bzl
+@@ -93,6 +93,12 @@ def embedded_jdk_repositories():
+         downloaded_file_path = "adoptopenjdk-ppc64le-vanilla.tar.gz",
+         url = "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.5%2B11/OpenJDK21U-jdk_ppc64le_linux_hotspot_21.0.5_11.tar.gz",
+     )
++    http_file(
++        name = "openjdk_linux_riscv64_vanilla",
++        integrity = "sha256-Lxs+QB423oAzmN+5gYhh+fFMqK59tlDqCUarBI/v47k=",
++        downloaded_file_path = "adoptopenjdk-riscv64-vanilla.tar.gz",
++        url = "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.5%2B11/OpenJDK21U-jdk_riscv64_linux_hotspot_21.0.5_11.tar.gz",
++    )
+     http_file(
+         name = "openjdk_macos_x86_64_vanilla",
+         integrity = "sha256-zXTl63OMkUWdS45eEOrJGK4qBdIan8fKXcLaZOZbzr0=",
+diff --git a/src/BUILD b/src/BUILD
+index abded2708a..9ecb09cc88 100644
+--- a/src/BUILD
++++ b/src/BUILD
+@@ -168,6 +168,9 @@ filegroup(
+         "//src/conditions:linux_ppc64le": [
+             "@openjdk_linux_ppc64le_vanilla//file",
+         ],
++        "//src/conditions:linux_riscv64": [
++            "@openjdk_linux_riscv64_vanilla//file",
++        ],
+         "//src/conditions:linux_s390x": [
+             "@openjdk_linux_s390x_vanilla//file",
+         ],
+diff --git a/src/MODULE.tools b/src/MODULE.tools
+index 51e51ac5e5..42ce4eb5ed 100644
+--- a/src/MODULE.tools
++++ b/src/MODULE.tools
+@@ -5,7 +5,7 @@
+ module(name = "bazel_tools")
+ 
+ bazel_dep(name = "rules_cc", version = "0.0.9")
+-bazel_dep(name = "rules_java", version = "7.6.5")
++bazel_dep(name = "rules_java", version = "7.12.5")
+ bazel_dep(name = "rules_license", version = "0.0.3")
+ bazel_dep(name = "rules_proto", version = "4.0.0")
+ bazel_dep(name = "rules_python", version = "0.22.1")
+diff --git a/src/main/cpp/archive_utils.h b/src/main/cpp/archive_utils.h
+index 18856ab67d..959ae16fe6 100644
+--- a/src/main/cpp/archive_utils.h
++++ b/src/main/cpp/archive_utils.h
+@@ -17,6 +17,7 @@
+ 
+ #include <string>
+ #include <vector>
++#include <cstdint>
+ 
+ #include "src/main/cpp/startup_options.h"
+ #include "src/main/cpp/util/logging.h"
+diff --git a/src/main/cpp/blaze.h b/src/main/cpp/blaze.h
+index 2350fa1449..2b431b49fb 100644
+--- a/src/main/cpp/blaze.h
++++ b/src/main/cpp/blaze.h
+@@ -15,6 +15,7 @@
+ #define BAZEL_SRC_MAIN_CPP_BLAZE_H_
+ 
+ #include <string>
++#include <cstdint>
+ 
+ #include "src/main/cpp/option_processor.h"
+ #include "src/main/cpp/workspace_layout.h"
+diff --git a/src/minimize_jdk.sh b/src/minimize_jdk.sh
+index afeeb65a1c..732896c471 100755
+--- a/src/minimize_jdk.sh
++++ b/src/minimize_jdk.sh
+@@ -30,8 +30,8 @@ else
+ fi
+ fulljdk=$1
+ out=$3
+-ARCH=`uname -p`
+-if [[ "${ARCH}" == 'ppc64le'  ]] || [[ "${ARCH}" == 's390x' ]]; then
++ARCH=`uname -m`
++if [[ "${ARCH}" == 'ppc64le'  ]] || [[ "${ARCH}" == 's390x' ]] || [[ "${ARCH}" == 'riscv64' ]]; then
+   FULL_JDK_DIR="jdk*"
+   DOCS=""
+ else
+diff --git a/third_party/rules_jvm_external_6.0.patch b/third_party/rules_jvm_external_6.1.patch
+similarity index 66%
+rename from third_party/rules_jvm_external_6.0.patch
+rename to third_party/rules_jvm_external_6.1.patch
+index 17c8d82205..cb63b1f56b 100644
+--- a/third_party/rules_jvm_external_6.0.patch
++++ b/third_party/rules_jvm_external_6.1.patch
+@@ -1,34 +1,39 @@
+-commit ec04b5431181421608c8ce55d1cb53626d51ab3e
+-Author: Yun Peng <pcloudy@google.com>
+-Date:   Tue Jan 30 11:39:34 2024 +0100
+-
+-    Add targets to make it easier to vendor the `@maven` repository
+-
+-    This change is required to support Bazel's offline bootstrap build.
+-    More context in https://github.com/bazelbuild/bazel/pull/17112
+-
+-    Instead of checking in jar files in Bazel's source tree, Bazel wants to use rules_jvm_external
+-    to fetch jars dependencies. However, to support Bazel's bootstrap build,
+-    we need to patch rules_jvm_external for vendoring the @maven repository.
+-
+-    - Generate a BUILD.vendor file to be used in the vendored `@maven` repository.
+-      Added a jvm_import and a filegroup rule for each downloaded jar artifact.
+-      The filegroup rule is required by the bootstrap Java toolchain used in Bazel's
+-      bootstrap build. The bootstrap Java toolchain cannot depend on a jvm_import target.
+-      Because the jvm_import rule depends on a java_binary tool "AddJarManifestEntry",
+-      which requires a Java toolchain. Depending on the jar via a filegroup rule helps
+-      avoid this cyclic dependency.
+-    - Added a filegroup rule to collect all sources needed for vendoring `@maven`,
+-      including BUILD.vendor, WORKSPACE and jar files.
++From 18f73cda0682be1dd843ce45150f89366ce874a1 Mon Sep 17 00:00:00 2001
++Message-ID: <18f73cda0682be1dd843ce45150f89366ce874a1.1742988914.git.rsworktech@outlook.com>
++From: Yun Peng <pcloudy@google.com>
++Date: Wed, 26 Mar 2025 19:34:16 +0800
++Subject: [PATCH] Add targets to make it easier to vendor the `@maven`
++ repository
++
++This change is required to support Bazel's offline bootstrap build.
++More context in https://github.com/bazelbuild/bazel/pull/17112
++
++Instead of checking in jar files in Bazel's source tree, Bazel wants to use rules_jvm_external
++to fetch jars dependencies. However, to support Bazel's bootstrap build,
++we need to patch rules_jvm_external for vendoring the @maven repository.
++
++- Generate a BUILD.vendor file to be used in the vendored `@maven` repository.
++  Added a jvm_import and a filegroup rule for each downloaded jar artifact.
++  The filegroup rule is required by the bootstrap Java toolchain used in Bazel's
++  bootstrap build. The bootstrap Java toolchain cannot depend on a jvm_import target.
++  Because the jvm_import rule depends on a java_binary tool "AddJarManifestEntry",
++  which requires a Java toolchain. Depending on the jar via a filegroup rule helps
++  avoid this cyclic dependency.
++- Added a filegroup rule to collect all sources needed for vendoring `@maven`,
++  including BUILD.vendor, WORKSPACE and jar files.
++---
++ coursier.bzl                       | 18 ++++++++++++++++--
++ private/dependency_tree_parser.bzl | 18 ++++++++++++++++--
++ 2 files changed, 32 insertions(+), 4 deletions(-)
+ 
+ diff --git a/coursier.bzl b/coursier.bzl
+-index c60c590..7b16164 100644
++index d19c06b..d1e464c 100644
+ --- a/coursier.bzl
+ +++ b/coursier.bzl
+-@@ -53,6 +53,12 @@ bzl_library(
++@@ -54,6 +54,12 @@ bzl_library(
+  )
+  """
+-
++ 
+ +_BUILD_VENDOR = """
+ +load("@rules_jvm_external//private/rules:jvm_import.bzl", "jvm_import")
+ +
+@@ -36,21 +41,21 @@ index c60c590..7b16164 100644
+ +"""
+ +
+  DEFAULT_AAR_IMPORT_LABEL = "@build_bazel_rules_android//android:rules.bzl"
+-
++ 
+  _AAR_IMPORT_STATEMENT = """\
+-@@ -593,7 +599,7 @@ def _pinned_coursier_fetch_impl(repository_ctx):
++@@ -606,7 +612,7 @@ def _pinned_coursier_fetch_impl(repository_ctx):
+      )
+-
++ 
+      repository_ctx.report_progress("Generating BUILD targets..")
+ -    (generated_imports, jar_versionless_target_labels) = parser.generate_imports(
+ +    (generated_imports, jar_versionless_target_labels, generated_vendor_targets) = parser.generate_imports(
+          repository_ctx = repository_ctx,
+          dependencies = importer.get_artifacts(maven_install_json_content),
+          explicit_artifacts = {
+-@@ -633,6 +639,14 @@ def _pinned_coursier_fetch_impl(repository_ctx):
++@@ -648,6 +654,14 @@ def _pinned_coursier_fetch_impl(repository_ctx):
+          executable = False,
+      )
+-
++ 
+ +    repository_ctx.file(
+ +        "BUILD.vendor",
+ +        (_BUILD_VENDOR).format(
+@@ -60,11 +65,11 @@ index c60c590..7b16164 100644
+ +    )
+ +
+      _add_outdated_files(repository_ctx, artifacts, repositories)
+-
++ 
+      # Generate a compatibility layer of external repositories for all jar artifacts.
+-@@ -1153,7 +1167,7 @@ def _coursier_fetch_impl(repository_ctx):
++@@ -1207,7 +1221,7 @@ def _coursier_fetch_impl(repository_ctx):
+      )
+-
++ 
+      repository_ctx.report_progress("Generating BUILD targets..")
+ -    (generated_imports, jar_versionless_target_labels) = parser.generate_imports(
+ +    (generated_imports, jar_versionless_target_labels, _) = parser.generate_imports(
+@@ -72,7 +77,7 @@ index c60c590..7b16164 100644
+          dependencies = v2_lock_file.get_artifacts(lock_file_contents),
+          explicit_artifacts = {
+ diff --git a/private/dependency_tree_parser.bzl b/private/dependency_tree_parser.bzl
+-index 103fe5e..21159ed 100644
++index 0dcce37..3262921 100644
+ --- a/private/dependency_tree_parser.bzl
+ +++ b/private/dependency_tree_parser.bzl
+ @@ -76,7 +76,8 @@ def _generate_target(
+@@ -85,43 +90,43 @@ index 103fe5e..21159ed 100644
+      to_return = []
+      simple_coord = strip_packaging_and_classifier_and_version(artifact["coordinates"])
+      target_label = escape(simple_coord)
+-@@ -284,6 +285,7 @@ def _generate_target(
++@@ -308,6 +309,7 @@ genrule(
+      target_import_string.append(")")
+-
++ 
+      to_return.append("\n".join(target_import_string))
+ +    vendor_targets.append("\n".join(target_import_string))
+-
++ 
+      # 10. Create a versionless alias target
+      #
+-@@ -294,6 +296,9 @@ def _generate_target(
++@@ -318,6 +320,9 @@ genrule(
+      versioned_target_alias_label = escape(strip_packaging_and_classifier(artifact["coordinates"]))
+      to_return.append("alias(\n\tname = \"%s\",\n\tactual = \"%s\",\n%s)" %
+                       (versioned_target_alias_label, target_label, alias_visibility))
+ +    file_group_target_string = "filegroup(\n\tname = \"%s\",\n\tsrcs = [\"%s\"],\n%s)" % (target_label + "_file", artifact_path, alias_visibility)
+ +    to_return.append(file_group_target_string)
+ +    vendor_targets.append(file_group_target_string)
+-
+-     # 11. If using maven_install.json, use a genrule to copy the file from the http_file
+-     # repository into this repository.
+-@@ -356,6 +361,9 @@ def _generate_imports(repository_ctx, dependencies, explicit_artifacts, neverlin
++ 
++     for annotation_processor in artifact.get("annotation_processors", []):
++         to_return.append(
++@@ -395,6 +400,9 @@ def _generate_imports(repository_ctx, dependencies, explicit_artifacts, neverlin
+                      if repository_ctx.attr.maven_install_json:
+                          all_imports.append(_genrule_copy_artifact_from_http_file(artifact, default_visibilities))
+-
++ 
+ +    artifact_paths = []
+ +    vendor_targets = []
+ +
+      # Iterate through the list of artifacts, and generate the target declaration strings.
+      for artifact in dependencies:
+          artifact_path = artifact["file"]
+-@@ -412,6 +420,7 @@ def _generate_imports(repository_ctx, dependencies, explicit_artifacts, neverlin
++@@ -451,6 +459,7 @@ def _generate_imports(repository_ctx, dependencies, explicit_artifacts, neverlin
+                  testonly_artifacts,
+                  default_visibilities,
+                  raw_artifact,
+ +                vendor_targets,
+              ))
+-
++ 
+          elif artifact_path != None:
+-@@ -426,7 +435,9 @@ def _generate_imports(repository_ctx, dependencies, explicit_artifacts, neverlin
++@@ -465,7 +474,9 @@ def _generate_imports(repository_ctx, dependencies, explicit_artifacts, neverlin
+                  testonly_artifacts,
+                  default_visibilities,
+                  artifact,
+@@ -131,15 +136,18 @@ index 103fe5e..21159ed 100644
+          else:  # artifact_path == None:
+              # Special case for certain artifacts that only come with a POM file.
+              # Such artifacts "aggregate" their dependencies, so they don't have
+-@@ -479,7 +490,10 @@ def _generate_imports(repository_ctx, dependencies, explicit_artifacts, neverlin
++@@ -518,7 +529,10 @@ def _generate_imports(repository_ctx, dependencies, explicit_artifacts, neverlin
+              all_imports.append("alias(\n\tname = \"%s\",\n\tactual = \"%s\",\n%s)" %
+                                 (versioned_target_alias_label, target_label, alias_visibility))
+-
++ 
+ -    return ("\n".join(all_imports), jar_versionless_target_labels)
+ +    all_imports.append("filegroup(\n\tname = \"srcs\",\n\tsrcs = [\n\t\t%s,\n\t],\n\tvisibility = [\"//visibility:public\"],\n)" %
+ +                       (",\n\t\t".join(["\"BUILD.vendor\"", "\"defs.bzl\"", "\"WORKSPACE\""] + artifact_paths)))
+ +
+ +    return ("\n".join(all_imports), jar_versionless_target_labels, "\n".join(vendor_targets))
+-
++ 
+  parser = struct(
+      generate_imports = _generate_imports,
++-- 
++2.49.0
++
+-- 
+2.47.1
+


### PR DESCRIPTION
This PR adds back the bazel7 package which is needed to build tensorflow. Arch has removed the bazel7 package and now downloads upstream bazel7 for building tensorflow, which is not an option for us (yet).

Compared with
https://github.com/felixonmars/archriscv-packages/pull/4625, we need to add a few header includes in the patch now.