### PR TITLE
fixpatch: linux 7.0.12.arch1-1: add riscv64 source files

### DIFF
--- a/linux/riscv64.patch
+++ b/linux/riscv64.patch
@@ -2,7 +2,7 @@ diff --git PKGBUILD PKGBUILD
 index 4ecc97d..f01811e 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -46,6 +46,16 @@ _srctag=v${pkgver%.*}-${pkgver##*.}
+@@ -46,8 +46,22 @@ _srctag=v${pkgver%.*}-${pkgver##*.}
  source=(
    https://cdn.kernel.org/pub/linux/kernel/v${pkgver%%.*}.x/${_srcname}.tar.{xz,sign}
    $url/releases/download/$_srctag/linux-$_srctag.patch.zst{,.sig}
@@ -18,9 +18,14 @@ index 4ecc97d..f01811e 100644
 +  0403-rust3.patch::https://github.com/revyos/linux/commit/5545a0d3db17b6858d2311fa29d284963c846698.patch?full_index=1
  )
  source_x86_64=(config.x86_64)
++source_riscv64=(
++  config.x86_64
++  riscv64.config-patch
++)
  validpgpkeys=(
-@@ -53,17 +63,32 @@ validpgpkeys=(
+   ABAF11C65A2970B130ABE3C479BE3E4300411886  # Linus Torvalds
    647F28654894E3BD457199BE38DBBDC86092693E  # Greg Kroah-Hartman
+@@ -54,16 +68,35 @@ validpgpkeys=(
    83BC8889351B5DEBBB68416EB8AC08600F108CDF  # Jan Alexander Steffens (heftig)
  )
 -b2sums=('2c53f205a940b0f9f68653b92ef46d49f828cbef3cfa8cf94d050c8e6df05c4fcaa4f9b9681b9130b14e3c790d31208eb244d123249a93e35e8e6165f3d858c9'
@@ -43,6 +48,8 @@ index 4ecc97d..f01811e 100644
 +            '6a29cee605a2d4188d905266e588a0871c7206e67be22889cdf09277761dd622'
 +            'f6b48feecacf0960bb630397a19bde9ad9bb1cff164358e9a16a41edbfa18011')
 +sha256sums_x86_64=('0ed8c43b4ad6c3c3f3affe1317581992ba0eac6697d421a5c6d8210bf1e29ad7')
++sha256sums_riscv64=('0ed8c43b4ad6c3c3f3affe1317581992ba0eac6697d421a5c6d8210bf1e29ad7'
++                   'a5b22b9502f5425a02da62be1d3043b92711d7063159f75cabd8c4d995f2015e')
 +b2sums=('2c53f205a940b0f9f68653b92ef46d49f828cbef3cfa8cf94d050c8e6df05c4fcaa4f9b9681b9130b14e3c790d31208eb244d123249a93e35e8e6165f3d858c9'
 +        'SKIP'
 +        '26230d1a111b24fe9239273acdfacda37c5bf009f861c448ad25392dcca433514246d629a077ce5c66478c7e0f4e5477ce5f95c91d08b3a02cc87bb35b849bcf'
@@ -55,6 +62,8 @@ index 4ecc97d..f01811e 100644
 +        '94be17594b686d08988d2fff12b94fea3a4773002efb178998b839df43066a7188a8081d337516bebd04c393743254f74091a27db51d31f6658599b6fc441b85'
 +        '0ca0802103e018c6fc5f4697f89c3353afb38006a7e2684da3a5c12ac29b1335624ebb7b9b46b9d59a31cdaba9663830acbf93934badbda416ae5750c52b429a')
 +b2sums_x86_64=('7082013345352c95303ee87cd78bf5d93ab49ec9f270e6cb803a05cb7f9a67c554bbd260de922d6d44145fd3712b410c13d67c8f76dc2b9f4088be86aeaec835')
++b2sums_riscv64=('7082013345352c95303ee87cd78bf5d93ab49ec9f270e6cb803a05cb7f9a67c554bbd260de922d6d44145fd3712b410c13d67c8f76dc2b9f4088be86aeaec835'
++                '809f8cf7ba91605bcd0ad45051c9dfadb76701bf572e029cdd44f44cecc20ad237d0f8183037a3fd6028b2e856fbdc65a565981ee49b810c5e9c51462219cffd')
 +
 +# https://www.kernel.org/pub/linux/kernel/v7.x/sha256sums.asc
  


### PR DESCRIPTION
The riscv64 prepare step copies ../config.x86_64 and applies ../riscv64.config-patch, but makepkg only places files listed for the active architecture in srcdir.

Add both files to source_riscv64 with matching checksums so the existing config refresh can run instead of failing with missing files during prepare().