### PR TITLE
addpatch: stoken 0.92-6

### DIFF
--- a/stoken/0001-stc-nettle-initialize-base64-decode-buffer-length.patch
+++ b/stoken/0001-stc-nettle-initialize-base64-decode-buffer-length.patch
@@ -1,0 +1,30 @@
+From b4078fc16f3ed3b4d2690be91867bb5aec893a0a Mon Sep 17 00:00:00 2001
+From: Felix Yan <felixonmars@archlinux.org>
+Date: Sun, 17 May 2026 18:16:03 +0800
+Subject: [PATCH] stc-nettle: initialize base64 decode buffer length
+
+nettle's base64_decode_update() treats *dst_length as the size of the output buffer on input and updates it with the number of bytes written on success.
+
+stoken passed an uninitialized local variable for that argument, which makes SDTID import depend on stack contents. In practice this can make valid SDTID test fixtures fail to decode their Seed field with 'missing required xml node Seed'.
+
+Initialize dst_length to the size of the temporary decode buffer before calling into nettle.
+---
+ src/stc-nettle.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/stc-nettle.c b/src/stc-nettle.c
+index ab7876d..4bb7ee6 100644
+--- a/src/stc-nettle.c
++++ b/src/stc-nettle.c
+@@ -137,7 +137,7 @@ int stc_b64_decode(const uint8_t *in,  unsigned long len,
+ 	struct base64_decode_ctx ctx;
+ 	char tmp[BASE64_DECODE_LENGTH(len)];
+ 	int ret;
+-	size_t dst_length;
++	size_t dst_length = sizeof(tmp);
+ 
+ 	base64_decode_init(&ctx);
+ 	ret = base64_decode_update(&ctx, &dst_length, tmp, len, in);
+-- 
+2.54.0
+

--- a/stoken/riscv64.patch
+++ b/stoken/riscv64.patch
@@ -1,0 +1,27 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,11 +14,13 @@
+ provides=('libstoken.so')
+ source=(https://downloads.sourceforge.net/stoken/${pkgname}-${pkgver}.tar.gz{,.asc}
+         https://github.com/stoken-dev/stoken/commit/8fc6f0dd.patch
+-        nettle-4.patch)
++        nettle-4.patch
++        0001-stc-nettle-initialize-base64-decode-buffer-length.patch)
+ sha256sums=('aa2b481b058e4caf068f7e747a2dcf5772bcbf278a4f89bc9efcbf82bcc9ef5a'
+             'SKIP'
+             'dc1bfc755a3b2b368398a4623817b4093840469b6fb45be65d53754c4a6042f7'
+-            'ac2e4a9506c9e70b4c200ad1d56799fdb36f15a7bf474b492939ca9f5d7e693c')
++            'ac2e4a9506c9e70b4c200ad1d56799fdb36f15a7bf474b492939ca9f5d7e693c'
++            '03166e85f099d8a32c984d337d0962a1f78f63b80be3238404687864d8ddae7b')
+ validpgpkeys=('45DFF2D5205FE8CD74C2EE6C63B81599BC0B0D65')
+ 
+ prepare() {
+@@ -26,6 +28,8 @@
+ # Fix build with nettle 4
+   patch -p1 -i ../8fc6f0dd.patch
+   patch -p1 -i ../nettle-4.patch
++  # Fix SDTID base64 decoding with nettle
++  patch -p1 -i ../0001-stc-nettle-initialize-base64-decode-buffer-length.patch
+   autoreconf -fiv
+ }
+ 


### PR DESCRIPTION
stoken's nettle-backed base64 decoder passes an uninitialized dst_length argument to base64_decode_update(). nettle treats that value as the output buffer size on input and stores the number of bytes written on output, so decoding depends on whatever stack contents happen to be present.

This can break SDTID import during check(), where a valid fixture fails after the Seed field is not decoded and stoken reports "missing required xml node Seed".

Initialize dst_length to sizeof(tmp), matching the temporary decode buffer passed to nettle. The source fix is architecture-independent, but it is needed for the riscv64 build where the test failure is reproducible.

Upstreamed at https://github.com/stoken-dev/stoken/pull/82