### PR TITLE
addpatch: rocprofiler 7.2.4-1: fix riscv64 build

### DIFF
--- a/rocprofiler/riscv64.patch
+++ b/rocprofiler/riscv64.patch
@@ -1,0 +1,22 @@
+--- PKGBUILD	2026-06-23 00:51:15.238734739 +0800
++++ PKGBUILD.riscv	2026-06-23 00:51:15.274550043 +0800
+@@ -52,11 +52,19 @@
+   git config submodule."perfetto".url "${srcdir}/rocm-system-perfetto"
+   git -c protocol.file.allow=always submodule update --init --recursive
+
++  # Respect ROCPROFILER_BUILD_TESTS=OFF; the forced CI tests include x86-only headers.
++  sed -i '/# Temporarily for CI to work/,+2d' CMakeLists.txt
++
+   # Use system packages for rocprofv3
+   # See https://github.com/ROCm/rocm-systems/pull/2319
+   cd "${srcdir}/rocm-systems"
+   git cherry-pick -n 86ee7b2eb2273adaf1181ef9a6b2091465c6f0c7
+
++  # rocprofv3-attach uses x86_64 ptrace registers and injected x86_64 opcodes.
++  sed -i '/add_subdirectory(rocprofv3-attach)/d' projects/rocprofiler-sdk/source/lib/CMakeLists.txt
++  sed -i '/configure_file(rocprofv3-attach.py/,/COMPONENT tools)/d' projects/rocprofiler-sdk/source/bin/CMakeLists.txt
++
++  grep -rl "fmt::format" projects/rocprofiler-sdk/source/ | grep -E '\.(cpp|hpp)$' | xargs sed -i '1i #include <fmt/format.h>'
+   grep -rl "fmt::join" projects/rocprofiler-sdk/source/ | grep -E '\.(cpp|hpp)$' | xargs sed -i '1i #include <fmt/ranges.h>'
+
+   # Add missing <cstdint> include


### PR DESCRIPTION
The riscv64 build log at https://archriscv.felixc.at/.status/logs/rocprofiler/rocprofiler-7.2.4-1.log fails in the deprecated rocprof test target because test/util/perf_timer.h includes the x86-only <x86intrin.h> header.

The Arch PKGBUILD already configures the deprecated build with -DROCPROFILER_BUILD_TESTS=OFF, but rocm-7.2.4 still forces ROCPROFILER_BUILD_TESTS and ROCPROFILER_BUILD_CI back ON in projects/rocprofiler/CMakeLists.txt: https://github.com/ROCm/rocm-systems/blob/rocm-7.2.4/projects/rocprofiler/CMakeLists.txt#L198-L200

Also add <fmt/format.h> to rocprofiler-sdk sources using fmt::format, matching the existing <fmt/ranges.h> workaround for fmt::join, because the system fmt headers no longer expose fmt::format through the currently included headers.

Disable rocprofv3-attach on riscv64 because projects/rocprofiler-sdk/source/lib/rocprofv3-attach/ptrace_session.cpp is explicitly x86_64-only: it static_asserts outside __x86_64__ and uses x86_64 ptrace registers plus injected x86_64 opcodes.

Patch the riscv64 PKGBUILD overlay during prepare(), so ROCPROFILER_BUILD_TESTS=OFF is honored and the SDK build skips the x86_64-only attach helper while keeping the rest of rocprofv3.