### PR TITLE
updpatch: vtk-9.6.1-1

### DIFF
--- a/vtk/riscv64.patch
+++ b/vtk/riscv64.patch
@@ -1,8 +1,8 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -72,11 +72,9 @@ makedepends=(
-   libtheora               # libvtkIOOggTheora.so (1 direct lib, 2 total libs)
+@@ -78,11 +78,9 @@ makedepends=(
    mariadb-libs            # libvtkIOMySQL.so (1 direct lib, 2 total libs)
+   onnxruntime             # libvtkFiltersONNX.so.1 (1 direct lib, 2 total libs)
    opencascade             # libvtkIOOCCT.so (1 direct lib, 2 total libs)
 -  openimagedenoise        # libvtkRenderingRayTracing.so (1 direct lib, 2 total libs)
    openvdb                 # libvtkIOOpenVDB.so (1 direct lib, 2 total libs)
@@ -12,20 +12,29 @@
    pdal                    # libvtkIOPDAL.so (1 direct lib, 2 total libs)
    postgresql-libs         # libvtkIOPostgreSQL.so (1 direct lib, 2 total libs)
    unixodbc                # libvtkIOODBC.so (1 direct lib, 2 total libs)
-@@ -113,8 +111,6 @@ optdepends=(
-   'anari-sdk: ANARI rendering module'
+@@ -120,8 +118,6 @@ optdepends=(
+   'onnxruntime: ONNX filter for AI-related computation'
    'openvr: rendering for virtual reality'
    'openxr: rendering for virtual and augmented reality'
 -  'openimagedenoise: rendering with raytracing support'
 -  'ospray: rendering with raytracing support'
    'openmpi: OpenMPI support'
+   'viskores: accelerators support'
    'adios2: IO module'
-   'alembic: IO module'
-@@ -165,6 +161,7 @@ build() {
-   local _tkver=$(echo 'puts $tcl_version' | tclsh)
-   cmake -B build -S ${pkgname^^}-${pkgver} \
-     -DCMAKE_BUILD_TYPE=Release \
-+    -DVTK_ENABLE_OSPRAY=OFF \
-     -DCMAKE_CXX_FLAGS="$CXXFLAGS -ffat-lto-objects" \
-     -DCMAKE_INSTALL_PREFIX=/usr \
-     -DCMAKE_INSTALL_LICENSEDIR=share/licenses/vtk \
+@@ -178,6 +174,7 @@ build() {
+     -G Ninja
+     -Wno-dev
+     -DCMAKE_BUILD_TYPE=Release
++    -DVTK_ENABLE_OSPRAY=OFF
+     -DCMAKE_CXX_FLAGS="$CXXFLAGS -ffat-lto-objects"
+     -DCMAKE_INSTALL_PREFIX=/usr
+     -DCMAKE_INSTALL_LICENSEDIR=share/licenses/vtk
+@@ -210,6 +207,8 @@ build() {
+     -DVTK_MODULE_ENABLE_VTK_IOCatalystConduit=YES
+     # building with the usd package does not work: https://gitlab.archlinux.org/archlinux/packaging/packages/usd/-/issues/7
+     -DVTK_MODULE_ENABLE_VTK_IOUSD=NO
++    # Depends on binary LookingGlass libraries not available for RISCV
++    -DVTK_MODULE_ENABLE_VTK_RenderingLookingGlass=NO
+     -DHDF5_NO_FIND_PACKAGE_CONFIG_FILE=ON
+     -DHDF5_C_COMPILER_EXECUTABLE=h5hlcc
+     -DHDF5_CXX_COMPILER_EXECUTABLE=h5hlc++


### PR DESCRIPTION
- refresh patch
- disable RenderingLookingGlass (depends on x86-only binary libs)

Additional note: needs liblas to be updated first.