### PR TITLE
addpatch: gemini-cli 1:0.18.4-1

### DIFF
--- a/gemini-cli/riscv64.patch
+++ b/gemini-cli/riscv64.patch
@@ -1,0 +1,13 @@
+diff --git PKGBUILD PKGBUILD
+index 9084df4..a0ebfb0 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,7 +14,7 @@
+   glibc
+   nodejs
+ )
+-makedepends=(npm)
++makedepends=(npm python)
+ source=("https://registry.npmjs.org/@google/$pkgname/-/$pkgname-$pkgver.tgz")
+ noextract=("$pkgname-$pkgver.tgz")
+ sha512sums=('a04aa6ab752e3ed0b9b6e017f22b890e35e9be637bdc78dbd2e7f32fff97a9bdc7f958f4524dccc4328239edc9968ab7b83912d97ae9d345d1c19f0e732e172d')


### PR DESCRIPTION
`node-sitter-bash` does not have prebuilt on riscv64. Building with `node-gyp` from source for that package needs `python`.

[Upstream issue](https://github.com/tree-sitter/workflows/issues/51)