### PR TITLE
updpatch: protobuf 35.0-1: refresh PyPI sdist workaround

### DIFF
--- a/protobuf/riscv64.patch
+++ b/protobuf/riscv64.patch
@@ -1,8 +1,6 @@
-diff --git PKGBUILD PKGBUILD
-index b23f32b..b8c9dde 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -24,7 +24,6 @@ depends=(
+@@ -24,7 +24,6 @@
    'zlib'
  )
  makedepends=(
@@ -10,30 +8,29 @@ index b23f32b..b8c9dde 100644
    'cmake'
    'git'
    'gtest'
-@@ -46,10 +45,13 @@ source=(
+@@ -45,9 +44,12 @@
+ source=(
    git+https://github.com/protocolbuffers/protobuf.git#tag=v$pkgver
    protobuf-fix-build-type-none.patch
-   protobuf-33-patch-enum-traits-impl.patch
 +  # Keep it here instead of bottom of the file because this file updates along with the package
 +  "$pkgbase-$pkgver-python.tar.gz::https://files.pythonhosted.org/packages/source/${pkgbase::1}/${pkgbase//-/_}/${pkgbase//-/_}-7.$pkgver.tar.gz"
  )
- sha512sums=('22083bdc3b71d4b77902eb2372b04136bbcac9a7ee05a2d3e197d9d2ce45e8cf0b6c0c445076102ace485162c5020b93ef52bd26d4fd8fba780137b80cacd1a4'
-             '18bc71031bbcbc3810a9985fa670465040f06a6c104ab8079b56bdfc499bb6cec40805a0cefd455031142490a576dc60aa8000523877ac0353b93558e9beabbd'
--            '8f7b8cb3829490962668bbb0eb8104f565a16bb336669e03afdc355c7ad50efb094851f7f78eba0d0a9704290b1c45ec56c9e6d6677cbf96ccfbfb659c014756')
-+            '8f7b8cb3829490962668bbb0eb8104f565a16bb336669e03afdc355c7ad50efb094851f7f78eba0d0a9704290b1c45ec56c9e6d6677cbf96ccfbfb659c014756'
-+            '9ad533b9bb72c7d490578e63afd704b1ec50b5b1689cfe4da8c7897ec523b7286f690e4952646fa95e65bac9c6a9722e55df41f42116e163bfec89e84d251b7f')
+ sha512sums=('4e7ae4e5a37e0156a57532b73b758282193d6d5dcaa772fd793ccbbd20ef9471dda670932605baa382fa387938c94ef7000ecb39cf5ef7a7010d4cb1069a9403'
+-            '18bc71031bbcbc3810a9985fa670465040f06a6c104ab8079b56bdfc499bb6cec40805a0cefd455031142490a576dc60aa8000523877ac0353b93558e9beabbd')
++            '18bc71031bbcbc3810a9985fa670465040f06a6c104ab8079b56bdfc499bb6cec40805a0cefd455031142490a576dc60aa8000523877ac0353b93558e9beabbd'
++            '009307d9d19139ec219f7d3f05db1f9d2894bcd8029c7ba12c367ea7f08a2393af2008baf92ae86b6ebbf1ab51f9578b842a124d2d8203a5d9ce6f2fbdb5ef2e')
  
  options=(!lto)
  
-@@ -57,7 +59,6 @@ _gemname=google-protobuf
+@@ -55,7 +57,6 @@
  
  prepare() {
    cd "$pkgname"
 -  bazel --version
  
    patch -p1 < ../protobuf-fix-build-type-none.patch # Fix cmake config compatibility mode
-   patch -p1 < ../protobuf-33-patch-enum-traits-impl.patch
-@@ -80,7 +81,7 @@ build() {
+ }
+@@ -77,7 +78,7 @@
    cmake "${cmake_options[@]}"
    cmake --build build --verbose
  
@@ -42,7 +39,7 @@ index b23f32b..b8c9dde 100644
    local bazel_options=()
  
    # protobuf has both osx-aarch_64 and linux-aarch_64 platforms
-@@ -88,9 +89,9 @@ build() {
+@@ -85,9 +86,9 @@
    # for aarch64
    [[ $CARCH == "aarch64" ]] && bazel_options+=(--cpu=linux-aarch_64)
  
@@ -54,7 +51,7 @@ index b23f32b..b8c9dde 100644
    local _gemdir="$(gem env gemdir)"
    local _gemver=4.$pkgver
    local _gemplatform=$(ruby -e "puts Gem::Platform.local")
-@@ -172,7 +173,7 @@ package_python-protobuf() {
+@@ -169,7 +170,7 @@
      'python'
    )
  


### PR DESCRIPTION
Keep building python-protobuf from the PyPI sdist instead of Bazel on riscv64.

Bazel issue: https://github.com/bazelbuild/bazel/issues/23018