### PR TITLE
addpatch: opensearch-neural-search-plugin 3.5.0.0-1

### DIFF
--- a/opensearch-neural-search-plugin/riscv64.patch
+++ b/opensearch-neural-search-plugin/riscv64.patch
@@ -1,0 +1,20 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -11,7 +11,7 @@ arch=('x86_64')
+ url="https://github.com/opensearch-project/neural-search"
+ license=('Apache-2.0')
+ depends=("opensearch=${_opensearchver}")
+-makedepends=("java-environment=${_jdkver}" 'unzip')
++makedepends=("java-environment=${_jdkver}" 'unzip' 'gradle')
+ source=("${pkgname}-${pkgver}.tar.gz::https://github.com/opensearch-project/neural-search/archive/${pkgver}.tar.gz")
+ sha256sums=('31ead1bdcd780b941c7839d3551da8b25f3f099805e8a18323a77696c18a8cc3')
+ 
+@@ -21,7 +21,7 @@ build() {
+   export PATH="/usr/lib/jvm/java-${_jdkver}-openjdk/bin:$PATH"
+   export GRADLE_OPTS="-Dbuild.snapshot=false -Dopensearch.version=${_opensearchver}"
+   # integTest (Reaper) requires JDK 14
+-  ./gradlew build \
++  gradle build \
+     --exclude-task "integTest" \
+     --exclude-task "jacocoTestReport" \
+     --exclude-task "jacocoTestCoverageVerification"


### PR DESCRIPTION
Use system gradle. Bundled gradle is missing gradle/native-platform@bc65f1d