### PR TITLE
updpatch: rust 1:1.96.0-1: refresh x86_64 cross-target revert

### DIFF
--- a/rust/riscv64.patch
+++ b/rust/riscv64.patch
@@ -1,15 +1,15 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -17,6 +17,8 @@ pkgname=(
+@@ -17,6 +17,8 @@
    # cross targets
    rust-aarch64-gnu
    rust-aarch64-musl
 +  rust-x86_64-gnu
 +  rust-x86_64-musl
  )
- pkgver=1.94.0
+ pkgver=1.96.0
  pkgrel=1
-@@ -61,12 +63,16 @@ makedepends_loong64=(
+@@ -63,12 +65,16 @@
    aarch64-linux-gnu-gcc
    aarch64-linux-gnu-glibc
    musl-aarch64
@@ -26,18 +26,18 @@
    musl-x86_64
  )
  makedepends_x86_64=(
-@@ -128,8 +134,8 @@ b2sums=('cab2e007c1a5401c653218ff0dd542d10c0d7a4fcc7bf2ee269cbbb9760bdd04c78276b
-         '6e473abbda7e77fb399b1b5ff0a50efa6b324a4b9f8e0904a0ebca1258e9a84be840465ef1ad716d968fbb580e7bb77d4af2f7dbbbad258749eb9025a7cbc899'
-         '991cb47155fb2a0d7969e3e2cbc44d030e9eb13474a38d9c9ad88365ce6ab6ecfb69692dd420d68f439585fa2a6e0139cd6f294b5487b77f6b875b773382a459')
- b2sums_aarch64=('0a2c2c5c4ddadbfe269b4acd5ed0028e01f78c266e56de30010a6706a619e23db14e5f7578fc7b5974832fe48ccb2b5827c268c9c79bccd6ffa057f61ca52c86')
--b2sums_loong64=('ca71cf8438d9a5cb898ffa176b99ef059ff0b62805bedce66c3f36dd20cd6be21e0d6bca7e765b717bdbb4a550404c75e64e0af7139bdb3dd98c3b281969de97')
--b2sums_riscv64=('b2809d686b4301f755d0769d9edc4a8427d9aab0a74024254848315c7a5abb5f2ec06b33deb7f2a7b72035a4cf08efd313d42aec304ad852598580ba72a17003')
-+b2sums_loong64=('49b7cdf068cd2b2d33a51c3b19477ac1c3062b01f183010bc646de977e6dde8a4de7d5da1b9553543e57193ff2f06c63119709313290d34f6db21c8deec380fe')
-+b2sums_riscv64=('df51aa640d1328a8b1a22f552fdb15633179c9d4fcaae74641c02867c132521e4d0b661ddac5c9bba80b3dbd7b55c5e404d4e8cbdbee42c244d2bb274a9a7fb3')
- b2sums_x86_64=('6310635b44227fe5ab6a9a70dd7d2b520d223624d1b9069723ef914b7feb8920186099ce77fe903fc089583bbeba8df7ae97d26030c37d6337689133ac726f08')
+@@ -130,8 +136,8 @@
+         'd9b974154aa5615f4ca0c8956405974d3a8458a5b267e5d1105793b2bbc092be1fba5b579fd7fa97c7eac9d0840cb87090f2cce2091c62ec70a5e121bac84002'
+         'd5fcda00c46e1e1ea9ed1d269d3ef549d4ad96148d7d0744acd673de802b3bf3747ceec1fa506d3e7c128cdff742410b1e69218d59ef20a5f246755c1bd02694')
+ b2sums_aarch64=('a5e1bc83740f2dd188df333a19276ade5a2fb90707565550b58b74dfd810af31ce1123ddf80b23bd27a477c145f2a45e07d64db19de6f734a1d9449f5d411190')
+-b2sums_loong64=('366b3db072ceba926b9bc6d015e917c3f3a51f2abe01ef91eae00502c157737d2f98839a825f2ebfaab0d2e3e724f94bb7150619e0233f84076367b1aab031ab')
+-b2sums_riscv64=('d011f1ff717fdfd2d0589d1a2dd7074c0af712c385ff6c02e3f8f88353bdb3ed9c37b8471b23d3290adfa08320c3f61a11980c31aca5c16d126879e486b4105c')
++b2sums_loong64=('ba958de30e7e794f43df76056e77264531374c8d6c29e096fb6408201d9a3943280fdb760a71f563220c6fa5c3b0e0c18cc305066dd4362c5b0bce7afc79d25e')
++b2sums_riscv64=('f20ec5aa83c2d617a990c78c4d580c5e5f3ce839105e0790c649a1e4162188aa8cdc7e426b89789f43437285c9b0f8a11fee59933b8e33ea4ab156d181da6092')
+ b2sums_x86_64=('bbc26877880cbdf0ddf100eb28f761d699885656c0650156a9c67ef7ccac639c3cd9c5f3da7c8516fd01e44f87dd88317cd7fc7b52e93da6736cbf9f45220c8b')
  validpgpkeys=(
    108F66205EAEB0AAA8DD5E1C85AB96E6FA1BE5FE  # Rust Language (Tag and Release Signing Key) <rust-key@rust-lang.org>
-@@ -225,6 +231,8 @@ build() {
+@@ -265,6 +271,8 @@
      loong64|riscv64)
        _pick dest-aarch64-gnu usr/lib/rustlib/aarch64-unknown-linux-gnu
        _pick dest-aarch64-musl usr/lib/rustlib/aarch64-unknown-linux-musl
@@ -46,7 +46,7 @@
        ;;
    esac
  }
