### PR TITLE
addpatch: tree-sitter 0.26.8-1

### DIFF
--- a/tree-sitter/riscv64.patch
+++ b/tree-sitter/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -37,6 +37,7 @@
+   cmake --build build
+ 
+   cd crates/cli
++  export BINDGEN_EXTRA_CLANG_ARGS="--target=riscv64-unknown-linux-gnu"
+   cargo build --release --locked --offline
+ 
+   for completion in bash elvish fish nushell zsh; do


### PR DESCRIPTION
tree-sitter-cli builds rquickjs-sys with bindgen on riscv64, where the build log fails in the rquickjs-sys custom build script with:

error: unknown target triple 'riscv64gc-unknown-linux-gnu'

Pass --target=riscv64-unknown-linux-gnu through BINDGEN_EXTRA_CLANG_ARGS before building crates/cli so libclang uses a target triple it recognizes.