### PR TITLE
updpatch: python-proton-vpn-local-agent 1.6.1-1

### DIFF
--- a/python-proton-vpn-local-agent/riscv64.patch
+++ b/python-proton-vpn-local-agent/riscv64.patch
@@ -8,7 +8,7 @@
 +  clang
  )
  source=("git+https://github.com/ProtonVPN/local-agent-rs.git#tag=${pkgver}")
- sha256sums=('e37902dd39ca9cbee37095ccce841e3e9f744f8b86f5935fa68f833dcd37d0ed')
+ sha256sums=('9fb13cf0362c47915036825d3249ea4915eb76149ccab4f2dc765888655deb05')
  
  prepare() {
      cd "${srcdir}"/local-agent-rs/python-proton-vpn-local-agent


### PR DESCRIPTION
Refresh the patch context for the 1.6.1 source checksum so the RISC-V overlay applies again.

Keep the existing aws-lc-sys workarounds. local-agent-rs 1.6.1 is still locked to aws-lc-sys 0.20.1, aws-lc-rs 1.8.1, and bindgen 0.69.4. On riscv64, aws-lc-sys still needs cmake/clang for the fallback bindgen path and the bindgen update that avoids the old missing generated wrapper symbols tracked in aws/aws-lc-rs#476.

The bundled aws-lc-sys 0.20.1 CMake files still require CMake 3.0, which CMake 4 rejects without CMAKE_POLICY_VERSION_MINIMUM=3.5. The warning suppressions remain tied to current GCC/glibc diagnostics in aws-lc: unterminated fixed-size string initializers and const-generic memchr causing discarded-qualifiers warnings. The _FORTIFY_SOURCE=3 removal is kept because upstream only fixed that class of issue in much newer aws-lc-sys releases.