### PR TITLE
addpatch: opensearch-knn-plugin 3.5.0.0-1

### DIFF
--- a/opensearch-knn-plugin/riscv64.patch
+++ b/opensearch-knn-plugin/riscv64.patch
@@ -1,0 +1,20 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -10,7 +10,7 @@ arch=('x86_64')
+ url="https://opensearch.org/docs/latest/search-plugins/knn"
+ license=('Apache-2.0')
+ depends=("opensearch=${_opensearchver}")
+-makedepends=("java-environment=${_jdkver}" 'unzip')
++makedepends=("java-environment=${_jdkver}" 'unzip' 'gradle')
+ source=(
+   "${pkgname}-${pkgver}.tar.gz::https://github.com/opensearch-project/k-NN/archive/${pkgver}.tar.gz"
+ )
+@@ -22,7 +22,7 @@ build() {
+   export PATH="/usr/lib/jvm/java-${_jdkver}-openjdk/bin:$PATH"
+   export GRADLE_OPTS="-Dbuild.snapshot=false -Dopensearch.version=${_opensearchver}"
+   # integTest (Reaper) requires JDK 14
+-  ./gradlew assemble \
++  gradle assemble \
+     --exclude-task ":integTest" \
+     --exclude-task ":jacocoTestReport"
+ }


### PR DESCRIPTION
Use system gradle. Bundled gradle is missing https://github.com/gradle/native-platform/commit/bc65f1dae7c140bdfc3e3da23958e44b2ff61a3d