### PR TITLE
qemu-user-blacklist.txt: add xfsprogs

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -140,6 +140,7 @@ valkey
 vim
 wanderlust
 wayland
+xfsprogs
 xmonk.lv2
 zeromq
 zram-generator


### PR DESCRIPTION
Architecture detection went wrong in qemu-user:

    gcc: error: '-march=x86-64': ISA string must begin with rv32 or rv64