### PR TITLE
addpatch: opensearch-performance-analyzer-plugin 3.5.0.0-1

### DIFF
--- a/opensearch-performance-analyzer-plugin/riscv64.patch
+++ b/opensearch-performance-analyzer-plugin/riscv64.patch
@@ -1,0 +1,20 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,7 +12,7 @@ arch=('x86_64')
+ url="https://opensearch.org/docs/latest/monitoring-plugins/pa"
+ license=('Apache-2.0')
+ depends=("opensearch=${_opensearchver}")
+-makedepends=("java-environment=${_jdkver}" 'unzip' 'git')
++makedepends=("java-environment=${_jdkver}" 'unzip' 'git' 'gradle')
+ source=(
+   "${pkgname}-${pkgver}.tar.gz::https://github.com/opensearch-project/performance-analyzer/archive/${pkgver}.tar.gz"
+   "git+https://github.com/opensearch-project/performance-analyzer-rca.git#branch=${_rcaver}"
+@@ -26,7 +26,7 @@ build() {
+   export PATH="/usr/lib/jvm/java-${_jdkver}-openjdk/bin:$PATH"
+   export GRADLE_OPTS="-Dbuild.snapshot=false -Dopensearch.version=${_opensearchver}"
+   # integTest (Reaper) requires JDK 14
+-  ./gradlew assemble \
++  gradle assemble \
+     -Dperformance-analyzer-rca.build=true \
+     -Dperformance-analyzer-rca.branch=${_rcaver} \
+     --exclude-task ":integTest" \


### PR DESCRIPTION
Use system gradle. Bundled gradle is missing gradle/native-platform@bc65f1d