### PR TITLE
qemu-user-blacklist: add chawan

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -11,6 +11,7 @@ caps
 cargo-audit
 cargo-generate-rpm
 cargo-nextest
+chawan
 cherrytree
 chezmoi
 cloud-init


### PR DESCRIPTION
qemu-user has limited seccomp support and the build would fail with `seccomp: Function not implemented`.