### PR TITLE
upgpatch: zig 0.16.0-1

### DIFF
--- a/zig/riscv64.patch
+++ b/zig/riscv64.patch
@@ -1,12 +1,30 @@
-Index: PKGBUILD
-===================================================================
---- PKGBUILD	(revision 1142351)
-+++ PKGBUILD	(working copy)
-@@ -10,7 +10,6 @@
- license=('MIT')
- depends=('clang' 'llvm-libs' 'lld')
- makedepends=('cmake' 'llvm')
+diff --git PKGBUILD PKGBUILD
+index 177151f..da8d4ca 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -11,19 +11,22 @@
+ options=('!lto')
+ depends=('clang21' 'lld21' 'llvm21-libs')
+ makedepends=('cmake' 'llvm21')
 -checkdepends=('lib32-glibc')
  source=("https://ziglang.org/download/$pkgver/zig-$pkgver.tar.xz"
-         "resolve_DNS.patch")
- sha256sums=('cd1be83b12f8269cc5965e59877b49fdd8fa638efb6995ac61eb4cea36a2e381'
+         "https://codeberg.org/ziglang/zig/commit/9df02121d0d87c17173f79d55692bed9cb65722c.patch"
+-        "skip-futex2-test.patch")
++        "skip-futex2-test.patch"
++        "skip-link-tests.patch")
+ sha256sums=('43186959edc87d5c7a1be7b7d2a25efffd22ce5807c7af99067f86f99641bfdf'
+             'cc513105cd250a107fcdefa6fed1147040f3cac4d377d545617840bd830da8d3'
+-            'eb30e0eb00e6ced4c99383f0658a0351f42882e303300ed1828d162d27171cd0')
++            'eb30e0eb00e6ced4c99383f0658a0351f42882e303300ed1828d162d27171cd0'
++            '0debe8de8b92f4ffa589983e577017dc1401b9046de84847389376a933e1fa1f')
+ 
+ prepare() {
+     cd "$pkgname-$pkgver"
+ 
+     patch -p1 -i ../9df02121d0d87c17173f79d55692bed9cb65722c.patch
+     patch -p1 -i ../skip-futex2-test.patch
++    # Backport https://codeberg.org/ziglang/zig/commit/e7d74e49b0
++    patch -p1 -i ../skip-link-tests.patch
+ }
+ 
+ build() {

--- a/zig/skip-link-tests.patch
+++ b/zig/skip-link-tests.patch
@@ -1,0 +1,24 @@
+Backport the relevant part of upstream e7d74e49b0dd91e679aa9063311a4513339cedd0
+("declare linker test bankruptcy").
+
+The old linker test harness runs cross-target ELF executables under any
+available binfmt/qemu handler. In a riscv64 build chroot hosted by x86_64
+qemu-user-static-binfmt, this makes `zig build test -Dskip-non-native=true`
+try to execute aarch64-linux-gnu test binaries via qemu-aarch64-static, which
+then fails because the chroot does not contain the aarch64 dynamic loader.
+
+Upstream master removed this test entry entirely, so only backport that small
+piece instead of carrying the full 11k-line test deletion.
+
+diff --git a/build.zig b/build.zig
+index 908887d3b5..9181573594 100644
+--- a/build.zig
++++ b/build.zig
+@@ -618,7 +618,6 @@ pub fn build(b: *std.Build) !void {
+         .skip_release = skip_release,
+         .max_rss = 3_300_000_000,
+     }));
+-    test_step.dependOn(tests.addLinkTests(b, enable_macos_sdk, enable_ios_sdk, enable_symlinks_windows));
+     test_step.dependOn(tests.addStackTraceTests(b, test_filters, skip_non_native));
+     test_step.dependOn(tests.addErrorTraceTests(b, test_filters, optimization_modes, skip_non_native));
+     test_step.dependOn(tests.addCliTests(b));


### PR DESCRIPTION
Backport https://codeberg.org/ziglang/zig/commit/e7d74e49b0

`check` passed and `zig init && zig build && ./zig-out/bin/*` works perfectly.