### PR TITLE
addpatch: openai-codex 0.131.0-1

### DIFF
--- a/openai-codex/codex-landlock-riscv64-seccomp.patch
+++ b/openai-codex/codex-landlock-riscv64-seccomp.patch
@@ -1,0 +1,11 @@
+--- a/codex-rs/linux-sandbox/src/landlock.rs
++++ b/codex-rs/linux-sandbox/src/landlock.rs
+@@ -254,6 +254,8 @@
+             TargetArch::x86_64
+         } else if cfg!(target_arch = "aarch64") {
+             TargetArch::aarch64
++        } else if cfg!(target_arch = "riscv64") {
++            TargetArch::riscv64
+         } else {
+             unimplemented!("unsupported architecture for seccomp filter");
+         },

--- a/openai-codex/riscv64.patch
+++ b/openai-codex/riscv64.patch
@@ -18,7 +18,7 @@
  optdepends=(
    'git: allow for repository actions'
    'nodejs: enable the js_repl experimental tool'
-@@ -31,7 +40,13 @@
+@@ -31,7 +40,14 @@
  b2sums=('61a4a87ad506b5cdb2707e2951c1867b79780c2a14cbcf5bc88cad6ec8839191086c1c27fbffac07689b057e1b704c7d61282dd21fde2f2a30df1e9bffd4cb5c')
  
  prepare() {
@@ -27,12 +27,13 @@
 +  printf '%s\n' x86_64-unknown-linux-gnu riscv64gc-unknown-linux-gnu > v8-146.4.0/build/rust/known-target-triples.txt
 +
    cd codex-rust-v$pkgver/codex-rs
++  patch -Np1 -d .. -i "$srcdir/codex-landlock-riscv64-seccomp.patch"
 +  sed -i '/^\[patch\.crates-io\]$/a v8 = { path = "../../v8-146.4.0" }' Cargo.toml
 +  cargo update -p v8
  
    cargo fetch --target "$(rustc --print host-tuple)"
  }
-@@ -40,6 +55,28 @@
+@@ -40,6 +56,28 @@
    cd codex-rust-v$pkgver/codex-rs
    # Reduces build time by about 10 minutes
    export CARGO_PROFILE_RELEASE_LTO=thin
@@ -61,14 +62,16 @@
    cargo build --frozen --release --bin codex --bin codex-responses-api-proxy
  }
  
-@@ -59,3 +96,10 @@
+@@ -59,3 +97,12 @@
  }
  
  # vim:set ts=2 sw=2 et:
 +
 +source+=("v8-146.4.0.tar.gz::https://crates.io/api/v1/crates/v8/146.4.0/download"
 +         "v8-skip-rust-toolchain-download.patch"
-+         "v8-compiler-rt-adjust-paths.patch")
++         "v8-compiler-rt-adjust-paths.patch"
++         "codex-landlock-riscv64-seccomp.patch")
 +b2sums+=('623da35878451e84728b8afd0b35a975fcfa01e1af3ac266975f2635e515dc8585ddfbaf6b7a8dcfa65d8d6a939accaa0c7004eb1533be723bbc05df03e310c0'
 +         '705796e3675e5f67fa6999a2f4ba7591511c2c3b00001d9b4f2d4106b5f27dc036c89c48923429e9ab350f2a9dd47ca8f6b30c807f5e55902d698555605ea835'
-+         '232da9d87d9bda14be5b766c1fc164ee797fd58f4e8c97c26ae854fdb67cae12bfe97a546a941441565e1f632f4a5f3cbca3bd5849e1e8f8514e034087ac14db')
++         '232da9d87d9bda14be5b766c1fc164ee797fd58f4e8c97c26ae854fdb67cae12bfe97a546a941441565e1f632f4a5f3cbca3bd5849e1e8f8514e034087ac14db'
++         'e37f8db50ca7dc8ad916f98dffb7b69f9461a1e9f196880172d199a0d0b8f30a9fd5fdc60d011159b0aafcb41608909014db3e24077550617d9d282b94ab6a58')

