### PR TITLE
updpatch: compiler-rt 22.1.6-1

### DIFF
--- a/compiler-rt/riscv64.patch
+++ b/compiler-rt/riscv64.patch
@@ -1,20 +1,6 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -14,9 +14,11 @@
- makedepends_x86_64=('lib32-gcc-libs')
- options=('staticlibs' '!lto')
- _source_base=https://github.com/llvm/llvm-project/releases/download/llvmorg-$pkgver
--source=($_source_base/llvm-project-$pkgver.src.tar.xz{,.sig})
-+source=($_source_base/llvm-project-$pkgver.src.tar.xz{,.sig}
-+        "fix-cfloat128-detection.patch::https://github.com/llvm/llvm-project/commit/ea9f8b77467fdbfab0d5bb3342e97de6b54e4e2d.patch")
- sha256sums=('7972b87b705a003ce70ab55f9f0fb495d156887cba0eb296d284731139118e2c'
--            'SKIP')
-+            'SKIP'
-+            '7889ae188557c6172d2a31e7c7354a69f8a8a561b064e569122ccd9c86c07545')
- 
- validpgpkeys=('474E22316ABF4785A88C6E8EA2C794A986419D8A'  # Tom Stellard <tstellar@redhat.com>
-               'D574BD5D1D0E98895E3BF90044F2485E45D59042'  # Tobias Hieta <tobias@hieta.se>
-@@ -25,7 +27,12 @@
+@@ -25,7 +25,12 @@
  )
  
  prepare() {
@@ -28,3 +14,11 @@
    mkdir build
  }
  
+@@ -50,4 +55,7 @@
+   install -Dm644 "$srcdir/llvm-project-$pkgver.src/compiler-rt/LICENSE.TXT" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+ }
+ 
++source+=("fix-cfloat128-detection.patch::https://github.com/llvm/llvm-project/commit/ea9f8b77467fdbfab0d5bb3342e97de6b54e4e2d.patch")
++sha256sums+=('7889ae188557c6172d2a31e7c7354a69f8a8a561b064e569122ccd9c86c07545')
++
+ # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
Use source+=/sha256sums+= for the backported cfloat128 fix.