### PR TITLE
updpatch: neovide 0.16.2-1

### DIFF
--- a/neovide/riscv64.patch
+++ b/neovide/riscv64.patch
@@ -1,11 +1,34 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -40,6 +40,8 @@ sha256sums=('21c8eaa53cf3290d2b1405c8cb2cde5f39bc14ef597b328e76f1789b0ef3539a')
+@@ -19,7 +19,7 @@
+          neovim
+          sndio
+          libpng libpng16.so
+-         harfbuzz libharfbuzz.so
++         harfbuzz libharfbuzz.so libharfbuzz-subset.so
+          icu libicuuc.so
+          expat libexpat.so
+          zlib libz.so)
+@@ -34,12 +34,20 @@
+             'libxkbcommon-x11: run on X11 (not needed for wayland)')
+ options=(!lto)
+ _archive=("$pkgname-$pkgver")
+-source=("$url/archive/$pkgver/$_archive.tar.gz")
+-sha256sums=('a2016cceab3cba50b6a8b2f6787ae9017a85923575e89a83ebb9d428e8f80ca9')
++source=("$url/archive/$pkgver/$_archive.tar.gz"
++        "skia-bindings-0.93.1.tar.gz::https://crates.io/api/v1/crates/skia-bindings/0.93.1/download"
++        "skia-bindings-riscv.patch")
++sha256sums=('a2016cceab3cba50b6a8b2f6787ae9017a85923575e89a83ebb9d428e8f80ca9'
++            '2359f7e30c9da3f322f8ca3d4ec0abbc12a40035ce758309db0cdab07b5d4476'
++            'd7811d4194fd1c8bd04a9dd7ea1fbc4099c59b9fbf70ae5f5ce8d2fce587a17a')
+ 
  prepare() {
++	patch -Np1 -d skia-bindings-0.93.1 -i "$srcdir/skia-bindings-riscv.patch"
++
  	cd "$_archive"
  	sed -r -i -e '/^incremental/a opt-level = 3' Cargo.toml
-+	echo -e "\n[patch.crates-io]\nskia-bindings = { git = 'https://github.com/hack3ric/rust-skia', branch = 'archrv-0.75.0' }" >> Cargo.toml
++	echo -e "\n[patch.crates-io]\nskia-bindings = { path = '../skia-bindings-0.93.1' }" >> Cargo.toml
 +	cargo update -p skia-bindings
- 	cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+ 	cargo fetch --locked --target "$(rustc --print host-tuple)"
  }
  

--- a/neovide/skia-bindings-riscv.patch
+++ b/neovide/skia-bindings-riscv.patch
@@ -1,0 +1,27 @@
+--- a/build_support/platform/linux.rs
++++ b/build_support/platform/linux.rs
+@@ -55,6 +55,7 @@
+         add_pkg_config_libs(&mut libs, "libpng", &["png16"]);
+         add_pkg_config_libs(&mut libs, "zlib", &["z"]);
+         add_pkg_config_libs(&mut libs, "harfbuzz", &["harfbuzz"]);
++        add_pkg_config_libs(&mut libs, "harfbuzz-subset", &["harfbuzz-subset", "harfbuzz"]);
+         add_pkg_config_libs(&mut libs, "expat", &["expat"]);
+ 
+         // ICU libraries - try pkg-config first, fallback to manual linking
+--- a/build_support/skia/config.rs
++++ b/build_support/skia/config.rs
+@@ -286,6 +286,14 @@
+         println!("Synchronizing Skia dependencies");
+         #[cfg(feature = "binary-cache")]
+         crate::build_support::binary_cache::resolve_dependencies();
++        if gn_command.is_some() {
++            let fetch_gn = build.skia_source_dir.join("bin").join("fetch-gn");
++            let fetch_gn_wrapper = "import sys\nsys.exit(0)\n";
++            if !fetch_gn.exists() {
++                std::fs::create_dir_all(fetch_gn.parent().unwrap()).unwrap();
++            }
++            std::fs::write(&fetch_gn, fetch_gn_wrapper).unwrap();
++        }
+         assert!(
+             Command::new(python)
+                 // Explicitly providing `GIT_SYNC_DEPS_PATH` fixes a problem with `git-sync-deps`


### PR DESCRIPTION
Build skia-bindings from a patched local crate source instead of pulling a git branch override.

skia-bindings runs Skia's fetch-gn during git-sync-deps, and that helper only maps amd64/x86_64 and arm64/aarch64, so it fails on riscv64 with KeyError: 'riscv64'. Arch already provides gn and the PKGBUILD sets SKIA_GN_COMMAND, so skip Skia's fetch-gn helper when an explicit GN command is configured.

Also add harfbuzz-subset to the runtime link dependencies and skia-bindings Linux system library list. Skia's PDF font subsetting code references hb_subset_input_create_or_fail and other hb_subset_* symbols, which are provided by libharfbuzz-subset rather than libharfbuzz.