### PR TITLE
addpatch: llvm-julia 18.1.7.4-3

### DIFF
--- a/llvm-julia/riscv64.patch
+++ b/llvm-julia/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -33,6 +33,8 @@ prepare() {
+   git cherry-pick -n 20dbc097256ca1bf1cfeb738d7a4610d379da8f5 \
+                      18021ff5420ed1945f9aa1e67679094112680f6b \
+                      7b28655847aa1d37dbf7e09f57a3db0284874115 # Fix build with GCC 15
++  # Fix JIT session error: No HI20 PCREL relocation type be found for LO12 PCREL relocation type
++  git cherry-pick -n 78f39dc70c1feaea5130b90ea3fb7b3ddd62446b
+ }
+ 
+ # Utilizing LLVM_DISTRIBUTION_COMPONENTS to avoid


### PR DESCRIPTION
Cherry-pick an upstream LLVM commit to fix
`JIT session error: No HI20 PCREL relocation type be found for LO12 PCREL relocation type` during the compilation of julia compiler.