### PR TITLE
updpatch: chromium 141.0.7390.122-1

### DIFF
--- a/chromium/riscv64.patch
+++ b/chromium/riscv64.patch
@@ -1,5 +1,14 @@
 --- PKGBUILD
 +++ PKGBUILD
+@@ -8,7 +8,7 @@ pkgname=chromium
+ pkgver=141.0.7390.122
+ pkgrel=1
+ _launcher_ver=8
+-_manual_clone=1
++_manual_clone=0
+ _system_clang=1
+ pkgdesc="A web browser built for speed, simplicity, and security"
+ arch=('x86_64')
 @@ -19,7 +19,7 @@ depends=('gtk3' 'nss' 'alsa-lib' 'xdg-utils' 'libxss' 'libcups' 'libgcrypt'
           'libffi' 'desktop-file-utils' 'hicolor-icon-theme')
  makedepends=('python' 'gn' 'ninja' 'clang' 'lld' 'gperf' 'nodejs' 'pipewire'
@@ -9,12 +18,16 @@
  optdepends=('pipewire: WebRTC desktop sharing under Wayland'
              'kdialog: support for native dialogs in Plasma'
              'gtk4: for --gtk-version=4 (GTK4 IME might work better on Wayland)'
-@@ -39,10 +39,15 @@ sha256sums=('e1a15924aeeee3cbd76cf15fd2dce755acea2a7cb034ea2993fd02dd63738764'
+@@ -35,14 +35,19 @@ source=(https://commondatastorage.googleapis.com/chromium-browser-official/chrom
+         increase-fortify-level.patch
+         use-oauth2-client-switches-as-default.patch
+         chromium-141-cssstylesheet-iwyu.patch)
+-sha256sums=('720a1196410080056cd97a1f5ec34d68ba216a281d9b5157b7ea81ea018ec661'
++sha256sums=('77015e6ce56d456f165012e8190553b1f6f5ad03be2ad06b31797c882c2f52e0'
              '213e50f48b67feb4441078d50b0fd431df34323be15be97c55302d3fdac4483a'
              '11a96ffa21448ec4c63dd5c8d6795a1998d8e5cd5a689d91aea4d2bdd13fb06e'
              '5abc8611463b3097fc5ce58017ef918af8b70d616ad093b8b486d017d021bbdf'
--            '81ba390a500a38c50b5adad9d185d08685cdf9a9d9448e1e33cfff4f2388618d'
-+            '1b36a49855a19dd44d4c9d120157bb58a71cddcc8d40182330f73de2abbd59c9'
+             'ec8e49b7114e2fa2d359155c9ef722ff1ba5fe2c518fa48e30863d71d3b82863'
              'd634d2ce1fc63da7ac41f432b1e84c59b7cceabf19d510848a7cff40c8025342'
              'e6da901e4d0860058dc2f90c6bbcdc38a0cf4b0a69122000f62204f24fa7e374'
 -            'de5c873564b09713b65dd9e6a0b9049d7b3cf8f881436f36e1c091824b63e876')
@@ -112,38 +125,3 @@
 +         Debian-fix-rust-linking.patch)
 +
  # vim:set ts=2 sw=2 et:
-diff --git compiler-rt-adjust-paths.patch compiler-rt-adjust-paths.patch
-index c3ac1f9..bb7d0f8 100644
---- compiler-rt-adjust-paths.patch
-+++ compiler-rt-adjust-paths.patch
-@@ -1,12 +1,11 @@
--diff -ura chromium-141.0.7390.54/build/config/clang/BUILD.gn chromium-141.0.7390.54.patched/build/config/clang/BUILD.gn
----- chromium-141.0.7390.54/build/config/clang/BUILD.gn  2025-10-01 13:36:59.000000000 +0000
--+++ chromium-141.0.7390.54.patched/build/config/clang/BUILD.gn  2025-10-01 13:42:38.977184172 +0000
--@@ -170,17 +170,22 @@
--         _dir = "darwin"
-+diff --git a/build/config/clang/BUILD.gn b/build/config/clang/BUILD.gn
-+index b171ee13ce7ed..d5b4e4fdcd0c8 100644
-+--- a/build/config/clang/BUILD.gn
-++++ b/build/config/clang/BUILD.gn
-+@@ -171,16 +171,21 @@ template("clang_lib") {
-        } else if (is_linux || is_chromeos) {
-          if (current_cpu == "x64") {
---          _dir = "x86_64-unknown-linux-gnu"
--+          _dir = "linux"
-+           _dir = "x86_64-unknown-linux-gnu"
- +          _suffix = "-x86_64"
-          } else if (current_cpu == "x86") {
-            _dir = "i386-unknown-linux-gnu"
-@@ -25,3 +24,11 @@ diff -ura chromium-141.0.7390.54/build/config/clang/BUILD.gn chromium-141.0.7390
-          } else if (current_cpu == "ppc64") {
-            _dir = "ppc64le-unknown-linux-gnu"
-          } else if (current_cpu == "s390x") {
-+@@ -188,6 +193,7 @@ template("clang_lib") {
-+         } else {
-+           assert(false)  # Unhandled cpu type
-+         }
-++          _dir = "linux"
-+       } else if (is_fuchsia) {
-+         if (current_cpu == "x64") {
-+           _dir = "x86_64-unknown-fuchsia"


### PR DESCRIPTION
- Disable `_manual_clone` since the chromium source tarball has been released.
- Drop upsteamed modification to compiler-rt-adjust-paths.patch