### PR TITLE
addpatch: dtkcore 5.7.23.-1

### DIFF
--- a/dtkcore/riscv64.patch
+++ b/dtkcore/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index 294c24d..bb80752 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -28,7 +28,7 @@ build() {
+       -DFEATURES_INSTALL_DIR=lib/qt/mkspecs/features/ \
+       -DBUILD_WITH_SYSTEMD=ON \
+       -DBUILD_DOCS=ON \
+-      -DBUILD_TESTING=ON \
++      -DBUILD_TESTING=OFF \
+       -DQCH_INSTALL_DESTINATION=share/doc/qt \
+       -DCMAKE_INSTALL_LIBDIR=lib \
+       -DCMAKE_INSTALL_LIBEXECDIR=lib \


### PR DESCRIPTION
riscv64 build() crashes when running LeakSanitizer."LeakSanitizer does not work under ptrace"