### PR TITLE
updpatch: rspamd 3.14.3-5

### DIFF
--- a/rspamd/riscv64.patch
+++ b/rspamd/riscv64.patch
@@ -1,33 +1,23 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -16,7 +16,6 @@ depends=(
-   gcc-libs
+@@ -14,7 +14,6 @@
+ depends=(
    glib2
    glibc
 -  hyperscan
    icu
    jemalloc
-   libelf
-@@ -149,6 +148,9 @@ pkgver() {
- 
- prepare() {
-   cd rspamd
-+  # Fix build without hyperscan
-+  git cherry-pick -n d907a95ac2e2cad6f7f65c4323f031f7931ae18b
-+  git cherry-pick -n ccb45df90df60fae36b9438cfb2b0088e590306b
-   sed 's/_rspamd/rspamd/g' -i rspamd.service
- }
- 
-@@ -163,7 +165,7 @@ build() {
+   libarchive
+@@ -165,7 +164,7 @@
      -DRSPAMD_USER=rspamd \
      -DNO_SHARED=ON \
      -DWANT_SYSTEMD_UNITS=ON \
 -    -DENABLE_HYPERSCAN=ON \
 +    -DENABLE_HYPERSCAN=OFF \
      -DENABLE_JEMALLOC=ON \
-     -DENABLE_OPTIMIZATION=ON
-   cmake --build build
-@@ -177,7 +179,6 @@ package() {
+     -DENABLE_OPTIMIZATION=ON \
+     -DENABLE_BLAS=ON
+@@ -180,7 +179,6 @@
    install -Dm 644 rspamd.logrotate "${pkgdir}"/etc/logrotate.d/rspamd
    install -Dm 644 rspamd-dmarc-report.service -t "${pkgdir}"/usr/lib/systemd/system/
    install -Dm 644 rspamd-dmarc-report.timer -t "${pkgdir}"/usr/lib/systemd/system/


### PR DESCRIPTION
Refresh the RISC-V overlay for current Arch packaging.

The no-Hyperscan fixes previously cherry-picked are already included in the 3.14.3 tag, so replaying d907a95a now conflicts in src/libserver/rspamd_control.c during prepare(). Drop the obsolete cherry-picks and keep only the riscv64 Hyperscan disablement.

Link: https://github.com/rspamd/rspamd/issues/4702
Link: https://github.com/rspamd/rspamd/commit/d907a95ac2e2cad6f7f65c4323f031f7931ae18b
Link: https://github.com/rspamd/rspamd/commit/ccb45df90df60fae36b9438cfb2b0088e590306b