### PR TITLE
addpatch: worktrunk 0.56.0-1

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -138,6 +138,7 @@ valkey
 vim
 wanderlust
 wayland
+worktrunk
 xfsprogs
 xmonk.lv2
 zeromq

--- a/worktrunk/riscv64.patch
+++ b/worktrunk/riscv64.patch
@@ -1,0 +1,12 @@
+diff --git PKGBUILD PKGBUILD
+index 2cc0e41..22f94ea 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -36,6 +36,7 @@
+   cargo test -- \
+     --skip git::recover::tests::test_current_or_recover_returns_repo_when_cwd_exists \
+     --skip git::recover::tests::test_hint_for_repo_suggests_switch \
++    --skip git::repository::working_tree::tests::working_tree_diff_stats_with_untracked_counts_untracked_and_preserves_real_index \
+     --skip integration_tests
+ }
+ 


### PR DESCRIPTION
- Add to qemu-user-blacklist. Two tests rely on the `CLONE_VFORK` behavior which is unimplemented on qemu-user. https://github.com/max-sixty/worktrunk/pull/3015
- Skip a git test which has concurrency issue on low-end machines. https://github.com/max-sixty/worktrunk/pull/3014