### PR TITLE
fixpatch: gcc 15.2.1+r301+gf24307422d1d-1

### DIFF
--- a/gcc/riscv64.patch
+++ b/gcc/riscv64.patch
@@ -52,19 +52,16 @@
      --enable-bootstrap \
      "${_confflags[@]:?_confflags unset}"
  
-@@ -161,9 +164,9 @@ check() {
- package_gcc-libs() {
-   pkgdesc='Runtime libraries shipped by GCC'
+@@ -163,7 +166,7 @@ package_gcc-libs() {
    depends=('glibc>=2.27')
--  options=(!emptydirs !strip)
-+  options=(!emptydirs !strip staticlibs)
+   options=(!emptydirs !strip)
    provides=($pkgname-multilib libgo.so libgfortran.so libgphobos.so
 -            libubsan.so libasan.so libtsan.so liblsan.so)
 +            libubsan.so libasan.so liblsan.so)
    replaces=($pkgname-multilib libgphobos)
  
    cd gcc-build
-@@ -176,9 +179,8 @@ package_gcc-libs() {
+@@ -177,9 +180,8 @@ package_gcc-libs() {
               libgomp \
               libitm \
               libquadmath \
@@ -76,7 +73,7 @@
      make -C $CHOST/$lib DESTDIR="$pkgdir" install-toolexeclibLTLIBRARIES
    done
  
-@@ -195,18 +197,17 @@ package_gcc-libs() {
+@@ -196,9 +198,6 @@ package_gcc-libs() {
      make -C $CHOST/$lib DESTDIR="$pkgdir" install-info
    done
  
@@ -86,11 +83,7 @@
    # Install Runtime Library Exception
    install -Dm644 "$srcdir/gcc/COPYING.RUNTIME" \
      "$pkgdir/usr/share/licenses/gcc-libs/RUNTIME.LIBRARY.EXCEPTION"
-+
-+  # Remove static library (.a) files except libatomic.a
-+  find "$pkgdir" -name '*.a' ! -name libatomic.a -delete
- }
- 
+@@ -207,7 +206,6 @@ package_gcc-libs() {
  package_gcc() {
    pkgdesc="The GNU Compiler Collection - C and C++ frontends"
    depends=("gcc-libs=$pkgver-$pkgrel" 'binutils>=2.28' libmpc zstd libisl.so)
@@ -98,7 +91,7 @@
    provides=($pkgname-multilib)
    replaces=($pkgname-multilib)
    options=(!emptydirs staticlibs)
-@@ -220,25 +221,20 @@ package_gcc() {
+@@ -221,25 +219,20 @@ package_gcc() {
    install -m755 -t "$pkgdir/${_libdir}/" gcc/{cc1,cc1plus,collect2,lto1}
  
    make -C $CHOST/libgcc DESTDIR="$pkgdir" install
@@ -127,7 +120,7 @@
  
    make DESTDIR="$pkgdir" install-fixincludes
    make -C gcc DESTDIR="$pkgdir" install-mkheaders
-@@ -253,17 +249,12 @@ package_gcc() {
+@@ -254,17 +247,12 @@ package_gcc() {
    make -C $CHOST/libquadmath DESTDIR="$pkgdir" install-nodist_libsubincludeHEADERS
    make -C $CHOST/libsanitizer DESTDIR="$pkgdir" install-nodist_{saninclude,toolexeclib}HEADERS
    make -C $CHOST/libsanitizer/asan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
@@ -146,7 +139,7 @@
  
    make -C libcpp DESTDIR="$pkgdir" install
    make -C gcc DESTDIR="$pkgdir" install-po
-@@ -274,7 +265,7 @@ package_gcc() {
+@@ -275,7 +263,7 @@ package_gcc() {
    # create cc-rs compatible symlinks
    # https://github.com/rust-lang/cc-rs/blob/1.0.73/src/lib.rs#L2578-L2581
    for binary in {c++,g++,gcc,gcc-ar,gcc-nm,gcc-ranlib}; do
@@ -155,7 +148,7 @@
    done
  
    # POSIX conformance launcher scripts for c89 and c99
-@@ -284,9 +275,6 @@ package_gcc() {
+@@ -285,9 +273,6 @@ package_gcc() {
    # install the libstdc++ man pages
    make -C $CHOST/libstdc++-v3/doc DESTDIR="$pkgdir" doc-install-man
  
@@ -165,7 +158,7 @@
    # byte-compile python libraries
    python -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
    python -O -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
-@@ -306,8 +294,6 @@ package_gcc-fortran() {
+@@ -307,8 +292,6 @@ package_gcc-fortran() {
    cd gcc-build
    make -C $CHOST/libgfortran DESTDIR="$pkgdir" install-cafexeclibLTLIBRARIES \
      install-{toolexeclibDATA,nodist_fincludeHEADERS,gfor_cHEADERS}
@@ -174,7 +167,7 @@
    make -C $CHOST/libgomp DESTDIR="$pkgdir" install-nodist_fincludeHEADERS
    make -C gcc DESTDIR="$pkgdir" fortran.install-{common,man,info}
    install -Dm755 gcc/f951 "$pkgdir/${_libdir}/f951"
-@@ -385,7 +371,6 @@ package_gcc-go() {
+@@ -386,7 +369,6 @@ package_gcc-go() {
  
    cd gcc-build
    make -C $CHOST/libgo DESTDIR="$pkgdir" install-exec-am


### PR DESCRIPTION
Arch now ships a static libatomic in gcc package.
Which conflicts with our approach of shipping it in gcc-libs. Drop libatomic.a in gcc-libs to align with Arch.

I am deeply sorry for the inconvenience caused.