### PR TITLE
updpatch: openai-codex 0.133.0-1

### DIFF
--- a/openai-codex/riscv64.patch
+++ b/openai-codex/riscv64.patch
@@ -18,22 +18,23 @@
  optdepends=(
    'git: allow for repository actions'
    'nodejs: enable the js_repl experimental tool'
-@@ -31,7 +40,14 @@
- b2sums=('61a4a87ad506b5cdb2707e2951c1867b79780c2a14cbcf5bc88cad6ec8839191086c1c27fbffac07689b057e1b704c7d61282dd21fde2f2a30df1e9bffd4cb5c')
+@@ -31,7 +40,15 @@
+ b2sums=('2d4b5b1aa7e5ca2b5d83736711ce6e45c3530ed8eee08c950161464c3159a9e5f0c446b261fd2c7df19cd28d6e212a69a05a3e1a19060d2c8cc31753639bbebb')
  
  prepare() {
-+  patch -Np1 -d v8-146.4.0 -i "$srcdir/v8-skip-rust-toolchain-download.patch"
-+  patch -Np1 -d v8-146.4.0 -i "$srcdir/v8-compiler-rt-adjust-paths.patch"
-+  printf '%s\n' x86_64-unknown-linux-gnu riscv64gc-unknown-linux-gnu > v8-146.4.0/build/rust/known-target-triples.txt
++  patch -Np1 -d v8-147.4.0 -i "$srcdir/v8-skip-rust-toolchain-download.patch"
++  patch -Np1 -d v8-147.4.0 -i "$srcdir/v8-compiler-rt-adjust-paths.patch"
++  patch -Np1 -d v8-147.4.0 -i "$srcdir/v8-drop-unsupported-clang-flags.patch"
++  printf '%s\n' x86_64-unknown-linux-gnu riscv64gc-unknown-linux-gnu > v8-147.4.0/build/rust/known-target-triples.txt
 +
    cd codex-rust-v$pkgver/codex-rs
 +  patch -Np1 -d .. -i "$srcdir/codex-landlock-riscv64-seccomp.patch"
-+  sed -i '/^\[patch\.crates-io\]$/a v8 = { path = "../../v8-146.4.0" }' Cargo.toml
++  sed -i '/^\[patch\.crates-io\]$/a v8 = { path = "../../v8-147.4.0" }' Cargo.toml
 +  cargo update -p v8
  
    cargo fetch --target "$(rustc --print host-tuple)"
  }
-@@ -40,6 +56,28 @@
+@@ -40,6 +57,28 @@
    cd codex-rust-v$pkgver/codex-rs
    # Reduces build time by about 10 minutes
    export CARGO_PROFILE_RELEASE_LTO=thin
@@ -62,16 +63,18 @@
    cargo build --frozen --release --bin codex --bin codex-responses-api-proxy
  }
  
-@@ -59,3 +97,12 @@
+@@ -59,3 +98,14 @@
  }
  
  # vim:set ts=2 sw=2 et:
 +
