### PR TITLE
addpatch: colm 0.14.7-5

### DIFF
--- a/colm/fix-runtests-core-detection.patch
+++ b/colm/fix-runtests-core-detection.patch
@@ -1,0 +1,15 @@
+--- colm-0.14.7.orig/test/runtests
++++ colm-0.14.7/test/runtests
+@@ -13,8 +13,11 @@
+ 		CORES=$(sysctl -n hw.physicalcpu)
+ 	fi
+ 
++	if ! echo $CORES | grep -q '^[1-9][0-9]*$'; then
++		CORES=$(nproc 2>/dev/null)
++	fi
+ 
+-	if ! echo $CORES | grep -q '^[1-9][0-9]\?$'; then
++	if ! echo $CORES | grep -q '^[1-9][0-9]*$'; then
+ 		echo "warning: could not determine number of cores, using 2"
+ 		CORES=2
+ 	fi

--- a/colm/riscv64.patch
+++ b/colm/riscv64.patch
@@ -1,0 +1,29 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -20,17 +20,25 @@
+   "https://www.colm.net/files/colm/$pkgname-$pkgver.tar.gz"{,.asc}
+   "$pkgname-fix-incompatible-pointer-type.patch"
+   "$pkgname-libfsm-ac-check-lib.patch::https://github.com/adrian-thurston/colm/commit/28b6e0a01157049b4cb279b0ef25ea9dcf3b46ed.patch"
++  "$pkgname-ragel-char-signedness.patch::https://github.com/adrian-thurston/colm-suite/commit/e1f1c598d5bf66484e4dccccddd420a8ed1ebc84.patch"
++  "fix-runtests-core-detection.patch"
+ )
+ b2sums=('c8be14001e8dc3340f5c55fbf8140b86237ec9462699e417f618cf44c759307eda0ede9f7a9ef897f5b8bc51d1fdf8b7360872a30b4cf07ba8191e405940030c'
+         'SKIP'
+         '93fc6eaba3a519a10fc81c81cdbfc857c08513acfbc25d503d2df6ad4a7b56ad36621723b288032c36499deeb4fdf1de10971d3bd5b3644359b24ffc5bde3d95'
+-        'c777ef380ec0d8526f95af2f985e01db4f233a0f1cb7a0f62c36c3ec81c0d35fbc73ff8799c43afdfda26deb189edbe3a369f38989d5f725a42b7ba29e0d7f34')
++        'c777ef380ec0d8526f95af2f985e01db4f233a0f1cb7a0f62c36c3ec81c0d35fbc73ff8799c43afdfda26deb189edbe3a369f38989d5f725a42b7ba29e0d7f34'
++        '1a93c4b5a38e9845472e9177d6ace62a6c8d9377a6cadbd3bc95a8c3a8c099ae8fad90ce768f1819ebe8e2ed33b8a44414f0c9a80352e1de1cf5a92e48970198'
++        '5c6baebd7925608268fcd199b71f6548e506e67eaa44ed7552333ba75035dc1660a75f9e1076b7e8f0a5e1e4d5bed147fd880c55fed7dda84e49e2a63fd01c49')
+ validpgpkeys=(C3260F001EE3780F1BC3D4F650FE47277DC196FB) # Adrian Thurston <thurston@cs.queensu.ca>
+ 
+ prepare() {
+   cd $pkgname-$pkgver
+   patch -Np1 < ../$pkgname-fix-incompatible-pointer-type.patch
+   patch -Np1 < ../$pkgname-libfsm-ac-check-lib.patch
++  # Fix generated Ragel code mismatches on targets where plain char is unsigned.
++  patch -Np1 < ../$pkgname-ragel-char-signedness.patch
++  # Avoid runtests falling back to 2 jobs when /proc/cpuinfo lacks cpu cores on riscv64.
++  patch -Np1 < ../fix-runtests-core-detection.patch
+   autoreconf -fiv
+ }
+ 


### PR DESCRIPTION
Backport the upstream Ragel fix for targets where plain char is unsigned. This fixes the Ragel test failures seen on riscv64, where generated code can otherwise disagree with the target compiler's char signedness.

Also fix runtests core detection on riscv64, where /proc/cpuinfo lacks the x86-style cpu cores field and check() falls back to only two jobs on large builders. Upstreamed at https://github.com/adrian-thurston/colm-suite/pull/207