### PR TITLE
updpatch: vid.stab 1.1.1-3: refresh SSE2 disable hunk

### DIFF
--- a/vid.stab/riscv64.patch
+++ b/vid.stab/riscv64.patch
@@ -1,14 +1,10 @@
-diff --git a/trunk/PKGBUILD b/trunk/PKGBUILD
-index 736a6083..4c3a926f 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -31,7 +31,8 @@ pkgver() {
- build() {
+@@ -32,6 +32,7 @@
    cmake -S vid.stab -B build -G Ninja \
      -DCMAKE_BUILD_TYPE=None \
--    -DCMAKE_INSTALL_PREFIX=/usr
-+    -DCMAKE_INSTALL_PREFIX=/usr \
-+    -DSSE2_FOUND=0
+     -DCMAKE_INSTALL_PREFIX=/usr \
++    -DSSE2_FOUND=0 \
+     -DCMAKE_POLICY_VERSION_MINIMUM=3.5
    cmake --build build
  }
- 


### PR DESCRIPTION
The riscv64 failure log shows the existing patch no longer applies after Arch package commit 0b618fa197bb7b1c2e39d8ce0e7eeab0318665c7 added -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to the CMake invocation.

Upstream v1.1.1 (https://github.com/georgmartius/vid.stab/tree/v1.1.1, commit 90c76aca2cb06c3ff6f7476a7cd6851b39436656) still drives SSE code from the cached SSE2_FOUND option, so keep the package-side -DSSE2_FOUND=0 workaround and refresh only the context.