-+source+=("v8-146.4.0.tar.gz::https://crates.io/api/v1/crates/v8/146.4.0/download"
++source+=("v8-147.4.0.tar.gz::https://crates.io/api/v1/crates/v8/147.4.0/download"
 +         "v8-skip-rust-toolchain-download.patch"
 +         "v8-compiler-rt-adjust-paths.patch"
++         "v8-drop-unsupported-clang-flags.patch"
 +         "codex-landlock-riscv64-seccomp.patch")
-+b2sums+=('623da35878451e84728b8afd0b35a975fcfa01e1af3ac266975f2635e515dc8585ddfbaf6b7a8dcfa65d8d6a939accaa0c7004eb1533be723bbc05df03e310c0'
++b2sums+=('cd31f952973fe76535641a3d6901328de55ec6b331f8997f025c8601ce458f66ad3b2064193a545e6814b6d38e56c493eb240823de94d4a41f547a32b36d93ae'
 +         '705796e3675e5f67fa6999a2f4ba7591511c2c3b00001d9b4f2d4106b5f27dc036c89c48923429e9ab350f2a9dd47ca8f6b30c807f5e55902d698555605ea835'
-+         '232da9d87d9bda14be5b766c1fc164ee797fd58f4e8c97c26ae854fdb67cae12bfe97a546a941441565e1f632f4a5f3cbca3bd5849e1e8f8514e034087ac14db'
++         '2a020432f57be950466617b3d0a8fc93233ded9ebed060a1f7b4f1635f5bca8001aa0cf0339331f99339bce6052efe8dd7edcfcb9e881d1e0116f91d3dfbf9b1'
++         '86e864f998e7755ab902c4f3dde08c9ad2bfaf0378cad7127f3ed491fa818afdcec9e3e6617917811e03a41664c5e8900446a480065efe9493f0a5d0ec7e3c0e'
 +         'e37f8db50ca7dc8ad916f98dffb7b69f9461a1e9f196880172d199a0d0b8f30a9fd5fdc60d011159b0aafcb41608909014db3e24077550617d9d282b94ab6a58')

--- a/openai-codex/v8-compiler-rt-adjust-paths.patch
+++ b/openai-codex/v8-compiler-rt-adjust-paths.patch
@@ -1,6 +1,6 @@
 --- a/build/config/clang/BUILD.gn
 +++ b/build/config/clang/BUILD.gn
-@@ -184,16 +184,20 @@
+@@ -187,16 +187,20 @@
        } else if (is_linux || is_chromeos) {
          if (current_cpu == "x64") {
            _dir = "x86_64-unknown-linux-gnu"
@@ -21,7 +21,7 @@
          } else if (current_cpu == "ppc64") {
            _dir = "ppc64le-unknown-linux-gnu"
          } else if (current_cpu == "s390x") {
-@@ -228,6 +232,12 @@
+@@ -231,6 +235,12 @@
          assert(false)  # Unhandled target platform
        }
  

--- a/openai-codex/v8-drop-unsupported-clang-flags.patch
+++ b/openai-codex/v8-drop-unsupported-clang-flags.patch
@@ -1,0 +1,29 @@
+--- a/build/config/compiler/BUILD.gn
++++ b/build/config/compiler/BUILD.gn
+@@ -625,13 +625,6 @@
+       ]
+     }
+ 
+-    # The performance improvement does not seem worth the risk. See
+-    # https://crbug.com/484082200 for background and https://crrev.com/c/7593035
+-    # for discussion.
+-    if (!is_wasm) {
+-      cflags += [ "-fno-lifetime-dse" ]
+-    }
+-
+     # TODO(hans): Remove this once Clang generates better optimized debug info
+     # by default. https://crbug.com/765793
+     cflags += [
+@@ -1893,12 +1886,6 @@
+       "-fsanitize=array-bounds",
+       "-fsanitize-trap=array-bounds",
+ 
+-      # Some code users feature detection to determine if UBSAN (or any
+-      # sanitizer) is enabled, they then do expensive debug like operations. We
+-      # want to suppress this behaviour since we want to keep performance costs
+-      # as low as possible while having these checks.
+-      "-fsanitize-ignore-for-ubsan-feature=array-bounds",
+-
+       # Because we've enabled array-bounds sanitizing we also want to suppress
+       # the related warning about "unsafe-buffer-usage-in-static-sized-array",
+       # since we know that the array bounds sanitizing will catch any out-of-


### PR DESCRIPTION
Refresh the V8 source override from 146.4.0 to 147.4.0 so Cargo uses the patched crate selected by openai-codex 0.133.0. Without this, the build falls back to registry v8 147.4.0 and looks for compiler-rt under riscv64-unknown-linux-gnu/libclang_rt.builtins.a instead of Arch's lib/linux/libclang_rt.builtins-riscv64.a.

Also drop V8 clang flags rejected by Arch's clang 22: -fno-lifetime-dse and -fsanitize-ignore-for-ubsan-feature=array-bounds. Chromium carries the same class of workaround until LLVM 23, and Deno removes these flags for rusty_v8 147.4.0 as well.