### PR TITLE
addpatch: opensearch-asynchronous-search-plugin 3.5.0.0-1

### DIFF
--- a/opensearch-asynchronous-search-plugin/riscv64.patch
+++ b/opensearch-asynchronous-search-plugin/riscv64.patch
@@ -1,0 +1,20 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -10,7 +10,7 @@ arch=('x86_64')
+ url="https://opensearch.org/docs/latest/search-plugins/async"
+ license=('Apache-2.0')
+ depends=("opensearch=${_opensearchver}")
+-makedepends=("java-environment-openjdk=${_jdkver}" 'unzip')
++makedepends=("java-environment-openjdk=${_jdkver}" 'unzip' 'gradle')
+ source=(
+   "${pkgname}-${pkgver}.tar.gz::https://github.com/opensearch-project/asynchronous-search/archive/${pkgver}.tar.gz"
+ )
+@@ -22,7 +22,7 @@ build() {
+   export PATH="/usr/lib/jvm/java-${_jdkver}-openjdk/bin:$PATH"
+   export GRADLE_OPTS="-Dbuild.snapshot=false -Dopensearch.version=${_opensearchver}"
+   # integTest (Reaper) requires JDK 14
+-  ./gradlew assemble \
++  gradle assemble \
+     --exclude-task ":integTest" \
+     --exclude-task ":jacocoTestReport"
+ }


### PR DESCRIPTION
Use system gradle. Bundled gradle is missing gradle/native-platform@bc65f1d