--- a/openai-codex/riscv64.patch
+++ b/openai-codex/riscv64.patch
@@ -1,0 +1,74 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -20,7 +20,16 @@
+   xz
+   zlib
+ )
+-makedepends=(cargo)
++makedepends=(
++  cargo
++  clang
++  gn
++  libffi
++  lld
++  ninja
++  python
++  rust-bindgen
++)
+ optdepends=(
+   'git: allow for repository actions'
+   'nodejs: enable the js_repl experimental tool'
+@@ -31,7 +40,13 @@
+ b2sums=('61a4a87ad506b5cdb2707e2951c1867b79780c2a14cbcf5bc88cad6ec8839191086c1c27fbffac07689b057e1b704c7d61282dd21fde2f2a30df1e9bffd4cb5c')
+ 
+ prepare() {
++  patch -Np1 -d v8-146.4.0 -i "$srcdir/v8-skip-rust-toolchain-download.patch"
++  patch -Np1 -d v8-146.4.0 -i "$srcdir/v8-compiler-rt-adjust-paths.patch"
++  printf '%s\n' x86_64-unknown-linux-gnu riscv64gc-unknown-linux-gnu > v8-146.4.0/build/rust/known-target-triples.txt
++
+   cd codex-rust-v$pkgver/codex-rs
++  sed -i '/^\[patch\.crates-io\]$/a v8 = { path = "../../v8-146.4.0" }' Cargo.toml
++  cargo update -p v8
+ 
+   cargo fetch --target "$(rustc --print host-tuple)"
+ }
+@@ -40,6 +55,28 @@
+   cd codex-rust-v$pkgver/codex-rs
+   # Reduces build time by about 10 minutes
+   export CARGO_PROFILE_RELEASE_LTO=thin
++
++  local _clang_version=$(clang -dumpversion | cut -d . -f 1)
++  local _rustc_version=$(rustc --version)
++  local _extra_gn_args=(
++    'custom_toolchain="//build/toolchain/linux/unbundle:default"'
++    'host_toolchain="//build/toolchain/linux/unbundle:default"'
++    "clang_version=\"$_clang_version\""
++    'rust_sysroot_absolute="/usr"'
++    'rust_bindgen_root="/usr"'
++    "rustc_version=\"$_rustc_version\""
++    'use_system_libffi=true'
++    # The crates.io v8 source omits third_party/rust/chromium_crates_io/vendor.
++    'v8_enable_temporal_support=false'
++  )
++
++  export CC=clang CXX=clang++ AR=ar NM=nm
++  export V8_FROM_SOURCE=1
++  export RUSTY_V8_SKIP_RUST_TOOLCHAIN_DOWNLOAD=1
++  export CLANG_BASE_PATH=/usr
++  export GN=/usr/bin/gn NINJA=/usr/bin/ninja
++  export EXTRA_GN_ARGS="${_extra_gn_args[*]}"
++
+   cargo build --frozen --release --bin codex --bin codex-responses-api-proxy
+ }
+ 
+@@ -59,3 +96,10 @@
+ }
+ 
+ # vim:set ts=2 sw=2 et:
++
++source+=("v8-146.4.0.tar.gz::https://crates.io/api/v1/crates/v8/146.4.0/download"
++         "v8-skip-rust-toolchain-download.patch"
++         "v8-compiler-rt-adjust-paths.patch")
++b2sums+=('623da35878451e84728b8afd0b35a975fcfa01e1af3ac266975f2635e515dc8585ddfbaf6b7a8dcfa65d8d6a939accaa0c7004eb1533be723bbc05df03e310c0'
++         '705796e3675e5f67fa6999a2f4ba7591511c2c3b00001d9b4f2d4106b5f27dc036c89c48923429e9ab350f2a9dd47ca8f6b30c807f5e55902d698555605ea835'
++         '232da9d87d9bda14be5b766c1fc164ee797fd58f4e8c97c26ae854fdb67cae12bfe97a546a941441565e1f632f4a5f3cbca3bd5849e1e8f8514e034087ac14db')

