### PR TITLE
addpatch: nettle 4.0-1: avoid GCC riscv64 branch in secp256r1

### DIFF
--- a/nettle/nettle-7e784d89875f6247f72ea251c28017fcd6616ff2.patch
+++ b/nettle/nettle-7e784d89875f6247f72ea251c28017fcd6616ff2.patch
@@ -1,0 +1,54 @@
+--- a/ecc-secp256r1.c
++++ b/ecc-secp256r1.c
+@@ -153,7 +153,9 @@
+       u1 = xp[--n];
+       u0 = xp[n-1];
+ 
+-      /* divappr2, specialized for d1 = 2^64 - 2^32, d0 = 2^64-1.
++      /* Schoolbook-division based on divappr2, see
++	 https://www.lysator.liu.se/~nisse/misc/schoolbook-divappr.pdf.
++	 Specialized for d1 = 2^64 - 2^32, d0 = 2^64-1.
+ 
+ 	 <q1, q0> = v * u1 + <u1,u0>, with v = 2^32 - 1:
+ 
+@@ -173,10 +175,14 @@
+       q0 += t;
+       q1 += (q0 < t);
+       t = u1 >> 32;
+-      /* The divappr2 algorithm handles only q < B - 1. If we check
+-	 for u1 >= d1 = 2^{64}-2^{32}, we cover all cases where q =
+-	 2^64-1, and some when q = 2^64-2. The latter case is
+-	 corrected by the final adjustment. */
++      /* The divappr2 algorithm checks for
++
++	   {u1, u0} >= {d1, d0} - d1 = {d1, 2^32 - 1}
++
++	 and returns 2^64 - 1 in this case. We instead check for u1 >=
++	 d1 = 2^{64}-2^{32}. That covers some additional inputs where
++	 divappr2 should return q = 2^64-2, but this is corrected by
++	 the final bignum adjustment. */
+       qmax = - (mp_limb_t) (t == 0xffffffff);
+       q1 += t + 1;
+ 
+@@ -185,14 +191,18 @@
+ 
+ 	 For general divappr2, the expression is
+ 
+-	   r = u_0 - q1 d1 - floor(q1 d0 / B) - 1
++	   r = u0 - q1 d1 - floor(q1 d0 / B) - 1 (mod B)
++
++	 but in our case floor(q1 d0 / B) simplifies to q1 - 1, and
+ 
+-	 but in our case floor(q1 d0 / B) simplifies to q1 - 1.
++	   r = u0 - q1 (2^64 - 2^32) - (q1 - 1) - 1 = u0 + q1 2^32 - q1 (mod B)
+       */
+       r = u0 + (q1 << 32) - q1;
+       mask = - (mp_limb_t) (r >= q0);
+       q1 += mask;
+-      r += (mask & (d1 + 1));
++      /* Equivalent to r += (mask & (d1 + 1)),
++	 but that expression makes gcc-15 on riscv64 generate a branch instruction. */
++      r += (mask << 32) | (mask & 1);
+       q1 += (r >= d1 - 1);
+ 
+       /* Replace by qmax, when that is needed */

--- a/nettle/riscv64.patch
+++ b/nettle/riscv64.patch
@@ -1,0 +1,24 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -11,11 +11,19 @@
+ depends=('glibc' 'gmp')
+ provides=('libnettle.so' 'libhogweed.so')
+ checkdepends=('valgrind')
+-source=(https://ftp.gnu.org/gnu/$pkgname/$pkgname-$pkgver.tar.gz{,.sig})
++source=(https://ftp.gnu.org/gnu/$pkgname/$pkgname-$pkgver.tar.gz{,.sig}
++        nettle-7e784d89875f6247f72ea251c28017fcd6616ff2.patch)
+ sha256sums=('3addbc00da01846b232fb3bc453538ea5468da43033f21bb345cb1e9073f5094'
+-            'SKIP')
++            'SKIP'
++            '25091cc7ab6fe194d54cb14e14b6bc9358d8c4db1fa63acd010a52bb6672dbd9')
+ validpgpkeys=('343C2FF0FBEE5EC2EDBEF399F3599FF828C67298') # Niels Möller <nisse@lysator.liu.se>
+ 
++prepare() {
++  cd $pkgname-$pkgver
++  # Backport upstream 7e784d89875f6247f72ea251c28017fcd6616ff2 to avoid GCC riscv64 branches.
++  patch -p1 < ../nettle-7e784d89875f6247f72ea251c28017fcd6616ff2.patch
++}
++
+ 
+ build() {
+   cd $pkgname-$pkgver


### PR DESCRIPTION
Backport upstream commit 7e784d89875f6247f72ea251c28017fcd6616ff2:

https://git.lysator.liu.se/nettle/nettle/-/commit/7e784d89875f6247f72ea251c28017fcd6616ff2

Refs: https://git.lysator.liu.se/nettle/nettle/-/work_items/18

nettle 4.0's side-channel tests expose GCC 15/16 on riscv64 lowering mask & (d1 + 1) in ecc_secp256r1_modq into secret-dependent control flow. The upstream patch rewrites the adjustment as shifts and bit operations.

The full upstream patch includes post-release ChangeLog context, so the package carries a plain unified diff of the source hunk that applies to the 4.0 release tarball.