### PR TITLE
updpatch: libtool 2.6.1-1: disable lib32 output

### DIFF
--- a/libtool/riscv64.patch
+++ b/libtool/riscv64.patch
@@ -6,8 +6,8 @@
  pkgbase=libtool
 -pkgname=(libtool lib32-libltdl)
 +pkgname=(libtool)
- pkgver=2.6.0+r23+gb08cb0a0
- _commit=b08cb0a06da153372dac8d184d24e7edfff2a209
+ pkgver=2.6.1
+ _commit=79de7bb71bc0a1167f4c4ae8bd897976a0ff2b51
  pkgrel=1
 @@ -24,8 +24,6 @@
    "gcc>=$_gccver"
@@ -18,24 +18,3 @@
    help2man
  )
  checkdepends=(
-@@ -54,20 +52,12 @@
-   git -c protocol.file.allow=always submodule update
- 
-   ./bootstrap
--
--  cp -ar "${srcdir}"/libtool "${srcdir}"/libtool32
- }
- 
- build() {
-   cd libtool
-   ./configure --prefix=/usr lt_cv_sys_lib_dlsearch_path_spec="/usr/lib /usr/lib32"
-   make
--
--  #lib32
--  cd "${srcdir}"/libtool32
--  export CC="gcc -m32" CXX="g++ -m32"
--  ./configure --prefix=/usr lt_cv_sys_lib_dlsearch_path_spec="/usr/lib /usr/lib32" --libdir=/usr/lib32
--  make
- }
- 
- check() {


### PR DESCRIPTION
Refresh the riscv64 patch after the 2.6.1 update.

Keep lib32-libltdl and lib32 makedepends out on riscv64.