### PR TITLE
addpatch: dagger 0.21.7-1: build installed CLI only

### DIFF
--- a/dagger/riscv64.patch
+++ b/dagger/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -44,7 +44,7 @@
+     -X github.com/dagger/dagger/engine.Version=v$pkgver \
+     -X github.com/dagger/dagger/engine.Tag=v$pkgver" \
+     -o build \
+-    ./cmd/...
++    ./cmd/dagger
+ }
+ 
+ # TODO tests now require docker *kicks docker*


### PR DESCRIPTION
The riscv64 build log for 0.21.7-1 fails while the Arch PKGBUILD builds ./cmd/..., because cmd/engine imports the eBPF tracer packages. At upstream v0.21.7 (054f94b2d86c0ac00bef11ac4550816973c4aeef), cmd/engine imports engine/ebpf/filetracer and engine/ebpf/ovltracer, but the generated bpf2go bindings are only committed for x86 and arm64, leaving riscv64 without fileopsObjects or ovlinuseObjects.

The Arch package installs only build/dagger, so restrict the riscv64 build target to ./cmd/dagger instead of the full cmd tree.

Refs: https://archriscv.felixc.at/.status/logs/dagger/dagger-0.21.7-1.log https://github.com/dagger/dagger/blob/v0.21.7/cmd/engine/main.go#L45-L46 https://github.com/dagger/dagger/tree/v0.21.7/engine/ebpf/filetracer https://github.com/dagger/dagger/tree/v0.21.7/engine/ebpf/ovltracer