### PR TITLE
updpatch: dart 3.11.4-1

### DIFF
--- a/dart/disable-warning-as-error.patch
+++ b/dart/disable-warning-as-error.patch
@@ -1,0 +1,11 @@
+--- build/config/compiler/BUILD.gn.orig	2026-03-30 07:49:33.983647986 -0400
++++ build/config/compiler/BUILD.gn	2026-03-30 07:50:03.867387605 -0400
+@@ -741,7 +741,7 @@
+     ]
+ 
+     if (dart_sysroot != "alpine") {
+-      cflags += [ "-Werror" ]
++      cflags += [ ]
+     }
+ 
+     defines = []

--- a/dart/riscv64.patch
+++ b/dart/riscv64.patch
@@ -1,23 +1,26 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -57,8 +57,16 @@ EOF
+@@ -57,8 +57,19 @@ EOF
  
    export PATH+=":$PWD/depot_tools" DEPOT_TOOLS_UPDATE=0
  
 +  # Bundled wheels are not available for riscv64
 +  sed -i '/wheel: </,$d' depot_tools/.vpython3
-+  sed -i '/wheel: </,$d' depot_tools/gsutil.vpython3
++  sed -i '/wheel: </,$d' depot_tools/gsutil.py.vpython3
++  sed -i '/wheel: </,$d' depot_tools/recipes/recipe_modules/gitiles/resources/gerrit_client.py.vpython3
 +  # Hack
 +  patch -Np0 -d depot_tools < HACK-gclient-fix-dep.diff
 +
    cd sdk
  
 +  patch -Np 1 --input=$srcdir/dart-riscv-no-cross.patch
++  # /usr/include/c++/15.2.1/bits/shared_ptr_base.h:181:35: error: ‘atomic_thread_fence’ is not supported with ‘-fsanitize=thread’ [-Werror=tsan]  
++  patch -Np 0 --input=$srcdir/disable-warning-as-error.patch
 +
    patch -Np 1 --input="$srcdir/DEPS.patch"
-   patch -Np 1 --input="$srcdir/0001-vm-Fix-gcc-build.patch"
+   patch -Np 1 --input="$srcdir/0001-fix-gcc-build-fails-with-msan-enabled.patch"
  
-@@ -80,7 +88,7 @@ build() {
+@@ -80,7 +91,7 @@ build() {
    # gn args --list out
  
    /usr/bin/gn gen -qv out --args='
@@ -26,12 +29,14 @@
                          is_debug = false
                          is_release = true
                          is_clang = false
-@@ -112,3 +120,8 @@ package() {
+@@ -112,3 +123,10 @@ package() {
  }
  
  # vim:set ts=2 sw=2 et:
 +
 +source+=("dart-riscv-no-cross.patch"
-+         "HACK-gclient-fix-dep.diff")
++         "HACK-gclient-fix-dep.diff"
++         "disable-warning-as-error.patch")
 +sha256sums+=('8c0d3a27a86aea34d7b932181111a9f660d2e7bf67d5e45055163e6b980b187f'
-+             'ba4ac7e5c41c4d4a20f3fa420af99e844c69255ce1472436568a1fdf77785104')
++             'ba4ac7e5c41c4d4a20f3fa420af99e844c69255ce1472436568a1fdf77785104'
++             '02d05169015375cc5fcdfc03f4ba258f82d88951d69d27aacf001f4d6f73fa9c')


### PR DESCRIPTION
- Add a patch to disable `-Werror` because of:

        /usr/include/c++/15.2.1/bits/shared_ptr_base.h:181:35: error: ‘atomic_thread_fence’ is not supported with ‘-fsanitize=thread’ [-Werror=tsan]

- Refresh patch
- This depends on tsan support in GCC: #5188