### PR TITLE
addpatch: fastd 23-1

### DIFF
--- a/fastd/riscv64.patch
+++ b/fastd/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -26,6 +26,9 @@ sha512sums=('2b35be0fc93be993c4d685c138b2e45aea6d2540a0de35e9da835e4cf8abfcc73dc
+ 
+ build() {
+   arch-meson $pkgname-$pkgver build \
++    -D cipher_salsa20_xmm=disabled \
++    -D cipher_salsa2012_xmm=disabled \
++    -D mac_ghash_pclmulqdq=disabled \
+     -D b_lto=true \
+     -D systemd=enabled \
+     -D build_tests=true


### PR DESCRIPTION
Disable x86 specific features.
These features are auto features, which are enabled by arch-meson.