### PR TITLE
addpatch: skim 4.4.0-1

### DIFF
--- a/skim/riscv64.patch
+++ b/skim/riscv64.patch
@@ -1,0 +1,24 @@
+diff --git PKGBUILD PKGBUILD
+index 6d4b54c..dd831e5 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -32,8 +32,9 @@
+ prepare() {
+   cd "$pkgname"
+ 
++  patch -Np1 -i "../$pkgname-only-enable-frizbee-on-x86_64-and-aarch64.patch"
+   # download dependencies
+-  cargo fetch --locked --target host-tuple
++  cargo fetch --locked
+ }
+ 
+ build() {
+@@ -78,4 +79,8 @@
+   install -vDm644 -t "$pkgdir/usr/share/licenses/$pkgname" LICENSE
+ }
+ 
++source+=("$pkgname-only-enable-frizbee-on-x86_64-and-aarch64.patch::https://github.com/Xeonacid/skim/commit/4a1208cceb0f78acd5ffb78ba7317940755b9990.patch?full_index=1")
++sha512sums+=('57e8d05b6cce05e117fd0afcb8d1d29bad6bbff4f350a5d9c704f7585d5314e3508fbe70d9392b86466cc4faf935798d2a15e0c6b0a53ebd387f63f0bdd9f718')
++b2sums+=('f70993beb7f03448da3675b37a6d2756f40e3eb0f9fdd40864c1bbe29223c6899c20a1d81754abe83c9ce04406bce6ab29db827120a9cccbcd5608cf224b7521')
++
+ # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
https://github.com/skim-rs/skim/pull/1028

`--target host-tuple` in `cargo fetch` is removed because `cargo build` requires downloading the dependency although it's not compiled for the current arch...