### PR TITLE
addpatch: rage-encryption 0.11.1-3

### DIFF
--- a/rage-encryption/riscv64.patch
+++ b/rage-encryption/riscv64.patch
@@ -1,0 +1,15 @@
+diff --git PKGBUILD PKGBUILD
+index 9de2de9..faeceb8 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -23,7 +23,9 @@
+ 
+ prepare() {
+ 	cd "$_archive"
+-	cargo fetch --locked --target "$(rustc --print host-tuple)"
++	# https://github.com/str4d/rage/commit/6b097057f65aae50860ef1f0417df2bf4a26cbde
++	sed -i 's/created: 20\[\.\.\]-\[\.\.\]-\[\.\.\]T\[\.\.\]:\[\.\.\]:\[\.\.\]Z/created: 20[..]-[..]-[..]T[..]:[..]:[..]/' rage/tests/cmd/rage-keygen/gen-output{.toml,.out/key.txt}
++	cargo fetch --locked
+ }
+ 
+ build() {


### PR DESCRIPTION
Backport https://github.com/str4d/rage/commit/6b097057f65aae50860ef1f0417df2bf4a26cbde

`--target host-tuple` in `cargo fetch` is removed because `cargo check` requires downloading a dependency which is not compiled for the current arch...