### PR TITLE
addpatch: julia 2:1.12.6-1

### DIFF
--- a/julia/riscv64.patch
+++ b/julia/riscv64.patch
@@ -1,0 +1,32 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -36,11 +36,13 @@ makedepends=(cmake
+              python)
+ optdepends=('gnuplot: If using the Gaston Package from julia')
+ source=(https://github.com/JuliaLang/julia/releases/download/v$pkgver/$pkgname-$pkgver-full.tar.gz{,.asc}
++        rv-cpu.diff
+         c12e8515.patch
+         julia-hardcoded-libs.patch)
+ backup=(etc/julia/startup.jl)
+ sha256sums=('711f3aa8d6ec5c9004593eb8f3d53e3564cd759acba8ad4adae967afc20332cc'
+             'SKIP'
++            '7b893f0453a4cd269c25f25cea332f5e7bfbe35ecb6a03863a049603a63e6f92'
+             '2cc294b63e601d50341979fb936826bdba59de2165a5929eae927e152652f367'
+             '120c3b77a1aecfdb045ac64902164210ea8dd139d2fb8e8b098155b344a8e1fb')
+ validpgpkeys=('3673DF529D9049477F76B37566E3C7DC03D6E495') # Julia (Binary signing key) <buildbot@julialang.org>
+@@ -49,6 +51,7 @@ options=(!lto)
+ prepare() {
+   cd $pkgname-$pkgver
+ 
++  patch -Np1 -i ../rv-cpu.diff
+ # Revert test that depends on patched gmp
+   patch -Rp1 -i ../c12e8515.patch
+ # Don't hardcode library names
+@@ -99,6 +102,7 @@ _make() {
+ 
+   [[ ${CARCH} == 'aarch64' ]] && make_options+=(MARCH=armv8.2-a JULIA_CPU_TARGET="generic;armv8.2-a,crypto,fullfp16,lse,rdm")
+   [[ ${CARCH} == 'x86_64' ]] &&  make_options+=(MARCH=x86-64 JULIA_CPU_TARGET="generic;sandybridge,-xsaveopt,clone_all;haswell,-rdrnd,base(1)")
++  [[ ${CARCH} == 'riscv64' ]] &&  make_options+=(MARCH=rv64gc JULIA_CPU_TARGET="generic-rv64,+i,+m,+a,+f,+d,+zicsr,+zifencei,+c" USE_BINARYBUILDER=0)
+ 
+   make "${make_options[@]}" "$@"
+ }

--- a/julia/rv-cpu.diff
+++ b/julia/rv-cpu.diff
@@ -1,0 +1,45 @@
+diff --git a/src/processor.cpp b/src/processor.cpp
+index 6f95ee7f37..fd7f6eb3c6 100644
+--- a/src/processor.cpp
++++ b/src/processor.cpp
+@@ -959,6 +959,38 @@ static std::string jl_get_cpu_features_llvm(void)
+ #else
+     llvm::StringMap<bool> HostFeatures;
+     llvm::sys::getHostCPUFeatures(HostFeatures);
++#endif
++#if defined(_CPU_RISCV64_)
++    // LLVM 18 does not support RISC-V CPU feature detection.
++    HostFeatures["i"] = true;
++# if defined(__riscv_mul) || defined(__riscv_m)
++    HostFeatures["m"] = true;
++# endif
++# if defined(__riscv_atomic)
++    HostFeatures["a"] = true;
++# endif
++# if defined(__riscv_float_abi_double)
++    HostFeatures["f"] = true;
++    HostFeatures["d"] = true;
++# elif defined(__riscv_float_abi_single)
++    HostFeatures["f"] = true;
++# elif defined(__riscv_flen)
++#  if __riscv_flen >= 32
++    HostFeatures["f"] = true;
++#  endif
++#  if __riscv_flen >= 64
++    HostFeatures["d"] = true;
++#  endif
++# endif
++# if defined(__riscv_compressed)
++    HostFeatures["c"] = true;
++# endif
++# if defined(__riscv_zicsr)
++    HostFeatures["zicsr"] = true;
++# endif
++# if defined(__riscv_zifencei)
++    HostFeatures["zifencei"] = true;
++# endif
+ #endif
+     std::string attr;
+     for (auto &ele: HostFeatures) {
+
+


### PR DESCRIPTION
- Set make_options according to https://docs.julialang.org/en/v1/devdocs/build/riscv/
- Patch julia to detect rv64gc at compile time because JIT runtime detection relies on LLVM's sys::getHostCPUFeatures which always returns an empty set with LLVM 18.
  - This patch does not need to be upstreamed since upstream has upgraded LLVM to 21, which includes a proper riscv_hwprobe based implementation for sys::getHostCPUFeatures.
- `--nocheck` is needed. Julia only has experimental support for riscv64. There are some unexpected and expected test failures like https://github.com/JuliaLang/julia/issues/56672. And some tests hangs forever.