### PR TITLE
sv39-blacklist.txt: add corepack

### DIFF
--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -1,4 +1,5 @@
 argocd
+corepack
 forgejo
 gitea
 grafana


### PR DESCRIPTION
corepack uses modern Yarn, which will cause wasm out of memory errors on sv39.

Bootstrap process for this package:

1. Get corepack package from Arch Linux x86_64 (since it's an `any' package): wget https://europe.mirror.pkgbuild.com/extra/os/x86_64/corepack-0.34.5-1-any.pkg.tar.zst
2. Build with `-I corepack-0.34.5-1-any.pkg.tar.zst`