### PR TITLE
Bootstrap GCC Ada

### DIFF
--- a/gcc-ada-bootstrap/gcc/gcc-ada-adac.patch
+++ b/gcc-ada-bootstrap/gcc/gcc-ada-adac.patch
@@ -1,0 +1,41 @@
+diff --git a/gcc/ada/gcc-interface/Makefile.in b/gcc/ada/gcc-interface/Makefile.in
+index d456ac1966f..47ba0b76422 100644
+--- a/gcc/ada/gcc-interface/Makefile.in
++++ b/gcc/ada/gcc-interface/Makefile.in
+@@ -293,10 +293,10 @@ ADA_INCLUDES_FOR_SUBDIR = -I. -I$(fsrcdir)/ada
+ 	$(CC) -c $(ALL_CFLAGS) $(ADA_CFLAGS) $(ALL_CPPFLAGS) $(INCLUDES) $< $(OUTPUT_OPTION)
+ 
+ .adb.o:
+-	$(CC) -c $(ALL_ADAFLAGS) $(ADA_INCLUDES) $< $(OUTPUT_OPTION)
++	$(ADAC) -c $(ALL_ADAFLAGS) $(ADA_INCLUDES) $< $(OUTPUT_OPTION)
+ 
+ .ads.o:
+-	$(CC) -c $(ALL_ADAFLAGS) $(ADA_INCLUDES) $< $(OUTPUT_OPTION)
++	$(ADAC) -c $(ALL_ADAFLAGS) $(ADA_INCLUDES) $< $(OUTPUT_OPTION)
+ 
+ # how to regenerate this file
+ Makefile: ../config.status $(srcdir)/ada/gcc-interface/Makefile.in $(srcdir)/ada/Makefile.in $(srcdir)/ada/version.c
+@@ -381,6 +381,7 @@ endif
+ 
+ TOOLS_FLAGS_TO_PASS=		\
+ 	"CC=$(CC)" 		\
++	"ADAC=$(ADAC)" 		\
+ 	"CFLAGS=$(CFLAGS) $(PICFLAG)"	\
+ 	"LDFLAGS=$(LDFLAGS) $(LD_PICFLAG)"	\
+ 	"ADAFLAGS=$(ADAFLAGS)"	\
+@@ -874,13 +875,13 @@ b_gnatl.adb : $(GNATLINK_OBJS)
+ 	$(GNATBIND) $(ADA_INCLUDES) -o b_gnatl.adb gnatlink.ali
+ 
+ b_gnatl.o : b_gnatl.adb
+-	$(CC) -c $(ALL_ADAFLAGS) $(ADA_INCLUDES) -gnatws -gnatyN $< $(OUTPUT_OPTION)
++	$(ADAC) -c $(ALL_ADAFLAGS) $(ADA_INCLUDES) -gnatws -gnatyN $< $(OUTPUT_OPTION)
+ 
+ b_gnatm.adb : $(GNATMAKE_OBJS)
+ 	$(GNATBIND) $(ADA_INCLUDES) -o b_gnatm.adb gnatmake.ali
+ 
+ b_gnatm.o : b_gnatm.adb
+-	$(CC) -c $(ALL_ADAFLAGS) $(ADA_INCLUDES) -gnatws -gnatyN $< $(OUTPUT_OPTION)
++	$(ADAC) -c $(ALL_ADAFLAGS) $(ADA_INCLUDES) -gnatws -gnatyN $< $(OUTPUT_OPTION)
+ 
+ # Provide a `toolexeclibdir' definition for when `gnat-install-lib' is
+ # wired through gcc/ in a configuration with top-level libada disabled.

