### PR TITLE
updpkg: devtools-riscv64 1:1.3.2+patch2-1

### DIFF
--- a/devtools-riscv64/PKGBUILD
+++ b/devtools-riscv64/PKGBUILD
@@ -2,24 +2,25 @@
 
 pkgname=devtools-riscv64
 epoch=1
-pkgver=1.3.2+patch1
+pkgver=1.3.2+patch2
 pkgrel=1
 pkgdesc='Tools for Arch Linux RISC-V package maintainers'
-arch=('x86_64' 'riscv64')
+arch=('x86_64' 'riscv64' 'loong64')
 license=('GPL-3.0-or-later')
 url='https://github.com/felixonmars/archriscv-packages'
 depends=(devtools)
 depends_x86_64=(qemu-user-static)
+depends_loong64=(qemu-user-static)
 source=(makepkg-riscv64.patch
         pacman-extra-riscv64.patch
         sogrep-riscv64.patch
-        valid-repos-riscv64.sh)
-source_x86_64=(z-archriscv-qemu-riscv64.conf)
+        valid-repos-riscv64.sh
+        z-archriscv-qemu-riscv64.conf)
 sha256sums=('efaa0c9ca426564921c7d2d909d0c331fd80ce4840019b26c0a259a15b45a087'
             'f01c8cfdbfffa3212a78117f2ce6e0feb97f6cb3d49f47d4f541e9c9f6136e87'
             'c8e9bfc390e42d358007578ca54212bda1d44c754c976be9ef262944d4a0d83c'
-            '94ee35597de8e46b1f0c09f95ced34c47ece2f95f92d1a7f2415373f2d129c63')
-sha256sums_x86_64=('c59273c423e815e4c27e8486632d80a768adddd172119035d48f7c2fac98a87a')
+            '94ee35597de8e46b1f0c09f95ced34c47ece2f95f92d1a7f2415373f2d129c63'
+            'c59273c423e815e4c27e8486632d80a768adddd172119035d48f7c2fac98a87a')
 
 package() {
   install -Dm644 valid-repos-riscv64.sh -t "$pkgdir"/usr/share/devtools/lib
@@ -41,6 +42,9 @@ package() {
   if [[ ! "$CARCH" =~ riscv ]]; then
     install -dm755 "$pkgdir"/usr/share/devtools/setarch-aliases.d
     echo "$CARCH" > "$pkgdir"/usr/share/devtools/setarch-aliases.d/riscv64
+
+    # On Loong Arch Linux, uname -m returns loongarch64 while CARCH is loong64
+    [[ "$CARCH" == "loong64" ]] && echo "loongarch64" > "$pkgdir"/usr/share/devtools/setarch-aliases.d/riscv64
 
     # qemu-user-static-binfmt, but with C flag
     install -Dm644 z-archriscv-qemu-riscv64.conf -t "$pkgdir"/usr/lib/binfmt.d/


### PR DESCRIPTION
Add support for loong64 qemu-user builders.