### PR TITLE
addpatch: nix-busybox 1.37.0-1: fix CBQ/SHA/link failures

### DIFF
--- a/nix-busybox/riscv64.patch
+++ b/nix-busybox/riscv64.patch
@@ -1,0 +1,40 @@
+--- PKGBUILD	2026-06-23 14:41:19.940646526 +0800
++++ PKGBUILD.riscv	2026-06-23 14:41:20.003767904 +0800
+@@ -28,6 +28,16 @@
+         'dbcc129ffde907b183fca6ea80f61b519f876acf9cc56bad2e498c0d414743ab6163511291297451232f5ee54ccb5d5adef57b3406eb54f3fefd7fe5d4a37ee7')
+ validpgpkeys=('C9E9416F76E610DBD09D040F47B70C55ACC9965B') # Denis Vlasenko <vda.linux@googlemail.com>
+ 
++prepare() {
++  cd "$_pkgname-$pkgver"
++
++  # Linux 6.8 removed CBQ UAPI definitions, but BusyBox still prints CBQ tc options.
++  patch -Np1 -i "$srcdir/busybox-1.36.1-no-cbq.patch"
++
++  # Arch's config enables SHA1_HWACCEL; guard the x86-only SHA-NI symbol on riscv64.
++  patch -Np1 -i "$srcdir/busybox-fix-sha1-on-non-x86.patch"
++}
++
+ build() {
+   cd "$_pkgname-$pkgver"
+ 
+@@ -35,6 +45,9 @@
+ 
+   # reproducible build
+   export KCONFIG_NOTIMESTAMP=1
++
++  # musl-gcc's specs hide GCC's libatomic_asneeded from the static link path.
++  export CFLAGS+=" -fno-link-libatomic"
+   make CC=musl-gcc
+ }
+ 
+@@ -43,3 +56,10 @@
+ 
+   install -vDm755 -t "$pkgdir/usr/lib/nix" busybox
+ }
++
++source+=("busybox-1.36.1-no-cbq.patch::https://git.openembedded.org/openembedded-core/plain/meta/recipes-core/busybox/busybox/busybox-1.36.1-no-cbq.patch?id=3afbeb1ea418a69a452e82cbce00c36452b75f1e"
++         "busybox-fix-sha1-on-non-x86.patch::https://github.com/mirror/busybox/commit/bf57f732a5b6842f6fa3e0f90385f039e5d6a92c.patch")
++sha512sums+=('36dac0115cb5cfe408a2a3b48c813744d548581535aa12bd2179941e49a26b9b760efe0a5e82a0de6c502405e5b6404c37339c049ef97f8afc82be2633e327bc'
++             '651ec61c6433b858fe6264f217cdcd6e1553c35670889395604dd037fee66120e59b7ba345487f01dcdcc6bcc7e6a7a453adee5c41ba6f371c6182b635fca3dc')
++b2sums+=('d5db048a8444d13a6cce894998ce7b43c42f6f96f61318712901e9c49e88d89398c6be5642a55dee99fd5be43d0c6b6996886fa6c32510c8e8fc28da290fae23'
++         '4641b971775af4735ca3c6f61b6afb508df9a6b2078d4880dac4f87fe456557f1b06915bb4edcf93e76722f4579dd24191cbc98155c9875723f1edec813a35ed')


### PR DESCRIPTION
The riscv64 build log at https://archriscv.felixc.at/.status/logs/nix-busybox/nix-busybox-1.37.0-1.log fails with kernel-headers-musl 6.12 because BusyBox tc still references CBQ UAPI definitions removed in Linux 6.8: https://github.com/torvalds/linux/commit/33241dca486264193ed68167c8eeae1fb197f3df

Apply OpenEmbedded's submitted no-CBQ patch, pinned to commit 3afbeb1ea418a69a452e82cbce00c36452b75f1e: https://git.openembedded.org/openembedded-core/plain/meta/recipes-core/busybox/busybox/busybox-1.36.1-no-cbq.patch?id=3afbeb1ea418a69a452e82cbce00c36452b75f1e

Arch's config enables SHA1_HWACCEL, and BusyBox 1.37.0 references the x86-only sha1_process_block64_shaNI symbol from sha1_end on riscv64. Apply upstream BusyBox commit bf57f732a5b6842f6fa3e0f90385f039e5d6a92c via the mirror patch URL: https://github.com/mirror/busybox/commit/bf57f732a5b6842f6fa3e0f90385f039e5d6a92c.patch

The final static musl link also asks for GCC's libatomic_asneeded, but musl-gcc's specs hide that helper from the static link path. Add -fno-link-libatomic for this package-side musl build so GCC does not inject the unavailable helper library.