### PR TITLE
addpatch: gmp 6.3.0-3

### DIFF
--- a/gmp/gmp-riscv64-sec-tabselect-public-loop.patch
+++ b/gmp/gmp-riscv64-sec-tabselect-public-loop.patch
@@ -1,0 +1,109 @@
+From: Felix Yan <felixonmars@archlinux.org>
+Subject: [PATCH] mpn/riscv64: keep sec_tabselect loop control public
+
+
+The current RISC-V mpn_sec_tabselect implementation derives the inner
+loop terminator from the selected table index:
+
+  k = which - nents
+
+The resulting branches still execute a fixed number of iterations, but
+their operands are derived from which.  Code which uses Valgrind
+undefinedness to check for secret-dependent control flow, such as
+Nettle's side-channel tests, therefore reports the branches as depending
+on secret data.
+
+Preserve nents by allocating k to a different register, and use it as the inner
+loop counter.  i is still used to form the selection mask, but not to control
+loop termination.  The function continues to scan every table entry and perform
+the same masked selection, while making the control flow independent of the
+selected entry.
+
+Improved-by: @dramforever
+
+---
+--- a/mpn/riscv/64/sec_tabselect.asm
++++ b/mpn/riscv/64/sec_tabselect.asm
+@@ -40,7 +40,7 @@ define(`which',	`a4')
+ define(`i',	`a6')
+ define(`j',	`a7')
+ define(`mask',	`s0')
+-define(`k',	`nents')
++define(`k',	`s1')
+ define(`one',	`s3')
+ 
+ ASM_START()
+@@ -55,7 +55,6 @@ PROLOGUE(mpn_sec_tabselect)
+ 	slli	n, n, 3
+ 	li	one, 1
+ 
+-	sub	k, which, nents
+ 	blt	j, zero, L(outer_end)
+ L(outer_top):
+ 	mv	s2, tp
+@@ -65,12 +64,15 @@ L(outer_top):
+ 	li	t3, 0
+ 	addi	j, j, -4
+ 	mv	i, which
++C Keep loop termination independent of which, since which is secret.
++	mv	k, nents
+ 
+ 	ALIGN(16)
+ L(top):	ld	t4, 0(tp)
+ 	ld	t5, 8(tp)
+ 	sltu	mask, i, one
+ 	addi	i, i, -1
++	addi	k, k, -1
+ 	neg	mask, mask
+ 	ld	t6, 16(tp)
+ 	ld	a5, 24(tp)
+@@ -83,7 +85,7 @@ L(top):	ld	t4, 0(tp)
+ 	or	t2, t6, t2
+ 	or	t3, a5, t3
+ 	add	tp, tp, n
+-	bne	i, k, L(top)
++	bne	k, zero, L(top)
+ 
+ 	sd	t0, 0(rp)
+ 	sd	t1, 8(rp)
+@@ -99,18 +101,20 @@ L(b1x):	mv	s2, tp
+ 	li	t0, 0
+ 	li	t1, 0
+ 	mv	i, which
++	mv	k, nents
+ 	ALIGN(16)
+ L(tp2):	ld	t4, 0(tp)
+ 	ld	t5, 8(tp)
+ 	sltu	mask, i, one
+ 	neg	mask, mask
+ 	addi	i, i, -1
++	addi	k, k, -1
+ 	and	t4, mask, t4
+ 	and	t5, mask, t5
+ 	or	t0, t4, t0
+ 	or	t1, t5, t1
+ 	add	tp, tp, n
+-	bne	i, k, L(tp2)
++	bne	k, zero, L(tp2)
+ 	sd	t0, 0(rp)
+ 	sd	t1, 8(rp)
+ 	addi	tp, s2, 16
+@@ -120,15 +124,17 @@ L(b0x):	andi	t0, n, 1*8
+ 	beq	t0, zero, L(b00)
+ L(b01):	li	t0, 0
+ 	mv	i, which
++	mv	k, nents
+ 	ALIGN(16)
+ L(tp1):	ld	t4, 0(tp)
+ 	sltu	mask, i, one
+ 	neg	mask, mask
+ 	addi	i, i, -1
++	addi	k, k, -1
+ 	and	t4, mask, t4
+ 	or	t0, t4, t0
+ 	add	tp, tp, n
+-	bne	i, k, L(tp1)
++	bne	k, zero, L(tp1)
+ 	sd	t0, 0(rp)
+ 
+ L(b00):	ld	s0,24(sp)

--- a/gmp/riscv64.patch
+++ b/gmp/riscv64.patch
@@ -1,0 +1,23 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,15 +14,18 @@
+ license=(GPL-2.0-or-later
+          LGPL-3.0-or-later)
+ source=(https://gmplib.org/download/gmp/gmp-$pkgver.tar.lz{,.sig}
+-        gmp-gcc-15.patch)
++        gmp-gcc-15.patch
++        gmp-riscv64-sec-tabselect-public-loop.patch)
+ sha256sums=('be5c908a7a836c3a9bd9d62aa58563c5e9e7fef94c43a7f42dbc35bb6d02733c'
+             'SKIP'
+-            'fd0f1b48dbe72413efbd9c45f1ca7013d555f46c578446ce3ba202e3a9b96c6c')
++            'fd0f1b48dbe72413efbd9c45f1ca7013d555f46c578446ce3ba202e3a9b96c6c'
++            '7296df25d7fee3b1f3a361aba824c5fd7317e2883172342781cb31b28db24298')
+ validpgpkeys=('343C2FF0FBEE5EC2EDBEF399F3599FF828C67298')   # Niels Möller
+ 
+ prepare() {
+   cd $pkgname-$pkgver
+   patch -p1 < ../gmp-gcc-15.patch # Fix build with GCC 15
++  patch -p1 < ../gmp-riscv64-sec-tabselect-public-loop.patch # Keep sec_tabselect branches public on RISC-V
+   autoreconf -vif
+ }
+ 


### PR DESCRIPTION
nettle 4.0 check() fails on riscv64 in the Valgrind side-channel wrappers for RSA/ECC/EdDSA. The common frame is GMP RISC-V __gmpn_sec_tabselect, where the inner loop branch compares values derived from the secret table index, which Valgrind treats as secret-dependent control flow.

Patch GMP instead of disabling nettle tests: keep the masked table selection using which, but drive loop termination from the public nents count so the function still scans every table entry while branch operands stay public.

Use @dramforever's improved version, which allocates k to s1 directly instead of adding a separate cnt alias.

After this GMP fix, nettle and nettle3 still have one remaining Valgrind side-channel failure in sc-ecdsa-sign, now inside nettle's own secp256r1 modq reduction. That issue is harder to fix properly at the moment, so keep this patch scoped to the GMP sec_tabselect problem.