### PR TITLE
updpatch: chromium 148.0.7778.167-2

### DIFF
--- a/chromium/DEPS-remove-native-binaries.diff
+++ b/chromium/DEPS-remove-native-binaries.diff
@@ -1,8 +1,19 @@
 diff --git a/DEPS b/DEPS
-index aeeb3bf541..fc215c3480 100644
+index 213a9a623b..3b88468a24 100644
 --- a/DEPS
 +++ b/DEPS
-@@ -1682,19 +1682,6 @@ deps = {
+@@ -1091,10 +1091,6 @@ deps = {
+   },
+   'src/buildtools/reclient': {
+     'packages': [
+-      {
+-        'package': Var('reclient_package') + '${{platform}}',
+-        'version': Var('reclient_version'),
+-      }
+     ],
+     'condition': 'download_reclient and non_git_source',
+     'dep_type': 'cipd',
+@@ -1694,19 +1690,6 @@ deps = {
  
    'src/tools/luci-go': {
        'packages': [
@@ -22,7 +33,18 @@ index aeeb3bf541..fc215c3480 100644
        ],
        'condition': 'non_git_source',
        'dep_type': 'cipd',
-@@ -2566,20 +2553,12 @@ deps = {
+@@ -2196,10 +2179,6 @@ deps = {
+ 
+   'src/third_party/gperf/cipd': {
+       'packages': [
+-        {
+-          'package': 'infra/3pp/tools/gperf/${{platform}}',
+-          'version': 'version:3@3.2',
+-        },
+       ],
+       'condition': 'host_os == "linux" and non_git_source',
+       'dep_type': 'cipd',
+@@ -2579,20 +2558,12 @@ deps = {
  
    'src/third_party/ninja': {
      'packages': [
@@ -43,3 +65,14 @@ index aeeb3bf541..fc215c3480 100644
      ],
      'condition': 'non_git_source',
      'dep_type': 'cipd',
+@@ -3442,10 +3413,6 @@ deps = {
+ 
+   'src/tools/resultdb': {
+       'packages': [
+-        {
+-          'package': 'infra/tools/result_adapter/${{platform}}',
+-          'version': Var('result_adapter_revision'),
+-        },
+       ],
+       'condition': 'non_git_source',
+       'dep_type': 'cipd',

--- a/chromium/riscv-v8.patch
+++ b/chromium/riscv-v8.patch
@@ -1,57 +1,32 @@
-From cd2c216e7658c19bc6501fc785ac2f4be1a3734f Mon Sep 17 00:00:00 2001
+From 6899a7f2d7a46b919151df31c7f1ee8048d0b5c4 Mon Sep 17 00:00:00 2001
 From: LuYahan <yahan@iscas.ac.cn>
-Date: Thu, 26 Feb 2026 08:53:12 +0800
-Subject: [PATCH] [riscv][jspi] Clear EPT entry on stack return
+Date: Thu, 02 Apr 2026 11:42:54 +0800
+Subject: [PATCH] [riscv] Reland [wasm-wide-arith] Turboshaft x64 implementation of wide multiplication ops.
 
-Port commit 54cf5fa964f0734a8277ea2837aa2e4168e3240a
-Bug: 485784597
+Port commit 3eaece8bee7483f7f71d3c7a6b3ad021c7c5fb65
+Bug: 491766259
 
-Change-Id: I4a7e12d9047f7a4257be4711d9d6645d42f02a38
-Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/7608971
-Commit-Queue: Ji Qiu <qiuji@iscas.ac.cn>
+Change-Id: I6696de994b643cd80c6d0cd1b3294a6b145f84d8
+Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/7722162
+Commit-Queue: Yahan Lu (LuYahan) <yahan@iscas.ac.cn>
 Reviewed-by: Ji Qiu <qiuji@iscas.ac.cn>
-Cr-Commit-Position: refs/heads/main@{#105464}
+Commit-Queue: Ji Qiu <qiuji@iscas.ac.cn>
+Auto-Submit: Yahan Lu (LuYahan) <yahan@iscas.ac.cn>
+Cr-Commit-Position: refs/heads/main@{#106298}
 ---
- src/builtins/riscv/builtins-riscv.cc | 12 +++++++-----
- 1 file changed, 7 insertions(+), 5 deletions(-)
 
-diff --git a/src/builtins/riscv/builtins-riscv.cc b/src/builtins/riscv/builtins-riscv.cc
-index 77918ffad3c..7c68c8b634c 100644
---- a/src/builtins/riscv/builtins-riscv.cc
-+++ b/src/builtins/riscv/builtins-riscv.cc
-@@ -3836,7 +3836,8 @@ void SwitchStacks(MacroAssembler* masm, ExternalReference fn,
-   {
-     FrameScope scope(masm, StackFrame::MANUAL);
-     DCHECK(old_stack.is_valid());
--    bool is_return = fn == ExternalReference::wasm_return_stack();
-+    bool is_return = fn == ExternalReference::wasm_return_jspi_stack() ||
-+                     fn == ExternalReference::wasm_return_wasmfx_stack();
-     int num_args = is_return ? 2 : 5;
-     if (maybe_suspender.is_valid()) {
-       num_args++;
-@@ -3874,8 +3875,9 @@ void ReloadParentStack(MacroAssembler* masm, Register return_reg,
-   __ LoadWord(parent, MemOperand(active_stack, wasm::kStackParentOffset));
- 
-   // Switch stack!
--  SwitchStacks(masm, ExternalReference::wasm_return_stack(), parent, nullptr,
--               no_reg, tmp3, {return_reg, return_value, context, parent});
-+  SwitchStacks(masm, ExternalReference::wasm_return_jspi_stack(), parent,
-+               nullptr, no_reg, tmp3,
-+               {return_reg, return_value, context, parent});
-   LoadJumpBuffer(masm, parent, false, tmp3);
+diff --git a/src/compiler/backend/riscv/instruction-selector-riscv64.cc b/src/compiler/backend/riscv/instruction-selector-riscv64.cc
+index d695f2a..29f6959 100644
+--- a/src/compiler/backend/riscv/instruction-selector-riscv64.cc
++++ b/src/compiler/backend/riscv/instruction-selector-riscv64.cc
+@@ -1100,6 +1100,10 @@
+   VisitRRR(this, kRiscvMul64, node);
  }
  
-@@ -4228,8 +4230,8 @@ void Builtins::Generate_WasmFXReturn(MacroAssembler* masm) {
-   DEFINE_PINNED(parent, a2);
-   __ Move(parent, MemOperand(active_stack, wasm::kStackParentOffset));
-   DEFINE_REG(scratch);
--  SwitchStacks(masm, ExternalReference::wasm_return_stack(), parent, nullptr,
--               no_reg, scratch, {parent, arg_buffer});
-+  SwitchStacks(masm, ExternalReference::wasm_return_wasmfx_stack(), parent,
-+               nullptr, no_reg, scratch, {parent, arg_buffer});
-   LoadJumpBuffer(masm, parent, true, scratch);
-   __ Trap();
- }
--- 
-2.53.0
-
++void InstructionSelector::VisitWord64MulWide(OpIndex node, bool is_signed) {
++  UNIMPLEMENTED();
++}
++
+ void InstructionSelector::VisitInt32Div(OpIndex node) {
+   VisitRRR(this, kRiscvDiv32, node,
+            OperandGenerator::RegisterUseKind::kUseUniqueRegister);

--- a/chromium/riscv64.patch
+++ b/chromium/riscv64.patch
@@ -1,6 +1,15 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -77,11 +77,15 @@ sha256sums=('57594966be592efdb9fe6491f5a834de237f5c7decdca5eb1f7d7a5d38dd54e9'
+@@ -69,7 +69,7 @@ source=(https://commondatastorage.googleapis.com/chromium-browser-official/chrom
+         enable-widevine-arm64.patch
+         use-oauth2-client-switches-as-default.patch
+         glibc-2.42-baud-rate-fix.patch)
+-sha256sums=('2e2f36e3cd1ebc4ad57fd310774a5e5e9db77883d5f9374fedeaabd3c103b819'
++sha256sums=('f0aed11f2dba184a4249094e33a1840be6705bba1cdb4e2a40b31e5d12fe80d3'
+             '213e50f48b67feb4441078d50b0fd431df34323be15be97c55302d3fdac4483a'
+             '11a96ffa21448ec4c63dd5c8d6795a1998d8e5cd5a689d91aea4d2bdd13fb06e'
+             '4fc040a0656a0a524dd8ad090cd129fc5b6cb21adcc66be82080165789e8c13e'
+@@ -83,11 +83,16 @@ sha256sums=('2e2f36e3cd1ebc4ad57fd310774a5e5e9db77883d5f9374fedeaabd3c103b819'
              'd634d2ce1fc63da7ac41f432b1e84c59b7cceabf19d510848a7cff40c8025342'
              '9c766b82d1143cb3413fe2057361bd2655e46287eacc2c6d6f8504b4c255647a'
              '9343afa1a4308a7cfb3317229f5aff7778688debcc03c4a74a85908aa1d0cc3a'
@@ -8,8 +17,9 @@
 +            '1c1898f263eaacbc069a8e1a3e732852350350d1dad4cb1a6bba430e3b796cd0'
 +            '2ea949ed1d20a1745ce72f760a7d9297dc0002a747c4bd53e243c4d58ba2c7ca'
 +            '7b5e90a85835ed867103a9e3bf7b334d35a3ac50dab58b7642978f6ec5fb9821'
++            'fee992c21a13d32b2a646d42833862a2e63af74934d53f9edf878cf10e5e7a35'
 +            '3eb5e621757be3f2984acb76d16cf3571bfe5bbbc71ad230b21aa983041ff5ea'
-+            'ddd02dbb1dafee30ea78c6694f064da3abce5230c84b27e12132c3a7f16b7a2f')
++            '1c4f34675ed826bff5eff7ee8a3d3004c2a7842072b931526f26debd040b96bb')
  
  if (( _manual_clone )); then
    source[0]=fetch-chromium-release
@@ -18,24 +28,34 @@
    makedepends+=('python-httplib2' 'python-pyparsing' 'python-six' 'npm' 'rsync')
  fi
  
-@@ -148,6 +152,11 @@ prepare() {
+@@ -157,6 +162,12 @@ prepare() {
    # runtime -- this allows signing into Chromium without baked-in values
    patch -Np1 -i ../use-oauth2-client-switches-as-default.patch
  
 +  # RISC-V
 +  patch -Np0 -i ../swiftshader-use-llvm16.patch
 +  patch -Np1 -i ../riscv-sandbox.patch
++  patch -Np1 -d v8 < ../riscv-v8.patch
 +  patch -Np0 -i ../Debian-fix-rust-linking.patch
 +
    # Upstream fixes
  
    # Fixes from Gentoo
-@@ -395,4 +404,9 @@ package() {
+@@ -205,6 +216,7 @@ prepare() {
+   ln -s /usr/bin/java third_party/jdk/current/bin/
+ 
+   # remove x86_64 binary and use our own
++  mkdir -p third_party/gperf/cipd/bin/
+   rm -f third_party/gperf/cipd/bin/gperf
+   ln -s /usr/bin/gperf third_party/gperf/cipd/bin/
+ 
+@@ -421,4 +433,10 @@ package() {
    install -Dvm644 LICENSE "$pkgdir/usr/share/licenses/chromium/LICENSE"
  }
  
 +source+=(swiftshader-use-llvm16.patch
 +         riscv-sandbox.patch
++         riscv-v8.patch
 +         Debian-fix-rust-linking.patch
 +         DEPS-remove-native-binaries.diff)
 +


### PR DESCRIPTION
- Update DEPS-remove-native-binaries.diff to handle more binaries to fix `gclient sync` failure.
- Pick up new v8 build fix.