### PR TITLE
updpatch: dart 3.11.4-1

### DIFF
--- a/dart/gcc-warning-errors.patch
+++ b/dart/gcc-warning-errors.patch
@@ -1,0 +1,12 @@
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -680,6 +680,9 @@
+     ]
+   } else {
+     default_warning_flags += [
++      "-Wno-error=array-bounds",
++      "-Wno-error=tsan",
++      "-Wno-error=unused-but-set-variable",
+       "-Wno-ignored-qualifiers",  # Warnings in BoringSSL headers
+     ]
+   }

--- a/dart/riscv64.patch
+++ b/dart/riscv64.patch
@@ -1,23 +1,24 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -57,8 +57,16 @@ EOF
+@@ -57,8 +57,17 @@
  
    export PATH+=":$PWD/depot_tools" DEPOT_TOOLS_UPDATE=0
  
 +  # Bundled wheels are not available for riscv64
 +  sed -i '/wheel: </,$d' depot_tools/.vpython3
-+  sed -i '/wheel: </,$d' depot_tools/gsutil.vpython3
++  sed -i '/wheel: </,$d' depot_tools/gsutil.py.vpython3
 +  # Hack
 +  patch -Np0 -d depot_tools < HACK-gclient-fix-dep.diff
 +
    cd sdk
  
 +  patch -Np 1 --input=$srcdir/dart-riscv-no-cross.patch
++  patch -Np 1 --input=$srcdir/gcc-warning-errors.patch
 +
    patch -Np 1 --input="$srcdir/DEPS.patch"
-   patch -Np 1 --input="$srcdir/0001-vm-Fix-gcc-build.patch"
+   patch -Np 1 --input="$srcdir/0001-fix-gcc-build-fails-with-msan-enabled.patch"
  
-@@ -80,7 +88,7 @@ build() {
+@@ -80,7 +89,7 @@
    # gn args --list out
  
    /usr/bin/gn gen -qv out --args='
@@ -26,12 +27,14 @@
                          is_debug = false
                          is_release = true
                          is_clang = false
-@@ -112,3 +120,8 @@ package() {
+@@ -112,3 +121,10 @@
  }
  
  # vim:set ts=2 sw=2 et:
 +
 +source+=("dart-riscv-no-cross.patch"
++         "gcc-warning-errors.patch"
 +         "HACK-gclient-fix-dep.diff")
 +sha256sums+=('8c0d3a27a86aea34d7b932181111a9f660d2e7bf67d5e45055163e6b980b187f'
++             'e3c43e1db6826f35c76a78db49d83b72a5296eb833ad616d6f4f8c02895e0e61'
 +             'ba4ac7e5c41c4d4a20f3fa420af99e844c69255ce1472436568a1fdf77785104')


### PR DESCRIPTION
- Refresh patch for current Arch packaging

- Use depot_tools/gsutil.py.vpython3 for the pinned depot_tools commit

- Keep GCC 16/libstdc++ diagnostics visible but non-fatal for RISC-V builds

References: GCC PR 97868, GCC PR 122197, GCC PR 123912, and GCC 16 -Wunused-but-set-variable porting notes