### PR TITLE
addpatch: bun{,-bootstrap} 1.3.13-1

### DIFF
--- a/bun-bootstrap/.SRCINFO
+++ b/bun-bootstrap/.SRCINFO
@@ -1,0 +1,47 @@
+pkgbase = bun-bootstrap
+	pkgdesc = Incredibly fast JavaScript runtime, bundler, test runner, and package manager – all in one
+	pkgver = 1.3.13
+	pkgrel = 1
+	url = https://github.com/oven-sh/bun
+	arch = any
+	license = MIT
+	makedepends = clang21
+	makedepends = cmake
+	makedepends = git
+	makedepends = lld21
+	makedepends = llvm21
+	makedepends = ninja
+	makedepends = python
+	makedepends = qemu-user-static
+	makedepends = riscv64-linux-gnu-gcc
+	makedepends = riscv64-linux-gnu-glibc
+	makedepends = ruby
+	makedepends = ruby-getoptlong
+	makedepends = rustup
+	makedepends = unzip
+	depends = glibc
+	depends = icu
+	provides = bun
+	conflicts = bun
+	noextract = bun-bootstrap-rootfs-riscv64.tar.zst
+	options = !lto
+	source = git+https://github.com/oven-sh/bun.git#tag=bun-v1.3.13
+	source = bun-WebKit::git+https://github.com/oven-sh/WebKit.git#commit=4d5e75ebd84a14edbc7ae264245dcd77fe597c10
+	source = bun-webkit-typed-array-int32-conversion.patch
+	source = bun-riscv64.patch
+	source = bun-riscv64-cross.patch
+	source = bun-webkit-riscv64.patch
+	source = bun-bootstrap-rootfs-riscv64.tar.zst
+	source = bun-bootstrap-1.3.13.zip::https://github.com/oven-sh/bun/releases/download/bun-v1.3.13/bun-linux-x64.zip
+	source = bun-zig-365343af4fc5a1a632e6b54aadd0b87be30edd81-x86_64.zip::https://github.com/oven-sh/zig/releases/download/autobuild-365343af4fc5a1a632e6b54aadd0b87be30edd81/bootstrap-x86_64-linux-musl.zip
+	b2sums = 0a300c8df9a5e40e72acdf23ba0319ebbea3ea1b09e4c367377a13fc6829429081aa35b8428734d988b87ff2590475505c038b694bd97f45d9fd6e5a50f5c8ea
+	b2sums = d1f67be7b083c61087e782be26456374d287231a731ef8f68ae7219667bc72c432b29f38070380b65078f77c76afa348a8b770e3ff3aa6ce2adf627b0ea8b57e
+	b2sums = 36a5af756df6aacb5e80dc19d76201f953a5e6fc0bdb700731421f03b0d44147f56d967eac307f9f41f85beb26aa4b23b6e67e87f500f1c400808a3caa43e2f1
+	b2sums = 8a0571cc5c597c0656da12ec2a540e6ba401e56101e4eb1701f71c054c43a0f10d7ce9eb265f7db4867ea84a6c7f3382afadd785747d9bd68fbaf4916ed5c331
+	b2sums = 45be49e3279398ed8fd4f8ea7b7643d9a7067e4ea73a0fecaf4f21165add25ce569f99d0679d2f0591501ecfa374983d3d0285769e5117a475e83a3fe539a215
+	b2sums = b64777e7bf3fb030235f3a53ad035c835a9c4335e3508ab9d94c93804041e5d3380a0c63803c6dd5612ecbef765a998cf9496ca8d612c9c361cff4cf8c187292
+	b2sums = SKIP
+	b2sums = 27d373ddff381e2cba9b8ba6c58ef0bcc6f002e8b814b6ea1252dd587c04381228f6dadfb03ffd9d7910dd935370c5017afd34d9075de12804463b7fe9baa638
+	b2sums = e9cde161c5da43d21ae3f99b3753223a2d26b7ed60a6ad0da0f15d5f3d3637d2304278b7e18a65d6fdea65460fc504ad8d809e35eebe403994ba4706c969087c
+
+pkgname = bun-bootstrap

