### PR TITLE
addpatch: blosc 1.21.6-2

### DIFF
--- a/blosc/0001-Set-std-gnu99-for-gcc-on-all-architectures.patch
+++ b/blosc/0001-Set-std-gnu99-for-gcc-on-all-architectures.patch
@@ -1,0 +1,50 @@
+From 9bf257c68d3645d28acee428171a49dec388ffef Mon Sep 17 00:00:00 2001
+From: Levi Zim <rsworktech@outlook.com>
+Date: Sat, 15 Nov 2025 20:05:01 +0800
+Subject: [PATCH] Set -std=gnu99 for gcc on all architectures
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Previously the cmake file only sets `-std=gnu99` when it is on x86(-64),
+which causes compilation failure on other architectures when gcc is
+used.
+
+GCC currently defaults to `-std=gnu23`, which would fail the build with:
+
+    blosc/shuffle.c:26:15: error: ‘bool’ cannot be defined via ‘typedef’
+
+This patch fixes it by setting `-std=gnu99` for gcc on all
+architectures.
+---
+ CMakeLists.txt | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index fac75f5..f0aab80 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -207,6 +207,11 @@ if(APPLE)
+   set(CMAKE_MACOSX_RPATH TRUE)
+ endif()
+ 
++if(CMAKE_C_COMPILER_ID STREQUAL GNU)
++    # We need C99 (GNU99 more exactly)
++    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
++endif()
++
+ # Based on the target system's processor and the compiler being used,
+ # set build variables indicating which hardware features can be targeted
+ # by the compiler. Note we DO NOT check which hardware features are supported
+@@ -215,8 +220,6 @@ endif()
+ message(STATUS "Building for system processor ${CMAKE_SYSTEM_PROCESSOR}")
+ if(CMAKE_SYSTEM_PROCESSOR MATCHES "(i386|i686|x86_64|amd64|AMD64)")
+     if(CMAKE_C_COMPILER_ID STREQUAL GNU)
+-        # We need C99 (GNU99 more exactly)
+-        SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
+         set(COMPILER_SUPPORT_SSE2 TRUE)
+         if(CMAKE_C_COMPILER_VERSION VERSION_GREATER 4.7 OR CMAKE_C_COMPILER_VERSION VERSION_EQUAL 4.7)
+             set(COMPILER_SUPPORT_AVX2 TRUE)
+-- 
+2.51.2
+

--- a/blosc/riscv64.patch
+++ b/blosc/riscv64.patch
@@ -1,0 +1,26 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -16,15 +16,20 @@ depends=(
+   zstd
+ )
+ makedepends=(git cmake)
+-source=("$pkgname::git+https://github.com/Blosc/c-blosc#tag=v$pkgver")
+-sha512sums=('ea5e14ed1ece973e8cb31544cc016ae01b4f59ae7b6e6425c8703f98bda68eff8fc6382fb6e2cb4ec406db22a9229de8148df9a9aca8570f218c431866f709cc')
+-b2sums=('e9027864a8a2f67cda8d7f71f22cfd4c99ace91b57ca02c1de274e36c546cad7e9dcb387323ca2924c3daf006f60f1f8a918f1e8c4b5a1cc3b0e248bfd895d0d')
++source=("$pkgname::git+https://github.com/Blosc/c-blosc#tag=v$pkgver"
++	0001-Set-std-gnu99-for-gcc-on-all-architectures.patch)
++sha512sums=('ea5e14ed1ece973e8cb31544cc016ae01b4f59ae7b6e6425c8703f98bda68eff8fc6382fb6e2cb4ec406db22a9229de8148df9a9aca8570f218c431866f709cc'
++            '209bf6f4604f115e4e2ac33527947be3c4cd1c4418b36ca17977dd528c08628448e7cb96b73a6b4a5bc775ec62a36c7717c89112a8e7a0a424082e890bc835ba')
++b2sums=('e9027864a8a2f67cda8d7f71f22cfd4c99ace91b57ca02c1de274e36c546cad7e9dcb387323ca2924c3daf006f60f1f8a918f1e8c4b5a1cc3b0e248bfd895d0d'
++        'd9339c4c20b750d170cdf34107f77823995d8714fda9a994d8152bb331f05de49fe873e92913a454389dfc720dce0c1ee45cc52c7f08e4d03c5a32ba6c46f6e9')
+ 
+ prepare() {
+   cd "$pkgname"
+ 
+   # update minimal cmake version
+   git cherry-pick --no-commit 051b9d2cb9437e375dead8574f66d80ebce47bee
++
++  patch -Np1 -i ../0001-Set-std-gnu99-for-gcc-on-all-architectures.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
Set `-std=gnu99` for all architectures to fix build: https://github.com/Blosc/c-blosc/pull/399