### PR TITLE
addpatch: opensearch-observability-plugin 3.5.0.0-1

### DIFF
--- a/opensearch-observability-plugin/riscv64.patch
+++ b/opensearch-observability-plugin/riscv64.patch
@@ -1,0 +1,20 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -10,7 +10,7 @@ arch=('x86_64')
+ url="https://github.com/opensearch-project/observability"
+ license=('Apache-2.0')
+ depends=("opensearch=${_opensearchver}")
+-makedepends=("java-environment=${_jdkver}" 'unzip')
++makedepends=("java-environment=${_jdkver}" 'unzip' 'gradle')
+ source=(
+   "${pkgname}-${pkgver}.tar.gz::https://github.com/opensearch-project/observability/archive/${pkgver}.tar.gz"
+ )
+@@ -21,7 +21,7 @@ build() {
+   export JAVA_HOME="/usr/lib/jvm/java-${_jdkver}-openjdk"
+   export PATH="/usr/lib/jvm/java-${_jdkver}-openjdk/bin:$PATH"
+   export GRADLE_OPTS="-Dbuild.snapshot=false -Dopensearch.version=${_opensearchver}"
+-  ./gradlew assemble \
++  gradle assemble -Dkotlin.version=2.2.10 \
+     --exclude-task ":jacocoTestReport"
+ }
+ 


### PR DESCRIPTION
- Use system gradle. Bundled gradle is missing gradle/native-platform@bc65f1d
- Update kotlin to support riscv: https://youtrack.jetbrains.com/projects/KT/issues/KT-77977/Unknown-hardware-platform-riscv64-on-JVM-project-build