### PR TITLE
addpatch: numbat 1.23.0-2

### DIFF
--- a/numbat/riscv64.patch
+++ b/numbat/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,7 +17,7 @@
+ prepare() {
+     cd "${pkgname}-${pkgver}"
+     export RUSTUP_TOOLCHAIN=stable
+-    cargo fetch --locked --target "${CARCH}-unknown-linux-gnu"
++    cargo fetch --locked --target host-tuple
+ }
+ 
+ build() {


### PR DESCRIPTION
Use Cargo host-tuple for fetch; rustc rejects riscv64-unknown-linux-gnu on native riscv64.