### PR TITLE
updpatch: dart 3.9.4-1

### DIFF
--- a/dart/HACK-gclient-fix-dep.diff
+++ b/dart/HACK-gclient-fix-dep.diff
@@ -1,0 +1,12 @@
+--- gclient.py.orig	2025-11-01 08:31:34.496028596 +0000
++++ gclient.py	2025-11-01 08:32:52.295977141 +0000
+@@ -79,6 +79,9 @@
+ #   To specify a target CPU, the variables target_cpu and target_cpu_only
+ #   are available and are analogous to target_os and target_os_only.
+ 
++import os, sys
++os.system(f"{sys.executable} -m pip install httplib2==0.13.1 six==1.10.0 requests==2.31.0")
++
+ __version__ = '0.7'
+ 
+ import copy

--- a/dart/riscv64.patch
+++ b/dart/riscv64.patch
@@ -1,14 +1,23 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -53,6 +53,7 @@ EOF
+@@ -57,8 +57,16 @@ EOF
+ 
+   export PATH+=":$PWD/depot_tools" DEPOT_TOOLS_UPDATE=0
+ 
++  # Bundled wheels are not available for riscv64
++  sed -i '/wheel: </,$d' depot_tools/.vpython3
++  sed -i '/wheel: </,$d' depot_tools/gsutil.vpython3
++  # Hack
++  patch -Np0 -d depot_tools < HACK-gclient-fix-dep.diff
++
    cd sdk
  
-   patch -Np 1 --input=$srcdir/DEPS.patch
 +  patch -Np 1 --input=$srcdir/dart-riscv-no-cross.patch
++
+   patch -Np 1 --input="$srcdir/DEPS.patch"
+   patch -Np 1 --input="$srcdir/0001-vm-Fix-gcc-build.patch"
  
-   python ../depot_tools/gclient.py sync -D \
-       --nohooks \
-@@ -72,7 +73,7 @@ build() {
+@@ -80,7 +88,7 @@ build() {
    # gn args --list out
  
    /usr/bin/gn gen -qv out --args='
@@ -17,10 +26,12 @@
                          is_debug = false
                          is_release = true
                          is_clang = false
-@@ -104,3 +105,6 @@ package() {
+@@ -112,3 +120,8 @@ package() {
  }
  
  # vim:set ts=2 sw=2 et:
 +
-+source+=("dart-riscv-no-cross.patch")
-+sha256sums+=('8c0d3a27a86aea34d7b932181111a9f660d2e7bf67d5e45055163e6b980b187f')
++source+=("dart-riscv-no-cross.patch"
++         "HACK-gclient-fix-dep.diff")
++sha256sums+=('8c0d3a27a86aea34d7b932181111a9f660d2e7bf67d5e45055163e6b980b187f'
++             'ba4ac7e5c41c4d4a20f3fa420af99e844c69255ce1472436568a1fdf77785104')


### PR DESCRIPTION
- Refresh patch
- Apply a hack for depot_tools to install required dependencies for gclient. Since there appears to be no way to get the path to gclient's specific venv, a hack is necessary here.