--- a/bun-bootstrap/PKGBUILD
+++ b/bun-bootstrap/PKGBUILD
@@ -1,0 +1,133 @@
+# Contributor: Daniele Basso <d dot bass 05 at proton dot me>
+# Maintainer: Carl Smedstad <carsme@archlinux.org>
+
+pkgname=bun-bootstrap
+_pkgname=bun
+pkgver=1.3.13
+# From https://github.com/oven-sh/bun/blob/main/scripts/build/deps/webkit.ts#L6
+_webkitver=4d5e75ebd84a14edbc7ae264245dcd77fe597c10
+# From https://github.com/oven-sh/bun/blob/main/scripts/build/zig.ts#L36
+_zigver=365343af4fc5a1a632e6b54aadd0b87be30edd81
+pkgrel=1
+pkgdesc="Incredibly fast JavaScript runtime, bundler, test runner, and package manager – all in one"
+arch=(any)
+url="https://github.com/oven-sh/bun"
+license=('MIT')
+depends=(
+  glibc
+  icu
+)
+makedepends=(
+  clang21         # bun, webkit
+  cmake
+  git
+  lld21           # bun, webkit
+  llvm21          # bun, webkit
+  ninja
+  python          # webkit
+  qemu-user-static
+  riscv64-linux-gnu-gcc
+  riscv64-linux-gnu-glibc
+  ruby            # webkit
+  ruby-getoptlong # webkit
+  rustup          # bun
+  unzip
+)
+conflicts=($_pkgname)
+provides=($_pkgname)
+options=('!lto')
+source=(
+  "git+$url.git#tag=bun-v$pkgver"
+  "$_pkgname-WebKit::git+https://github.com/oven-sh/WebKit.git#commit=$_webkitver"
+  "$_pkgname-webkit-typed-array-int32-conversion.patch"
+  "$_pkgname-riscv64.patch"
+  "$_pkgname-riscv64-cross.patch"
+  "$_pkgname-webkit-riscv64.patch"
+  "$pkgname-rootfs-riscv64.tar.zst"
+  "$_pkgname-bootstrap-$pkgver.zip::https://github.com/oven-sh/bun/releases/download/bun-v$pkgver/bun-linux-x64.zip"
+  "$_pkgname-zig-$_zigver-x86_64.zip::https://github.com/oven-sh/zig/releases/download/autobuild-$_zigver/bootstrap-x86_64-linux-musl.zip"
+)
+b2sums=('0a300c8df9a5e40e72acdf23ba0319ebbea3ea1b09e4c367377a13fc6829429081aa35b8428734d988b87ff2590475505c038b694bd97f45d9fd6e5a50f5c8ea'
+        'd1f67be7b083c61087e782be26456374d287231a731ef8f68ae7219667bc72c432b29f38070380b65078f77c76afa348a8b770e3ff3aa6ce2adf627b0ea8b57e'
+        '36a5af756df6aacb5e80dc19d76201f953a5e6fc0bdb700731421f03b0d44147f56d967eac307f9f41f85beb26aa4b23b6e67e87f500f1c400808a3caa43e2f1'
+        '8a0571cc5c597c0656da12ec2a540e6ba401e56101e4eb1701f71c054c43a0f10d7ce9eb265f7db4867ea84a6c7f3382afadd785747d9bd68fbaf4916ed5c331'
+        '45be49e3279398ed8fd4f8ea7b7643d9a7067e4ea73a0fecaf4f21165add25ce569f99d0679d2f0591501ecfa374983d3d0285769e5117a475e83a3fe539a215'
+        'b64777e7bf3fb030235f3a53ad035c835a9c4335e3508ab9d94c93804041e5d3380a0c63803c6dd5612ecbef765a998cf9496ca8d612c9c361cff4cf8c187292'
+        'SKIP'
+        '27d373ddff381e2cba9b8ba6c58ef0bcc6f002e8b814b6ea1252dd587c04381228f6dadfb03ffd9d7910dd935370c5017afd34d9075de12804463b7fe9baa638'
+        'e9cde161c5da43d21ae3f99b3753223a2d26b7ed60a6ad0da0f15d5f3d3637d2304278b7e18a65d6fdea65460fc504ad8d809e35eebe403994ba4706c969087c')
+noextract=("$pkgname-rootfs-riscv64.tar.zst")
+
+prepare() {
+  export RUSTUP_TOOLCHAIN=stable
+
+  mkdir rootfs
+  bsdtar -xf "$pkgname-rootfs-riscv64.tar.zst" -C rootfs
+
+  # Fix UB in JSC typed array int32 conversion that causes wrong values
+  # to be stored for numbers > INT32_MAX (https://github.com/oven-sh/bun/issues/28607)
+  patch -Np1 -d $_pkgname-WebKit < $_pkgname-webkit-typed-array-int32-conversion.patch
+  patch -Np1 -d $_pkgname-WebKit < $_pkgname-webkit-riscv64.patch
+
+  cd $_pkgname
+  patch -Np1 < "$srcdir/$_pkgname-riscv64.patch"
+  patch -Np1 < "$srcdir/$_pkgname-riscv64-cross.patch"
+
+  grep -q "WEBKIT_VERSION = \"$_webkitver\"" scripts/build/deps/webkit.ts \
+    || (echo "WebKit version mismatch"; exit 1)
+  grep -q "ZIG_COMMIT = \"$_zigver\"" scripts/build/zig.ts \
+    || (echo "Zig version mismatch"; exit 1)
+
+  # Place the WebKit checkout where bun's build system expects local WebKit sources
+  # See also https://bun.sh/docs/project/contributing#building-webkit-locally-+-debug-mode-of-jsc
+  mkdir -p vendor
+  cp -r "$srcdir/$_pkgname-WebKit" vendor/WebKit
+
+  # unzip can't strip dirs but we want to get rid of the first contained dir so we have to do a little dance
+  mkdir -p vendor/zig.extract
+  unzip -q "$srcdir/$_pkgname-zig-$_zigver-x86_64.zip" -d vendor/zig.extract
+  mv vendor/zig.extract/* vendor/zig
+  printf '%s\n' "$_zigver" > vendor/zig/.zig-commit
+
+  rustup target add riscv64gc-unknown-linux-gnu
+}
+
+build() {
+  export RUSTUP_TOOLCHAIN=stable
+  export TARGET_ARCH=riscv64
+  export CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc
+
+  case "$CARCH" in
+    x86_64)
+      _bundir="bun-linux-x64"
+      _arch_args=(--arch=riscv64)
+      ;;
+  esac
+
+  cd $_pkgname
+  BUN_RISCV64_ROOTFS="$srcdir/rootfs" \
+  PATH="/usr/lib/llvm21/bin:$srcdir/$_bundir:$PATH" \
+    bun scripts/build.ts \
+    --profile=release-local \
+    "${_arch_args[@]}" \
+    --target=bun \
+    --build-dir=build/release \
+    --cache-dir="$srcdir/build-cache"
+}
+
+check() {
+  cd $_pkgname
+  qemu-riscv64-static -L "$srcdir/rootfs" ./build/release/bun --version
+  echo 'console.log("ok")' | qemu-riscv64-static -L "$srcdir/rootfs" ./build/release/bun run -
+}
+
+package() {
+  cd $_pkgname
+  install -vDm755 build/release/bun "$pkgdir/usr/bin/bun"
+  ln -vs /usr/bin/bun "$pkgdir/usr/bin/bunx"
+  install -vDm644 -t "$pkgdir/usr/share/licenses/$pkgname" LICENSE.md
+
+  install -vDm644 completions/bun.bash "$pkgdir/usr/share/bash-completion/completions/bun"
+  install -vDm644 completions/bun.fish "$pkgdir/usr/share/fish/vendor_completions.d/bun.fish"
+  install -vDm644 completions/bun.zsh "$pkgdir/usr/share/zsh/site-functions/_bun"
+}

--- a/bun-bootstrap/build_rootfs.sh
+++ b/bun-bootstrap/build_rootfs.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+packages=(icu)
+
+mkdir rootfs
+sudo pacstrap -C /usr/share/devtools/pacman.conf.d/extra-riscv64.conf -M rootfs base-devel ${packages[*]}
+echo -e "y\ny" | sudo pacman --sysroot rootfs -Scc
+
+# rustup will try to find file in /. A permission denied will lead to failure...
+sudo rm -rf rootfs/var/lib/tpm2-tss/system/keystore
+
+sudo bsdtar --acls --xattrs -C rootfs -caf bun-bootstrap-rootfs-riscv64.tar.zst .

--- a/bun-bootstrap/bun-riscv64-cross.patch
+++ b/bun-bootstrap/bun-riscv64-cross.patch
@@ -1,0 +1,254 @@
+diff --git a/scripts/build/bun.ts b/scripts/build/bun.ts
+index f641f6c81c..6855dd1b57 100644
+--- a/scripts/build/bun.ts
++++ b/scripts/build/bun.ts
+@@ -68,7 +68,16 @@ function systemLibs(cfg: Config): string[] {
+     // Linux local WebKit: link system ICU (prebuilt bundles its own).
+     // Assumes system ICU is in default lib paths — true on most distros.
+     if (cfg.webkit === "local") {
+-      libs.push("-licudata", "-licui18n", "-licuuc");
++      if (cfg.crossIcuRoot !== undefined) {
++        const icuLib = resolve(cfg.crossIcuRoot, "usr/lib");
++        libs.push(
++          resolve(icuLib, "libicudata.so"),
++          resolve(icuLib, "libicui18n.so"),
++          resolve(icuLib, "libicuuc.so"),
++        );
++      } else {
++        libs.push("-licudata", "-licui18n", "-licuuc");
++      }
+     }
+   }
+ 
+diff --git a/scripts/build/config.ts b/scripts/build/config.ts
+index 8ba9135e82..6b3e3f2dda 100644
+--- a/scripts/build/config.ts
++++ b/scripts/build/config.ts
+@@ -182,6 +182,15 @@ export interface Config {
+   /** Windows: llvm-mt for nested cmake (CMAKE_MT). May be absent in some LLVM distros. */
+   mt: string | undefined;
+ 
++  /** Clang target triple for C/C++ cross-compiles. */
++  crossTarget: string | undefined;
++  /** Target sysroot for C/C++ cross-compiles. */
++  crossSysroot: string | undefined;
++  /** GCC toolchain root used by clang for target libgcc/libstdc++ discovery. */
++  crossGccToolchain: string | undefined;
++  /** Target rootfs containing riscv64 ICU. */
++  crossIcuRoot: string | undefined;
++
+   // ─── macOS SDK (darwin only, undefined elsewhere) ───
+   /** e.g. "13.0". Passed to deps as -DCMAKE_OSX_DEPLOYMENT_TARGET. */
+   osxDeploymentTarget: string | undefined;
+@@ -328,6 +337,39 @@ export function detectLinuxAbi(): Abi {
+   return existsSync("/etc/alpine-release") ? "musl" : "gnu";
+ }
+ 
++function resolveRiscv64CrossToolchain(enabled: boolean): {
++  crossTarget: string | undefined;
++  crossSysroot: string | undefined;
++  crossGccToolchain: string | undefined;
++} {
++  if (!enabled) {
++    return { crossTarget: undefined, crossSysroot: undefined, crossGccToolchain: undefined };
++  }
++
++  const crossGcc = "riscv64-linux-gnu-gcc";
++  let crossSysroot: string;
++  let libgccPath: string;
++  try {
++    crossSysroot = execSync(`${crossGcc} -print-sysroot`, { encoding: "utf8" }).trim();
++    libgccPath = execSync(`${crossGcc} -print-libgcc-file-name`, { encoding: "utf8" }).trim();
++  } catch (cause) {
++    throw new BuildError("Failed to query riscv64 cross GCC toolchain", {
++      hint: "Install riscv64-linux-gnu-gcc and riscv64-linux-gnu-glibc",
++      cause,
++    });
++  }
++
++  assert(crossSysroot.length > 0 && existsSync(crossSysroot), `riscv64 sysroot does not exist: ${crossSysroot}`);
++
++  const marker = `${sep}lib${sep}gcc${sep}`;
++  const markerIndex = libgccPath.indexOf(marker);
++  assert(markerIndex > 0, `Could not derive GCC toolchain root from ${libgccPath}`);
++  const crossGccToolchain = libgccPath.slice(0, markerIndex);
++  assert(existsSync(crossGccToolchain), `riscv64 GCC toolchain root does not exist: ${crossGccToolchain}`);
++
++  return { crossTarget: "riscv64-unknown-linux-gnu", crossSysroot, crossGccToolchain };
++}
++
+ /**
+  * Resolve a PartialConfig into a full Config.
+  *
+@@ -355,6 +397,8 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
+   const arm64 = arch === "aarch64";
+   const riscv64 = arch === "riscv64";
+ 
++  const { crossTarget, crossSysroot, crossGccToolchain } = resolveRiscv64CrossToolchain(linux && riscv64);
++
+   // Platform file conventions — MSVC style on Windows, Unix everywhere else.
+   const exeSuffix = windows ? ".exe" : "";
+   const objSuffix = windows ? ".obj" : ".o";
+@@ -454,12 +498,22 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
+         ? resolve(buildDir, "cache")
+         : resolve(bunInstall, "build-cache");
+   const vendorDir = resolve(cwd, "vendor");
++  const crossIcuRoot = crossTarget !== undefined ? resolve(process.env.BUN_RISCV64_ROOTFS ?? "") : undefined;
+ 
+   // ─── Validation ───
+   assert(!baseline || x64, "baseline=true requires arch=x64 (baseline disables AVX which is x64-only)");
+   assert(!valgrind || linux, "valgrind=true requires os=linux");
+   assert(!(asan && valgrind), "Cannot enable both asan and valgrind simultaneously");
+   assert(os !== "linux" || abi !== undefined, "Linux builds require an abi (gnu or musl)");
++  assert(crossTarget === undefined || process.env.BUN_RISCV64_ROOTFS !== undefined, "BUN_RISCV64_ROOTFS must point to the riscv64 rootfs");
++  assert(
++    crossIcuRoot === undefined || existsSync(resolve(crossIcuRoot, "usr/include/unicode")),
++    `riscv64 ICU headers do not exist under ${crossIcuRoot}`,
++  );
++  assert(
++    crossIcuRoot === undefined || existsSync(resolve(crossIcuRoot, "usr/lib")),
++    `riscv64 ICU libraries do not exist under ${crossIcuRoot}`,
++  );
+ 
+   // ─── Versioning ───
+   const pkgJsonPath = resolve(cwd, "package.json");
+@@ -534,7 +588,7 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
+     ar: toolchain.ar,
+     ranlib: toolchain.ranlib,
+     ld: toolchain.ld,
+-    strip: toolchain.strip,
++    strip: crossTarget !== undefined ? "riscv64-linux-gnu-strip" : toolchain.strip,
+     dsymutil: toolchain.dsymutil,
+     zig: toolchain.zig,
+     bun: toolchain.bun,
+@@ -548,6 +602,10 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
+     msvcLinker: toolchain.msvcLinker,
+     rc: toolchain.rc,
+     mt: toolchain.mt,
++    crossTarget,
++    crossSysroot,
++    crossGccToolchain,
++    crossIcuRoot,
+     osxDeploymentTarget,
+     osxSysroot,
+     version,
+diff --git a/scripts/build/deps/lolhtml.ts b/scripts/build/deps/lolhtml.ts
+index 901f12f461..19e4c4b527 100644
+--- a/scripts/build/deps/lolhtml.ts
++++ b/scripts/build/deps/lolhtml.ts
+@@ -44,6 +44,9 @@ export const lolhtml: Dependency = {
+     if (cfg.windows && cfg.arm64) {
+       spec.rustTarget = "aarch64-pc-windows-msvc";
+     }
++    if (cfg.linux && cfg.riscv64) {
++      spec.rustTarget = "riscv64gc-unknown-linux-gnu";
++    }
+ 
+     return spec;
+   },
+diff --git a/scripts/build/deps/webkit.ts b/scripts/build/deps/webkit.ts
+index 160fa78bfd..b0c55eba8f 100644
+--- a/scripts/build/deps/webkit.ts
++++ b/scripts/build/deps/webkit.ts
+@@ -42,7 +42,7 @@ export const WEBKIT_VERSION = "4d5e75ebd84a14edbc7ae264245dcd77fe597c10";
+ import { homedir } from "node:os";
+ import { join, resolve } from "node:path";
+ import type { Config } from "../config.ts";
+-import { computeCpuTargetFlags } from "../flags.ts";
++import { computeCrossCompileFlags, computeCpuTargetFlags } from "../flags.ts";
+ import { slash } from "../shell.ts";
+ import { type Dependency, type NestedCmakeBuild, type Source, depBuildDir, depSourceDir } from "../source.ts";
+ 
+@@ -220,7 +220,7 @@ export const webkit: Dependency = {
+     // WebKit's cmake finds it via ICU_ROOT. On posix, system ICU is used
+     // (macOS: Homebrew headers + system libs; Linux: libicu-dev) — cmake
+     // auto-detects.
+-    const optFlags: string[] = computeCpuTargetFlags(cfg);
++    const optFlags: string[] = [...computeCrossCompileFlags(cfg), ...computeCpuTargetFlags(cfg)];
+     if (cfg.lto) optFlags.push("-flto=full");
+     if (cfg.pgoGenerate) optFlags.push(`-fprofile-generate=${cfg.pgoGenerate}`);
+     if (cfg.pgoUse) {
+@@ -262,6 +262,12 @@ export const webkit: Dependency = {
+         ENABLE_WEBASSEMBLY_BBQJIT: "OFF",
+         ENABLE_WEBASSEMBLY_OMGJIT: "OFF",
+       });
++      if (cfg.crossIcuRoot !== undefined) {
++        const icu = resolve(cfg.crossIcuRoot, "usr");
++        args.ICU_ROOT = slash(icu);
++        args.ICU_LIBRARY = slash(resolve(icu, "lib"));
++        args.ICU_INCLUDE_DIR = slash(resolve(icu, "include"));
++      }
+     }
+ 
+     const spec: NestedCmakeBuild = {
+@@ -357,6 +363,7 @@ export const webkit: Dependency = {
+     ];
+     // Windows: ICU headers from preBuild output.
+     if (cfg.windows) includes.push(resolve(icuDir(cfg), "include"));
++    if (cfg.crossIcuRoot !== undefined) includes.push(resolve(cfg.crossIcuRoot, "usr/include"));
+ 
+     return { libs, includes };
+   },
+diff --git a/scripts/build/flags.ts b/scripts/build/flags.ts
+index 525a545b52..6aadb97686 100644
+--- a/scripts/build/flags.ts
++++ b/scripts/build/flags.ts
+@@ -75,6 +75,11 @@ export const cpuTargetFlags: Flag[] = [
+ // ═══════════════════════════════════════════════════════════════════════════
+ 
+ export const globalFlags: Flag[] = [
++  {
++    flag: c => computeCrossCompileFlags(c),
++    when: c => c.crossTarget !== undefined,
++    desc: "C/C++ cross target and toolchain",
++  },
+   // ─── CPU target ───
+   ...cpuTargetFlags,
+   {
+@@ -598,6 +603,11 @@ export const defines: Flag[] = [
+ // ═══════════════════════════════════════════════════════════════════════════
+ 
+ export const linkerFlags: Flag[] = [
++  {
++    flag: c => computeCrossCompileFlags(c),
++    when: c => c.crossTarget !== undefined,
++    desc: "Link for the cross target and toolchain",
++  },
+   // ─── Sanitizers ───
+   {
+     flag: "-fsanitize=address",
+@@ -1051,6 +1061,14 @@ export function computeCpuTargetFlags(cfg: Config): string[] {
+   return out;
+ }
+ 
++export function computeCrossCompileFlags(cfg: Config): string[] {
++  if (cfg.crossTarget === undefined) return [];
++  const out = [`--target=${cfg.crossTarget}`];
++  if (cfg.crossSysroot !== undefined) out.push(`--sysroot=${cfg.crossSysroot}`);
++  if (cfg.crossGccToolchain !== undefined) out.push(`--gcc-toolchain=${cfg.crossGccToolchain}`);
++  return out;
++}
++
+ /**
+  * Per-file extra flags lookup. Call after computeFlags() when compiling a
+  * specific source. Returns extra flags to append (may be empty).
+diff --git a/scripts/build/source.ts b/scripts/build/source.ts
+index 4cdc14c587..738fb4132e 100644
+--- a/scripts/build/source.ts
++++ b/scripts/build/source.ts
+@@ -1030,6 +1030,15 @@ function emitNestedCmake(
+     args.push(`-DCMAKE_EXE_LINKER_FLAGS=${linkerFlags.join(" ")}`);
+     args.push(`-DCMAKE_SHARED_LINKER_FLAGS=${linkerFlags.join(" ")}`);
+   }
++  if (cfg.crossTarget !== undefined) {
++    args.push(`-DCMAKE_SYSTEM_NAME=Linux`);
++    args.push(`-DCMAKE_SYSTEM_PROCESSOR=${cfg.arch}`);
++    args.push(`-DCMAKE_C_COMPILER_TARGET=${cfg.crossTarget}`);
++    args.push(`-DCMAKE_CXX_COMPILER_TARGET=${cfg.crossTarget}`);
++    if (cfg.crossSysroot !== undefined) {
++      args.push(`-DCMAKE_SYSROOT=${slash(cfg.crossSysroot)}`);
++    }
++  }
+   if (cfg.windows) {
+     // Windows-specific toolchain forwarding. When CMAKE_C_COMPILER is
+     // an explicit path, cmake's find_program for the supporting tools

--- a/bun-bootstrap/bun-riscv64.patch
+++ b/bun-bootstrap/bun-riscv64.patch
@@ -1,0 +1,779 @@
+diff --git a/build.zig b/build.zig
+index 39fb92d1e2..e965646985 100644
+--- a/build.zig
++++ b/build.zig
+@@ -120,10 +120,14 @@ pub fn getOSVersionMin(os: OperatingSystem) ?Target.Query.OsVersion {
+     };
+ }
+ 
+-pub fn getOSGlibCVersion(os: OperatingSystem) ?Version {
++pub fn getOSGlibCVersion(os: OperatingSystem, arch: Arch) ?Version {
+     return switch (os) {
+         // Compiling with a newer glibc than this will break certain cloud environments. See symbols.test.ts.
+-        .linux => .{ .major = 2, .minor = 17, .patch = 0 },
++        .linux => switch (arch) {
++            // riscv64 support was added in glibc 2.27.
++            .riscv64 => .{ .major = 2, .minor = 27, .patch = 0 },
++            else => .{ .major = 2, .minor = 17, .patch = 0 },
++        },
+ 
+         else => null,
+     };
+@@ -180,7 +184,7 @@ pub fn build(b: *Build) !void {
+     }
+ 
+     target_query.os_version_min = getOSVersionMin(os);
+-    target_query.glibc_version = if (abi.isGnu()) getOSGlibCVersion(os) else null;
++    target_query.glibc_version = if (abi.isGnu()) getOSGlibCVersion(os, arch) else null;
+ 
+     const target = b.resolveTargetQuery(target_query);
+ 
+@@ -612,7 +616,7 @@ const TargetDescription = struct {
+             .cpu_arch = desc.arch,
+             .cpu_model = getCpuModel(desc.os, desc.arch) orelse .determined_by_arch_os,
+             .os_version_min = getOSVersionMin(desc.os),
+-            .glibc_version = if (desc.musl) null else getOSGlibCVersion(desc.os),
++            .glibc_version = if (desc.musl) null else getOSGlibCVersion(desc.os, desc.arch),
+         });
+     }
+ };
+diff --git a/scripts/build/config.ts b/scripts/build/config.ts
+index f5a672b070..8ba9135e82 100644
+--- a/scripts/build/config.ts
++++ b/scripts/build/config.ts
+@@ -18,7 +18,7 @@ import { cyan, dim, green } from "./tty.ts";
+ import { defaultZigCommit } from "./zig.ts";
+ 
+ export type OS = "linux" | "darwin" | "windows";
+-export type Arch = "x64" | "aarch64";
++export type Arch = "x64" | "aarch64" | "riscv64";
+ export type Abi = "gnu" | "musl";
+ export type BuildType = "Debug" | "Release" | "RelWithDebInfo" | "MinSizeRel";
+ export type BuildMode = "full" | "cpp-only" | "zig-only" | "link-only";
+@@ -75,6 +75,7 @@ export interface Config {
+   unix: boolean;
+   x64: boolean;
+   arm64: boolean;
++  riscv64: boolean;
+ 
+   /**
+    * What's running the build. Differs from os/arch/windows (target) in
+@@ -352,6 +353,7 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
+   const unix = linux || darwin;
+   const x64 = arch === "x64";
+   const arm64 = arch === "aarch64";
++  const riscv64 = arch === "riscv64";
+ 
+   // Platform file conventions — MSVC style on Windows, Unix everywhere else.
+   const exeSuffix = windows ? ".exe" : "";
+@@ -421,8 +423,8 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
+   // failure is loud ("cannot find -l:libatomic.a") and the fix is obvious.
+   const staticLibatomic = partial.staticLibatomic ?? true;
+ 
+-  // TinyCC: off on Windows ARM64 (not supported), on elsewhere
+-  const tinycc = partial.tinycc ?? !(windows && arm64);
++  // TinyCC: off where the embedded JIT backend is not wired up.
++  const tinycc = partial.tinycc ?? (!(windows && arm64) && !riscv64);
+ 
+   const valgrind = partial.valgrind ?? false;
+   const fuzzilli = partial.fuzzilli ?? false;
+@@ -493,6 +495,7 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
+     unix,
+     x64,
+     arm64,
++    riscv64,
+     host,
+     exeSuffix,
+     objSuffix,
+diff --git a/scripts/build/deps/boringssl.ts b/scripts/build/deps/boringssl.ts
+index e1e12d494d..2f2cb660a9 100644
+--- a/scripts/build/deps/boringssl.ts
++++ b/scripts/build/deps/boringssl.ts
+@@ -17,11 +17,15 @@ export const boringssl: Dependency = {
+     commit: BORINGSSL_COMMIT,
+   }),
+ 
+-  build: () => ({
++  build: cfg => ({
+     kind: "nested-cmake",
+     // No explicit targets — defaults to lib names (crypto, ssl, decrepit).
+     // BoringSSL's cmake targets match its output library names.
+-    args: {},
++    //
++    // BoringSSL's generated source list includes assembly for every supported
++    // ISA. On riscv64 that can leave x86/arm objects in libcrypto.a unless ASM
++    // is disabled explicitly.
++    args: cfg.riscv64 ? { OPENSSL_NO_ASM: "1" } : {},
+   }),
+ 
+   provides: () => ({
+diff --git a/scripts/build/deps/webkit.ts b/scripts/build/deps/webkit.ts
+index 2dcc0ab836..160fa78bfd 100644
+--- a/scripts/build/deps/webkit.ts
++++ b/scripts/build/deps/webkit.ts
+@@ -251,6 +251,19 @@ export const webkit: Dependency = {
+       ...(cfg.asan ? { ENABLE_SANITIZERS: "address" } : {}),
+     };
+ 
++    if (cfg.riscv64) {
++      Object.assign(args, {
++        ENABLE_JIT: "OFF",
++        ENABLE_DFG_JIT: "OFF",
++        ENABLE_FTL_JIT: "OFF",
++        ENABLE_C_LOOP: "OFF",
++        ENABLE_SAMPLING_PROFILER: "ON",
++        ENABLE_WEBASSEMBLY: "ON",
++        ENABLE_WEBASSEMBLY_BBQJIT: "OFF",
++        ENABLE_WEBASSEMBLY_OMGJIT: "OFF",
++      });
++    }
++
+     const spec: NestedCmakeBuild = {
+       kind: "nested-cmake",
+       targets: ["jsc"],
+diff --git a/scripts/build/flags.ts b/scripts/build/flags.ts
+index 1ac5b4d4f0..525a545b52 100644
+--- a/scripts/build/flags.ts
++++ b/scripts/build/flags.ts
+@@ -36,6 +36,11 @@ export interface Flag {
+ // ═══════════════════════════════════════════════════════════════════════════
+ 
+ export const cpuTargetFlags: Flag[] = [
++  {
++    flag: ["-march=rv64gc", "-mabi=lp64d", "-mno-relax"],
++    when: c => c.linux && c.riscv64,
++    desc: "RISC-V Linux: RV64GC with double-float ABI and fixed instruction layout",
++  },
+   {
+     flag: "-mcpu=apple-m1",
+     when: c => c.darwin && c.arm64,
+@@ -441,7 +446,7 @@ export const bunOnlyFlags: Flag[] = [
+   },
+   {
+     flag: ["-fno-pic", "-fno-pie"],
+-    when: c => c.unix,
++    when: c => c.unix && !c.riscv64,
+     desc: "No position-independent code (we're a final executable)",
+   },
+ 
+@@ -706,19 +711,27 @@ export const linkerFlags: Flag[] = [
+       "-Wl,--wrap=exp",
+       "-Wl,--wrap=exp2",
+       "-Wl,--wrap=expf",
+-      "-Wl,--wrap=fcntl64",
+-      "-Wl,--wrap=getrandom",
+-      "-Wl,--wrap=gettid",
+       "-Wl,--wrap=log",
+       "-Wl,--wrap=log2",
+       "-Wl,--wrap=log2f",
+       "-Wl,--wrap=logf",
+       "-Wl,--wrap=pow",
+       "-Wl,--wrap=powf",
++    ],
++    when: c => c.linux && c.abi !== "musl" && !c.riscv64,
++    desc: "Wrap old glibc libm symbols (portable down to glibc 2.17)",
++  },
++  {
++    // RISC-V glibc starts at 2.27, so the libm version wrappers above are not
++    // needed there and recurse without an architecture-specific .symver alias.
++    flag: [
++      "-Wl,--wrap=fcntl64",
++      "-Wl,--wrap=getrandom",
++      "-Wl,--wrap=gettid",
+       "-Wl,--wrap=quick_exit",
+     ],
+     when: c => c.linux && c.abi !== "musl",
+-    desc: "Wrap glibc 2.18+ symbols (portable down to glibc 2.17)",
++    desc: "Wrap newer glibc runtime symbols",
+   },
+   {
+     flag: ["-static-libstdc++", "-static-libgcc"],
+@@ -747,9 +760,14 @@ export const linkerFlags: Flag[] = [
+     when: c => c.linux,
+     desc: "Use lld instead of system ld",
+   },
++  {
++    flag: "-Wl,--no-relax",
++    when: c => c.linux && c.riscv64,
++    desc: "Disable RISC-V linker relaxation so JSC IPInt opcode labels keep fixed spacing",
++  },
+   {
+     flag: ["-fno-pic", "-Wl,-no-pie"],
+-    when: c => c.linux,
++    when: c => c.linux && !c.riscv64,
+     desc: "No PIE (we don't need ASLR; simpler codegen)",
+   },
+   {
+diff --git a/scripts/build/source.ts b/scripts/build/source.ts
+index bee06834a8..4cdc14c587 100644
+--- a/scripts/build/source.ts
++++ b/scripts/build/source.ts
+@@ -1023,8 +1023,12 @@ function emitNestedCmake(
+     // Most deps are static-lib-only so this usually doesn't matter, but when
+     // it does (dep builds a tool to generate a header), using lld keeps the
+     // toolchain consistent.
+-    args.push(`-DCMAKE_EXE_LINKER_FLAGS=--ld-path=${cfg.ld}`);
+-    args.push(`-DCMAKE_SHARED_LINKER_FLAGS=--ld-path=${cfg.ld}`);
++    const linkerFlags = [`--ld-path=${cfg.ld}`];
++    if (cfg.riscv64) {
++      linkerFlags.push("-Wl,--no-relax");
++    }
++    args.push(`-DCMAKE_EXE_LINKER_FLAGS=${linkerFlags.join(" ")}`);
++    args.push(`-DCMAKE_SHARED_LINKER_FLAGS=${linkerFlags.join(" ")}`);
+   }
+   if (cfg.windows) {
+     // Windows-specific toolchain forwarding. When CMAKE_C_COMPILER is
+diff --git a/scripts/build/tools.ts b/scripts/build/tools.ts
+index 4af051385b..af9fcf30eb 100644
+--- a/scripts/build/tools.ts
++++ b/scripts/build/tools.ts
+@@ -425,9 +425,10 @@ export function resolveLlvmToolchain(
+     ld = ""; // darwin: unused
+   }
+ 
+-  // strip: GNU strip on Linux (more features), llvm-strip elsewhere
++  // strip: GNU strip on native Linux (more features), llvm-strip for cross
++  // targets because the host binutils may not recognize the target ELF.
+   let strip: string;
+-  if (os === "linux") {
++  if (os === "linux" && arch !== "riscv64") {
+     strip = findTool({ names: ["strip"], required: true, hint: "Install binutils for your distro" })?.path ?? "";
+   } else {
+     strip = findLlvmTool("llvm-strip", paths, os, { checkVersion: false, required: true })?.path ?? "";
+diff --git a/scripts/build/zig.ts b/scripts/build/zig.ts
+index cc3867919c..db083d960a 100644
+--- a/scripts/build/zig.ts
++++ b/scripts/build/zig.ts
+@@ -74,11 +74,10 @@ function usingParallelCompiler(cfg: Config): boolean {
+ // ───────────────────────────────────────────────────────────────────────────
+ 
+ /**
+- * Zig target triple. Arch is always `x86_64`/`aarch64` (zig's naming),
+- * not `x64`/`arm64`.
++ * Zig target triple. Arch is always zig's naming, not Node's `x64`/`arm64`.
+  */
+ export function zigTarget(cfg: Config): string {
+-  const arch = cfg.x64 ? "x86_64" : "aarch64";
++  const arch = cfg.x64 ? "x86_64" : cfg.arm64 ? "aarch64" : "riscv64";
+   if (cfg.darwin) return `${arch}-macos-none`;
+   if (cfg.windows) return `${arch}-windows-msvc`;
+   // linux: abi is always set (resolveConfig asserts)
+@@ -129,6 +128,9 @@ export function zigCpu(cfg: Config): string {
+     if (cfg.windows) return "cortex_a76";
+     return "native";
+   }
++  if (cfg.riscv64) {
++    return "baseline_rv64";
++  }
+   // x64
+   return cfg.baseline ? "nehalem" : "haswell";
+ }
+diff --git a/src/Global.zig b/src/Global.zig
+index 1c6c1bf22a..9231367932 100644
+--- a/src/Global.zig
++++ b/src/Global.zig
+@@ -53,6 +53,8 @@ else if (Environment.isX86)
+     "x86"
+ else if (Environment.isAarch64)
+     "arm64"
++else if (Environment.isRiscV64)
++    "riscv64"
+ else
+     "unknown";
+ 
+diff --git a/src/analytics.zig b/src/analytics.zig
+index f62f8f4408..9571db90cc 100644
+--- a/src/analytics.zig
++++ b/src/analytics.zig
+@@ -240,7 +240,7 @@ pub const EventName = enum(u8) {
+ 
+ var random: std.rand.DefaultPrng = undefined;
+ 
+-const platform_arch = if (Environment.isAarch64) analytics.Architecture.arm else analytics.Architecture.x64;
++const platform_arch = if (Environment.isAarch64) analytics.Architecture.arm else if (Environment.isRiscV64) analytics.Architecture.riscv64 else analytics.Architecture.x64;
+ 
+ // TODO: move this code somewhere more appropriate, and remove it from "analytics"
+ // The following code is not currently even used for analytics, just feature-detection
+diff --git a/src/analytics/schema.zig b/src/analytics/schema.zig
+index 33d3fcadbb..02c860dd1e 100644
+--- a/src/analytics/schema.zig
++++ b/src/analytics/schema.zig
+@@ -350,6 +350,9 @@ pub const analytics = struct {
+         /// arm
+         arm,
+ 
++        /// riscv64
++        riscv64,
++
+         _,
+ 
+         pub fn jsonStringify(self: @This(), writer: anytype) !void {
+diff --git a/src/bun.js/api/ffi.zig b/src/bun.js/api/ffi.zig
+index 6f4ec41433..79017a581e 100644
+--- a/src/bun.js/api/ffi.zig
++++ b/src/bun.js/api/ffi.zig
+@@ -301,6 +301,18 @@ pub const FFI = struct {
+                     } else if (bun.FD.cwd().directoryExistsAt("/usr/lib64").isTrue()) {
+                         cached_default_system_library_dir = "/usr/lib64";
+                     }
++                } else if (Environment.isRiscV64) {
++                    if (bun.FD.cwd().directoryExistsAt("/usr/include/riscv64-linux-gnu").isTrue()) {
++                        cached_default_system_include_dir = "/usr/include/riscv64-linux-gnu";
++                    } else if (bun.FD.cwd().directoryExistsAt("/usr/include").isTrue()) {
++                        cached_default_system_include_dir = "/usr/include";
++                    }
++
++                    if (bun.FD.cwd().directoryExistsAt("/usr/lib/riscv64-linux-gnu").isTrue()) {
++                        cached_default_system_library_dir = "/usr/lib/riscv64-linux-gnu";
++                    } else if (bun.FD.cwd().directoryExistsAt("/usr/lib64").isTrue()) {
++                        cached_default_system_library_dir = "/usr/lib64";
++                    }
+                 }
+             }
+         }
+diff --git a/src/bun.js/bindings/BunProcess.cpp b/src/bun.js/bindings/BunProcess.cpp
+index a5c074c385..a3cdbbce41 100644
+--- a/src/bun.js/bindings/BunProcess.cpp
++++ b/src/bun.js/bindings/BunProcess.cpp
+@@ -172,6 +172,8 @@ static JSValue constructArch(VM& vm, JSObject* processObject)
+     return JSC::jsString(vm, makeAtomString("x64"_s));
+ #elif CPU(ARM64)
+     return JSC::jsString(vm, makeAtomString("arm64"_s));
++#elif CPU(RISCV64)
++    return JSC::jsString(vm, makeAtomString("riscv64"_s));
+ #else
+ #error "Unknown architecture"
+ #endif
+@@ -2293,6 +2295,9 @@ static JSValue constructProcessConfigObject(VM& vm, JSObject* processObject)
+ #elif CPU(ARM64)
+     variables->putDirect(vm, JSC::Identifier::fromString(vm, "host_arch"_s), JSC::jsString(vm, String("arm64"_s)), 0);
+     variables->putDirect(vm, JSC::Identifier::fromString(vm, "target_arch"_s), JSC::jsString(vm, String("arm64"_s)), 0);
++#elif CPU(RISCV64)
++    variables->putDirect(vm, JSC::Identifier::fromString(vm, "host_arch"_s), JSC::jsString(vm, String("riscv64"_s)), 0);
++    variables->putDirect(vm, JSC::Identifier::fromString(vm, "target_arch"_s), JSC::jsString(vm, String("riscv64"_s)), 0);
+ #else
+ #error "Unsupported architecture"
+ #endif
+diff --git a/src/bun.js/bindings/CPUFeatures.cpp b/src/bun.js/bindings/CPUFeatures.cpp
+index d1b1560565..f7feb1db0a 100644
+--- a/src/bun.js/bindings/CPUFeatures.cpp
++++ b/src/bun.js/bindings/CPUFeatures.cpp
+@@ -17,6 +17,15 @@ enum class AArch64CPUFeature : uint8_t {
+     sve = 6,
+ };
+ 
++enum class RISCV64CPUFeature : uint8_t {
++    m = 1,
++    a = 2,
++    f = 3,
++    d = 4,
++    c = 5,
++    v = 6,
++};
++
+ #if CPU(X86_64)
+ 
+ #if OS(WINDOWS)
+@@ -130,12 +139,46 @@ static uint8_t aarch64_cpu_features()
+ 
+ #endif
+ 
++#if CPU(RISCV64)
++
++#if OS(LINUX)
++#include <asm/hwcap.h>
++#include <sys/auxv.h>
++#endif
++
++static uint8_t riscv64_cpu_features()
++{
++    uint8_t features = 0;
++
++#if OS(LINUX)
++    unsigned long hwcaps = getauxval(AT_HWCAP);
++    if (hwcaps & COMPAT_HWCAP_ISA_M)
++        features |= 1 << static_cast<uint8_t>(RISCV64CPUFeature::m);
++    if (hwcaps & COMPAT_HWCAP_ISA_A)
++        features |= 1 << static_cast<uint8_t>(RISCV64CPUFeature::a);
++    if (hwcaps & COMPAT_HWCAP_ISA_F)
++        features |= 1 << static_cast<uint8_t>(RISCV64CPUFeature::f);
++    if (hwcaps & COMPAT_HWCAP_ISA_D)
++        features |= 1 << static_cast<uint8_t>(RISCV64CPUFeature::d);
++    if (hwcaps & COMPAT_HWCAP_ISA_C)
++        features |= 1 << static_cast<uint8_t>(RISCV64CPUFeature::c);
++    if (hwcaps & COMPAT_HWCAP_ISA_V)
++        features |= 1 << static_cast<uint8_t>(RISCV64CPUFeature::v);
++#endif
++
++    return features;
++}
++
++#endif
++
+ extern "C" uint8_t bun_cpu_features()
+ {
+ #if CPU(X86_64)
+     return x86_cpu_features();
+ #elif CPU(ARM64)
+     return aarch64_cpu_features();
++#elif CPU(RISCV64)
++    return riscv64_cpu_features();
+ #else
+ #error "Unknown architecture"
+ #endif
+diff --git a/src/bun.js/bindings/CPUFeatures.zig b/src/bun.js/bindings/CPUFeatures.zig
+index 29e4a6e040..ec4cfde413 100644
+--- a/src/bun.js/bindings/CPUFeatures.zig
++++ b/src/bun.js/bindings/CPUFeatures.zig
+@@ -28,6 +28,18 @@ pub const Flags = switch (@import("builtin").cpu.arch) {
+ 
+         padding: u1 = 0,
+     },
++    .riscv64 => packed struct(u8) {
++        none: bool,
++
++        m: bool,
++        a: bool,
++        f: bool,
++        d: bool,
++        c: bool,
++        v: bool,
++
++        padding: u1 = 0,
++    },
+     else => unreachable,
+ };
+ 
+@@ -52,6 +64,7 @@ pub fn isEmpty(features: CPUFeatures) bool {
+ }
+ 
+ pub fn hasAnyAVX(features: CPUFeatures) bool {
++    if (comptime !bun.Environment.isX64) return false;
+     return features.flags.avx or features.flags.avx2 or features.flags.avx512;
+ }
+ 
+diff --git a/src/bun.js/bindings/JSBuffer.cpp b/src/bun.js/bindings/JSBuffer.cpp
+index 5b1ccd84da..56e7a21b66 100644
+--- a/src/bun.js/bindings/JSBuffer.cpp
++++ b/src/bun.js/bindings/JSBuffer.cpp
+@@ -2060,16 +2060,18 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_toStringBody(JSC::JSGlobalO
+         RETURN_IF_EXCEPTION(scope, {});
+     }
+ 
+-    auto fstart = arg2.toNumber(lexicalGlobalObject);
+-    RETURN_IF_EXCEPTION(scope, {});
+-    if (fstart < 0) {
+-        fstart = 0;
+-        goto lstart;
+-    }
+-    if (fstart > byteLength) {
+-        return JSC::JSValue::encode(JSC::jsEmptyString(vm));
++    if (!arg2.isUndefined()) {
++        auto fstart = arg2.toNumber(lexicalGlobalObject);
++        RETURN_IF_EXCEPTION(scope, {});
++        if (fstart < 0) {
++            fstart = 0;
++            goto lstart;
++        }
++        if (fstart > byteLength) {
++            return JSC::JSValue::encode(JSC::jsEmptyString(vm));
++        }
++        start = static_cast<uint32_t>(fstart);
+     }
+-    start = static_cast<uint32_t>(fstart);
+ lstart:
+ 
+     if (!arg3.isUndefined()) {
+diff --git a/src/bun.js/bindings/NodeVMScript.cpp b/src/bun.js/bindings/NodeVMScript.cpp
+index b6ae742d67..c6ce606bbd 100644
+--- a/src/bun.js/bindings/NodeVMScript.cpp
++++ b/src/bun.js/bindings/NodeVMScript.cpp
+@@ -8,6 +8,7 @@
+ #include "JavaScriptCore/JSWeakMapInlines.h"
+ #include "JavaScriptCore/ProgramCodeBlock.h"
+ #include "JavaScriptCore/SourceCodeKey.h"
++#include "JavaScriptCore/Watchdog.h"
+ 
+ #include "NodeVMScriptFetcher.h"
+ #include "../vm/SigintWatcher.h"
+@@ -163,6 +164,7 @@ constructScript(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newT
+                 codeBlock = JSC::ProgramCodeBlock::create(vm, executable, unlinkedBlock, jsScope);
+                 RETURN_IF_EXCEPTION(scope, {});
+             }
++#if ENABLE(JIT)
+             JSC::CompilationResult compilationResult = JIT::compileSync(vm, codeBlock, JITCompilationEffort::JITCompilationCanFail);
+             if (compilationResult != JSC::CompilationResult::CompilationFailed) {
+                 executable->installCode(codeBlock);
+@@ -170,6 +172,9 @@ constructScript(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newT
+             } else {
+                 script->cachedDataRejected(TriState::True);
+             }
++#else
++            script->cachedDataRejected(TriState::True);
++#endif
+         }
+     } else if (produceCachedData) {
+         script->cacheBytecode();
+diff --git a/src/bun.js/bindings/NodeVMSourceTextModule.cpp b/src/bun.js/bindings/NodeVMSourceTextModule.cpp
+index 5c3ad694ec..e4ac037db7 100644
+--- a/src/bun.js/bindings/NodeVMSourceTextModule.cpp
++++ b/src/bun.js/bindings/NodeVMSourceTextModule.cpp
+@@ -140,12 +140,16 @@ NodeVMSourceTextModule* NodeVMSourceTextModule::create(VM& vm, JSGlobalObject* g
+             RETURN_IF_EXCEPTION(scope, nullptr);
+         }
+         if (codeBlock) {
++#if ENABLE(JIT)
+             CompilationResult compilationResult = JIT::compileSync(vm, codeBlock, JITCompilationEffort::JITCompilationCanFail);
+             RETURN_IF_EXCEPTION(scope, nullptr);
+             if (compilationResult != CompilationResult::CompilationFailed) {
+                 executable->installCode(codeBlock);
+                 return ptr;
+             }
++#else
++            UNUSED_PARAM(codeBlock);
++#endif
+         }
+     }
+ 
+diff --git a/src/bun.js/bindings/napi.cpp b/src/bun.js/bindings/napi.cpp
+index 60cf7df2d4..95595dd7d1 100644
+--- a/src/bun.js/bindings/napi.cpp
++++ b/src/bun.js/bindings/napi.cpp
+@@ -2174,7 +2174,7 @@ extern "C" napi_status napi_get_value_int64(napi_env env, napi_value value, int6
+     NAPI_RETURN_EARLY_IF_FALSE(env, jsValue.isNumber(), napi_number_expected);
+ 
+     double js_number = jsValue.asNumber();
+-    if (isfinite(js_number)) {
++    if (std::isfinite(js_number)) {
+         // upper is 2^63 exactly, not 2^63-1, as the latter can't be represented exactly
+         constexpr double lower = std::numeric_limits<int64_t>::min(), upper = 1ull << 63;
+         if (js_number >= upper) {
+diff --git a/src/bun.js/bindings/webcore/SerializedScriptValue.cpp b/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
+index 3125ee8411..e8400b7cb0 100644
+--- a/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
++++ b/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
+@@ -3424,12 +3424,13 @@ private:
+         ptr += length * sizeof(char16_t);
+ #else
+         std::span<char16_t> characters;
+-        str = String::createUninitialized(length, characters);
++        auto string = String::createUninitialized(length, characters);
+         for (unsigned i = 0; i < length; ++i) {
+             uint16_t c;
+             readLittleEndian(ptr, end, c);
+             characters[i] = c;
+         }
++        str = Identifier::fromString(vm, string);
+ #endif
+         return true;
+     }
+diff --git a/src/bun.js/modules/BunJSCModule.h b/src/bun.js/modules/BunJSCModule.h
+index 038fbe1c14..f3d3ae2eaa 100644
+--- a/src/bun.js/modules/BunJSCModule.h
++++ b/src/bun.js/modules/BunJSCModule.h
+@@ -582,7 +582,11 @@ JSC_DECLARE_HOST_FUNCTION(functionTotalCompileTime);
+ JSC_DEFINE_HOST_FUNCTION(functionTotalCompileTime,
+     (JSGlobalObject*, CallFrame*))
+ {
++#if ENABLE(JIT)
+     return JSValue::encode(jsNumber(JIT::totalCompileTime().milliseconds()));
++#else
++    return JSValue::encode(jsNumber(0));
++#endif
+ }
+ 
+ JSC_DECLARE_HOST_FUNCTION(functionGetProtectedObjects);
+diff --git a/src/cli/upgrade_command.zig b/src/cli/upgrade_command.zig
+index 036d9d9e75..20125d2487 100644
+--- a/src/cli/upgrade_command.zig
++++ b/src/cli/upgrade_command.zig
+@@ -42,7 +42,7 @@ pub const Version = struct {
+         .wasm => @compileError("Unsupported OS for Bun Upgrade"),
+     };
+ 
+-    pub const arch_label = if (Environment.isAarch64) "aarch64" else "x64";
++    pub const arch_label = if (Environment.isAarch64) "aarch64" else if (Environment.isRiscV64) "riscv64" else "x64";
+     pub const triplet = platform_label ++ "-" ++ arch_label;
+     const suffix_abi = if (Environment.isMusl) "-musl" else "";
+     const suffix_cpu = if (Environment.baseline) "-baseline" else "";
+diff --git a/src/compile_target.zig b/src/compile_target.zig
+index a1400d0151..629fe568dc 100644
+--- a/src/compile_target.zig
++++ b/src/compile_target.zig
+@@ -462,13 +462,14 @@ pub fn defineValues(this: *const CompileTarget) []const []const u8 {
+     // Use inline else to avoid extra allocations.
+     switch (this.os) {
+         inline else => |os| switch (this.arch) {
+-            inline .arm64, .x64 => |arch| return struct {
++            inline .arm64, .x64, .riscv64 => |arch| return struct {
+                 pub const values = &.{
+                     "\"" ++ os.nameString() ++ "\"",
+ 
+                     switch (arch) {
+                         .x64 => "\"x64\"",
+                         .arm64 => "\"arm64\"",
++                        .riscv64 => "\"riscv64\"",
+                         .wasm => @compileError("TODO"),
+                     },
+ 
+diff --git a/src/crash_handler.zig b/src/crash_handler.zig
+index 58a6a191bd..8f6e8e22e3 100644
+--- a/src/crash_handler.zig
++++ b/src/crash_handler.zig
+@@ -813,6 +813,8 @@ pub fn reportBaseUrl() []const u8 {
+ 
+ const arch_display_string = if (bun.Environment.isAarch64)
+     if (bun.Environment.isMac) "Silicon" else "arm64"
++else if (bun.Environment.isRiscV64)
++    "riscv64"
+ else
+     "x64";
+ 
+@@ -1096,6 +1098,7 @@ const Platform = enum(u8) {
+     linux_x86_64 = 'l',
+     linux_x86_64_baseline = 'B',
+     linux_aarch64 = 'L',
++    linux_riscv64 = 'r',
+ 
+     mac_x86_64_baseline = 'b',
+     mac_x86_64 = 'm',
+diff --git a/src/env.zig b/src/env.zig
+index 4d4fa2bbda..ddd972a5de 100644
+--- a/src/env.zig
++++ b/src/env.zig
+@@ -20,6 +20,7 @@ pub const isLinux = builtin.target.os.tag == .linux;
+ pub const isAarch64 = builtin.target.cpu.arch.isAARCH64();
+ pub const isX86 = builtin.target.cpu.arch.isX86();
+ pub const isX64 = builtin.target.cpu.arch == .x86_64;
++pub const isRiscV64 = builtin.target.cpu.arch == .riscv64;
+ pub const isMusl = builtin.target.abi.isMusl();
+ pub const allow_assert = isDebug or isTest or std.builtin.OptimizeMode.ReleaseSafe == builtin.mode;
+ pub const ci_assert = isDebug or isTest or enable_asan or (std.builtin.OptimizeMode.ReleaseSafe == builtin.mode and is_canary);
+@@ -144,6 +145,7 @@ else
+ pub const Architecture = enum {
+     x64,
+     arm64,
++    riscv64,
+     wasm,
+ 
+     /// npm package name, `@oven-sh/bun-{os}-{arch}`
+@@ -151,6 +153,7 @@ pub const Architecture = enum {
+         return switch (this) {
+             .x64 => "x64",
+             .arm64 => "aarch64",
++            .riscv64 => "riscv64",
+             .wasm => "wasm",
+         };
+     }
+@@ -161,6 +164,7 @@ pub const Architecture = enum {
+         .{ "amd64", .x64 },
+         .{ "aarch64", .arm64 },
+         .{ "arm64", .arm64 },
++        .{ "riscv64", .riscv64 },
+         .{ "wasm", .wasm },
+     });
+ };
+@@ -171,6 +175,8 @@ else if (isX64)
+     .x64
+ else if (isAarch64)
+     .arm64
++else if (isRiscV64)
++    .riscv64
+ else
+     @compileError("Please add your architecture to the Architecture enum");
+ 
+diff --git a/src/install/npm.zig b/src/install/npm.zig
+index 255a4f7f30..81d64f091d 100644
+--- a/src/install/npm.zig
++++ b/src/install/npm.zig
+@@ -759,18 +759,21 @@ pub const Architecture = enum(u16) {
+     pub const s390x: u16 = 1 << 9;
+     pub const x32: u16 = 1 << 10;
+     pub const x64: u16 = 1 << 11;
++    pub const riscv64: u16 = 1 << 12;
+ 
+-    pub const all_value: u16 = arm | arm64 | ia32 | mips | mipsel | ppc | ppc64 | s390 | s390x | x32 | x64;
++    pub const all_value: u16 = arm | arm64 | ia32 | mips | mipsel | ppc | ppc64 | s390 | s390x | x32 | x64 | riscv64;
+ 
+     pub const current: Architecture = switch (Environment.arch) {
+         .arm64 => @enumFromInt(arm64),
+         .x64 => @enumFromInt(x64),
++        .riscv64 => @enumFromInt(riscv64),
+         .wasm => @compileError("Specify architecture: " ++ Environment.arch),
+     };
+ 
+     pub const current_name = switch (Environment.arch) {
+         .arm64 => "arm64",
+         .x64 => "x64",
++        .riscv64 => "riscv64",
+         .wasm => @compileError("Unsupported architecture: " ++ @tagName(current)),
+     };
+ 
+@@ -786,6 +789,7 @@ pub const Architecture = enum(u16) {
+         .{ "s390x", s390x },
+         .{ "x32", x32 },
+         .{ "x64", x64 },
++        .{ "riscv64", riscv64 },
+     });
+ 
+     pub inline fn has(this: Architecture, other: u16) bool {
+diff --git a/src/js/node/os.ts b/src/js/node/os.ts
+index 64b1a1c0ac..c81a16f037 100644
+--- a/src/js/node/os.ts
++++ b/src/js/node/os.ts
+@@ -96,7 +96,7 @@ function bound(binding) {
+     },
+     cpus: lazyCpus(binding),
+     endianness: function () {
+-      return process.arch === "arm64" || process.arch === "x64" //
++      return process.arch === "arm64" || process.arch === "x64" || process.arch === "riscv64" //
+         ? "LE"
+         : $bundleError("TODO: endianness");
+     },
+@@ -132,7 +132,9 @@ function bound(binding) {
+         ? "arm64"
+         : process.arch === "x64"
+           ? "x86_64"
+-          : $bundleError("TODO: machine");
++          : process.arch === "riscv64"
++            ? "riscv64"
++            : $bundleError("TODO: machine");
+     },
+     devNull: process.platform === "win32" ? "\\\\.\\nul" : "/dev/null",
+     get EOL() {
+diff --git a/src/sys.zig b/src/sys.zig
+index 9f48b78540..bad867e41a 100644
+--- a/src/sys.zig
++++ b/src/sys.zig
+@@ -93,7 +93,7 @@ pub const O = switch (Environment.os) {
+ 
+         pub const toPacked = toPackedO;
+     },
+-    .linux, .wasm => switch (Environment.isX86) {
++    .linux, .wasm => switch (Environment.isX86 or Environment.isRiscV64) {
+         true => struct {
+             pub const RDONLY = 0x0000;
+             pub const WRONLY = 0x0001;
+diff --git a/src/workaround_missing_symbols.zig b/src/workaround_missing_symbols.zig
+index fda57737a6..0e888e99cd 100644
+--- a/src/workaround_missing_symbols.zig
++++ b/src/workaround_missing_symbols.zig
+@@ -66,15 +66,15 @@ pub const darwin = struct {
+ 
+     pub const lstat = blk: {
+         const T = *const fn (?[*:0]const u8, ?*bun.Stat) callconv(.c) c_int;
+-        break :blk @extern(T, .{ .name = if (bun.Environment.isAarch64) "lstat" else "lstat64" });
++        break :blk @extern(T, .{ .name = if (bun.Environment.isAarch64 or bun.Environment.isRiscV64) "lstat" else "lstat64" });
+     };
+     pub const fstat = blk: {
+         const T = *const fn (i32, ?*bun.Stat) callconv(.c) c_int;
+-        break :blk @extern(T, .{ .name = if (bun.Environment.isAarch64) "fstat" else "fstat64" });
++        break :blk @extern(T, .{ .name = if (bun.Environment.isAarch64 or bun.Environment.isRiscV64) "fstat" else "fstat64" });
+     };
+     pub const stat = blk: {
+         const T = *const fn (?[*:0]const u8, ?*bun.Stat) callconv(.c) c_int;
+-        break :blk @extern(T, .{ .name = if (bun.Environment.isAarch64) "stat" else "stat64" });
++        break :blk @extern(T, .{ .name = if (bun.Environment.isAarch64 or bun.Environment.isRiscV64) "stat" else "stat64" });
+     };
+ };
+ pub const windows = struct {

--- a/bun-bootstrap/bun-webkit-riscv64.patch
+++ b/bun-bootstrap/bun-webkit-riscv64.patch
@@ -1,0 +1,947 @@
+diff --git a/Source/JavaScriptCore/CMakeLists.txt b/Source/JavaScriptCore/CMakeLists.txt
+index d7e3e82010e8..5d9926ce3018 100644
+--- a/Source/JavaScriptCore/CMakeLists.txt
++++ b/Source/JavaScriptCore/CMakeLists.txt
+@@ -56,6 +56,10 @@ if(USE_CAPSTONE)
+     list(APPEND JavaScriptCore_PRIVATE_INCLUDE_DIRECTORIES "${THIRDPARTY_DIR}/capstone/Source/include")
+ endif()
+ 
++if(USE_MIMALLOC)
++    list(APPEND JavaScriptCore_PRIVATE_INCLUDE_DIRECTORIES "${BMALLOC_DIR}/mimalloc/mimalloc/include")
++endif()
++
+ set(JavaScriptCore_OBJECT_LUT_SOURCES
+     runtime/ArrayConstructor.cpp
+     runtime/AsyncFromSyncIteratorPrototype.cpp
+diff --git a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
+index 2f58ddbe6d91..77b6910ef4fa 100644
+--- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
++++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
+@@ -4365,20 +4365,20 @@ private:
+         using IType = RISCV64Assembler::IImmediate;
+         template<int32_t value>
+         static IType I() { return IType::v<IType, value>(); }
+-        template<typename T, typename = EnableIfInteger<T>>
++        template<std::integral T>
+         static IType I(T value) { return IType::v<IType>(value); }
+         static IType I(uint32_t value) { return IType(value); }
+ 
+         using SType = RISCV64Assembler::SImmediate;
+         template<int32_t value>
+         static SType S() { return SType::v<SType, value>(); }
+-        template<typename T, typename = EnableIfInteger<T>>
++        template<std::integral T>
+         static SType S(T value) { return SType::v<SType>(value); }
+ 
+         using BType = RISCV64Assembler::BImmediate;
+         template<int32_t value>
+         static BType B() { return BType::v<BType, value>(); }
+-        template<typename T, typename = EnableIfInteger<T>>
++        template<std::integral T>
+         static BType B(T value) { return BType::v<BType>(value); }
+         static BType B(uint32_t value) { return BType(value); }
+ 
+diff --git a/Source/JavaScriptCore/b3/B3Validate.cpp b/Source/JavaScriptCore/b3/B3Validate.cpp
+index a3f5f6cb8f9a..1879239b565e 100644
+--- a/Source/JavaScriptCore/b3/B3Validate.cpp
++++ b/Source/JavaScriptCore/b3/B3Validate.cpp
+@@ -493,7 +493,7 @@ public:
+             case VectorExtractLane:
+                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
+                 VALIDATE(value->numChildren() == 1, ("At ", *value));
+-                VALIDATE(value->type() == Wasm::toB3Type(Wasm::simdScalarType(value->asSIMDValue()->simdLane())), ("At ", *value));
++                VALIDATE(value->type() == simdB3ScalarType(value->asSIMDValue()->simdLane()), ("At ", *value));
+                 VALIDATE(value->child(0)->type() == V128, ("At ", *value));
+                 break;
+             case VectorReplaceLane:
+@@ -501,7 +501,7 @@ public:
+                 VALIDATE(value->numChildren() == 2, ("At ", *value));
+                 VALIDATE(value->type() == V128, ("At ", *value));
+                 VALIDATE(value->child(0)->type() == V128, ("At ", *value));
+-                VALIDATE(value->child(1)->type() == Wasm::toB3Type(Wasm::simdScalarType(value->asSIMDValue()->simdLane())), ("At ", *value));
++                VALIDATE(value->child(1)->type() == simdB3ScalarType(value->asSIMDValue()->simdLane()), ("At ", *value));
+                 break;
+             case VectorDupElement:
+                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
+@@ -523,7 +523,7 @@ public:
+                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
+                 VALIDATE(value->numChildren() == 1, ("At ", *value));
+                 VALIDATE(value->type() == V128, ("At ", *value));
+-                VALIDATE(value->child(0)->type() == Wasm::toB3Type(Wasm::simdScalarType(value->asSIMDValue()->simdLane())), ("At ", *value));
++                VALIDATE(value->child(0)->type() == simdB3ScalarType(value->asSIMDValue()->simdLane()), ("At ", *value));
+                 break;
+ 
+             case VectorPopcnt:
+diff --git a/Source/JavaScriptCore/b3/air/AirArg.h b/Source/JavaScriptCore/b3/air/AirArg.h
+index 5012f3318a5c..de62de31be18 100644
+--- a/Source/JavaScriptCore/b3/air/AirArg.h
++++ b/Source/JavaScriptCore/b3/air/AirArg.h
+@@ -1475,17 +1475,15 @@ public:
+         if (!isARM64() && !isX86_64())
+             return false;
+ 
++        uint64_t u64 = static_cast<uint64_t>(value);
+ #if CPU(ARM64)
+         if (ARM64Assembler::canEncodeFPImm<64>(value))
+             return true;
+ 
+-        uint64_t u64 = static_cast<uint64_t>(value);
+         if (ARM64FPImmediate::create64(u64).isValid())
+             return true;
+ 
+ #elif CPU(X86_64)
+-        uint64_t u64 = static_cast<uint64_t>(value);
+-
+         if (u64 == 0xFFFFFFFFFFFFFFFFULL)
+             return true;
+ 
+diff --git a/Source/JavaScriptCore/domjit/DOMJITEffect.h b/Source/JavaScriptCore/domjit/DOMJITEffect.h
+index 6ba85116d1be..943754f793a4 100644
+--- a/Source/JavaScriptCore/domjit/DOMJITEffect.h
++++ b/Source/JavaScriptCore/domjit/DOMJITEffect.h
+@@ -28,6 +28,16 @@
+ #include "DFGAbstractHeap.h"
+ #include "DOMJITHeapRange.h"
+ 
++#if !ENABLE(DFG_JIT)
++namespace JSC { namespace DFG {
++enum AbstractHeapKind : unsigned {
++    InvalidAbstractHeap,
++    Heap,
++    SideState,
++};
++} }
++#endif
++
+ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+ 
+ namespace JSC {
+diff --git a/Source/JavaScriptCore/jit/GdbJIT.cpp b/Source/JavaScriptCore/jit/GdbJIT.cpp
+index a812a7622291..d9599230a09f 100644
+--- a/Source/JavaScriptCore/jit/GdbJIT.cpp
++++ b/Source/JavaScriptCore/jit/GdbJIT.cpp
+@@ -873,7 +873,7 @@ private:
+             0x7F, 'E', 'L', 'F', 1, 1, 1, 0,
+             0, 0, 0, 0, 0, 0, 0, 0
+         };
+-#elif CPU(X86_64) || CPU(ARM64)
++#elif CPU(X86_64) || CPU(ARM64) || CPU(RISCV64)
+         const uint8_t ident[16] = {
+             0x7F, 'E', 'L', 'F', 2, 1, 1, 0,
+             0, 0, 0, 0, 0, 0, 0, 0
+@@ -895,6 +895,9 @@ private:
+ #elif CPU(ARM64)
+         // AARCH64
+         header->machine = 0xB7;
++#elif CPU(RISCV64)
++        // RISC-V
++        header->machine = 0xF3;
+ #else
+ #error Unsupported target architecture.
+ #endif
+@@ -996,7 +999,7 @@ public:
+         uint8_t m_other;
+         uint16_t m_section;
+     } __attribute__((packed,aligned(1)));
+-#elif CPU(X86_64) || CPU(ARM64)
++#elif CPU(X86_64) || CPU(ARM64) || CPU(RISCV64)
+     struct SerializedLayout {
+         SerializedLayout(uint32_t name, uintptr_t value, uintptr_t size, Binding binding, Type type, uint16_t section)
+             : m_name(name)
+diff --git a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+index 74697f1525a1..9cc5fafef17f 100644
+--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
++++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+@@ -332,14 +332,19 @@ end
+ macro ipintAtomicOp(name, impl)
+     atomicInstructionLabel(name)
+ 
+-    if TRACING
+-        move cfr, a1
+-        move PC, a2
+-        move MC, a3
+-        operationCall(macro() cCall4(_ipint_extern_trace) end)
+-    end
++    if RISCV64
++        validateOpcodeConfig(a0)
++        break
++    else
++        if TRACING
++            move cfr, a1
++            move PC, a2
++            move MC, a3
++            operationCall(macro() cCall4(_ipint_extern_trace) end)
++        end
+ 
+-    impl()
++        impl()
++    end
+ end
+ 
+ macro reservedAtomicOpcode(opcode)
+@@ -1275,7 +1280,7 @@ op(wasm_throw_from_fault_handler_trampoline_reg_instance, macro ()
+ end)
+ 
+ op(ipint_entry, macro()
+-if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
++if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7 or RISCV64)
+     preserveCallerPCAndCFR()
+     saveIPIntRegisters()
+     storep wasmInstance, CodeBlock[cfr]
+@@ -1289,10 +1294,15 @@ else
+ end
+ end)
+ 
+-if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
++if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7 or RISCV64)
+ .ipint_entry_end_local:
+     argumINTInitializeDefaultLocals()
++if RISCV64
++    pcrtoaddr .ipint_entry_end_local, csr4
++    jmp csr4
++else
+     jmp .ipint_entry_end_local
++end
+ 
+ .ipint_entry_finish_zero:
+     argumINTFinish()
+@@ -1421,7 +1431,7 @@ end
+ end)
+ 
+ op(ipint_table_catch_entry, macro()
+-if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
++if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7 or RISCV64)
+     ipintCatchCommon()
+ 
+     # push arguments but no ref: sp in a2, call normal operation
+@@ -1440,7 +1450,7 @@ end
+ end)
+ 
+ op(ipint_table_catch_ref_entry, macro()
+-if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
++if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7 or RISCV64)
+     ipintCatchCommon()
+ 
+     # push both arguments and ref
+@@ -1459,7 +1469,7 @@ end
+ end)
+ 
+ op(ipint_table_catch_all_entry, macro()
+-if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
++if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7 or RISCV64)
+     ipintCatchCommon()
+ 
+     # do nothing: 0 in sp for no arguments, call normal operation
+@@ -1478,7 +1488,7 @@ end
+ end)
+ 
+ op(ipint_table_catch_allref_entry, macro()
+-if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
++if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7 or RISCV64)
+     ipintCatchCommon()
+ 
+     # push only the ref
+@@ -1985,7 +1995,7 @@ _pinballHandlerRejectFunction:
+ # 5. Instruction implementation #
+ #################################
+ 
+-if JSVALUE64 and (ARM64 or ARM64E or X86_64)
++if JSVALUE64 and (ARM64 or ARM64E or X86_64 or RISCV64)
+     include InPlaceInterpreter64
+ else
+ # For unimplemented architectures: make sure that the assertions can still find the labels
+diff --git a/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp b/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
+index a14c01138994..0c97a67b71fb 100644
+--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
++++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
+@@ -78,7 +78,7 @@ do { \
+ 
+ void initialize()
+ {
+-#if !ENABLE(C_LOOP) && (CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64)))
++#if !ENABLE(C_LOOP) && (CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64) || CPU(RISCV64)))
+ 
+ #define INIT_IPINT_BASE_POINTER(basePointerName, targetAddress) \
+     g_opcodeConfig.basePointerName = removeCodePtrTag(reinterpret_cast<void*>(targetAddress));
+@@ -97,13 +97,13 @@ void initialize()
+     FOR_EACH_IPINT_MINT_RETURN_OPCODE(VALIDATE_IPINT_MINT_RETURN_OPCODE);
+     FOR_EACH_IPINT_UINT_OPCODE(VALIDATE_IPINT_UINT_OPCODE);
+ #else
+-    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now).");
++    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64, X86_64, and RISCV64 (for now).");
+ #endif
+ }
+ 
+ void verifyInitialization()
+ {
+-#if !ENABLE(C_LOOP) && (CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64)))
++#if !ENABLE(C_LOOP) && (CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64) || CPU(RISCV64)))
+ 
+ #define VERIFY_IPINT_BASE_POINTER(basePointerName, targetAddress) \
+     RELEASE_ASSERT(g_opcodeConfig.basePointerName == removeCodePtrTag(reinterpret_cast<void*>(targetAddress)));
+diff --git a/Source/JavaScriptCore/llint/InPlaceInterpreter.h b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
+index 6d6d95024df9..c16754a5ce94 100644
+--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.h
++++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
+@@ -788,7 +788,7 @@ extern "C" void SYSV_ABI ipint_entry();
+     m(0x11, uint_stack_vector) \
+     m(0x12, uint_ret) \
+ 
+-#if !ENABLE(C_LOOP) && (CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64)))
++#if !ENABLE(C_LOOP) && (CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64) || CPU(RISCV64)))
+ FOR_EACH_IPINT_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
+ FOR_EACH_IPINT_GC_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
+ FOR_EACH_IPINT_CONVERSION_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
+diff --git a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+index 653b6a343537..8805ace80a5f 100644
+--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
++++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+@@ -51,7 +51,7 @@ end
+ 
+ # Dispatch target bases
+ 
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+ const ipint_dispatch_base = _ipint_unreachable
+ end
+ 
+@@ -71,7 +71,7 @@ if ARM64 or ARM64E
+     pcrtoaddr ipint_dispatch_base, t7
+     addlshiftp t7, t0, (constexpr (WTF::fastLog2(JSC::IPInt::alignIPInt))), t0
+     jmp t0
+-elsif X86_64
++elsif X86_64 or RISCV64
+     pcrtoaddr ipint_dispatch_base, t1
+     lshiftq (constexpr (WTF::fastLog2(JSC::IPInt::alignIPInt))), t0
+     addq t1, t0
+@@ -87,7 +87,7 @@ end
+ macro pushQuad(reg)
+     if ARM64 or ARM64E
+         push reg, reg
+-    elsif X86_64
++    elsif X86_64 or RISCV64
+         push reg, reg
+     else
+         break
+@@ -102,7 +102,7 @@ macro popQuad(reg)
+     # FIXME: emit post-increment in offlineasm
+     if ARM64 or ARM64E
+         loadqinc [sp], reg, V128ISize
+-    elsif X86_64
++    elsif X86_64 or RISCV64
+         loadq [sp], reg
+         addq V128ISize, sp
+     else
+@@ -200,7 +200,7 @@ macro argumINTDispatch()
+     addp 1, MC
+     bbgteq argumINTTmp, (constexpr IPInt::ArgumINTBytecode::NumOpcodes), _ipint_argument_dispatch_err
+     lshiftp (constexpr (WTF::fastLog2(JSC::IPInt::alignArgumInt))), argumINTTmp
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     pcrtoaddr _argumINT_begin, argumINTDsp
+     addp argumINTTmp, argumINTDsp
+     jmp argumINTDsp
+@@ -219,7 +219,7 @@ macro argumINTInitializeDefaultLocals()
+ if ARM64 or ARM64E
+     # offlineasm doesn't have xzr so emit it
+     emit "stp x19, xzr, [x9]"
+-elsif X86_64
++elsif X86_64 or RISCV64
+     storep argumINTTmp, [argumINTDst]
+     storep 0, 8[argumINTDst]
+ end
+@@ -502,7 +502,7 @@ end)
+ if ARM64 or ARM64E
+     const IPIntCallCallee = sc1
+     const IPIntCallFunctionSlot = sc0
+-elsif X86_64
++elsif X86_64 or RISCV64
+     const IPIntCallCallee = t7
+     const IPIntCallFunctionSlot = t6
+ end
+@@ -3201,7 +3201,7 @@ ipintOp(_atomic_prefix, macro()
+     if ARM64 or ARM64E
+         addlshiftp t1, t0, constexpr (WTF::fastLog2(JSC::IPInt::alignAtomicIPInt)), t0
+         jmp t0
+-    elsif X86_64
++    elsif X86_64 or RISCV64
+         lshiftq constexpr (WTF::fastLog2(JSC::IPInt::alignAtomicIPInt)), t0
+         addq t1, t0
+         jmp t0
+@@ -10953,7 +10953,7 @@ macro mintArgDispatch()
+     addq 1, MC
+     bigteq sc0, (constexpr IPInt::CallArgumentBytecode::NumOpcodes), _ipint_mint_arg_dispatch_err
+     lshiftq (constexpr (WTF::fastLog2(JSC::IPInt::alignMInt))), sc0
+-if ARM64 or ARM64E
++if ARM64 or ARM64E or RISCV64
+     pcrtoaddr _mint_begin, csr4
+     addq sc0, csr4
+     jmp csr4
+@@ -10969,7 +10969,7 @@ macro mintRetDispatch()
+     addq 1, MC
+     bigteq sc0, (constexpr IPInt::CallResultBytecode::NumOpcodes), _ipint_mint_ret_dispatch_err
+     lshiftq (constexpr (WTF::fastLog2(JSC::IPInt::alignMInt))), sc0
+-if ARM64 or ARM64E
++if ARM64 or ARM64E or RISCV64
+     pcrtoaddr _mint_begin_return, csr4
+     addq sc0, csr4
+     jmp csr4
+@@ -11205,7 +11205,7 @@ mintAlign(_a1)
+     mintArgDispatch()
+ 
+ mintAlign(_a2)
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     mintPop(a2)
+     mintArgDispatch()
+ else
+@@ -11213,7 +11213,7 @@ else
+ end
+ 
+ mintAlign(_a3)
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     mintPop(a3)
+     mintArgDispatch()
+ else
+@@ -11221,7 +11221,7 @@ else
+ end
+ 
+ mintAlign(_a4)
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     mintPop(a4)
+     mintArgDispatch()
+ else
+@@ -11229,7 +11229,7 @@ else
+ end
+ 
+ mintAlign(_a5)
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     mintPop(a5)
+     mintArgDispatch()
+ else
+@@ -11237,7 +11237,7 @@ else
+ end
+ 
+ mintAlign(_a6)
+-if ARM64 or ARM64E
++if ARM64 or ARM64E or RISCV64
+     mintPop(a6)
+     mintArgDispatch()
+ else
+@@ -11245,7 +11245,7 @@ else
+ end
+ 
+ mintAlign(_a7)
+-if ARM64 or ARM64E
++if ARM64 or ARM64E or RISCV64
+     mintPop(a7)
+     mintArgDispatch()
+ else
+@@ -11447,7 +11447,7 @@ mintAlign(_r1)
+     mintRetDispatch()
+ 
+ mintAlign(_r2)
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     subp StackValueSize, mintRetDst
+     storeq wa2, [mintRetDst]
+     mintRetDispatch()
+@@ -11456,7 +11456,7 @@ else
+ end
+ 
+ mintAlign(_r3)
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     subp StackValueSize, mintRetDst
+     storeq wa3, [mintRetDst]
+     mintRetDispatch()
+@@ -11465,7 +11465,7 @@ else
+ end
+ 
+ mintAlign(_r4)
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     subp StackValueSize, mintRetDst
+     storeq wa4, [mintRetDst]
+     mintRetDispatch()
+@@ -11474,7 +11474,7 @@ else
+ end
+ 
+ mintAlign(_r5)
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     subp StackValueSize, mintRetDst
+     storeq wa5, [mintRetDst]
+     mintRetDispatch()
+@@ -11483,7 +11483,7 @@ else
+ end
+ 
+ mintAlign(_r6)
+-if ARM64 or ARM64E
++if ARM64 or ARM64E or RISCV64
+     subp StackValueSize, mintRetDst
+     storeq wa6, [mintRetDst]
+     mintRetDispatch()
+@@ -11492,7 +11492,7 @@ else
+ end
+ 
+ mintAlign(_r7)
+-if ARM64 or ARM64E
++if ARM64 or ARM64E or RISCV64
+     subp StackValueSize, mintRetDst
+     storeq wa7, [mintRetDst]
+     mintRetDispatch()
+@@ -11854,7 +11854,7 @@ argumINTAlign(_a1)
+     argumINTDispatch()
+ 
+ argumINTAlign(_a2)
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     storeq wa2, [argumINTDst]
+     addp LocalSize, argumINTDst
+     argumINTDispatch()
+@@ -11864,7 +11864,7 @@ end
+ 
+ 
+ argumINTAlign(_a3)
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     storeq wa3, [argumINTDst]
+     addp LocalSize, argumINTDst
+     argumINTDispatch()
+@@ -11873,7 +11873,7 @@ else
+ end
+ 
+ argumINTAlign(_a4)
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     storeq wa4, [argumINTDst]
+     addp LocalSize, argumINTDst
+     argumINTDispatch()
+@@ -11882,7 +11882,7 @@ else
+ end
+ 
+ argumINTAlign(_a5)
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     storeq wa5, [argumINTDst]
+     addp LocalSize, argumINTDst
+     argumINTDispatch()
+@@ -11891,7 +11891,7 @@ else
+ end
+ 
+ argumINTAlign(_a6)
+-if ARM64 or ARM64E
++if ARM64 or ARM64E or RISCV64
+     storeq wa6, [argumINTDst]
+     addp LocalSize, argumINTDst
+     argumINTDispatch()
+@@ -11900,7 +11900,7 @@ else
+ end
+ 
+ argumINTAlign(_a7)
+-if ARM64 or ARM64E
++if ARM64 or ARM64E or RISCV64
+     storeq wa7, [argumINTDst]
+     addp LocalSize, argumINTDst
+     argumINTDispatch()
+@@ -11965,7 +11965,12 @@ argumINTAlign(_stack_vector)
+     argumINTDispatch()
+ 
+ argumINTAlign(_end)
++if RISCV64
++    pcrtoaddr .ipint_entry_end_local, argumINTDsp
++    jmp argumINTDsp
++else
+     jmp .ipint_entry_end_local
++end
+ 
+ if ARM64E
+     global _wasmTailCallTrampoline
+diff --git a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+index 71cf86f85df2..219faf9d36f1 100644
+--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
++++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+@@ -364,6 +364,43 @@ elsif X86_64
+     const wfa6 = ft6
+     const wfa7 = ft7
+ 
++    const fr = fa0
++elsif RISCV64
++    const a0 = t0
++    const a1 = t1
++    const a2 = t2
++    const a3 = t3
++    const a4 = t4
++    const a5 = t5
++    const a6 = t6
++    const a7 = t7
++
++    const wa0 = a0
++    const wa1 = a1
++    const wa2 = a2
++    const wa3 = a3
++    const wa4 = a4
++    const wa5 = a5
++    const wa6 = a6
++    const wa7 = a7
++
++    const ws0 = t9
++    const ws1 = t10
++    const ws2 = t11
++    const ws3 = t12
++
++    const r0 = a0
++    const r1 = a1
++
++    const wfa0 = fa0
++    const wfa1 = fa1
++    const wfa2 = fa2
++    const wfa3 = fa3
++    const wfa4 = fa4
++    const wfa5 = fa5
++    const wfa6 = fa6
++    const wfa7 = fa7
++
+     const fr = fa0
+ else
+     const a0 = t0
+@@ -906,8 +943,12 @@ macro checkStackPointerAlignment(tempReg, location)
+     end
+ end
+ 
+-if C_LOOP or ARM64 or ARM64E or X86_64 or RISCV64
++if C_LOOP or ARM64 or ARM64E or X86_64
+     const CalleeSaveRegisterCount = 0
++elsif RISCV64
++    # Save s1-s11 and fs0-fs11. s0/fp is already saved as cfr by functionPrologue().
++    # The extra slot keeps the stack 16-byte aligned after pushCalleeSaves().
++    const CalleeSaveRegisterCount = 24
+ elsif ARMv7
+     const CalleeSaveRegisterCount = 5 + 2 * 2 // 5 32-bit GPRs + 2 64-bit FPRs
+ end
+@@ -923,7 +964,32 @@ macro pushCalleeSaves()
+     # but are not in RegisterSet::vmCalleeSaveRegisters() need to be saved here,
+     # i.e.: only those registers that are callee save in the C ABI, but are not
+     # callee save in the JIT ABI.
+-    if C_LOOP or ARM64 or ARM64E or X86_64 or RISCV64
++    if C_LOOP or ARM64 or ARM64E or X86_64
++    elsif RISCV64
++        subp CalleeRegisterSaveSize, sp
++        storeq csr0, [sp]
++        storeq csr1, 8[sp]
++        storeq csr2, 16[sp]
++        storeq csr3, 24[sp]
++        storeq csr4, 32[sp]
++        storeq csr5, 40[sp]
++        storeq csr6, 48[sp]
++        storeq csr7, 56[sp]
++        storeq csr8, 64[sp]
++        storeq csr9, 72[sp]
++        storeq csr10, 80[sp]
++        stored csfr0, 88[sp]
++        stored csfr1, 96[sp]
++        stored csfr2, 104[sp]
++        stored csfr3, 112[sp]
++        stored csfr4, 120[sp]
++        stored csfr5, 128[sp]
++        stored csfr6, 136[sp]
++        stored csfr7, 144[sp]
++        stored csfr8, 152[sp]
++        stored csfr9, 160[sp]
++        stored csfr10, 168[sp]
++        stored csfr11, 176[sp]
+     elsif ARMv7
+         emit "vpush.64 {d14, d15}"
+         emit "push {r4-r6, r8-r9}"
+@@ -931,7 +997,32 @@ macro pushCalleeSaves()
+ end
+ 
+ macro popCalleeSaves()
+-    if C_LOOP or ARM64 or ARM64E or X86_64 or RISCV64
++    if C_LOOP or ARM64 or ARM64E or X86_64
++    elsif RISCV64
++        loadq [sp], csr0
++        loadq 8[sp], csr1
++        loadq 16[sp], csr2
++        loadq 24[sp], csr3
++        loadq 32[sp], csr4
++        loadq 40[sp], csr5
++        loadq 48[sp], csr6
++        loadq 56[sp], csr7
++        loadq 64[sp], csr8
++        loadq 72[sp], csr9
++        loadq 80[sp], csr10
++        loadd 88[sp], csfr0
++        loadd 96[sp], csfr1
++        loadd 104[sp], csfr2
++        loadd 112[sp], csfr3
++        loadd 120[sp], csfr4
++        loadd 128[sp], csfr5
++        loadd 136[sp], csfr6
++        loadd 144[sp], csfr7
++        loadd 152[sp], csfr8
++        loadd 160[sp], csfr9
++        loadd 168[sp], csfr10
++        loadd 176[sp], csfr11
++        addp CalleeRegisterSaveSize, sp
+     elsif ARMv7
+         emit "pop {r4-r6, r8-r9}"
+         emit "vpop.64 {d14, d15}"
+diff --git a/Source/JavaScriptCore/offlineasm/registers.rb b/Source/JavaScriptCore/offlineasm/registers.rb
+index 9c605e6f52d4..38715831151a 100644
+--- a/Source/JavaScriptCore/offlineasm/registers.rb
++++ b/Source/JavaScriptCore/offlineasm/registers.rb
+@@ -67,6 +67,22 @@ FPRS =
+      "ft5",
+      "ft6",
+      "ft7",
++     "fa0",
++     "fa1",
++     "fa2",
++     "fa3",
++     "fa4",
++     "fa5",
++     "fa6",
++     "fa7",
++     "wfa0",
++     "wfa1",
++     "wfa2",
++     "wfa3",
++     "wfa4",
++     "wfa5",
++     "wfa6",
++     "wfa7",
+      "csfr0",
+      "csfr1",
+      "csfr2",
+diff --git a/Source/JavaScriptCore/offlineasm/riscv64.rb b/Source/JavaScriptCore/offlineasm/riscv64.rb
+index d9ed36aa5350..1953bf837f20 100644
+--- a/Source/JavaScriptCore/offlineasm/riscv64.rb
++++ b/Source/JavaScriptCore/offlineasm/riscv64.rb
+@@ -170,10 +170,16 @@ class RegisterID
+             'x16'
+         when 't7', 'a7', 'wa7'
+             'x17'
+-        when 'ws0'
++        when 't8'
++            'x5'
++        when 't9', 'ws0'
+             'x6'
+-        when 'ws1'
++        when 't10', 'ws1'
+             'x7'
++        when 't11'
++            'x28'
++        when 't12'
++            'x29'
+         when 'csr0'
+             'x9'
+         when 'csr1'
+@@ -223,6 +229,10 @@ class FPRegisterID
+             'f4'
+         when 'ft5'
+             'f5'
++        when 'ft6'
++            'f6'
++        when 'ft7'
++            'f7'
+         when 'csfr0'
+             'f8'
+         when 'csfr1'
+@@ -467,7 +477,7 @@ def riscv64LowerAddressLoads(list)
+                 riscv64ValidateOperands(node.operands, [LabelReference, RegisterID])
+                 newList << Instruction.new(node.codeOrigin, "rv_la", node.operands)
+             when "pcrtoaddr"
+-                riscv64ValidateOperands(node.operands, [LabelReference, RegisterID])
++                riscv64ValidateOperands(node.operands, [LabelReference, RegisterID], [LocalLabelReference, RegisterID])
+                 newList << Instruction.new(node.codeOrigin, "rv_lla", node.operands)
+             else
+                 newList << node
+@@ -570,6 +580,25 @@ def riscv64LowerOperation(list)
+         newList << Instruction.new(node.codeOrigin, "rv_s#{suffix}", node.operands)
+     end
+ 
++    def emitTransferOperation(newList, node, size)
++        riscv64ValidateOperands(node.operands, [Address, Address])
++
++        case size
++        when :i
++            loadSuffix = "wu"
++            storeSuffix = "w"
++        when :p, :q
++            loadSuffix = "d"
++            storeSuffix = "d"
++        else
++            raise "Invalid size #{size}"
++        end
++
++        tmp = Tmp.new(node.codeOrigin, :gpr)
++        newList << Instruction.new(node.codeOrigin, "rv_l#{loadSuffix}", [node.operands[0], tmp])
++        newList << Instruction.new(node.codeOrigin, "rv_s#{storeSuffix}", [tmp, node.operands[1]])
++    end
++
+     def emitMove(newList, node)
+         case riscv64OperandTypes(node.operands)
+         when [RegisterID, RegisterID]
+@@ -600,7 +629,7 @@ def riscv64LowerOperation(list)
+         case riscv64OperandTypes(node.operands)
+         when [RegisterID]
+             callOpcode = "jalr"
+-        when [LabelReference]
++        when [LabelReference], [LocalLabelReference]
+             callOpcode = "call"
+         else
+             riscv64RaiseMismatchedOperands(node.operands)
+@@ -784,13 +813,24 @@ def riscv64LowerOperation(list)
+             return
+         end
+ 
++        case [extension, fromSize, toSize]
++        when [:z, :b, :i], [:z, :b, :p], [:z, :b, :q]
++            newList << Instruction.new(node.codeOrigin, "rv_slli", [source, Immediate.new(node.codeOrigin, 56), dest])
++            newList << Instruction.new(node.codeOrigin, "rv_srli", [dest, Immediate.new(node.codeOrigin, 56), dest])
++            return
++        when [:z, :h, :i], [:z, :h, :p], [:z, :h, :q]
++            newList << Instruction.new(node.codeOrigin, "rv_slli", [source, Immediate.new(node.codeOrigin, 48), dest])
++            newList << Instruction.new(node.codeOrigin, "rv_srli", [dest, Immediate.new(node.codeOrigin, 48), dest])
++            return
++        end
++
+         raise "Invalid zero extension" unless extension == :s
+         case [fromSize, toSize]
+         when [:b, :i]
+             newList << Instruction.new(node.codeOrigin, "rv_slli", [source, Immediate.new(node.codeOrigin, 56), dest])
+             newList << Instruction.new(node.codeOrigin, "rv_srai", [dest, Immediate.new(node.codeOrigin, 24), dest])
+             newList << Instruction.new(node.codeOrigin, "rv_srli", [dest, Immediate.new(node.codeOrigin, 32), dest])
+-        when [:b, :q]
++        when [:b, :p], [:b, :q]
+             newList << Instruction.new(node.codeOrigin, "rv_slli", [source, Immediate.new(node.codeOrigin, 56), dest])
+             newList << Instruction.new(node.codeOrigin, "rv_srai", [dest, Immediate.new(node.codeOrigin, 56), dest])
+         when [:h, :i]
+@@ -852,6 +892,8 @@ def riscv64LowerOperation(list)
+                 emitLoadOperation(newList, node, $1.to_sym)
+             when /^store(b|h|i|p|q)$/
+                 emitStoreOperation(newList, node, $1.to_sym)
++            when /^transfer(i|p|q)$/
++                emitTransferOperation(newList, node, $1.to_sym)
+             when "move"
+                 emitMove(newList, node)
+             when "jmp"
+@@ -1197,6 +1239,60 @@ def riscv64LowerFPOperation(list)
+         newList << Instruction.new(node.codeOrigin, "rv_fs#{suffix}", node.operands)
+     end
+ 
++    def emitLoadVectorOperation(newList, node)
++        case riscv64OperandTypes(node.operands)
++        when [Address, FPRegisterID]
++            newList << Instruction.new(node.codeOrigin, "rv_fld", node.operands)
++        when [Address, VecRegisterID]
++            newList << Instruction.new(node.codeOrigin, "rv_ebreak", [], "WebAssembly placeholder for opcode loadv")
++        else
++            riscv64RaiseMismatchedOperands(node.operands)
++        end
++    end
++
++    def emitStoreVectorOperation(newList, node)
++        case riscv64OperandTypes(node.operands)
++        when [FPRegisterID, Address]
++            newList << Instruction.new(node.codeOrigin, "rv_fsd", node.operands)
++        when [VecRegisterID, Address]
++            newList << Instruction.new(node.codeOrigin, "rv_ebreak", [], "WebAssembly placeholder for opcode storev")
++        else
++            riscv64RaiseMismatchedOperands(node.operands)
++        end
++    end
++
++    def emitPushVectorOperation(newList, node)
++        sp = RegisterID.forName(node.codeOrigin, 'sp')
++        node.operands.each {
++            | op |
++            case riscv64OperandTypes([op])
++            when [FPRegisterID]
++                newList << Instruction.new(node.codeOrigin, "rv_addi", [sp, Immediate.new(node.codeOrigin, -16), sp])
++                newList << Instruction.new(node.codeOrigin, "rv_fsd", [op, Address.new(node.codeOrigin, sp, Immediate.new(node.codeOrigin, 0))])
++            when [VecRegisterID]
++                newList << Instruction.new(node.codeOrigin, "rv_ebreak", [], "WebAssembly placeholder for opcode pushv")
++            else
++                riscv64RaiseMismatchedOperands([op])
++            end
++        }
++    end
++
++    def emitPopVectorOperation(newList, node)
++        sp = RegisterID.forName(node.codeOrigin, 'sp')
++        node.operands.each {
++            | op |
++            case riscv64OperandTypes([op])
++            when [FPRegisterID]
++                newList << Instruction.new(node.codeOrigin, "rv_fld", [Address.new(node.codeOrigin, sp, Immediate.new(node.codeOrigin, 0)), op])
++                newList << Instruction.new(node.codeOrigin, "rv_addi", [sp, Immediate.new(node.codeOrigin, 16), sp])
++            when [VecRegisterID]
++                newList << Instruction.new(node.codeOrigin, "rv_ebreak", [], "WebAssembly placeholder for opcode popv")
++            else
++                riscv64RaiseMismatchedOperands([op])
++            end
++        }
++    end
++
+     def emitMoveOperation(newList, node, precision)
+         riscv64ValidateOperands(node.operands, [FPRegisterID, FPRegisterID])
+         raise "Invalid precision" unless [:f, :d].include? precision
+@@ -1366,6 +1462,14 @@ def riscv64LowerFPOperation(list)
+                 emitLoadOperation(newList, node, $1.to_sym)
+             when /^store(f|d)$/
+                 emitStoreOperation(newList, node, $1.to_sym)
++            when "loadv"
++                emitLoadVectorOperation(newList, node)
++            when "storev"
++                emitStoreVectorOperation(newList, node)
++            when "pushv"
++                emitPushVectorOperation(newList, node)
++            when "popv"
++                emitPopVectorOperation(newList, node)
+             when /^move(d)$/
+                 emitMoveOperation(newList, node, $1.to_sym)
+             when /^f(i|p|q|f|d)2(i|p|q|f|d)$/
+@@ -1589,7 +1693,7 @@ class Instruction
+             riscv64ValidateOperands(operands, [LabelReference], [LocalLabelReference])
+             $asm.puts "#{rvop(opcode)} #{operands[0].asmLabel}"
+         when /^rv_(la|lla)$/
+-            riscv64ValidateOperands(operands, [LabelReference, RegisterID])
++            riscv64ValidateOperands(operands, [LabelReference, RegisterID], [LocalLabelReference, RegisterID])
+             $asm.puts "#{rvop(opcode)} #{operands[1].riscv64Operand}, #{operands[0].asmLabel}"
+         when "rv_mv"
+             riscv64ValidateOperands(operands, [RegisterID, RegisterID])
+diff --git a/Source/JavaScriptCore/runtime/Options.cpp b/Source/JavaScriptCore/runtime/Options.cpp
+index a4cf996708be..a9dffffce1f5 100644
+--- a/Source/JavaScriptCore/runtime/Options.cpp
++++ b/Source/JavaScriptCore/runtime/Options.cpp
+@@ -801,7 +801,11 @@ void Options::notifyOptionsChanged()
+     Options::useConcurrentGC() = false;
+     Options::forceUnlinkedDFG() = false;
+     Options::useWasmSIMD() = false;
++#if CPU(RISCV64)
++    Options::useWasmIPIntSIMD() = false;
++#else
+     Options::useWasmIPInt() = false;
++#endif
+ #if !CPU(ARM_THUMB2)
+     Options::useBBQJIT() = false;
+ #endif
+diff --git a/Source/JavaScriptCore/runtime/Options.h b/Source/JavaScriptCore/runtime/Options.h
+index 6c707f34ef73..47c73896f51b 100644
+--- a/Source/JavaScriptCore/runtime/Options.h
++++ b/Source/JavaScriptCore/runtime/Options.h
+@@ -175,7 +175,7 @@ private:
+     static unsigned computeNumberOfWorkerThreads(int maxNumberOfWorkerThreads, int minimum = 1);
+     static int32_t computePriorityDeltaOfWorkerThreads(int32_t twoCorePriorityDelta, int32_t multiCorePriorityDelta);
+     static constexpr bool jitEnabledByDefault() { return isAddress64Bit(); }
+-    static constexpr bool ipintEnabledByDefault() { return isARM64() || isARM64E() || isX86_64(); }
++    static constexpr bool ipintEnabledByDefault() { return isARM64() || isARM64E() || isRISCV64() || isX86_64(); }
+     static double defaultQuickDFGTierUpThresholdFactor()
+     {
+ #if PLATFORM(MAC)

--- a/bun-bootstrap/bun-webkit-typed-array-int32-conversion.patch
+++ b/bun-bootstrap/bun-webkit-typed-array-int32-conversion.patch
@@ -1,0 +1,19 @@
+diff --git i/Source/JavaScriptCore/runtime/TypedArrayAdaptors.h w/Source/JavaScriptCore/runtime/TypedArrayAdaptors.h
+index b6c443ca1833..4dd85f48d8b1 100644
+--- i/Source/JavaScriptCore/runtime/TypedArrayAdaptors.h
++++ w/Source/JavaScriptCore/runtime/TypedArrayAdaptors.h
+@@ -68,14 +68,7 @@ struct IntegralTypedArrayAdaptor {
+     
+     static Type toNativeFromDouble(double value)
+     {
+-#if HAVE(FJCVTZS_INSTRUCTION)
+         return static_cast<Type>(toInt32(value));
+-#else
+-        int32_t result = static_cast<int32_t>(value);
+-        if (static_cast<double>(result) != value)
+-            result = toInt32(value);
+-        return static_cast<Type>(result);
+-#endif
+     }
+ 
+     static constexpr Type toNativeFromUndefined()

--- a/bun/bun-riscv64.patch
+++ b/bun/bun-riscv64.patch
@@ -1,0 +1,765 @@
+diff --git a/build.zig b/build.zig
+index 39fb92d1e2..e965646985 100644
+--- a/build.zig
++++ b/build.zig
+@@ -120,10 +120,14 @@ pub fn getOSVersionMin(os: OperatingSystem) ?Target.Query.OsVersion {
+     };
+ }
+ 
+-pub fn getOSGlibCVersion(os: OperatingSystem) ?Version {
++pub fn getOSGlibCVersion(os: OperatingSystem, arch: Arch) ?Version {
+     return switch (os) {
+         // Compiling with a newer glibc than this will break certain cloud environments. See symbols.test.ts.
+-        .linux => .{ .major = 2, .minor = 17, .patch = 0 },
++        .linux => switch (arch) {
++            // riscv64 support was added in glibc 2.27.
++            .riscv64 => .{ .major = 2, .minor = 27, .patch = 0 },
++            else => .{ .major = 2, .minor = 17, .patch = 0 },
++        },
+ 
+         else => null,
+     };
+@@ -180,7 +184,7 @@ pub fn build(b: *Build) !void {
+     }
+ 
+     target_query.os_version_min = getOSVersionMin(os);
+-    target_query.glibc_version = if (abi.isGnu()) getOSGlibCVersion(os) else null;
++    target_query.glibc_version = if (abi.isGnu()) getOSGlibCVersion(os, arch) else null;
+ 
+     const target = b.resolveTargetQuery(target_query);
+ 
+@@ -612,7 +616,7 @@ const TargetDescription = struct {
+             .cpu_arch = desc.arch,
+             .cpu_model = getCpuModel(desc.os, desc.arch) orelse .determined_by_arch_os,
+             .os_version_min = getOSVersionMin(desc.os),
+-            .glibc_version = if (desc.musl) null else getOSGlibCVersion(desc.os),
++            .glibc_version = if (desc.musl) null else getOSGlibCVersion(desc.os, desc.arch),
+         });
+     }
+ };
+diff --git a/scripts/build/config.ts b/scripts/build/config.ts
+index f5a672b070..da79542bed 100644
+--- a/scripts/build/config.ts
++++ b/scripts/build/config.ts
+@@ -18,7 +18,7 @@ import { cyan, dim, green } from "./tty.ts";
+ import { defaultZigCommit } from "./zig.ts";
+ 
+ export type OS = "linux" | "darwin" | "windows";
+-export type Arch = "x64" | "aarch64";
++export type Arch = "x64" | "aarch64" | "riscv64";
+ export type Abi = "gnu" | "musl";
+ export type BuildType = "Debug" | "Release" | "RelWithDebInfo" | "MinSizeRel";
+ export type BuildMode = "full" | "cpp-only" | "zig-only" | "link-only";
+@@ -75,6 +75,7 @@ export interface Config {
+   unix: boolean;
+   x64: boolean;
+   arm64: boolean;
++  riscv64: boolean;
+ 
+   /**
+    * What's running the build. Differs from os/arch/windows (target) in
+@@ -313,8 +314,10 @@ export function detectHost(): Host {
+       ? "x64"
+       : a === "arm64"
+         ? "aarch64"
++        : a === "riscv64"
++          ? "riscv64"
+         : (() => {
+-            throw new BuildError(`Unsupported host architecture: ${a}`, { hint: "Bun builds on x64 or arm64" });
++            throw new BuildError(`Unsupported host architecture: ${a}`, { hint: "Bun builds on x64, arm64, or riscv64" });
+           })();
+ 
+   return { os, arch, exeSuffix: os === "windows" ? ".exe" : "" };
+@@ -352,6 +355,7 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
+   const unix = linux || darwin;
+   const x64 = arch === "x64";
+   const arm64 = arch === "aarch64";
++  const riscv64 = arch === "riscv64";
+ 
+   // Platform file conventions — MSVC style on Windows, Unix everywhere else.
+   const exeSuffix = windows ? ".exe" : "";
+@@ -421,8 +425,8 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
+   // failure is loud ("cannot find -l:libatomic.a") and the fix is obvious.
+   const staticLibatomic = partial.staticLibatomic ?? true;
+ 
+-  // TinyCC: off on Windows ARM64 (not supported), on elsewhere
+-  const tinycc = partial.tinycc ?? !(windows && arm64);
++  // TinyCC: off where the embedded JIT backend is not wired up.
++  const tinycc = partial.tinycc ?? (!(windows && arm64) && !riscv64);
+ 
+   const valgrind = partial.valgrind ?? false;
+   const fuzzilli = partial.fuzzilli ?? false;
+@@ -493,6 +497,7 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
+     unix,
+     x64,
+     arm64,
++    riscv64,
+     host,
+     exeSuffix,
+     objSuffix,
+diff --git a/scripts/build/deps/boringssl.ts b/scripts/build/deps/boringssl.ts
+index e1e12d494d..2f2cb660a9 100644
+--- a/scripts/build/deps/boringssl.ts
++++ b/scripts/build/deps/boringssl.ts
+@@ -17,11 +17,15 @@ export const boringssl: Dependency = {
+     commit: BORINGSSL_COMMIT,
+   }),
+ 
+-  build: () => ({
++  build: cfg => ({
+     kind: "nested-cmake",
+     // No explicit targets — defaults to lib names (crypto, ssl, decrepit).
+     // BoringSSL's cmake targets match its output library names.
+-    args: {},
++    //
++    // BoringSSL's generated source list includes assembly for every supported
++    // ISA. On riscv64 that can leave x86/arm objects in libcrypto.a unless ASM
++    // is disabled explicitly.
++    args: cfg.riscv64 ? { OPENSSL_NO_ASM: "1" } : {},
+   }),
+ 
+   provides: () => ({
+diff --git a/scripts/build/deps/webkit.ts b/scripts/build/deps/webkit.ts
+index 2dcc0ab836..160fa78bfd 100644
+--- a/scripts/build/deps/webkit.ts
++++ b/scripts/build/deps/webkit.ts
+@@ -251,6 +251,19 @@ export const webkit: Dependency = {
+       ...(cfg.asan ? { ENABLE_SANITIZERS: "address" } : {}),
+     };
+ 
++    if (cfg.riscv64) {
++      Object.assign(args, {
++        ENABLE_JIT: "OFF",
++        ENABLE_DFG_JIT: "OFF",
++        ENABLE_FTL_JIT: "OFF",
++        ENABLE_C_LOOP: "OFF",
++        ENABLE_SAMPLING_PROFILER: "ON",
++        ENABLE_WEBASSEMBLY: "ON",
++        ENABLE_WEBASSEMBLY_BBQJIT: "OFF",
++        ENABLE_WEBASSEMBLY_OMGJIT: "OFF",
++      });
++    }
++
+     const spec: NestedCmakeBuild = {
+       kind: "nested-cmake",
+       targets: ["jsc"],
+diff --git a/scripts/build/flags.ts b/scripts/build/flags.ts
+index 1ac5b4d4f0..2484c8469c 100644
+--- a/scripts/build/flags.ts
++++ b/scripts/build/flags.ts
+@@ -36,6 +36,11 @@ export interface Flag {
+ // ═══════════════════════════════════════════════════════════════════════════
+ 
+ export const cpuTargetFlags: Flag[] = [
++  {
++    flag: ["-march=rv64gc", "-mabi=lp64d", "-mno-relax"],
++    when: c => c.linux && c.riscv64,
++    desc: "RISC-V Linux: RV64GC with double-float ABI and fixed instruction layout",
++  },
+   {
+     flag: "-mcpu=apple-m1",
+     when: c => c.darwin && c.arm64,
+@@ -706,19 +711,27 @@ export const linkerFlags: Flag[] = [
+       "-Wl,--wrap=exp",
+       "-Wl,--wrap=exp2",
+       "-Wl,--wrap=expf",
+-      "-Wl,--wrap=fcntl64",
+-      "-Wl,--wrap=getrandom",
+-      "-Wl,--wrap=gettid",
+       "-Wl,--wrap=log",
+       "-Wl,--wrap=log2",
+       "-Wl,--wrap=log2f",
+       "-Wl,--wrap=logf",
+       "-Wl,--wrap=pow",
+       "-Wl,--wrap=powf",
++    ],
++    when: c => c.linux && c.abi !== "musl" && !c.riscv64,
++    desc: "Wrap old glibc libm symbols (portable down to glibc 2.17)",
++  },
++  {
++    // RISC-V glibc starts at 2.27, so the libm version wrappers above are not
++    // needed there and recurse without an architecture-specific .symver alias.
++    flag: [
++      "-Wl,--wrap=fcntl64",
++      "-Wl,--wrap=getrandom",
++      "-Wl,--wrap=gettid",
+       "-Wl,--wrap=quick_exit",
+     ],
+     when: c => c.linux && c.abi !== "musl",
+-    desc: "Wrap glibc 2.18+ symbols (portable down to glibc 2.17)",
++    desc: "Wrap newer glibc runtime symbols",
+   },
+   {
+     flag: ["-static-libstdc++", "-static-libgcc"],
+@@ -747,6 +760,11 @@ export const linkerFlags: Flag[] = [
+     when: c => c.linux,
+     desc: "Use lld instead of system ld",
+   },
++  {
++    flag: "-Wl,--no-relax",
++    when: c => c.linux && c.riscv64,
++    desc: "Disable RISC-V linker relaxation so JSC IPInt opcode labels keep fixed spacing",
++  },
+   {
+     flag: ["-fno-pic", "-Wl,-no-pie"],
+     when: c => c.linux,
+diff --git a/scripts/build/source.ts b/scripts/build/source.ts
+index bee06834a8..4cdc14c587 100644
+--- a/scripts/build/source.ts
++++ b/scripts/build/source.ts
+@@ -1023,8 +1023,12 @@ function emitNestedCmake(
+     // Most deps are static-lib-only so this usually doesn't matter, but when
+     // it does (dep builds a tool to generate a header), using lld keeps the
+     // toolchain consistent.
+-    args.push(`-DCMAKE_EXE_LINKER_FLAGS=--ld-path=${cfg.ld}`);
+-    args.push(`-DCMAKE_SHARED_LINKER_FLAGS=--ld-path=${cfg.ld}`);
++    const linkerFlags = [`--ld-path=${cfg.ld}`];
++    if (cfg.riscv64) {
++      linkerFlags.push("-Wl,--no-relax");
++    }
++    args.push(`-DCMAKE_EXE_LINKER_FLAGS=${linkerFlags.join(" ")}`);
++    args.push(`-DCMAKE_SHARED_LINKER_FLAGS=${linkerFlags.join(" ")}`);
+   }
+   if (cfg.windows) {
+     // Windows-specific toolchain forwarding. When CMAKE_C_COMPILER is
+diff --git a/scripts/build/tools.ts b/scripts/build/tools.ts
+index 4af051385b..af9fcf30eb 100644
+--- a/scripts/build/tools.ts
++++ b/scripts/build/tools.ts
+@@ -425,9 +425,10 @@ export function resolveLlvmToolchain(
+     ld = ""; // darwin: unused
+   }
+ 
+-  // strip: GNU strip on Linux (more features), llvm-strip elsewhere
++  // strip: GNU strip on native Linux (more features), llvm-strip for cross
++  // targets because the host binutils may not recognize the target ELF.
+   let strip: string;
+-  if (os === "linux") {
++  if (os === "linux" && arch !== "riscv64") {
+     strip = findTool({ names: ["strip"], required: true, hint: "Install binutils for your distro" })?.path ?? "";
+   } else {
+     strip = findLlvmTool("llvm-strip", paths, os, { checkVersion: false, required: true })?.path ?? "";
+diff --git a/scripts/build/zig.ts b/scripts/build/zig.ts
+index cc3867919c..db083d960a 100644
+--- a/scripts/build/zig.ts
++++ b/scripts/build/zig.ts
+@@ -74,11 +74,10 @@ function usingParallelCompiler(cfg: Config): boolean {
+ // ───────────────────────────────────────────────────────────────────────────
+ 
+ /**
+- * Zig target triple. Arch is always `x86_64`/`aarch64` (zig's naming),
+- * not `x64`/`arm64`.
++ * Zig target triple. Arch is always zig's naming, not Node's `x64`/`arm64`.
+  */
+ export function zigTarget(cfg: Config): string {
+-  const arch = cfg.x64 ? "x86_64" : "aarch64";
++  const arch = cfg.x64 ? "x86_64" : cfg.arm64 ? "aarch64" : "riscv64";
+   if (cfg.darwin) return `${arch}-macos-none`;
+   if (cfg.windows) return `${arch}-windows-msvc`;
+   // linux: abi is always set (resolveConfig asserts)
+@@ -129,6 +128,9 @@ export function zigCpu(cfg: Config): string {
+     if (cfg.windows) return "cortex_a76";
+     return "native";
+   }
++  if (cfg.riscv64) {
++    return "baseline_rv64";
++  }
+   // x64
+   return cfg.baseline ? "nehalem" : "haswell";
+ }
+diff --git a/src/Global.zig b/src/Global.zig
+index 1c6c1bf22a..9231367932 100644
+--- a/src/Global.zig
++++ b/src/Global.zig
+@@ -53,6 +53,8 @@ else if (Environment.isX86)
+     "x86"
+ else if (Environment.isAarch64)
+     "arm64"
++else if (Environment.isRiscV64)
++    "riscv64"
+ else
+     "unknown";
+ 
+diff --git a/src/analytics.zig b/src/analytics.zig
+index f62f8f4408..9571db90cc 100644
+--- a/src/analytics.zig
++++ b/src/analytics.zig
+@@ -240,7 +240,7 @@ pub const EventName = enum(u8) {
+ 
+ var random: std.rand.DefaultPrng = undefined;
+ 
+-const platform_arch = if (Environment.isAarch64) analytics.Architecture.arm else analytics.Architecture.x64;
++const platform_arch = if (Environment.isAarch64) analytics.Architecture.arm else if (Environment.isRiscV64) analytics.Architecture.riscv64 else analytics.Architecture.x64;
+ 
+ // TODO: move this code somewhere more appropriate, and remove it from "analytics"
+ // The following code is not currently even used for analytics, just feature-detection
+diff --git a/src/analytics/schema.zig b/src/analytics/schema.zig
+index 33d3fcadbb..02c860dd1e 100644
+--- a/src/analytics/schema.zig
++++ b/src/analytics/schema.zig
+@@ -350,6 +350,9 @@ pub const analytics = struct {
+         /// arm
+         arm,
+ 
++        /// riscv64
++        riscv64,
++
+         _,
+ 
+         pub fn jsonStringify(self: @This(), writer: anytype) !void {
+diff --git a/src/bun.js/api/ffi.zig b/src/bun.js/api/ffi.zig
+index 6f4ec41433..79017a581e 100644
+--- a/src/bun.js/api/ffi.zig
++++ b/src/bun.js/api/ffi.zig
+@@ -301,6 +301,18 @@ pub const FFI = struct {
+                     } else if (bun.FD.cwd().directoryExistsAt("/usr/lib64").isTrue()) {
+                         cached_default_system_library_dir = "/usr/lib64";
+                     }
++                } else if (Environment.isRiscV64) {
++                    if (bun.FD.cwd().directoryExistsAt("/usr/include/riscv64-linux-gnu").isTrue()) {
++                        cached_default_system_include_dir = "/usr/include/riscv64-linux-gnu";
++                    } else if (bun.FD.cwd().directoryExistsAt("/usr/include").isTrue()) {
++                        cached_default_system_include_dir = "/usr/include";
++                    }
++
++                    if (bun.FD.cwd().directoryExistsAt("/usr/lib/riscv64-linux-gnu").isTrue()) {
++                        cached_default_system_library_dir = "/usr/lib/riscv64-linux-gnu";
++                    } else if (bun.FD.cwd().directoryExistsAt("/usr/lib64").isTrue()) {
++                        cached_default_system_library_dir = "/usr/lib64";
++                    }
+                 }
+             }
+         }
+diff --git a/src/bun.js/bindings/BunProcess.cpp b/src/bun.js/bindings/BunProcess.cpp
+index a5c074c385..a3cdbbce41 100644
+--- a/src/bun.js/bindings/BunProcess.cpp
++++ b/src/bun.js/bindings/BunProcess.cpp
+@@ -172,6 +172,8 @@ static JSValue constructArch(VM& vm, JSObject* processObject)
+     return JSC::jsString(vm, makeAtomString("x64"_s));
+ #elif CPU(ARM64)
+     return JSC::jsString(vm, makeAtomString("arm64"_s));
++#elif CPU(RISCV64)
++    return JSC::jsString(vm, makeAtomString("riscv64"_s));
+ #else
+ #error "Unknown architecture"
+ #endif
+@@ -2293,6 +2295,9 @@ static JSValue constructProcessConfigObject(VM& vm, JSObject* processObject)
+ #elif CPU(ARM64)
+     variables->putDirect(vm, JSC::Identifier::fromString(vm, "host_arch"_s), JSC::jsString(vm, String("arm64"_s)), 0);
+     variables->putDirect(vm, JSC::Identifier::fromString(vm, "target_arch"_s), JSC::jsString(vm, String("arm64"_s)), 0);
++#elif CPU(RISCV64)
++    variables->putDirect(vm, JSC::Identifier::fromString(vm, "host_arch"_s), JSC::jsString(vm, String("riscv64"_s)), 0);
++    variables->putDirect(vm, JSC::Identifier::fromString(vm, "target_arch"_s), JSC::jsString(vm, String("riscv64"_s)), 0);
+ #else
+ #error "Unsupported architecture"
+ #endif
+diff --git a/src/bun.js/bindings/CPUFeatures.cpp b/src/bun.js/bindings/CPUFeatures.cpp
+index d1b1560565..f7feb1db0a 100644
+--- a/src/bun.js/bindings/CPUFeatures.cpp
++++ b/src/bun.js/bindings/CPUFeatures.cpp
+@@ -17,6 +17,15 @@ enum class AArch64CPUFeature : uint8_t {
+     sve = 6,
+ };
+ 
++enum class RISCV64CPUFeature : uint8_t {
++    m = 1,
++    a = 2,
++    f = 3,
++    d = 4,
++    c = 5,
++    v = 6,
++};
++
+ #if CPU(X86_64)
+ 
+ #if OS(WINDOWS)
+@@ -130,12 +139,46 @@ static uint8_t aarch64_cpu_features()
+ 
+ #endif
+ 
++#if CPU(RISCV64)
++
++#if OS(LINUX)
++#include <asm/hwcap.h>
++#include <sys/auxv.h>
++#endif
++
++static uint8_t riscv64_cpu_features()
++{
++    uint8_t features = 0;
++
++#if OS(LINUX)
++    unsigned long hwcaps = getauxval(AT_HWCAP);
++    if (hwcaps & COMPAT_HWCAP_ISA_M)
++        features |= 1 << static_cast<uint8_t>(RISCV64CPUFeature::m);
++    if (hwcaps & COMPAT_HWCAP_ISA_A)
++        features |= 1 << static_cast<uint8_t>(RISCV64CPUFeature::a);
++    if (hwcaps & COMPAT_HWCAP_ISA_F)
++        features |= 1 << static_cast<uint8_t>(RISCV64CPUFeature::f);
++    if (hwcaps & COMPAT_HWCAP_ISA_D)
++        features |= 1 << static_cast<uint8_t>(RISCV64CPUFeature::d);
++    if (hwcaps & COMPAT_HWCAP_ISA_C)
++        features |= 1 << static_cast<uint8_t>(RISCV64CPUFeature::c);
++    if (hwcaps & COMPAT_HWCAP_ISA_V)
++        features |= 1 << static_cast<uint8_t>(RISCV64CPUFeature::v);
++#endif
++
++    return features;
++}
++
++#endif
++
+ extern "C" uint8_t bun_cpu_features()
+ {
+ #if CPU(X86_64)
+     return x86_cpu_features();
+ #elif CPU(ARM64)
+     return aarch64_cpu_features();
++#elif CPU(RISCV64)
++    return riscv64_cpu_features();
+ #else
+ #error "Unknown architecture"
+ #endif
+diff --git a/src/bun.js/bindings/CPUFeatures.zig b/src/bun.js/bindings/CPUFeatures.zig
+index 29e4a6e040..ec4cfde413 100644
+--- a/src/bun.js/bindings/CPUFeatures.zig
++++ b/src/bun.js/bindings/CPUFeatures.zig
+@@ -28,6 +28,18 @@ pub const Flags = switch (@import("builtin").cpu.arch) {
+ 
+         padding: u1 = 0,
+     },
++    .riscv64 => packed struct(u8) {
++        none: bool,
++
++        m: bool,
++        a: bool,
++        f: bool,
++        d: bool,
++        c: bool,
++        v: bool,
++
++        padding: u1 = 0,
++    },
+     else => unreachable,
+ };
+ 
+@@ -52,6 +64,7 @@ pub fn isEmpty(features: CPUFeatures) bool {
+ }
+ 
+ pub fn hasAnyAVX(features: CPUFeatures) bool {
++    if (comptime !bun.Environment.isX64) return false;
+     return features.flags.avx or features.flags.avx2 or features.flags.avx512;
+ }
+ 
+diff --git a/src/bun.js/bindings/JSBuffer.cpp b/src/bun.js/bindings/JSBuffer.cpp
+index 5b1ccd84da..56e7a21b66 100644
+--- a/src/bun.js/bindings/JSBuffer.cpp
++++ b/src/bun.js/bindings/JSBuffer.cpp
+@@ -2060,16 +2060,18 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_toStringBody(JSC::JSGlobalO
+         RETURN_IF_EXCEPTION(scope, {});
+     }
+ 
+-    auto fstart = arg2.toNumber(lexicalGlobalObject);
+-    RETURN_IF_EXCEPTION(scope, {});
+-    if (fstart < 0) {
+-        fstart = 0;
+-        goto lstart;
+-    }
+-    if (fstart > byteLength) {
+-        return JSC::JSValue::encode(JSC::jsEmptyString(vm));
++    if (!arg2.isUndefined()) {
++        auto fstart = arg2.toNumber(lexicalGlobalObject);
++        RETURN_IF_EXCEPTION(scope, {});
++        if (fstart < 0) {
++            fstart = 0;
++            goto lstart;
++        }
++        if (fstart > byteLength) {
++            return JSC::JSValue::encode(JSC::jsEmptyString(vm));
++        }
++        start = static_cast<uint32_t>(fstart);
+     }
+-    start = static_cast<uint32_t>(fstart);
+ lstart:
+ 
+     if (!arg3.isUndefined()) {
+diff --git a/src/bun.js/bindings/NodeVMScript.cpp b/src/bun.js/bindings/NodeVMScript.cpp
+index b6ae742d67..c6ce606bbd 100644
+--- a/src/bun.js/bindings/NodeVMScript.cpp
++++ b/src/bun.js/bindings/NodeVMScript.cpp
+@@ -8,6 +8,7 @@
+ #include "JavaScriptCore/JSWeakMapInlines.h"
+ #include "JavaScriptCore/ProgramCodeBlock.h"
+ #include "JavaScriptCore/SourceCodeKey.h"
++#include "JavaScriptCore/Watchdog.h"
+ 
+ #include "NodeVMScriptFetcher.h"
+ #include "../vm/SigintWatcher.h"
+@@ -163,6 +164,7 @@ constructScript(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newT
+                 codeBlock = JSC::ProgramCodeBlock::create(vm, executable, unlinkedBlock, jsScope);
+                 RETURN_IF_EXCEPTION(scope, {});
+             }
++#if ENABLE(JIT)
+             JSC::CompilationResult compilationResult = JIT::compileSync(vm, codeBlock, JITCompilationEffort::JITCompilationCanFail);
+             if (compilationResult != JSC::CompilationResult::CompilationFailed) {
+                 executable->installCode(codeBlock);
+@@ -170,6 +172,9 @@ constructScript(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newT
+             } else {
+                 script->cachedDataRejected(TriState::True);
+             }
++#else
++            script->cachedDataRejected(TriState::True);
++#endif
+         }
+     } else if (produceCachedData) {
+         script->cacheBytecode();
+diff --git a/src/bun.js/bindings/NodeVMSourceTextModule.cpp b/src/bun.js/bindings/NodeVMSourceTextModule.cpp
+index 5c3ad694ec..e4ac037db7 100644
+--- a/src/bun.js/bindings/NodeVMSourceTextModule.cpp
++++ b/src/bun.js/bindings/NodeVMSourceTextModule.cpp
+@@ -140,12 +140,16 @@ NodeVMSourceTextModule* NodeVMSourceTextModule::create(VM& vm, JSGlobalObject* g
+             RETURN_IF_EXCEPTION(scope, nullptr);
+         }
+         if (codeBlock) {
++#if ENABLE(JIT)
+             CompilationResult compilationResult = JIT::compileSync(vm, codeBlock, JITCompilationEffort::JITCompilationCanFail);
+             RETURN_IF_EXCEPTION(scope, nullptr);
+             if (compilationResult != CompilationResult::CompilationFailed) {
+                 executable->installCode(codeBlock);
+                 return ptr;
+             }
++#else
++            UNUSED_PARAM(codeBlock);
++#endif
+         }
+     }
+ 
+diff --git a/src/bun.js/bindings/webcore/SerializedScriptValue.cpp b/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
+index 3125ee8411..e8400b7cb0 100644
+--- a/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
++++ b/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
+@@ -3424,12 +3424,13 @@ private:
+         ptr += length * sizeof(char16_t);
+ #else
+         std::span<char16_t> characters;
+-        str = String::createUninitialized(length, characters);
++        auto string = String::createUninitialized(length, characters);
+         for (unsigned i = 0; i < length; ++i) {
+             uint16_t c;
+             readLittleEndian(ptr, end, c);
+             characters[i] = c;
+         }
++        str = Identifier::fromString(vm, string);
+ #endif
+         return true;
+     }
+diff --git a/src/bun.js/modules/BunJSCModule.h b/src/bun.js/modules/BunJSCModule.h
+index 038fbe1c14..f3d3ae2eaa 100644
+--- a/src/bun.js/modules/BunJSCModule.h
++++ b/src/bun.js/modules/BunJSCModule.h
+@@ -582,7 +582,11 @@ JSC_DECLARE_HOST_FUNCTION(functionTotalCompileTime);
+ JSC_DEFINE_HOST_FUNCTION(functionTotalCompileTime,
+     (JSGlobalObject*, CallFrame*))
+ {
++#if ENABLE(JIT)
+     return JSValue::encode(jsNumber(JIT::totalCompileTime().milliseconds()));
++#else
++    return JSValue::encode(jsNumber(0));
++#endif
+ }
+ 
+ JSC_DECLARE_HOST_FUNCTION(functionGetProtectedObjects);
+diff --git a/src/cli/upgrade_command.zig b/src/cli/upgrade_command.zig
+index 036d9d9e75..20125d2487 100644
+--- a/src/cli/upgrade_command.zig
++++ b/src/cli/upgrade_command.zig
+@@ -42,7 +42,7 @@ pub const Version = struct {
+         .wasm => @compileError("Unsupported OS for Bun Upgrade"),
+     };
+ 
+-    pub const arch_label = if (Environment.isAarch64) "aarch64" else "x64";
++    pub const arch_label = if (Environment.isAarch64) "aarch64" else if (Environment.isRiscV64) "riscv64" else "x64";
+     pub const triplet = platform_label ++ "-" ++ arch_label;
+     const suffix_abi = if (Environment.isMusl) "-musl" else "";
+     const suffix_cpu = if (Environment.baseline) "-baseline" else "";
+diff --git a/src/compile_target.zig b/src/compile_target.zig
+index a1400d0151..629fe568dc 100644
+--- a/src/compile_target.zig
++++ b/src/compile_target.zig
+@@ -462,13 +462,14 @@ pub fn defineValues(this: *const CompileTarget) []const []const u8 {
+     // Use inline else to avoid extra allocations.
+     switch (this.os) {
+         inline else => |os| switch (this.arch) {
+-            inline .arm64, .x64 => |arch| return struct {
++            inline .arm64, .x64, .riscv64 => |arch| return struct {
+                 pub const values = &.{
+                     "\"" ++ os.nameString() ++ "\"",
+ 
+                     switch (arch) {
+                         .x64 => "\"x64\"",
+                         .arm64 => "\"arm64\"",
++                        .riscv64 => "\"riscv64\"",
+                         .wasm => @compileError("TODO"),
+                     },
+ 
+diff --git a/src/crash_handler.zig b/src/crash_handler.zig
+index 58a6a191bd..8f6e8e22e3 100644
+--- a/src/crash_handler.zig
++++ b/src/crash_handler.zig
+@@ -813,6 +813,8 @@ pub fn reportBaseUrl() []const u8 {
+ 
+ const arch_display_string = if (bun.Environment.isAarch64)
+     if (bun.Environment.isMac) "Silicon" else "arm64"
++else if (bun.Environment.isRiscV64)
++    "riscv64"
+ else
+     "x64";
+ 
+@@ -1096,6 +1098,7 @@ const Platform = enum(u8) {
+     linux_x86_64 = 'l',
+     linux_x86_64_baseline = 'B',
+     linux_aarch64 = 'L',
++    linux_riscv64 = 'r',
+ 
+     mac_x86_64_baseline = 'b',
+     mac_x86_64 = 'm',
+diff --git a/src/env.zig b/src/env.zig
+index 4d4fa2bbda..ddd972a5de 100644
+--- a/src/env.zig
++++ b/src/env.zig
+@@ -20,6 +20,7 @@ pub const isLinux = builtin.target.os.tag == .linux;
+ pub const isAarch64 = builtin.target.cpu.arch.isAARCH64();
+ pub const isX86 = builtin.target.cpu.arch.isX86();
+ pub const isX64 = builtin.target.cpu.arch == .x86_64;
++pub const isRiscV64 = builtin.target.cpu.arch == .riscv64;
+ pub const isMusl = builtin.target.abi.isMusl();
+ pub const allow_assert = isDebug or isTest or std.builtin.OptimizeMode.ReleaseSafe == builtin.mode;
+ pub const ci_assert = isDebug or isTest or enable_asan or (std.builtin.OptimizeMode.ReleaseSafe == builtin.mode and is_canary);
+@@ -144,6 +145,7 @@ else
+ pub const Architecture = enum {
+     x64,
+     arm64,
++    riscv64,
+     wasm,
+ 
+     /// npm package name, `@oven-sh/bun-{os}-{arch}`
+@@ -151,6 +153,7 @@ pub const Architecture = enum {
+         return switch (this) {
+             .x64 => "x64",
+             .arm64 => "aarch64",
++            .riscv64 => "riscv64",
+             .wasm => "wasm",
+         };
+     }
+@@ -161,6 +164,7 @@ pub const Architecture = enum {
+         .{ "amd64", .x64 },
+         .{ "aarch64", .arm64 },
+         .{ "arm64", .arm64 },
++        .{ "riscv64", .riscv64 },
+         .{ "wasm", .wasm },
+     });
+ };
+@@ -171,6 +175,8 @@ else if (isX64)
+     .x64
+ else if (isAarch64)
+     .arm64
++else if (isRiscV64)
++    .riscv64
+ else
+     @compileError("Please add your architecture to the Architecture enum");
+ 
+diff --git a/src/install/npm.zig b/src/install/npm.zig
+index 255a4f7f30..81d64f091d 100644
+--- a/src/install/npm.zig
++++ b/src/install/npm.zig
+@@ -759,18 +759,21 @@ pub const Architecture = enum(u16) {
+     pub const s390x: u16 = 1 << 9;
+     pub const x32: u16 = 1 << 10;
+     pub const x64: u16 = 1 << 11;
++    pub const riscv64: u16 = 1 << 12;
+ 
+-    pub const all_value: u16 = arm | arm64 | ia32 | mips | mipsel | ppc | ppc64 | s390 | s390x | x32 | x64;
++    pub const all_value: u16 = arm | arm64 | ia32 | mips | mipsel | ppc | ppc64 | s390 | s390x | x32 | x64 | riscv64;
+ 
+     pub const current: Architecture = switch (Environment.arch) {
+         .arm64 => @enumFromInt(arm64),
+         .x64 => @enumFromInt(x64),
++        .riscv64 => @enumFromInt(riscv64),
+         .wasm => @compileError("Specify architecture: " ++ Environment.arch),
+     };
+ 
+     pub const current_name = switch (Environment.arch) {
+         .arm64 => "arm64",
+         .x64 => "x64",
++        .riscv64 => "riscv64",
+         .wasm => @compileError("Unsupported architecture: " ++ @tagName(current)),
+     };
+ 
+@@ -786,6 +789,7 @@ pub const Architecture = enum(u16) {
+         .{ "s390x", s390x },
+         .{ "x32", x32 },
+         .{ "x64", x64 },
++        .{ "riscv64", riscv64 },
+     });
+ 
+     pub inline fn has(this: Architecture, other: u16) bool {
+diff --git a/src/js/node/os.ts b/src/js/node/os.ts
+index 64b1a1c0ac..c81a16f037 100644
+--- a/src/js/node/os.ts
++++ b/src/js/node/os.ts
+@@ -96,7 +96,7 @@ function bound(binding) {
+     },
+     cpus: lazyCpus(binding),
+     endianness: function () {
+-      return process.arch === "arm64" || process.arch === "x64" //
++      return process.arch === "arm64" || process.arch === "x64" || process.arch === "riscv64" //
+         ? "LE"
+         : $bundleError("TODO: endianness");
+     },
+@@ -132,7 +132,9 @@ function bound(binding) {
+         ? "arm64"
+         : process.arch === "x64"
+           ? "x86_64"
+-          : $bundleError("TODO: machine");
++          : process.arch === "riscv64"
++            ? "riscv64"
++            : $bundleError("TODO: machine");
+     },
+     devNull: process.platform === "win32" ? "\\\\.\\nul" : "/dev/null",
+     get EOL() {
+diff --git a/src/sys.zig b/src/sys.zig
+index 9f48b78540..bad867e41a 100644
+--- a/src/sys.zig
++++ b/src/sys.zig
+@@ -93,7 +93,7 @@ pub const O = switch (Environment.os) {
+ 
+         pub const toPacked = toPackedO;
+     },
+-    .linux, .wasm => switch (Environment.isX86) {
++    .linux, .wasm => switch (Environment.isX86 or Environment.isRiscV64) {
+         true => struct {
+             pub const RDONLY = 0x0000;
+             pub const WRONLY = 0x0001;
+diff --git a/src/workaround_missing_symbols.zig b/src/workaround_missing_symbols.zig
+index fda57737a6..0e888e99cd 100644
+--- a/src/workaround_missing_symbols.zig
++++ b/src/workaround_missing_symbols.zig
+@@ -66,15 +66,15 @@ pub const darwin = struct {
+ 
+     pub const lstat = blk: {
+         const T = *const fn (?[*:0]const u8, ?*bun.Stat) callconv(.c) c_int;
+-        break :blk @extern(T, .{ .name = if (bun.Environment.isAarch64) "lstat" else "lstat64" });
++        break :blk @extern(T, .{ .name = if (bun.Environment.isAarch64 or bun.Environment.isRiscV64) "lstat" else "lstat64" });
+     };
+     pub const fstat = blk: {
+         const T = *const fn (i32, ?*bun.Stat) callconv(.c) c_int;
+-        break :blk @extern(T, .{ .name = if (bun.Environment.isAarch64) "fstat" else "fstat64" });
++        break :blk @extern(T, .{ .name = if (bun.Environment.isAarch64 or bun.Environment.isRiscV64) "fstat" else "fstat64" });
+     };
+     pub const stat = blk: {
+         const T = *const fn (?[*:0]const u8, ?*bun.Stat) callconv(.c) c_int;
+-        break :blk @extern(T, .{ .name = if (bun.Environment.isAarch64) "stat" else "stat64" });
++        break :blk @extern(T, .{ .name = if (bun.Environment.isAarch64 or bun.Environment.isRiscV64) "stat" else "stat64" });
+     };
+ };
+ pub const windows = struct {

--- a/bun/bun-webkit-riscv64.patch
+++ b/bun/bun-webkit-riscv64.patch
@@ -1,0 +1,947 @@
+diff --git a/Source/JavaScriptCore/CMakeLists.txt b/Source/JavaScriptCore/CMakeLists.txt
+index d7e3e82010e8..5d9926ce3018 100644
+--- a/Source/JavaScriptCore/CMakeLists.txt
++++ b/Source/JavaScriptCore/CMakeLists.txt
+@@ -56,6 +56,10 @@ if(USE_CAPSTONE)
+     list(APPEND JavaScriptCore_PRIVATE_INCLUDE_DIRECTORIES "${THIRDPARTY_DIR}/capstone/Source/include")
+ endif()
+ 
++if(USE_MIMALLOC)
++    list(APPEND JavaScriptCore_PRIVATE_INCLUDE_DIRECTORIES "${BMALLOC_DIR}/mimalloc/mimalloc/include")
++endif()
++
+ set(JavaScriptCore_OBJECT_LUT_SOURCES
+     runtime/ArrayConstructor.cpp
+     runtime/AsyncFromSyncIteratorPrototype.cpp
+diff --git a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
+index 2f58ddbe6d91..77b6910ef4fa 100644
+--- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
++++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
+@@ -4365,20 +4365,20 @@ private:
+         using IType = RISCV64Assembler::IImmediate;
+         template<int32_t value>
+         static IType I() { return IType::v<IType, value>(); }
+-        template<typename T, typename = EnableIfInteger<T>>
++        template<std::integral T>
+         static IType I(T value) { return IType::v<IType>(value); }
+         static IType I(uint32_t value) { return IType(value); }
+ 
+         using SType = RISCV64Assembler::SImmediate;
+         template<int32_t value>
+         static SType S() { return SType::v<SType, value>(); }
+-        template<typename T, typename = EnableIfInteger<T>>
++        template<std::integral T>
+         static SType S(T value) { return SType::v<SType>(value); }
+ 
+         using BType = RISCV64Assembler::BImmediate;
+         template<int32_t value>
+         static BType B() { return BType::v<BType, value>(); }
+-        template<typename T, typename = EnableIfInteger<T>>
++        template<std::integral T>
+         static BType B(T value) { return BType::v<BType>(value); }
+         static BType B(uint32_t value) { return BType(value); }
+ 
+diff --git a/Source/JavaScriptCore/b3/B3Validate.cpp b/Source/JavaScriptCore/b3/B3Validate.cpp
+index a3f5f6cb8f9a..1879239b565e 100644
+--- a/Source/JavaScriptCore/b3/B3Validate.cpp
++++ b/Source/JavaScriptCore/b3/B3Validate.cpp
+@@ -493,7 +493,7 @@ public:
+             case VectorExtractLane:
+                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
+                 VALIDATE(value->numChildren() == 1, ("At ", *value));
+-                VALIDATE(value->type() == Wasm::toB3Type(Wasm::simdScalarType(value->asSIMDValue()->simdLane())), ("At ", *value));
++                VALIDATE(value->type() == simdB3ScalarType(value->asSIMDValue()->simdLane()), ("At ", *value));
+                 VALIDATE(value->child(0)->type() == V128, ("At ", *value));
+                 break;
+             case VectorReplaceLane:
+@@ -501,7 +501,7 @@ public:
+                 VALIDATE(value->numChildren() == 2, ("At ", *value));
+                 VALIDATE(value->type() == V128, ("At ", *value));
+                 VALIDATE(value->child(0)->type() == V128, ("At ", *value));
+-                VALIDATE(value->child(1)->type() == Wasm::toB3Type(Wasm::simdScalarType(value->asSIMDValue()->simdLane())), ("At ", *value));
++                VALIDATE(value->child(1)->type() == simdB3ScalarType(value->asSIMDValue()->simdLane()), ("At ", *value));
+                 break;
+             case VectorDupElement:
+                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
+@@ -523,7 +523,7 @@ public:
+                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
+                 VALIDATE(value->numChildren() == 1, ("At ", *value));
+                 VALIDATE(value->type() == V128, ("At ", *value));
+-                VALIDATE(value->child(0)->type() == Wasm::toB3Type(Wasm::simdScalarType(value->asSIMDValue()->simdLane())), ("At ", *value));
++                VALIDATE(value->child(0)->type() == simdB3ScalarType(value->asSIMDValue()->simdLane()), ("At ", *value));
+                 break;
+ 
+             case VectorPopcnt:
+diff --git a/Source/JavaScriptCore/b3/air/AirArg.h b/Source/JavaScriptCore/b3/air/AirArg.h
+index 5012f3318a5c..de62de31be18 100644
+--- a/Source/JavaScriptCore/b3/air/AirArg.h
++++ b/Source/JavaScriptCore/b3/air/AirArg.h
+@@ -1475,17 +1475,15 @@ public:
+         if (!isARM64() && !isX86_64())
+             return false;
+ 
++        uint64_t u64 = static_cast<uint64_t>(value);
+ #if CPU(ARM64)
+         if (ARM64Assembler::canEncodeFPImm<64>(value))
+             return true;
+ 
+-        uint64_t u64 = static_cast<uint64_t>(value);
+         if (ARM64FPImmediate::create64(u64).isValid())
+             return true;
+ 
+ #elif CPU(X86_64)
+-        uint64_t u64 = static_cast<uint64_t>(value);
+-
+         if (u64 == 0xFFFFFFFFFFFFFFFFULL)
+             return true;
+ 
+diff --git a/Source/JavaScriptCore/domjit/DOMJITEffect.h b/Source/JavaScriptCore/domjit/DOMJITEffect.h
+index 6ba85116d1be..943754f793a4 100644
+--- a/Source/JavaScriptCore/domjit/DOMJITEffect.h
++++ b/Source/JavaScriptCore/domjit/DOMJITEffect.h
+@@ -28,6 +28,16 @@
+ #include "DFGAbstractHeap.h"
+ #include "DOMJITHeapRange.h"
+ 
++#if !ENABLE(DFG_JIT)
++namespace JSC { namespace DFG {
++enum AbstractHeapKind : unsigned {
++    InvalidAbstractHeap,
++    Heap,
++    SideState,
++};
++} }
++#endif
++
+ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+ 
+ namespace JSC {
+diff --git a/Source/JavaScriptCore/jit/GdbJIT.cpp b/Source/JavaScriptCore/jit/GdbJIT.cpp
+index a812a7622291..d9599230a09f 100644
+--- a/Source/JavaScriptCore/jit/GdbJIT.cpp
++++ b/Source/JavaScriptCore/jit/GdbJIT.cpp
+@@ -873,7 +873,7 @@ private:
+             0x7F, 'E', 'L', 'F', 1, 1, 1, 0,
+             0, 0, 0, 0, 0, 0, 0, 0
+         };
+-#elif CPU(X86_64) || CPU(ARM64)
++#elif CPU(X86_64) || CPU(ARM64) || CPU(RISCV64)
+         const uint8_t ident[16] = {
+             0x7F, 'E', 'L', 'F', 2, 1, 1, 0,
+             0, 0, 0, 0, 0, 0, 0, 0
+@@ -895,6 +895,9 @@ private:
+ #elif CPU(ARM64)
+         // AARCH64
+         header->machine = 0xB7;
++#elif CPU(RISCV64)
++        // RISC-V
++        header->machine = 0xF3;
+ #else
+ #error Unsupported target architecture.
+ #endif
+@@ -996,7 +999,7 @@ public:
+         uint8_t m_other;
+         uint16_t m_section;
+     } __attribute__((packed,aligned(1)));
+-#elif CPU(X86_64) || CPU(ARM64)
++#elif CPU(X86_64) || CPU(ARM64) || CPU(RISCV64)
+     struct SerializedLayout {
+         SerializedLayout(uint32_t name, uintptr_t value, uintptr_t size, Binding binding, Type type, uint16_t section)
+             : m_name(name)
+diff --git a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+index 74697f1525a1..9cc5fafef17f 100644
+--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
++++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+@@ -332,14 +332,19 @@ end
+ macro ipintAtomicOp(name, impl)
+     atomicInstructionLabel(name)
+ 
+-    if TRACING
+-        move cfr, a1
+-        move PC, a2
+-        move MC, a3
+-        operationCall(macro() cCall4(_ipint_extern_trace) end)
+-    end
++    if RISCV64
++        validateOpcodeConfig(a0)
++        break
++    else
++        if TRACING
++            move cfr, a1
++            move PC, a2
++            move MC, a3
++            operationCall(macro() cCall4(_ipint_extern_trace) end)
++        end
+ 
+-    impl()
++        impl()
++    end
+ end
+ 
+ macro reservedAtomicOpcode(opcode)
+@@ -1275,7 +1280,7 @@ op(wasm_throw_from_fault_handler_trampoline_reg_instance, macro ()
+ end)
+ 
+ op(ipint_entry, macro()
+-if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
++if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7 or RISCV64)
+     preserveCallerPCAndCFR()
+     saveIPIntRegisters()
+     storep wasmInstance, CodeBlock[cfr]
+@@ -1289,10 +1294,15 @@ else
+ end
+ end)
+ 
+-if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
++if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7 or RISCV64)
+ .ipint_entry_end_local:
+     argumINTInitializeDefaultLocals()
++if RISCV64
++    pcrtoaddr .ipint_entry_end_local, csr4
++    jmp csr4
++else
+     jmp .ipint_entry_end_local
++end
+ 
+ .ipint_entry_finish_zero:
+     argumINTFinish()
+@@ -1421,7 +1431,7 @@ end
+ end)
+ 
+ op(ipint_table_catch_entry, macro()
+-if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
++if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7 or RISCV64)
+     ipintCatchCommon()
+ 
+     # push arguments but no ref: sp in a2, call normal operation
+@@ -1440,7 +1450,7 @@ end
+ end)
+ 
+ op(ipint_table_catch_ref_entry, macro()
+-if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
++if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7 or RISCV64)
+     ipintCatchCommon()
+ 
+     # push both arguments and ref
+@@ -1459,7 +1469,7 @@ end
+ end)
+ 
+ op(ipint_table_catch_all_entry, macro()
+-if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
++if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7 or RISCV64)
+     ipintCatchCommon()
+ 
+     # do nothing: 0 in sp for no arguments, call normal operation
+@@ -1478,7 +1488,7 @@ end
+ end)
+ 
+ op(ipint_table_catch_allref_entry, macro()
+-if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
++if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7 or RISCV64)
+     ipintCatchCommon()
+ 
+     # push only the ref
+@@ -1985,7 +1995,7 @@ _pinballHandlerRejectFunction:
+ # 5. Instruction implementation #
+ #################################
+ 
+-if JSVALUE64 and (ARM64 or ARM64E or X86_64)
++if JSVALUE64 and (ARM64 or ARM64E or X86_64 or RISCV64)
+     include InPlaceInterpreter64
+ else
+ # For unimplemented architectures: make sure that the assertions can still find the labels
+diff --git a/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp b/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
+index a14c01138994..0c97a67b71fb 100644
+--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
++++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
+@@ -78,7 +78,7 @@ do { \
+ 
+ void initialize()
+ {
+-#if !ENABLE(C_LOOP) && (CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64)))
++#if !ENABLE(C_LOOP) && (CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64) || CPU(RISCV64)))
+ 
+ #define INIT_IPINT_BASE_POINTER(basePointerName, targetAddress) \
+     g_opcodeConfig.basePointerName = removeCodePtrTag(reinterpret_cast<void*>(targetAddress));
+@@ -97,13 +97,13 @@ void initialize()
+     FOR_EACH_IPINT_MINT_RETURN_OPCODE(VALIDATE_IPINT_MINT_RETURN_OPCODE);
+     FOR_EACH_IPINT_UINT_OPCODE(VALIDATE_IPINT_UINT_OPCODE);
+ #else
+-    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64 and X86_64 (for now).");
++    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64, X86_64, and RISCV64 (for now).");
+ #endif
+ }
+ 
+ void verifyInitialization()
+ {
+-#if !ENABLE(C_LOOP) && (CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64)))
++#if !ENABLE(C_LOOP) && (CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64) || CPU(RISCV64)))
+ 
+ #define VERIFY_IPINT_BASE_POINTER(basePointerName, targetAddress) \
+     RELEASE_ASSERT(g_opcodeConfig.basePointerName == removeCodePtrTag(reinterpret_cast<void*>(targetAddress)));
+diff --git a/Source/JavaScriptCore/llint/InPlaceInterpreter.h b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
+index 6d6d95024df9..c16754a5ce94 100644
+--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.h
++++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
+@@ -788,7 +788,7 @@ extern "C" void SYSV_ABI ipint_entry();
+     m(0x11, uint_stack_vector) \
+     m(0x12, uint_ret) \
+ 
+-#if !ENABLE(C_LOOP) && (CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64)))
++#if !ENABLE(C_LOOP) && (CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64) || CPU(RISCV64)))
+ FOR_EACH_IPINT_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
+ FOR_EACH_IPINT_GC_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
+ FOR_EACH_IPINT_CONVERSION_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
+diff --git a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+index 653b6a343537..8805ace80a5f 100644
+--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
++++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+@@ -51,7 +51,7 @@ end
+ 
+ # Dispatch target bases
+ 
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+ const ipint_dispatch_base = _ipint_unreachable
+ end
+ 
+@@ -71,7 +71,7 @@ if ARM64 or ARM64E
+     pcrtoaddr ipint_dispatch_base, t7
+     addlshiftp t7, t0, (constexpr (WTF::fastLog2(JSC::IPInt::alignIPInt))), t0
+     jmp t0
+-elsif X86_64
++elsif X86_64 or RISCV64
+     pcrtoaddr ipint_dispatch_base, t1
+     lshiftq (constexpr (WTF::fastLog2(JSC::IPInt::alignIPInt))), t0
+     addq t1, t0
+@@ -87,7 +87,7 @@ end
+ macro pushQuad(reg)
+     if ARM64 or ARM64E
+         push reg, reg
+-    elsif X86_64
++    elsif X86_64 or RISCV64
+         push reg, reg
+     else
+         break
+@@ -102,7 +102,7 @@ macro popQuad(reg)
+     # FIXME: emit post-increment in offlineasm
+     if ARM64 or ARM64E
+         loadqinc [sp], reg, V128ISize
+-    elsif X86_64
++    elsif X86_64 or RISCV64
+         loadq [sp], reg
+         addq V128ISize, sp
+     else
+@@ -200,7 +200,7 @@ macro argumINTDispatch()
+     addp 1, MC
+     bbgteq argumINTTmp, (constexpr IPInt::ArgumINTBytecode::NumOpcodes), _ipint_argument_dispatch_err
+     lshiftp (constexpr (WTF::fastLog2(JSC::IPInt::alignArgumInt))), argumINTTmp
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     pcrtoaddr _argumINT_begin, argumINTDsp
+     addp argumINTTmp, argumINTDsp
+     jmp argumINTDsp
+@@ -219,7 +219,7 @@ macro argumINTInitializeDefaultLocals()
+ if ARM64 or ARM64E
+     # offlineasm doesn't have xzr so emit it
+     emit "stp x19, xzr, [x9]"
+-elsif X86_64
++elsif X86_64 or RISCV64
+     storep argumINTTmp, [argumINTDst]
+     storep 0, 8[argumINTDst]
+ end
+@@ -502,7 +502,7 @@ end)
+ if ARM64 or ARM64E
+     const IPIntCallCallee = sc1
+     const IPIntCallFunctionSlot = sc0
+-elsif X86_64
++elsif X86_64 or RISCV64
+     const IPIntCallCallee = t7
+     const IPIntCallFunctionSlot = t6
+ end
+@@ -3201,7 +3201,7 @@ ipintOp(_atomic_prefix, macro()
+     if ARM64 or ARM64E
+         addlshiftp t1, t0, constexpr (WTF::fastLog2(JSC::IPInt::alignAtomicIPInt)), t0
+         jmp t0
+-    elsif X86_64
++    elsif X86_64 or RISCV64
+         lshiftq constexpr (WTF::fastLog2(JSC::IPInt::alignAtomicIPInt)), t0
+         addq t1, t0
+         jmp t0
+@@ -10953,7 +10953,7 @@ macro mintArgDispatch()
+     addq 1, MC
+     bigteq sc0, (constexpr IPInt::CallArgumentBytecode::NumOpcodes), _ipint_mint_arg_dispatch_err
+     lshiftq (constexpr (WTF::fastLog2(JSC::IPInt::alignMInt))), sc0
+-if ARM64 or ARM64E
++if ARM64 or ARM64E or RISCV64
+     pcrtoaddr _mint_begin, csr4
+     addq sc0, csr4
+     jmp csr4
+@@ -10969,7 +10969,7 @@ macro mintRetDispatch()
+     addq 1, MC
+     bigteq sc0, (constexpr IPInt::CallResultBytecode::NumOpcodes), _ipint_mint_ret_dispatch_err
+     lshiftq (constexpr (WTF::fastLog2(JSC::IPInt::alignMInt))), sc0
+-if ARM64 or ARM64E
++if ARM64 or ARM64E or RISCV64
+     pcrtoaddr _mint_begin_return, csr4
+     addq sc0, csr4
+     jmp csr4
+@@ -11205,7 +11205,7 @@ mintAlign(_a1)
+     mintArgDispatch()
+ 
+ mintAlign(_a2)
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     mintPop(a2)
+     mintArgDispatch()
+ else
+@@ -11213,7 +11213,7 @@ else
+ end
+ 
+ mintAlign(_a3)
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     mintPop(a3)
+     mintArgDispatch()
+ else
+@@ -11221,7 +11221,7 @@ else
+ end
+ 
+ mintAlign(_a4)
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     mintPop(a4)
+     mintArgDispatch()
+ else
+@@ -11229,7 +11229,7 @@ else
+ end
+ 
+ mintAlign(_a5)
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     mintPop(a5)
+     mintArgDispatch()
+ else
+@@ -11237,7 +11237,7 @@ else
+ end
+ 
+ mintAlign(_a6)
+-if ARM64 or ARM64E
++if ARM64 or ARM64E or RISCV64
+     mintPop(a6)
+     mintArgDispatch()
+ else
+@@ -11245,7 +11245,7 @@ else
+ end
+ 
+ mintAlign(_a7)
+-if ARM64 or ARM64E
++if ARM64 or ARM64E or RISCV64
+     mintPop(a7)
+     mintArgDispatch()
+ else
+@@ -11447,7 +11447,7 @@ mintAlign(_r1)
+     mintRetDispatch()
+ 
+ mintAlign(_r2)
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     subp StackValueSize, mintRetDst
+     storeq wa2, [mintRetDst]
+     mintRetDispatch()
+@@ -11456,7 +11456,7 @@ else
+ end
+ 
+ mintAlign(_r3)
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     subp StackValueSize, mintRetDst
+     storeq wa3, [mintRetDst]
+     mintRetDispatch()
+@@ -11465,7 +11465,7 @@ else
+ end
+ 
+ mintAlign(_r4)
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     subp StackValueSize, mintRetDst
+     storeq wa4, [mintRetDst]
+     mintRetDispatch()
+@@ -11474,7 +11474,7 @@ else
+ end
+ 
+ mintAlign(_r5)
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     subp StackValueSize, mintRetDst
+     storeq wa5, [mintRetDst]
+     mintRetDispatch()
+@@ -11483,7 +11483,7 @@ else
+ end
+ 
+ mintAlign(_r6)
+-if ARM64 or ARM64E
++if ARM64 or ARM64E or RISCV64
+     subp StackValueSize, mintRetDst
+     storeq wa6, [mintRetDst]
+     mintRetDispatch()
+@@ -11492,7 +11492,7 @@ else
+ end
+ 
+ mintAlign(_r7)
+-if ARM64 or ARM64E
++if ARM64 or ARM64E or RISCV64
+     subp StackValueSize, mintRetDst
+     storeq wa7, [mintRetDst]
+     mintRetDispatch()
+@@ -11854,7 +11854,7 @@ argumINTAlign(_a1)
+     argumINTDispatch()
+ 
+ argumINTAlign(_a2)
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     storeq wa2, [argumINTDst]
+     addp LocalSize, argumINTDst
+     argumINTDispatch()
+@@ -11864,7 +11864,7 @@ end
+ 
+ 
+ argumINTAlign(_a3)
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     storeq wa3, [argumINTDst]
+     addp LocalSize, argumINTDst
+     argumINTDispatch()
+@@ -11873,7 +11873,7 @@ else
+ end
+ 
+ argumINTAlign(_a4)
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     storeq wa4, [argumINTDst]
+     addp LocalSize, argumINTDst
+     argumINTDispatch()
+@@ -11882,7 +11882,7 @@ else
+ end
+ 
+ argumINTAlign(_a5)
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
+     storeq wa5, [argumINTDst]
+     addp LocalSize, argumINTDst
+     argumINTDispatch()
+@@ -11891,7 +11891,7 @@ else
+ end
+ 
+ argumINTAlign(_a6)
+-if ARM64 or ARM64E
++if ARM64 or ARM64E or RISCV64
+     storeq wa6, [argumINTDst]
+     addp LocalSize, argumINTDst
+     argumINTDispatch()
+@@ -11900,7 +11900,7 @@ else
+ end
+ 
+ argumINTAlign(_a7)
+-if ARM64 or ARM64E
++if ARM64 or ARM64E or RISCV64
+     storeq wa7, [argumINTDst]
+     addp LocalSize, argumINTDst
+     argumINTDispatch()
+@@ -11965,7 +11965,12 @@ argumINTAlign(_stack_vector)
+     argumINTDispatch()
+ 
+ argumINTAlign(_end)
++if RISCV64
++    pcrtoaddr .ipint_entry_end_local, argumINTDsp
++    jmp argumINTDsp
++else
+     jmp .ipint_entry_end_local
++end
+ 
+ if ARM64E
+     global _wasmTailCallTrampoline
+diff --git a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+index 71cf86f85df2..219faf9d36f1 100644
+--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
++++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+@@ -364,6 +364,43 @@ elsif X86_64
+     const wfa6 = ft6
+     const wfa7 = ft7
+ 
++    const fr = fa0
++elsif RISCV64
++    const a0 = t0
++    const a1 = t1
++    const a2 = t2
++    const a3 = t3
++    const a4 = t4
++    const a5 = t5
++    const a6 = t6
++    const a7 = t7
++
++    const wa0 = a0
++    const wa1 = a1
++    const wa2 = a2
++    const wa3 = a3
++    const wa4 = a4
++    const wa5 = a5
++    const wa6 = a6
++    const wa7 = a7
++
++    const ws0 = t9
++    const ws1 = t10
++    const ws2 = t11
++    const ws3 = t12
++
++    const r0 = a0
++    const r1 = a1
++
++    const wfa0 = fa0
++    const wfa1 = fa1
++    const wfa2 = fa2
++    const wfa3 = fa3
++    const wfa4 = fa4
++    const wfa5 = fa5
++    const wfa6 = fa6
++    const wfa7 = fa7
++
+     const fr = fa0
+ else
+     const a0 = t0
+@@ -906,8 +943,12 @@ macro checkStackPointerAlignment(tempReg, location)
+     end
+ end
+ 
+-if C_LOOP or ARM64 or ARM64E or X86_64 or RISCV64
++if C_LOOP or ARM64 or ARM64E or X86_64
+     const CalleeSaveRegisterCount = 0
++elsif RISCV64
++    # Save s1-s11 and fs0-fs11. s0/fp is already saved as cfr by functionPrologue().
++    # The extra slot keeps the stack 16-byte aligned after pushCalleeSaves().
++    const CalleeSaveRegisterCount = 24
+ elsif ARMv7
+     const CalleeSaveRegisterCount = 5 + 2 * 2 // 5 32-bit GPRs + 2 64-bit FPRs
+ end
+@@ -923,7 +964,32 @@ macro pushCalleeSaves()
+     # but are not in RegisterSet::vmCalleeSaveRegisters() need to be saved here,
+     # i.e.: only those registers that are callee save in the C ABI, but are not
+     # callee save in the JIT ABI.
+-    if C_LOOP or ARM64 or ARM64E or X86_64 or RISCV64
++    if C_LOOP or ARM64 or ARM64E or X86_64
++    elsif RISCV64
++        subp CalleeRegisterSaveSize, sp
++        storeq csr0, [sp]
++        storeq csr1, 8[sp]
++        storeq csr2, 16[sp]
++        storeq csr3, 24[sp]
++        storeq csr4, 32[sp]
++        storeq csr5, 40[sp]
++        storeq csr6, 48[sp]
++        storeq csr7, 56[sp]
++        storeq csr8, 64[sp]
++        storeq csr9, 72[sp]
++        storeq csr10, 80[sp]
++        stored csfr0, 88[sp]
++        stored csfr1, 96[sp]
++        stored csfr2, 104[sp]
++        stored csfr3, 112[sp]
++        stored csfr4, 120[sp]
++        stored csfr5, 128[sp]
++        stored csfr6, 136[sp]
++        stored csfr7, 144[sp]
++        stored csfr8, 152[sp]
++        stored csfr9, 160[sp]
++        stored csfr10, 168[sp]
++        stored csfr11, 176[sp]
+     elsif ARMv7
+         emit "vpush.64 {d14, d15}"
+         emit "push {r4-r6, r8-r9}"
+@@ -931,7 +997,32 @@ macro pushCalleeSaves()
+ end
+ 
+ macro popCalleeSaves()
+-    if C_LOOP or ARM64 or ARM64E or X86_64 or RISCV64
++    if C_LOOP or ARM64 or ARM64E or X86_64
++    elsif RISCV64
++        loadq [sp], csr0
++        loadq 8[sp], csr1
++        loadq 16[sp], csr2
++        loadq 24[sp], csr3
++        loadq 32[sp], csr4
++        loadq 40[sp], csr5
++        loadq 48[sp], csr6
++        loadq 56[sp], csr7
++        loadq 64[sp], csr8
++        loadq 72[sp], csr9
++        loadq 80[sp], csr10
++        loadd 88[sp], csfr0
++        loadd 96[sp], csfr1
++        loadd 104[sp], csfr2
++        loadd 112[sp], csfr3
++        loadd 120[sp], csfr4
++        loadd 128[sp], csfr5
++        loadd 136[sp], csfr6
++        loadd 144[sp], csfr7
++        loadd 152[sp], csfr8
++        loadd 160[sp], csfr9
++        loadd 168[sp], csfr10
++        loadd 176[sp], csfr11
++        addp CalleeRegisterSaveSize, sp
+     elsif ARMv7
+         emit "pop {r4-r6, r8-r9}"
+         emit "vpop.64 {d14, d15}"
+diff --git a/Source/JavaScriptCore/offlineasm/registers.rb b/Source/JavaScriptCore/offlineasm/registers.rb
+index 9c605e6f52d4..38715831151a 100644
+--- a/Source/JavaScriptCore/offlineasm/registers.rb
++++ b/Source/JavaScriptCore/offlineasm/registers.rb
+@@ -67,6 +67,22 @@ FPRS =
+      "ft5",
+      "ft6",
+      "ft7",
++     "fa0",
++     "fa1",
++     "fa2",
++     "fa3",
++     "fa4",
++     "fa5",
++     "fa6",
++     "fa7",
++     "wfa0",
++     "wfa1",
++     "wfa2",
++     "wfa3",
++     "wfa4",
++     "wfa5",
++     "wfa6",
++     "wfa7",
+      "csfr0",
+      "csfr1",
+      "csfr2",
+diff --git a/Source/JavaScriptCore/offlineasm/riscv64.rb b/Source/JavaScriptCore/offlineasm/riscv64.rb
+index d9ed36aa5350..1953bf837f20 100644
+--- a/Source/JavaScriptCore/offlineasm/riscv64.rb
++++ b/Source/JavaScriptCore/offlineasm/riscv64.rb
+@@ -170,10 +170,16 @@ class RegisterID
+             'x16'
+         when 't7', 'a7', 'wa7'
+             'x17'
+-        when 'ws0'
++        when 't8'
++            'x5'
++        when 't9', 'ws0'
+             'x6'
+-        when 'ws1'
++        when 't10', 'ws1'
+             'x7'
++        when 't11'
++            'x28'
++        when 't12'
++            'x29'
+         when 'csr0'
+             'x9'
+         when 'csr1'
+@@ -223,6 +229,10 @@ class FPRegisterID
+             'f4'
+         when 'ft5'
+             'f5'
++        when 'ft6'
++            'f6'
++        when 'ft7'
++            'f7'
+         when 'csfr0'
+             'f8'
+         when 'csfr1'
+@@ -467,7 +477,7 @@ def riscv64LowerAddressLoads(list)
+                 riscv64ValidateOperands(node.operands, [LabelReference, RegisterID])
+                 newList << Instruction.new(node.codeOrigin, "rv_la", node.operands)
+             when "pcrtoaddr"
+-                riscv64ValidateOperands(node.operands, [LabelReference, RegisterID])
++                riscv64ValidateOperands(node.operands, [LabelReference, RegisterID], [LocalLabelReference, RegisterID])
+                 newList << Instruction.new(node.codeOrigin, "rv_lla", node.operands)
+             else
+                 newList << node
+@@ -570,6 +580,25 @@ def riscv64LowerOperation(list)
+         newList << Instruction.new(node.codeOrigin, "rv_s#{suffix}", node.operands)
+     end
+ 
++    def emitTransferOperation(newList, node, size)
++        riscv64ValidateOperands(node.operands, [Address, Address])
++
++        case size
++        when :i
++            loadSuffix = "wu"
++            storeSuffix = "w"
++        when :p, :q
++            loadSuffix = "d"
++            storeSuffix = "d"
++        else
++            raise "Invalid size #{size}"
++        end
++
++        tmp = Tmp.new(node.codeOrigin, :gpr)
++        newList << Instruction.new(node.codeOrigin, "rv_l#{loadSuffix}", [node.operands[0], tmp])
++        newList << Instruction.new(node.codeOrigin, "rv_s#{storeSuffix}", [tmp, node.operands[1]])
++    end
++
+     def emitMove(newList, node)
+         case riscv64OperandTypes(node.operands)
+         when [RegisterID, RegisterID]
+@@ -600,7 +629,7 @@ def riscv64LowerOperation(list)
+         case riscv64OperandTypes(node.operands)
+         when [RegisterID]
+             callOpcode = "jalr"
+-        when [LabelReference]
++        when [LabelReference], [LocalLabelReference]
+             callOpcode = "call"
+         else
+             riscv64RaiseMismatchedOperands(node.operands)
+@@ -784,13 +813,24 @@ def riscv64LowerOperation(list)
+             return
+         end
+ 
++        case [extension, fromSize, toSize]
++        when [:z, :b, :i], [:z, :b, :p], [:z, :b, :q]
++            newList << Instruction.new(node.codeOrigin, "rv_slli", [source, Immediate.new(node.codeOrigin, 56), dest])
++            newList << Instruction.new(node.codeOrigin, "rv_srli", [dest, Immediate.new(node.codeOrigin, 56), dest])
++            return
++        when [:z, :h, :i], [:z, :h, :p], [:z, :h, :q]
++            newList << Instruction.new(node.codeOrigin, "rv_slli", [source, Immediate.new(node.codeOrigin, 48), dest])
++            newList << Instruction.new(node.codeOrigin, "rv_srli", [dest, Immediate.new(node.codeOrigin, 48), dest])
++            return
++        end
++
+         raise "Invalid zero extension" unless extension == :s
+         case [fromSize, toSize]
+         when [:b, :i]
+             newList << Instruction.new(node.codeOrigin, "rv_slli", [source, Immediate.new(node.codeOrigin, 56), dest])
+             newList << Instruction.new(node.codeOrigin, "rv_srai", [dest, Immediate.new(node.codeOrigin, 24), dest])
+             newList << Instruction.new(node.codeOrigin, "rv_srli", [dest, Immediate.new(node.codeOrigin, 32), dest])
+-        when [:b, :q]
++        when [:b, :p], [:b, :q]
+             newList << Instruction.new(node.codeOrigin, "rv_slli", [source, Immediate.new(node.codeOrigin, 56), dest])
+             newList << Instruction.new(node.codeOrigin, "rv_srai", [dest, Immediate.new(node.codeOrigin, 56), dest])
+         when [:h, :i]
+@@ -852,6 +892,8 @@ def riscv64LowerOperation(list)
+                 emitLoadOperation(newList, node, $1.to_sym)
+             when /^store(b|h|i|p|q)$/
+                 emitStoreOperation(newList, node, $1.to_sym)
++            when /^transfer(i|p|q)$/
++                emitTransferOperation(newList, node, $1.to_sym)
+             when "move"
+                 emitMove(newList, node)
+             when "jmp"
+@@ -1197,6 +1239,60 @@ def riscv64LowerFPOperation(list)
+         newList << Instruction.new(node.codeOrigin, "rv_fs#{suffix}", node.operands)
+     end
+ 
++    def emitLoadVectorOperation(newList, node)
++        case riscv64OperandTypes(node.operands)
++        when [Address, FPRegisterID]
++            newList << Instruction.new(node.codeOrigin, "rv_fld", node.operands)
++        when [Address, VecRegisterID]
++            newList << Instruction.new(node.codeOrigin, "rv_ebreak", [], "WebAssembly placeholder for opcode loadv")
++        else
++            riscv64RaiseMismatchedOperands(node.operands)
++        end
++    end
++
++    def emitStoreVectorOperation(newList, node)
++        case riscv64OperandTypes(node.operands)
++        when [FPRegisterID, Address]
++            newList << Instruction.new(node.codeOrigin, "rv_fsd", node.operands)
++        when [VecRegisterID, Address]
++            newList << Instruction.new(node.codeOrigin, "rv_ebreak", [], "WebAssembly placeholder for opcode storev")
++        else
++            riscv64RaiseMismatchedOperands(node.operands)
++        end
++    end
++
++    def emitPushVectorOperation(newList, node)
++        sp = RegisterID.forName(node.codeOrigin, 'sp')
++        node.operands.each {
++            | op |
++            case riscv64OperandTypes([op])
++            when [FPRegisterID]
++                newList << Instruction.new(node.codeOrigin, "rv_addi", [sp, Immediate.new(node.codeOrigin, -16), sp])
++                newList << Instruction.new(node.codeOrigin, "rv_fsd", [op, Address.new(node.codeOrigin, sp, Immediate.new(node.codeOrigin, 0))])
++            when [VecRegisterID]
++                newList << Instruction.new(node.codeOrigin, "rv_ebreak", [], "WebAssembly placeholder for opcode pushv")
++            else
++                riscv64RaiseMismatchedOperands([op])
++            end
++        }
++    end
++
++    def emitPopVectorOperation(newList, node)
++        sp = RegisterID.forName(node.codeOrigin, 'sp')
++        node.operands.each {
++            | op |
++            case riscv64OperandTypes([op])
++            when [FPRegisterID]
++                newList << Instruction.new(node.codeOrigin, "rv_fld", [Address.new(node.codeOrigin, sp, Immediate.new(node.codeOrigin, 0)), op])
++                newList << Instruction.new(node.codeOrigin, "rv_addi", [sp, Immediate.new(node.codeOrigin, 16), sp])
++            when [VecRegisterID]
++                newList << Instruction.new(node.codeOrigin, "rv_ebreak", [], "WebAssembly placeholder for opcode popv")
++            else
++                riscv64RaiseMismatchedOperands([op])
++            end
++        }
++    end
++
+     def emitMoveOperation(newList, node, precision)
+         riscv64ValidateOperands(node.operands, [FPRegisterID, FPRegisterID])
+         raise "Invalid precision" unless [:f, :d].include? precision
+@@ -1366,6 +1462,14 @@ def riscv64LowerFPOperation(list)
+                 emitLoadOperation(newList, node, $1.to_sym)
+             when /^store(f|d)$/
+                 emitStoreOperation(newList, node, $1.to_sym)
++            when "loadv"
++                emitLoadVectorOperation(newList, node)
++            when "storev"
++                emitStoreVectorOperation(newList, node)
++            when "pushv"
++                emitPushVectorOperation(newList, node)
++            when "popv"
++                emitPopVectorOperation(newList, node)
+             when /^move(d)$/
+                 emitMoveOperation(newList, node, $1.to_sym)
+             when /^f(i|p|q|f|d)2(i|p|q|f|d)$/
+@@ -1589,7 +1693,7 @@ class Instruction
+             riscv64ValidateOperands(operands, [LabelReference], [LocalLabelReference])
+             $asm.puts "#{rvop(opcode)} #{operands[0].asmLabel}"
+         when /^rv_(la|lla)$/
+-            riscv64ValidateOperands(operands, [LabelReference, RegisterID])
++            riscv64ValidateOperands(operands, [LabelReference, RegisterID], [LocalLabelReference, RegisterID])
+             $asm.puts "#{rvop(opcode)} #{operands[1].riscv64Operand}, #{operands[0].asmLabel}"
+         when "rv_mv"
+             riscv64ValidateOperands(operands, [RegisterID, RegisterID])
+diff --git a/Source/JavaScriptCore/runtime/Options.cpp b/Source/JavaScriptCore/runtime/Options.cpp
+index a4cf996708be..a9dffffce1f5 100644
+--- a/Source/JavaScriptCore/runtime/Options.cpp
++++ b/Source/JavaScriptCore/runtime/Options.cpp
+@@ -801,7 +801,11 @@ void Options::notifyOptionsChanged()
+     Options::useConcurrentGC() = false;
+     Options::forceUnlinkedDFG() = false;
+     Options::useWasmSIMD() = false;
++#if CPU(RISCV64)
++    Options::useWasmIPIntSIMD() = false;
++#else
+     Options::useWasmIPInt() = false;
++#endif
+ #if !CPU(ARM_THUMB2)
+     Options::useBBQJIT() = false;
+ #endif
+diff --git a/Source/JavaScriptCore/runtime/Options.h b/Source/JavaScriptCore/runtime/Options.h
+index 6c707f34ef73..47c73896f51b 100644
+--- a/Source/JavaScriptCore/runtime/Options.h
++++ b/Source/JavaScriptCore/runtime/Options.h
+@@ -175,7 +175,7 @@ private:
+     static unsigned computeNumberOfWorkerThreads(int maxNumberOfWorkerThreads, int minimum = 1);
+     static int32_t computePriorityDeltaOfWorkerThreads(int32_t twoCorePriorityDelta, int32_t multiCorePriorityDelta);
+     static constexpr bool jitEnabledByDefault() { return isAddress64Bit(); }
+-    static constexpr bool ipintEnabledByDefault() { return isARM64() || isARM64E() || isX86_64(); }
++    static constexpr bool ipintEnabledByDefault() { return isARM64() || isARM64E() || isRISCV64() || isX86_64(); }
+     static double defaultQuickDFGTierUpThresholdFactor()
+     {
+ #if PLATFORM(MAC)

--- a/bun/riscv64.patch
+++ b/bun/riscv64.patch
@@ -1,0 +1,78 @@
+diff --git PKGBUILD PKGBUILD
+index 0c96862..9b92159 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -29,6 +29,10 @@
+   ruby-getoptlong # webkit
+   unzip
+ )
++makedepends_riscv64=(
++  bun
++  zig
++)
+ options=('!lto')
+ source=(
+   "git+$url.git#tag=bun-v$pkgver"
+@@ -68,15 +72,35 @@
+   mkdir -p vendor
+   cp -r "$srcdir/$pkgname-WebKit" vendor/WebKit
+ 
++  rm -rf vendor/zig vendor/zig.extract
+   case "$CARCH" in
+     x86_64)  _zigzip="$srcdir/$pkgname-zig-$_zigver-x86_64.zip" ;;
+     aarch64) _zigzip="$srcdir/$pkgname-zig-$_zigver-aarch64.zip" ;;
++    riscv64)
++      patch -Np1 -d vendor/WebKit < "$srcdir/$pkgname-webkit-riscv64.patch"
++      patch -Np1 < "$srcdir/$pkgname-riscv64.patch"
++
++      _zigbin="$(command -v zig)"
++      _ziglib="$(zig env | sed -n \
++        -e 's/^[[:space:]]*"lib_dir": "\(.*\)",\?$/\1/p' \
++        -e 's/^[[:space:]]*\.lib_dir = "\(.*\)",\?$/\1/p')"
++      if [[ -z "$_ziglib" || ! -d "$_ziglib" ]]; then
++        echo "Could not determine Zig lib_dir"
++        exit 1
++      fi
++      mkdir -p vendor/zig
++      ln -s "$_zigbin" vendor/zig/zig
++      ln -s "$_ziglib" vendor/zig/lib
++      printf '%s\n' "system-$(zig version)" > vendor/zig/.zig-commit
++      ;;
+   esac
+-  # unzip can't strip dirs but we want to get rid of the first contained dir so we have to do a little dance
+-  mkdir -p vendor/zig.extract
+-  unzip -q "$_zigzip" -d vendor/zig.extract
+-  mv vendor/zig.extract/* vendor/zig
+-  printf '%s\n' "$_zigver" > vendor/zig/.zig-commit
++  if [[ -n "${_zigzip:-}" ]]; then
++    # unzip can't strip dirs but we want to get rid of the first contained dir so we have to do a little dance
++    mkdir -p vendor/zig.extract
++    unzip -q "$_zigzip" -d vendor/zig.extract
++    mv vendor/zig.extract/* vendor/zig
++    printf '%s\n' "$_zigver" > vendor/zig/.zig-commit
++  fi
+ }
+ 
+ build() {
+@@ -87,7 +111,9 @@
+     aarch64) _bundir="bun-linux-aarch64" ;;
+   esac
+ 
+-  export PATH="$srcdir/$_bundir:$PATH"
++  if [[ -n "${_bundir:-}" ]]; then
++    export PATH="$srcdir/$_bundir:$PATH"
++  fi
+ 
+   cd $pkgname
+   bun scripts/build.ts \
+@@ -112,3 +138,10 @@
+   install -vDm644 completions/bun.fish "$pkgdir/usr/share/fish/vendor_completions.d/bun.fish"
+   install -vDm644 completions/bun.zsh "$pkgdir/usr/share/zsh/site-functions/_bun"
+ }
++
++source_riscv64=(
++  "$pkgname-riscv64.patch"
++  "$pkgname-webkit-riscv64.patch"
++)
++b2sums_riscv64=('d815fa6f73e37b3c2d20183fc3418a313592752b8e381fc7d3217952a5ba7b65c278bcca63173eb083a7a3f04d00ea25ccc67ec75418b7d6d75de4183ca05fb7'
++                'b64777e7bf3fb030235f3a53ad035c835a9c4335e3508ab9d94c93804041e5d3380a0c63803c6dd5612ecbef765a998cf9496ca8d612c9c361cff4cf8c187292')


### PR DESCRIPTION
Build steps:

1. Build bun-bootstrap on x86_64 host
    - `sudo ./build_rootfs.sh`
    - `extra-x86_64-build`

2. Build bun on riscv64 host
    - Feed the bun-bootstrap package in the previous step with `extra-riscv64-build -- -I`
    - #5330 needs to be built first for a working zig
    
The patch would be upstreamed gradually. Upstreamed ones:
https://github.com/WebKit/WebKit/pull/64755
https://github.com/WebKit/WebKit/pull/64756
https://github.com/WebKit/WebKit/pull/64760