--- a/openai-codex/v8-compiler-rt-adjust-paths.patch
+++ b/openai-codex/v8-compiler-rt-adjust-paths.patch
@@ -1,0 +1,36 @@
+--- a/build/config/clang/BUILD.gn
++++ b/build/config/clang/BUILD.gn
+@@ -184,16 +184,20 @@
+       } else if (is_linux || is_chromeos) {
+         if (current_cpu == "x64") {
+           _dir = "x86_64-unknown-linux-gnu"
++          _suffix = "-x86_64"
+         } else if (current_cpu == "x86") {
+           _dir = "i386-unknown-linux-gnu"
++          _suffix = "-i386"
+         } else if (current_cpu == "arm") {
+           _dir = "armv7-unknown-linux-gnueabihf"
+         } else if (current_cpu == "arm64") {
+           _dir = "aarch64-unknown-linux-gnu"
++          _suffix = "-aarch64"
+         } else if (current_cpu == "loong64") {
+           _dir = "loongarch64-unknown-linux-gnu"
+         } else if (current_cpu == "riscv64") {
+           _dir = "riscv64-unknown-linux-gnu"
++          _suffix = "-riscv64"
+         } else if (current_cpu == "ppc64") {
+           _dir = "ppc64le-unknown-linux-gnu"
+         } else if (current_cpu == "s390x") {
+@@ -228,6 +232,12 @@
+         assert(false)  # Unhandled target platform
+       }
+ 
++      # Arch's compiler-rt package installs Linux runtimes as
++      # lib/linux/libclang_rt.*-$arch.a.
++      if (is_linux || is_chromeos) {
++        _dir = "linux"
++      }
++
+       _clang_lib_dir = "$clang_base_path/lib/clang/$clang_version/lib"
+       _lib_file = "${_prefix}clang_rt.${_libname}${_suffix}.${_ext}"
+       libs = [ "$_clang_lib_dir/$_dir/$_lib_file" ]

--- a/openai-codex/v8-skip-rust-toolchain-download.patch
+++ b/openai-codex/v8-skip-rust-toolchain-download.patch
@@ -1,0 +1,21 @@
+--- a/build.rs
++++ b/build.rs
+@@ -41,6 +41,7 @@
+     "RUSTY_V8_ARCHIVE",
+     "RUSTY_V8_MIRROR",
+     "RUSTY_V8_SRC_BINDING_PATH",
++    "RUSTY_V8_SKIP_RUST_TOOLCHAIN_DOWNLOAD",
+     "SCCACHE",
+     "V8_FORCE_DEBUG",
+     "V8_FROM_SOURCE",
+@@ -253,7 +254,9 @@
+     download_ninja_gn_binaries();
+   }
+ 
+-  download_rust_toolchain();
++  if env::var_os("RUSTY_V8_SKIP_RUST_TOOLCHAIN_DOWNLOAD").is_none() {
++    download_rust_toolchain();
++  }
+ 
+   // `#[cfg(...)]` attributes don't work as expected from build.rs -- they refer to the configuration
+   // of the host system which the build.rs script will be running on. In short, `cfg!(target_<os/arch>)`


### PR DESCRIPTION
rusty_v8 has no upstream prebuilt artifact for riscv64, so the package has to build the locked v8 146.4.0 crate from source.

The source build first fails in GN because build/config/rust.gni tries to read build/rust/known-target-triples.txt, which is not present in the crates.io v8 archive. Provide the host and target triples before cargo runs the v8 build script.

After that, ninja looks for /usr/lib/clang/22/lib/riscv64-unknown-linux-gnu/libclang_rt.builtins.a. Arch's compiler-rt package installs the runtime under lib/linux/libclang_rt.builtins-riscv64.a instead, matching the path adjustment carried by other Chromium/V8 based packages such as deno.

The crates.io v8 archive also omits third_party/rust/chromium_crates_io/vendor, while the default GN graph can reference missing targets such as vendor/icu_calendar_data-v2/build.rs through Temporal support. Disable v8_enable_temporal_support for this package-side source build rather than pulling in a full Chromium submodule checkout.

Patch rusty_v8 so RUSTY_V8_SKIP_RUST_TOOLCHAIN_DOWNLOAD can keep the build on Arch's system Rust toolchain, and pass GN arguments for system clang, gn, ninja, bindgen, and libffi.

codex-rs/linux-sandbox/src/landlock.rs selects a seccomp TargetArch only for x86_64 and aarch64. On riscv64 the package would reach the unsupported architecture branch for the network seccomp filter.

Add riscv64 to the Landlock seccomp architecture selection and apply that patch before the Cargo build. Keep it separate from the V8 source-build patches so the local Codex change is visible.

Patch suggested by @Xeonacid.