### PR TITLE
addpatch: opensearch-security-plugin 3.5.0.0-1

### DIFF
--- a/opensearch-security-plugin/riscv64.patch
+++ b/opensearch-security-plugin/riscv64.patch
@@ -1,0 +1,20 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -10,7 +10,7 @@ arch=('x86_64')
+ url="https://opensearch.org/docs/latest/security-plugin"
+ license=('Apache-2.0')
+ depends=("opensearch=${_opensearchver}")
+-makedepends=("java-environment=${_jdkver}" 'unzip' 'git')
++makedepends=("java-environment=${_jdkver}" 'unzip' 'git' 'gradle')
+ source=("git+https://github.com/opensearch-project/security.git#tag=${pkgver}") # Build requires git
+ sha256sums=('e99b6f3446f1d097c426b653f0fd4571ee9aa96aa54a363e449c85572a067196')
+ 
+@@ -22,7 +22,7 @@ build() {
+ 
+   # Currently the tests don't provide a way to skip the integration tests
+   # … so we skip them entirely for now
+-  ./gradlew assemble
++  gradle assemble
+ }
+ 
+ package() {


### PR DESCRIPTION
Use system gradle. Bundled gradle is missing gradle/native-platform@bc65f1d