### PR TITLE
addpatch: dvdauthor 0.7.2-13

### DIFF
--- a/dvdauthor/riscv64.patch
+++ b/dvdauthor/riscv64.patch
@@ -1,0 +1,14 @@
+diff --git PKGBUILD PKGBUILD
+index 94d0dd8..4ae11dc 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -29,7 +29,8 @@ prepare() {
+   # don't search for obsolete freetype-config
+   patch -p1 -i ../dvdauthor-0.7.2-freetype-pkgconfig.patch 
+ 
+-  autoreconf -vi
++  # autoreconf -vi
++  autoreconf -fvi -I /usr/share/gettext/m4
+ }
+ 
+ build() {


### PR DESCRIPTION
fix "configure.ac:134: error: possibly undefined macro: AM_ICONV" caused by the m4 files moved.[upstreamed](https://gitlab.archlinux.org/archlinux/packaging/packages/dvdauthor/-/merge_requests/2)