### PR TITLE
addpatch: gcc15 15.2.1+r934+gbcd3e3ff5aa7-1

### DIFF
--- a/gcc15/riscv64.patch
+++ b/gcc15/riscv64.patch
@@ -1,0 +1,30 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -132,8 +132,6 @@
+ 
+   cd gcc-build
+   make -C $CHOST/libgcc DESTDIR="$pkgdir" install-shared
+-  mv "${pkgdir}/${_libdir}"/../lib/* "${pkgdir}/${_libdir}"
+-  rmdir "${pkgdir}/${_libdir}"/../lib
+   rm -f "$pkgdir/$_libdir/libgcc_eh.a"
+ 
+   for lib in libasan.so \
+@@ -175,8 +173,7 @@
+   install -m755 -t "$pkgdir/${_libdir}/" gcc/{cc1,cc1plus,collect2,lto1,gcov{,-tool}}
+ 
+   make -C $CHOST/libgcc DESTDIR="$pkgdir" install
+-  rm -f "${pkgdir}/${_libdir}"/../lib/libgcc_s.so*
+-  rmdir "${pkgdir}/${_libdir}"/../lib
++  rm -f "${pkgdir}/${_libdir}"/libgcc_s.so*
+ 
+   make -C $CHOST/libstdc++-v3/src DESTDIR="$pkgdir" install
+   make -C $CHOST/libstdc++-v3/include DESTDIR="$pkgdir" install
+@@ -210,7 +207,7 @@
+   # create cc-rs compatible symlinks
+   # https://github.com/rust-lang/cc-rs/blob/1.0.73/src/lib.rs#L2578-L2581
+   for binary in {c++,g++,gcc,gcc-ar,gcc-nm,gcc-ranlib}; do
+-    ln -s /usr/bin/${binary} "${pkgdir}"/usr/bin/x86_64-linux-gnu-${binary}-15
++    ln -s /usr/bin/${binary} "${pkgdir}"/usr/bin/riscv64-linux-gnu-${binary}-15
+   done
+ 
+   # POSIX conformance launcher scripts for c89 and c99


### PR DESCRIPTION
package_gcc15-libs() fails on riscv64 with:

mv: cannot stat '/build/gcc15/pkg/gcc15-libs/usr/lib/gcc/riscv64-unknown-linux-gnu/15.2.1/../lib/*': No such file or directory

The package assumes the x86_64 version-specific-runtime-libs layout where libgcc shared files are installed below \/../lib and then moved into \. On riscv64 the libgcc install already places those files in \, so the move and rmdir target a directory that does not exist.

Drop the invalid move in package_gcc15-libs() and remove libgcc_s.so directly from \ in package_gcc15(), matching the riscv64 layout. Also create the cc-rs compatibility symlinks with the riscv64-linux-gnu triplet instead of x86_64-linux-gnu.