### PR TITLE
addpatch: clpeak 2.0.12-1: skip CUDA variant

### DIFF
--- a/clpeak/riscv64.patch
+++ b/clpeak/riscv64.patch
@@ -1,0 +1,32 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -1,5 +1,5 @@
+ # Maintainer: Sven-Hendrik Haase <svenstaro@archlinux.org>
+-pkgname=(clpeak clpeak-cuda)
++pkgname=(clpeak)
+ pkgver=2.0.12
+ pkgrel=1
+ pkgdesc="A tool which profiles OpenCL devices to find their peak capacities (OpenCL/Vulkan support)"
+@@ -7,7 +7,7 @@
+ url="https://github.com/krrishnarraj/clpeak"
+ license=("Unlicense")
+ depends=('ocl-icd' 'libgcc' 'libstdc++' 'glibc' 'vulkan-icd-loader')
+-makedepends=('cmake' 'opencl-headers' 'ninja' 'git' 'vulkan-headers' 'shaderc' 'cuda')
++makedepends=('cmake' 'opencl-headers' 'ninja' 'git' 'vulkan-headers' 'shaderc')
+ source=(git+https://github.com/krrishnarraj/clpeak#tag=$pkgver)
+ sha512sums=('12e1410645e16ddd298336e90792551e79ea1f2e6e7401eb625d1916e7bd07b238a2e17aaa72f44e4708c2622b6c120b61f1e6aacec0545bff185c405720430f')
+ 
+@@ -21,13 +21,6 @@
+     -DCLPEAK_ENABLE_CUDA=OFF
+   ninja -C build
+ 
+-  cmake \
+-    -Bbuild-cuda \
+-    -GNinja \
+-    -DCMAKE_BUILD_TYPE=Release \
+-    -DCMAKE_INSTALL_PREFIX=/usr \
+-    -DCLPEAK_ENABLE_CUDA=ON
+-  ninja -C build-cuda
+ }
+ 
+ package_clpeak() {


### PR DESCRIPTION
Build only clpeak on riscv64 and drop the CUDA makedep.