### PR TITLE
addpatch: thrift 0.22.0-6

### DIFF
--- a/thrift/riscv64.patch
+++ b/thrift/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -16,6 +16,7 @@
+ license=(Apache-2.0)
+ makedepends=(
+   boost
++  boost-libs
+   cmake
+   emacs-nox
+   git


### PR DESCRIPTION
CMake finds Boost through the files shipped by the boost package, but the generated build rules link the C++ test binaries against the versioned Boost shared libraries from boost-libs.

Without boost-libs installed, the build stops with no rule to make target '/usr/lib/libboost_filesystem.so.1.91.0', needed by targets such as TFDTransportTest, TPipedTransportTest and OpenSSLManualInitTest.

Add boost-libs to makedepends for riscv64 so those imported Boost targets resolve to libraries that are present during build().