### PR TITLE
addpatch: srsgui 2.0-5

### DIFF
--- a/srsgui/riscv64.patch
+++ b/srsgui/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -10,7 +10,7 @@
+ url='https://github.com/srsLTE/srsGUI'
+ license=('AGPL3')
+ depends=('qt5-base' 'qwt-qt5')
+-makedepends=('cmake' 'boost')
++makedepends=('cmake' 'boost' 'boost-libs')
+ source=("$_pkgname-$pkgver.tar.gz::$url/archive/$_tag.tar.gz"
+          srsgui-qwt-6.2.patch
+          boost-1.83.patch


### PR DESCRIPTION
Add boost-libs to makedepends for the RISC-V build.

Since the Boost 1.90 split, boost no longer depends on boost-libs. srsgui still finds Boost CMake metadata from boost, but its C++ test targets link Boost::thread and Boost::unit_test_framework, so make records versioned libboost_thread/libboost_unit_test_framework paths that are absent unless boost-libs is installed.

Current boost-libs still ships the required compiled libraries on riscv64.

Link: https://archlinux.org/todo/boost-1900/
Link: https://archlinux.org/packages/extra/x86_64/boost-libs/files/