### PR TITLE
addpatch: nvm 0.40.4-1

### DIFF
--- a/nvm/riscv64.patch
+++ b/nvm/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -28,6 +28,8 @@
+   rm -v "test/fast/Unit tests/nvm_download"
+   rm -v "test/fast/Unit tests/nvm_get_arch"
+   rm -v "test/fast/Unit tests/nvm_get_arch_unofficial"
++  # Hardcodes a linux-x64 Node.js v0.12.18 binary; that release has no riscv64 binary.
++  rm -v "test/fast/Unit tests/nvm_install_no_progress_bar"
+   # Requires submodule, skip.
+   rm -v "test/fast/Unit tests/nvm_process_nvmrc"
+   # Fails in a chroot for some reason.


### PR DESCRIPTION
Skip nvm_install_no_progress_bar on riscv64. The test hardcodes the linux-x64 Node.js v0.12.18 binary in its expected output, but that old Node.js release only ships Linux x64 and x86 binaries.

The observed failure is: Could not find /build/nvm/src/nvm/*/bin in PATH; Alias default doesn't exist. This keeps the existing Arch test skips unchanged and removes only the non-portable test.