--- a/gcc-ada-bootstrap/gcc/riscv64.patch
+++ b/gcc-ada-bootstrap/gcc/riscv64.patch
@@ -1,0 +1,224 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -54,8 +54,6 @@ makedepends=(
+   gcc-ada
+   gcc-d
+   git
+-  lib32-glibc
+-  lib32-gcc-libs
+   libisl
+   libmpc
+   python
+@@ -77,6 +75,7 @@ _libdir=usr/lib/gcc/$CHOST/${pkgver%%+*}
+ source=(git+https://sourceware.org/git/gcc.git#commit=$_commit
+         c89 c99
+         gcc-ada-repro.patch
++	gcc-ada-adac.patch
+ )
+ validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.org
+               86CFFCA918CF3AF47147588051E8B148A9999C34  # foutrelis@archlinux.org
+@@ -85,12 +84,19 @@ validpgpkeys=(F3691687D867B81B51CE07D9BBE43771487328A9  # bpiotrowski@archlinux.
+ sha256sums=('e7641bfddebaada298ca0a631183ef8d81bb3c5dfd3aef30bc7d4223f1c0e450'
+             '7b09ec947f90b98315397af675369a1e3dfc527fa70013062e6e85c4be0275ab'
+             '44ea973558842f3f4bd666bdaf6e810fd7b7c7bd36b5cc4c69f93d2cd0124fc7'
+-            '1773f5137f08ac1f48f0f7297e324d5d868d55201c03068670ee4602babdef2f')
++            '1773f5137f08ac1f48f0f7297e324d5d868d55201c03068670ee4602babdef2f'
++            '845c201c46c1f2a29e1ee848d3edfaf03e77506a1ff16f94c3b2af9d88120e11')
+ pkgver() {
+   cd gcc
+   echo "$(cat gcc/BASE-VER)+$(git describe --abbrev=12 --tags | sed 's/[^-]*-[^-]*-//;s/[^-]*-/r&/;s/-/+/g;s/_/./')"
+ }
+ 
++for i in "${!pkgname[@]}"; do
++  if [[ ${pkgname[i]} = "lib32-gcc-libs" ]]; then
++    unset 'pkgname[i]'
++  fi
++done
++
+ prepare() {
+   [[ ! -d gcc ]] && ln -s gcc-${pkgver/+/-} gcc
+   cd gcc
+@@ -103,6 +109,10 @@ prepare() {
+ 
+   mkdir -p "$srcdir/gcc-build"
+   mkdir -p "$srcdir/libgccjit-build"
++
++  # Replace hard-coded $(CC) with $(ADAC) in gcc-ada
++  sed -i 's:$(CC):$(ADAC):' gcc/ada/gcc-interface/Make-lang.in
++  patch -Np1 < "$srcdir/gcc-ada-adac.patch"
+ }
+ 
+ build() {
+@@ -112,8 +122,7 @@ build() {
+       --libexecdir=/usr/lib
+       --mandir=/usr/share/man
+       --infodir=/usr/share/info
+-      --with-bugurl=https://gitlab.archlinux.org/archlinux/packaging/packages/gcc/-/issues \
+-      --with-build-config=bootstrap-lto
++      --with-bugurl=https://github.com/felixonmars/archriscv-packages/issues \
+       --with-linker-hash-style=gnu
+       --with-system-zlib
+       --enable-cet=auto
+@@ -126,8 +135,7 @@ build() {
+       --enable-libstdcxx-backtrace
+       --enable-link-serialization=1
+       --enable-linker-build-id
+-      --enable-lto
+-      --enable-multilib
++      --disable-multilib
+       --enable-plugin
+       --enable-shared
+       --enable-threads=posix
+@@ -145,10 +153,18 @@ build() {
+   CFLAGS=${CFLAGS/-Werror=format-security/}
+   CXXFLAGS=${CXXFLAGS/-Werror=format-security/}
+ 
++  # GCC does not respect ADAC in some code and uses CC to compile Ada files :(
++  # Use acx_cv_cc_gcc_supports_ada to bypass ada detection as that uses CC
++  export acx_cv_cc_gcc_supports_ada=yes
++  export ADAC=/opt/gcc-ada/bin/gcc
++  export PATH="$PATH:/opt/gcc-ada/bin"
++  export LIBRARY_PATH=/opt/gcc-ada/lib/
+   "$srcdir/gcc/configure" \
+     --enable-languages=ada,c,c++,d,fortran,go,lto,m2,objc,obj-c++,rust,cobol \
+     --enable-bootstrap \
+     "${_confflags[@]:?_confflags unset}"
++  # https://gcc.gnu.org/pipermail/gcc/2001-October/070278.html
++  env -C "$srcdir/gcc/gcc/ada" touch treeprs.ads [es]info.h nmake.ad[bs]
+ 
+   # see https://bugs.archlinux.org/task/71777 for rationale re *FLAGS handling
+   make -O STAGE1_CFLAGS="-O2" \
+@@ -215,9 +231,6 @@ package_gcc() {
+     zlib
+     zstd
+   )
+-  optdepends=(
+-    'lib32-gcc-libs: for generating code for 32-bit ABI'
+-  )
+   provides=(
+     $pkgname-multilib
+   )
+@@ -230,6 +243,9 @@ package_gcc() {
+   )
+ 
+   cd gcc-build
++  export PATH="$PATH:/opt/gcc-ada/bin"
++  export ADAC=/opt/gcc-ada/bin/gcc
++  export LIBRARY_PATH=/opt/gcc-ada/lib/
+ 
+   make -C gcc DESTDIR="$pkgdir" install-driver install-cpp install-gcc-ar \
+     c++.install-common install-headers install-plugin install-lto-wrapper
+@@ -238,24 +254,19 @@ package_gcc() {
+   install -m755 -t "$pkgdir/$_libdir/" gcc/{cc1,cc1plus,collect2,lto1}
+ 
+   make -C $CHOST/libgcc DESTDIR="$pkgdir" install
+-  make -C $CHOST/32/libgcc DESTDIR="$pkgdir" install
+ 
+   make -C $CHOST/libstdc++-v3/src DESTDIR="$pkgdir" install
+   make -C $CHOST/libstdc++-v3/include DESTDIR="$pkgdir" install
+   make -C $CHOST/libstdc++-v3/libsupc++ DESTDIR="$pkgdir" install
+   make -C $CHOST/libstdc++-v3/python DESTDIR="$pkgdir" install
+   make -C $CHOST/libatomic DESTDIR="$pkgdir" install
+-  make -C $CHOST/32/libstdc++-v3/src DESTDIR="$pkgdir" install
+-  make -C $CHOST/32/libstdc++-v3/include DESTDIR="$pkgdir" install
+-  make -C $CHOST/32/libstdc++-v3/libsupc++ DESTDIR="$pkgdir" install
+-  make -C $CHOST/32/libatomic DESTDIR="$pkgdir" install
+ 
+   make DESTDIR="$pkgdir" install-libcc1
+   install -d "$pkgdir/usr/share/gdb/auto-load/usr/lib"
+   mv "$pkgdir"/usr/lib/libstdc++.so.6.*-gdb.py \
+     "$pkgdir/usr/share/gdb/auto-load/usr/lib/"
+-  rm "$pkgdir"/usr/lib{,32}/libstdc++.so*
+-  rm "$pkgdir"/usr/lib{,32}/libatomic.so*
++  rm "$pkgdir"/usr/lib/libstdc++.so*
++  rm "$pkgdir"/usr/lib/libatomic.so*
+ 
+   make DESTDIR="$pkgdir" install-fixincludes
+   make -C gcc DESTDIR="$pkgdir" install-mkheaders
+@@ -272,10 +283,6 @@ package_gcc() {
+   make -C $CHOST/libsanitizer/asan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
+   make -C $CHOST/libsanitizer/tsan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
+   make -C $CHOST/libsanitizer/lsan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
+-  make -C $CHOST/32/libgomp DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
+-  make -C $CHOST/32/libitm DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
+-  make -C $CHOST/32/libsanitizer DESTDIR="$pkgdir" install-nodist_{saninclude,toolexeclib}HEADERS
+-  make -C $CHOST/32/libsanitizer/asan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
+ 
+   make -C gcc DESTDIR="$pkgdir" install-man install-info
+   rm "$pkgdir"/usr/share/man/man1/{gccgo,gfortran,lto-dump,gdc,gm2,gcobol}.1
+@@ -291,7 +298,7 @@ package_gcc() {
+   # create cc-rs compatible symlinks
+   # https://github.com/rust-lang/cc-rs/blob/1.0.73/src/lib.rs#L2578-L2581
+   for binary in {c++,g++,gcc,gcc-ar,gcc-nm,gcc-ranlib}; do
+-    ln -s /usr/bin/$binary "$pkgdir"/usr/bin/x86_64-linux-gnu-$binary
++    ln -s /usr/bin/$binary "$pkgdir"/usr/bin/riscv64-linux-gnu-$binary
+   done
+ 
+   # POSIX conformance launcher scripts for c89 and c99
+@@ -302,8 +309,7 @@ package_gcc() {
+   make -C $CHOST/libstdc++-v3/doc DESTDIR="$pkgdir" doc-install-man
+ 
+   # remove files provided by lib32-gcc-libs and libgcc
+-  rm -f "$pkgdir"/usr/lib{,32}/libgcc_s{,_asneeded}.so*
+-  rm -f "$pkgdir"/usr/lib32/libstdc++.so
++  rm -f "$pkgdir"/usr/lib/libgcc_s{,_asneeded}.so*
+ 
+   # byte-compile python libraries
+   python -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
+@@ -336,6 +342,10 @@ package_gcc-ada() {
+     staticlibs
+   )
+ 
++  export PATH="$srcdir/ada-bin:$PATH"
++  export ADAC=/opt/gcc-ada/bin/gcc
++  export LIBRARY_PATH=/opt/gcc-ada/lib/
++
+   cd gcc-build/gcc
+   make DESTDIR="$pkgdir" ada.install-{common,info}
+   install -m755 gnat1 "$pkgdir/$_libdir"
+@@ -344,10 +354,6 @@ package_gcc-ada() {
+   make DESTDIR="$pkgdir" INSTALL="install" \
+     INSTALL_DATA="install -m644" install-libada
+ 
+-  cd "$srcdir"/gcc-build/$CHOST/32/libada
+-  make DESTDIR="$pkgdir" INSTALL="install" \
+-    INSTALL_DATA="install -m644" install-libada
+-
+   ln -s gcc "$pkgdir/usr/bin/gnatgcc"
+ 
+   # insist on dynamic linking, but keep static libraries because gnatmake complains
+@@ -356,12 +362,6 @@ package_gcc-ada() {
+   ln -s libgnat-${pkgver%%.*}.so "$pkgdir/usr/lib/libgnat.so"
+   rm -f "$pkgdir"/$_libdir/adalib/libgna{rl,t}.so
+ 
+-  install -d "$pkgdir/usr/lib32/"
+-  mv "$pkgdir"/$_libdir/32/adalib/libgna{rl,t}-${pkgver%%.*}.so "$pkgdir/usr/lib32"
+-  ln -s libgnarl-${pkgver%%.*}.so "$pkgdir/usr/lib32/libgnarl.so"
+-  ln -s libgnat-${pkgver%%.*}.so "$pkgdir/usr/lib32/libgnat.so"
+-  rm -f "$pkgdir"/$_libdir/32/adalib/libgna{rl,t}.so
+-
+   _install_runtime_library_exception
+ }
+ 
+@@ -425,8 +425,6 @@ package_gcc-fortran() {
+   cd gcc-build
+   make -C $CHOST/libgfortran DESTDIR="$pkgdir" install-cafexeclibLTLIBRARIES \
+     install-{toolexeclibDATA,nodist_fincludeHEADERS,gfor_cHEADERS}
+-  make -C $CHOST/32/libgfortran DESTDIR="$pkgdir" install-cafexeclibLTLIBRARIES \
+-    install-{toolexeclibDATA,nodist_fincludeHEADERS,gfor_cHEADERS}
+   make -C $CHOST/libgomp DESTDIR="$pkgdir" install-nodist_fincludeHEADERS
+   make -C gcc DESTDIR="$pkgdir" fortran.install-{common,man,info}
+   install -Dm755 gcc/f951 "$pkgdir/$_libdir/f951"
+@@ -486,11 +484,10 @@ package_gcc-go() {
+ 
+   cd gcc-build
+   make -C $CHOST/libgo DESTDIR="$pkgdir" install-exec-am
+-  make -C $CHOST/32/libgo DESTDIR="$pkgdir" install-exec-am
+   make DESTDIR="$pkgdir" install-gotools
+   make -C gcc DESTDIR="$pkgdir" go.install-{common,man,info}
+ 
+-  rm -f "$pkgdir"/usr/lib{,32}/libgo.so*
++  rm -f "$pkgdir"/usr/lib/libgo.so*
+   install -Dm755 gcc/go1 "$pkgdir/$_libdir/go1"
+ 
+   _install_runtime_library_exception

--- a/gcc-ada-bootstrap/riscv64-linux-gnu-gcc/PKGBUILD
+++ b/gcc-ada-bootstrap/riscv64-linux-gnu-gcc/PKGBUILD
@@ -1,0 +1,126 @@
+# Maintainer: Felix Yan <felixonmars@archlinux.org>
+# Maintainer: Filipe Laíns (FFY00) <lains@archlinux.org>
+# Contributor: Alexander F. Rødseth <xyproto@archlinux.org>
+# Contributor: Emil Renner Berthing <aur@esmil.dk>
+
+_target=riscv64-linux-gnu
+pkgname=$_target-gcc
+pkgver=16.1.1+r12+g301eb08fa2c5
+_commit=301eb08fa2c5b6f3045260bf1294c2e2bacbcd90
+pkgrel=1
+pkgdesc='Cross compiler for 32-bit and 64-bit RISC-V'
+arch=('x86_64')
+url='https://gcc.gnu.org/'
+license=('GPL' 'LGPL' 'FDL')
+groups=('risc-v')
+makedepends=(git)
+depends=(
+  "$_target-binutils"
+  "$_target-glibc"
+  'gcc-libs'
+  'gcc-ada'
+  'glibc'
+  'gmp'
+  'libisl' 'libisl.so'
+  'libmpc'
+  'mpfr' 'libmpfr.so'
+  'zlib' 'libz.so'
+  'zstd' 'libzstd.so'
+)
+options=(!emptydirs !strip  staticlibs !lto)
+source=("git+https://sourceware.org/git/gcc.git#commit=$_commit")
+sha256sums=('e7641bfddebaada298ca0a631183ef8d81bb3c5dfd3aef30bc7d4223f1c0e450')
+b2sums=('15fa6929b5bddc7dc042a3d590fced204d2012ab8421b13b1dfa83b2bbde9de1487cced0134823c1cc978c005041589bbb811d1816cdaa618697485ff1f9820f')
+
+if [[ -n "$_snapshot" ]]; then
+  _basedir=gcc-$_snapshot
+else
+  _basedir=gcc
+fi
+
+pkgver() {
+  cd gcc
+  echo "$(cat gcc/BASE-VER)+$(git describe --abbrev=12 --tags | sed 's/[^-]*-[^-]*-//;s/[^-]*-/r&/;s/-/+/g;s/_/./')"
+}
+
+prepare() {
+  cd $_basedir
+
+  # Do not run fixincludes
+  sed -i 's@\./fixinc\.sh@-c true@' gcc/Makefile.in
+
+  rm -rf "$srcdir/gcc-build"
+  mkdir "$srcdir/gcc-build"
+}
+
+build() {
+  cd gcc-build
+
+  CFLAGS=${CFLAGS/-Werror=format-security/}
+  CXXFLAGS=${CXXFLAGS/-Werror=format-security/}
+
+  # Using -pipe causes spurious test-suite failures.
+  # http://gcc.gnu.org/bugzilla/show_bug.cgi?id=48565
+  CFLAGS=${CFLAGS/-pipe/}
+  CXXFLAGS=${CXXFLAGS/-pipe/}
+
+  "$srcdir/$_basedir/configure" \
+      --prefix=/usr \
+      --program-prefix=$_target- \
+      --with-local-prefix=/usr/$_target \
+      --with-sysroot=/usr/$_target \
+      --with-build-sysroot=/usr/$_target \
+      --libdir=/usr/lib \
+      --libexecdir=/usr/lib \
+      --target=$_target \
+      --host=$CHOST \
+      --build=$CHOST \
+      --with-system-zlib \
+      --with-isl \
+      --with-linker-hash-style=gnu \
+      --disable-nls \
+      --disable-libunwind-exceptions \
+      --disable-libstdcxx-pch \
+      --disable-libssp \
+      --disable-multilib \
+      --disable-werror \
+      --enable-languages=c,c++,ada \
+      --enable-shared \
+      --enable-threads=posix \
+      --enable-__cxa_atexit \
+      --enable-clocale=gnu \
+      --enable-gnu-unique-object \
+      --enable-linker-build-id \
+      --enable-lto \
+      --enable-plugin \
+      --enable-install-libiberty \
+      --enable-gnu-indirect-function \
+      --enable-default-pie \
+      --enable-checking=release
+  make -j$(nproc)
+  make -C gcc -j$(nproc) cross-gnattools ada.all.cross
+}
+
+package() {
+  make -C gcc-build DESTDIR="$pkgdir" \
+    install-gcc install-target-{libgcc,libstdc++-v3,libgomp,libgfortran,libquadmath,libatomic,libada}
+
+  ln -s $_target-gcc "$pkgdir/usr/bin/$_target-gnatgcc"
+
+  # Strip target binaries
+  find "$pkgdir/usr/lib/gcc/$_target/" "$pkgdir/usr/$_target/lib" -type f \
+    -and \( -name \*.a -or -name \*.o \) -exec $_target-objcopy \
+    -R .comment -R .note -R .debug_info -R .debug_aranges -R .debug_pubnames \
+    -R .debug_pubtypes -R .debug_abbrev -R .debug_line -R .debug_str \
+    -R .debug_ranges -R .debug_loc '{}' \;
+
+  # Strip host binaries
+  find "$pkgdir/usr/bin/" "$pkgdir/usr/lib/gcc/$_target/" -type f \
+    -and \( -executable \) -exec strip '{}' \;
+
+
+  # Remove files that conflict with host gcc package
+  rm -r "$pkgdir/usr/share/"{man/man7,info,"gcc-${pkgver%%+*}"}
+}
+
+# vim: ts=2 sw=2 et:

--- a/gcc-ada-bootstrap/riscv64-unknown-linux-gnu-target-gcc-ada/PKGBUILD
+++ b/gcc-ada-bootstrap/riscv64-unknown-linux-gnu-target-gcc-ada/PKGBUILD
@@ -1,0 +1,108 @@
+# Maintainer: Felix Yan <felixonmars@archlinux.org>
+# Maintainer: Filipe Laíns (FFY00) <lains@archlinux.org>
+# Contributor: Alexander F. Rødseth <xyproto@archlinux.org>
+# Contributor: Emil Renner Berthing <aur@esmil.dk>
+
+_target=riscv64-unknown-linux-gnu
+_short_target=riscv64-linux-gnu
+pkgname=$_target-target-gcc-ada
+pkgver=16.1.1+r12+g301eb08fa2c5
+_commit=301eb08fa2c5b6f3045260bf1294c2e2bacbcd90
+pkgrel=1
+pkgdesc='Cross compiler for 32-bit and 64-bit RISC-V'
+provides=(gcc-ada)
+arch=('any')
+url='https://gcc.gnu.org/'
+license=('GPL' 'LGPL' 'FDL')
+groups=('risc-v')
+makedepends=(
+  "git"
+  "$_short_target-binutils"
+  "$_short_target-glibc"
+  'gcc-ada'
+)
+depends=(
+  'gcc-libs'
+  'glibc'
+)
+options=(!emptydirs !strip  staticlibs !lto !debug)
+source=("git+https://sourceware.org/git/gcc.git#commit=$_commit")
+sha256sums=('e7641bfddebaada298ca0a631183ef8d81bb3c5dfd3aef30bc7d4223f1c0e450')
+b2sums=('15fa6929b5bddc7dc042a3d590fced204d2012ab8421b13b1dfa83b2bbde9de1487cced0134823c1cc978c005041589bbb811d1816cdaa618697485ff1f9820f')
+
+if [[ -n "$_snapshot" ]]; then
+  _basedir=gcc-$_snapshot
+else
+  _basedir=gcc
+fi
+
+pkgver() {
+  cd gcc
+  echo "$(cat gcc/BASE-VER)+$(git describe --abbrev=12 --tags | sed 's/[^-]*-[^-]*-//;s/[^-]*-/r&/;s/-/+/g;s/_/./')"
+}
+
+prepare() {
+  # We need the riscv64-unknown-linux-* symlinks
+  LINKDIR="$PWD/riscv-unknown-bin"
+  mkdir -p "$LINKDIR"
+  for src in /usr/bin/riscv64-linux-gnu-*; do
+      base=$(basename "$src")
+      new=${base/riscv64-linux-gnu/riscv64-unknown-linux-gnu}
+
+      ln -sf "$src" "$LINKDIR/$new"
+  done
+
+  cd $_basedir
+
+
+  # Do not run fixincludes
+  sed -i 's@\./fixinc\.sh@-c true@' gcc/Makefile.in
+
+  rm -rf "$srcdir/gcc-build"
+  mkdir "$srcdir/gcc-build"
+
+  ./contrib/download_prerequisites
+}
+
+build() {
+  export PATH="$srcdir/riscv-unknown-bin:$PATH"
+  cd gcc-build
+
+  unset CFLAGS
+  unset CXXFLAGS
+
+  "$srcdir/$_basedir/configure" \
+      --prefix=/opt/gcc-ada \
+      --with-build-sysroot=/usr/$_short_target \
+      --libdir=/opt/gcc-ada/lib \
+      --libexecdir=/opt/gcc-ada/lib \
+      --target=$_target \
+      --host=$_target \
+      --build=$CHOST \
+      --with-isl \
+      --with-linker-hash-style=gnu \
+      --disable-nls \
+      --disable-libunwind-exceptions \
+      --disable-libstdcxx-pch \
+      --disable-libssp \
+      --disable-multilib \
+      --disable-werror \
+      --enable-languages=c,ada \
+      --enable-shared \
+      --enable-threads=posix \
+      --enable-__cxa_atexit \
+      --enable-clocale=gnu \
+      --enable-gnu-unique-object \
+      --enable-linker-build-id \
+      --enable-default-pie \
+      --enable-checking=release
+  make -j$(nproc)
+}
+
+package() {
+  export PATH="$srcdir/riscv-unknown-bin:$PATH"
+  make -C gcc-build DESTDIR="$pkgdir" \
+    install-gcc install-target-{libada,libgcc,libatomic,libstdc++-v3,libgomp,libquadmath}
+}
+
+# vim: ts=2 sw=2 et:


### PR DESCRIPTION
This PR bootstraps `gcc-ada` package. Some steps could run in parallel as shown in the following chart. 

```mermaid
flowchart TD
S1[Step1: <br>Build gcc 16.1.1 natively with gcc 15 on riscv64] --> S4
S2[Step2: <br>Build gcc cross-compiler with Ada support] --> S3[Step3: <br>Cross target riscv64 Ada compiler from x86_64]
S3 --> S4[Step4: <br>Build gcc 16.1.1 natively on riscv64 with Ada from Step3]
S4 --> S5[Step5: <br>Build gcc 16.1.1 with itself]
```

## Step1: Build gcc 16.1.1 natively with gcc 15 on riscv64

This is PR https://github.com/felixonmars/archriscv-packages/pull/5326

We need to update to 16.1.1 first as the bootstrap process here uses gcc 16.1.1.
This ensures that we are using the same version of the compiler across the whole bootstrap process.

## Step2: Build gcc cross compiler with Ada support

On Arch Linux x86_64, use gcc `16.1.1+r12+g301eb08fa2c5-1` to build `riscv64-linux-gnu-gcc` package from `gcc-ada-bootstrap/riscv64-linux-gnu-gcc` directory.

We get an Ada cross-compiler that could cross compile to riscv64 from this step.

(build=x86_64-linux-gnu, host=x86_64-linux-gnu, target=riscv64-linux-gnu)


## Step3: Cross target riscv64 Ada compiler from x86_64

On Arch Linux x86_64, use gcc `16.1.1+r12+g301eb08fa2c5-1` and `riscv64-linux-gnu-gcc` package built in previous step to cross build a native riscv64 Ada compiler.

We will get a `riscv64-unknown-linux-gnu-target-gcc-ada` package from this step.
This package uses `/opt/gcc-ada` prefix to avoid conflict with our gcc package.

```bash
extra-x86_64-build  -- -I ~/p/riscv64-linux-gnu-gcc/riscv64-linux-gnu-gcc-16.1.1+r12+g301eb08fa2c5-2-x86_64.pkg.tar.zst
```

(build=x86_64-linux-gnu, host=riscv64-linux-gnu, target=riscv64-linux-gnu)

## Step4: Build gcc 16.1.1 natively on riscv64 with Ada from Step3

Build gcc 16.1.1 with the gcc compiler from Step1 and the ada compiler from step3.
This step uses the patches located in `gcc-ada-bootstrap/gcc`

- GCC uses CC as ada compiler in many places, which causes trouble
  since we use a seperate ada compiler. Patch gcc to respect ADAC
  environment variable in more places.
- Set ADAC to /opt/gcc-ada/bin/gcc which comes from the
  riscv64-unknown-linux-gnu-target-gcc-ada package.
- Disable LTO as the gcc compiler from
  riscv64-unknown-linux-gnu-target-gcc-ada package is compiled without
  zstd and thus the host gcc compiler and this compiler disagrees about
  whether the lto objects are zstd compressed or not.

```
extra-riscv64-build -- -I ../gcc/gcc-16.1.1+r12+g301eb08fa2c5-1-riscv64.pkg.tar.zst -I ../gcc/gcc-libs-16.1.1+r12+g301eb08fa2c5-1-riscv64.pkg.tar.zst -I ../gcc/gcc-d-16.1.1+r12+g301eb08fa2c5-1-riscv64.pkg.tar.zst -I ../gcc/libgcc-16.1.1+r12+g301eb08fa2c5-1-riscv64.pkg.tar.zst -I ../gcc/libgphobos-16.1.1+r12+g301eb08fa2c5-1-riscv64.pkg.tar.zst -I ../gcc/libatomic-16.1.1+r12+g301eb08fa2c5-1-riscv64.pkg.tar.zst -I ../gcc/libasan-16.1.1+r12+g301eb08fa2c5-1-riscv64.pkg.tar.zst -I ../gcc/libtsan-16.1.1+r12+g301eb08fa2c5-1-riscv64.pkg.tar.zst -I ../gcc/liblsan-16.1.1+r12+g301eb08fa2c5-1-riscv64.pkg.tar.zst -I ../gcc/libubsan-16.1.1+r12+g301eb08fa2c5-1-riscv64.pkg.tar.zst -I ../gcc/libstdc++-16.1.1+r12+g301eb08fa2c5-1-riscv64.pkg.tar.zst -I ../gcc/gcc-ada-16.1.1+r12+g301eb08fa2c5-1-riscv64.pkg.tar.zst -- -A
```

## Step5: Build gcc 16.1.1 with itself

Build gcc 16.1.1 with the gcc 16.1.1 compiler we get from Step4 to validate that the bootstrap could be finished here.

My build is still running. I will open a PR once https://github.com/felixonmars/archriscv-packages/pull/5326 is merged.