### PR TITLE
updpatch: gcc 16.1.1+r12+g301eb08fa2c5-1

### DIFF
--- a/gcc/riscv64.patch
+++ b/gcc/riscv64.patch
@@ -1,10 +1,7 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -51,11 +51,8 @@ url='https://gcc.gnu.org'
- makedepends=(
-   binutils
-   doxygen
--  gcc-ada
+@@ -54,8 +54,6 @@ makedepends=(
+   gcc-ada
    gcc-d
    git
 -  lib32-glibc
@@ -12,12 +9,12 @@
    libisl
    libmpc
    python
-@@ -91,6 +88,12 @@ pkgver() {
+@@ -91,6 +89,12 @@ pkgver() {
    echo "$(cat gcc/BASE-VER)+$(git describe --abbrev=12 --tags | sed 's/[^-]*-[^-]*-//;s/[^-]*-/r&/;s/-/+/g;s/_/./')"
  }
  
 +for i in "${!pkgname[@]}"; do
-+  if [[ ${pkgname[i]} = "gcc-ada" ]] || [[ ${pkgname[i]} = "lib32-gcc-libs" ]]; then
++  if [[ ${pkgname[i]} = "lib32-gcc-libs" ]]; then
 +    unset 'pkgname[i]'
 +  fi
 +done
@@ -25,16 +22,16 @@
  prepare() {
    [[ ! -d gcc ]] && ln -s gcc-${pkgver/+/-} gcc
    cd gcc
-@@ -112,7 +115,7 @@ build() {
+@@ -112,7 +116,7 @@ build() {
        --libexecdir=/usr/lib
        --mandir=/usr/share/man
        --infodir=/usr/share/info
 -      --with-bugurl=https://gitlab.archlinux.org/archlinux/packaging/packages/gcc/-/issues \
-+      --with-bugurl=https://github.com/felixonmars/archriscv-packages/issues \
++      --with-bugurl=https://github.com/felixonmars/archriscv-packages/issues
        --with-build-config=bootstrap-lto
        --with-linker-hash-style=gnu
        --with-system-zlib
-@@ -127,7 +130,7 @@ build() {
+@@ -127,7 +131,7 @@ build() {
        --enable-link-serialization=1
        --enable-linker-build-id
        --enable-lto
@@ -43,16 +40,7 @@
        --enable-plugin
        --enable-shared
        --enable-threads=posix
-@@ -146,7 +149,7 @@ build() {
-   CXXFLAGS=${CXXFLAGS/-Werror=format-security/}
- 
-   "$srcdir/gcc/configure" \
--    --enable-languages=ada,c,c++,d,fortran,go,lto,m2,objc,obj-c++,rust,cobol \
-+    --enable-languages=c,c++,d,fortran,go,lto,m2,objc,obj-c++,rust,cobol \
-     --enable-bootstrap \
-     "${_confflags[@]:?_confflags unset}"
- 
-@@ -215,9 +218,6 @@ package_gcc() {
+@@ -215,9 +219,6 @@ package_gcc() {
      zlib
      zstd
    )
@@ -62,7 +50,7 @@
    provides=(
      $pkgname-multilib
    )
-@@ -238,24 +238,19 @@ package_gcc() {
+@@ -238,24 +239,19 @@ package_gcc() {
    install -m755 -t "$pkgdir/$_libdir/" gcc/{cc1,cc1plus,collect2,lto1}
  
    make -C $CHOST/libgcc DESTDIR="$pkgdir" install
@@ -89,7 +77,7 @@
  
    make DESTDIR="$pkgdir" install-fixincludes
    make -C gcc DESTDIR="$pkgdir" install-mkheaders
-@@ -272,15 +267,11 @@ package_gcc() {
+@@ -272,10 +268,6 @@ package_gcc() {
    make -C $CHOST/libsanitizer/asan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
    make -C $CHOST/libsanitizer/tsan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
    make -C $CHOST/libsanitizer/lsan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
@@ -100,13 +88,7 @@
  
    make -C gcc DESTDIR="$pkgdir" install-man install-info
    rm "$pkgdir"/usr/share/man/man1/{gccgo,gfortran,lto-dump,gdc,gm2,gcobol}.1
-   rm "$pkgdir"/usr/share/man/man3/gcobol-io.3
--  rm "$pkgdir"/usr/share/info/{gccgo,gfortran,gnat-style,gnat_rm,gnat_ugn,gdc,m2}.info
-+  rm "$pkgdir"/usr/share/info/{gccgo,gfortran,gdc,m2}.info
- 
-   make -C libcpp DESTDIR="$pkgdir" install
-   make -C gcc DESTDIR="$pkgdir" install-po
-@@ -291,7 +282,7 @@ package_gcc() {
+@@ -291,7 +283,7 @@ package_gcc() {
    # create cc-rs compatible symlinks
    # https://github.com/rust-lang/cc-rs/blob/1.0.73/src/lib.rs#L2578-L2581
    for binary in {c++,g++,gcc,gcc-ar,gcc-nm,gcc-ranlib}; do
@@ -115,7 +97,7 @@
    done
  
    # POSIX conformance launcher scripts for c89 and c99
-@@ -302,8 +293,7 @@ package_gcc() {
+@@ -302,8 +294,7 @@ package_gcc() {
    make -C $CHOST/libstdc++-v3/doc DESTDIR="$pkgdir" doc-install-man
  
    # remove files provided by lib32-gcc-libs and libgcc
@@ -125,7 +107,31 @@
  
    # byte-compile python libraries
    python -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
-@@ -425,8 +415,6 @@ package_gcc-fortran() {
+@@ -344,10 +335,6 @@ package_gcc-ada() {
+   make DESTDIR="$pkgdir" INSTALL="install" \
+     INSTALL_DATA="install -m644" install-libada
+ 
+-  cd "$srcdir"/gcc-build/$CHOST/32/libada
+-  make DESTDIR="$pkgdir" INSTALL="install" \
+-    INSTALL_DATA="install -m644" install-libada
+-
+   ln -s gcc "$pkgdir/usr/bin/gnatgcc"
+ 
+   # insist on dynamic linking, but keep static libraries because gnatmake complains
+@@ -356,12 +343,6 @@ package_gcc-ada() {
+   ln -s libgnat-${pkgver%%.*}.so "$pkgdir/usr/lib/libgnat.so"
+   rm -f "$pkgdir"/$_libdir/adalib/libgna{rl,t}.so
+ 
+-  install -d "$pkgdir/usr/lib32/"
+-  mv "$pkgdir"/$_libdir/32/adalib/libgna{rl,t}-${pkgver%%.*}.so "$pkgdir/usr/lib32"
+-  ln -s libgnarl-${pkgver%%.*}.so "$pkgdir/usr/lib32/libgnarl.so"
+-  ln -s libgnat-${pkgver%%.*}.so "$pkgdir/usr/lib32/libgnat.so"
+-  rm -f "$pkgdir"/$_libdir/32/adalib/libgna{rl,t}.so
+-
+   _install_runtime_library_exception
+ }
+ 
+@@ -425,8 +406,6 @@ package_gcc-fortran() {
    cd gcc-build
    make -C $CHOST/libgfortran DESTDIR="$pkgdir" install-cafexeclibLTLIBRARIES \
      install-{toolexeclibDATA,nodist_fincludeHEADERS,gfor_cHEADERS}
@@ -134,7 +140,7 @@
    make -C $CHOST/libgomp DESTDIR="$pkgdir" install-nodist_fincludeHEADERS
    make -C gcc DESTDIR="$pkgdir" fortran.install-{common,man,info}
    install -Dm755 gcc/f951 "$pkgdir/$_libdir/f951"
-@@ -486,11 +474,10 @@ package_gcc-go() {
+@@ -486,11 +465,10 @@ package_gcc-go() {
  
    cd gcc-build
    make -C $CHOST/libgo DESTDIR="$pkgdir" install-exec-am
@@ -147,11 +153,3 @@
    install -Dm755 gcc/go1 "$pkgdir/$_libdir/go1"
  
    _install_runtime_library_exception
-@@ -510,7 +497,6 @@ package_gcc-libs() {
-     libobjc
-     libquadmath
-     libstdc++
--    libtsan
-     libubsan
-   )
-   provides=(


### PR DESCRIPTION
This is the final step of the GCC Ada bootstrap in #5327.

Perhaps it's time to upstream this patch to Arch.