### PR TITLE
addpatch: kdegraphics-mobipocket 25.08.2

### DIFF
--- a/kdegraphics-mobipocket/riscv64.patch
+++ b/kdegraphics-mobipocket/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index 712e721..19142ac 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -13,7 +13,7 @@ depends=(gcc-libs
+          glibc
+          qt6-base)
+ makedepends=(extra-cmake-modules)
+-source=(https://download.kde.org/25.08.2/release-service/$pkgver/src/$pkgname-$pkgver.tar.xz{,.sig})
++source=(https://download.kde.org/stable/release-service/$pkgver/src/$pkgname-$pkgver.tar.xz{,.sig})
+ sha256sums=('799af3ba4190313397389330645c3fa00f429017f7338433c8d4abee55ad64d2'
+             'SKIP')
+ validpgpkeys=(CA262C6C83DE4D2FB28A332A3A6A4DB839EAA6D7  # Albert Astals Cid <aacid@kde.org>


### PR DESCRIPTION
Address template error.[upstreamed](https://gitlab.archlinux.org/archlinux/packaging/packages/kdegraphics-mobipocket/-/merge_requests/1)