-@@ -338,4 +346,35 @@ package_rust-aarch64-musl() {
+@@ -386,4 +394,35 @@
    _install_licenses
  }
  
@@ -82,11 +82,9 @@
 +}
 +
  # vim:set ts=2 sw=2 et:
-diff --git bootstrap.loong64.toml bootstrap.loong64.toml
-index 23a1d1f..e22e212 100644
 --- bootstrap.loong64.toml
 +++ bootstrap.loong64.toml
-@@ -18,6 +18,8 @@ target = [
+@@ -18,6 +18,8 @@
    "loongarch64-unknown-linux-musl",
    "aarch64-unknown-linux-gnu",
    "aarch64-unknown-linux-musl",
@@ -95,7 +93,7 @@ index 23a1d1f..e22e212 100644
    "wasm32-unknown-unknown",
    "wasm32v1-none",
    "wasm32-wasip1",
-@@ -107,6 +109,25 @@ linker = "aarch64-linux-gnu-gcc"
+@@ -107,6 +109,25 @@
  default-linker = "aarch64-linux-gnu-gcc"
  sanitizers = false
  
@@ -121,11 +119,9 @@ index 23a1d1f..e22e212 100644
  [target.wasm32-unknown-unknown]
  cc = "clang"
  cxx = "clang++"
-diff --git bootstrap.riscv64.toml bootstrap.riscv64.toml
-index 66812cc..ffc2626 100644
 --- bootstrap.riscv64.toml
 +++ bootstrap.riscv64.toml
-@@ -18,6 +18,8 @@ target = [
+@@ -18,6 +18,8 @@
    "riscv64gc-unknown-linux-musl",
    "aarch64-unknown-linux-gnu",
    "aarch64-unknown-linux-musl",
@@ -134,7 +130,7 @@ index 66812cc..ffc2626 100644
    "wasm32-unknown-unknown",
    "wasm32v1-none",
    "wasm32-wasip1",
-@@ -107,6 +109,25 @@ linker = "aarch64-linux-gnu-gcc"
+@@ -107,6 +109,25 @@
  default-linker = "aarch64-linux-gnu-gcc"
  sanitizers = false
  


### PR DESCRIPTION
Keep re-adding x86_64 GNU/musl targets for loong64/riscv64.

Reverts Arch removal: https://gitlab.archlinux.org/archlinux/packaging/packages/rust/-/commit/f5b260c32cb31f64d38f227fced86293608a2395