### PR TITLE
addpkg: newlib & esos-spacemit-k3

### DIFF
--- a/esos-spacemit-k3/PKGBUILD
+++ b/esos-spacemit-k3/PKGBUILD
@@ -1,0 +1,115 @@
+# Maintainer: Felix Yan <felixonmars@archlinux.org>
+
+pkgname=esos-spacemit-k3
+pkgver=1.0.0
+_tag=k3-br-v${pkgver}
+pkgrel=1
+pkgdesc='ESOS firmware for SpacemiT K3 platforms'
+arch=('riscv64')
+url='https://github.com/spacemit-com/esos'
+license=('Apache-2.0')
+install=esos-spacemit.install
+depends=(
+  'bash'
+)
+makedepends=(
+  'dtc'
+  'git'
+  'newlib'
+  'lzop'
+  'python'
+  'scons'
+  'uboot-tools'
+)
+optdepends=(
+  'dracut: initramfs integration'
+  'mkinitcpio: initramfs integration'
+)
+options=('!strip' '!debug')
+source=(
+  "git+https://github.com/spacemit-com/esos.git#tag=${_tag}"
+  "git+https://github.com/spacemit-com/esos-lite.git#tag=${_tag}"
+  'pinctrl-single-include-strings-for-fls.patch::https://github.com/spacemit-com/esos/pull/1.patch'
+  'esos-install'
+  'esos-spacemit-flash'
+  'module-setup.sh'
+)
+sha512sums=('SKIP'
+            'SKIP'
+            '077162c196b66ff9d2ea0aea8f499a497a9cb94b3eede4a5b517d8a72f726b6c7e19b9eb6f54d22bbbf9060703ece27a62360a88eba750d85a2517a86001c2d3'
+            'ffa46804aff6da2ef87c5e38563a76ee9a9b41b0825df465699e422defec7c4162a7aeced5d69920d971058f457f73c524542570caf3de8fe91c7b7c448a7a87'
+            '5774e9608903c08cce46a1a28aaf83a00b6ca944019f432e2290bc91d3269dcc7a74d856d6e9e5795966ee1b3d81958d95500931f70bb3759efebd7938118d39'
+            '5a465d12b1c548bd582d064e46751ace8eaad01318ac06d610e5daf881918dd99d110b3f90c5367ad42b6ccd8621dc257faa8d57e9682dad8084abda3eac4052')
+
+prepare() {
+  cd esos
+
+  install -d components
+  rm -rf components/esos-lite
+  cp -a "$srcdir"/esos-lite components/esos-lite
+
+  echo 'export TOP_TARGET_CHIP=rt24' > bsp/spacemit/.esos_top.config
+  touch bsp/spacemit/rtconfig.h
+
+  local _rtconfigs=(
+    bsp/spacemit/rtconfig.py
+    components/esos-lite/rt-thread/bsp/spacemit/rtconfig.py
+  )
+  local _sconstructs=(
+    bsp/spacemit/SConstruct
+    components/esos-lite/rt-thread/bsp/spacemit/SConstruct
+  )
+
+  # https://github.com/spacemit-com/esos/pull/1
+  patch -Np1 -i "$srcdir"/pinctrl-single-include-strings-for-fls.patch
+
+  sed -i "s|PREFIX  = 'riscv64-unknown-elf-'|PREFIX  = ''|" "${_rtconfigs[@]}"
+  sed -i 's|-ffreestanding -flax-vector-conversions|-ffreestanding -fno-pie -fno-stack-protector -U__linux__ -U__gnu_linux__ -U__unix__ -Ulinux -Uunix -I/usr/riscv64-unknown-elf/include -flax-vector-conversions|' \
+    "${_rtconfigs[@]}"
+  sed -i "/LFLAGS.*-nostartfiles/s|-nostartfiles|-nostdlib -static -no-pie|" \
+    "${_rtconfigs[@]}"
+  sed -i 's|-Wl,--start-group $_LIBFLAGS -Wl,--end-group|-L/usr/riscv64-unknown-elf/lib -Wl,--start-group $_LIBFLAGS -lc -lnosys -lgcc -Wl,--end-group|' \
+    "${_sconstructs[@]}"
+  sed -i 's|/usr/include/newlib|/usr/riscv64-unknown-elf/include|' \
+    bsp/spacemit/platform/SConscript
+
+  # Build with the native toolchain instead of unpacking upstream's bundled -elf toolchain.
+  sed -i 's|if \[ ! -d "${TOP_DIR}/tools/toolchain/spacemit-toolchain-elf-newlib-x86_64-v1.0.9" \]; then|if false; then|' \
+    build_top.sh
+  sed -i 's|if \[ ! -d "${TOP_LITE_DIR}/../../../tools/toolchain/spacemit-toolchain-elf-newlib-x86_64-v1.0.9" \]; then|if false; then|' \
+    components/esos-lite/rt-thread/build_top.sh
+}
+
+build() {
+  cd esos
+
+  export TOP_DIR="$PWD"
+  export TOP_BSP_DIR="$TOP_DIR/bsp/spacemit"
+  export TOP_ESOS_BASE_DEFCONF="$TOP_BSP_DIR/.esos_top.config"
+  export TOP_OUTPUT_DIR="$TOP_DIR/output/esos"
+  export RTT_EXEC_PATH=/usr/bin
+
+  ./build_top.sh
+}
+
+package() {
+  cd esos
+
+  install -Dm644 output/esos/esos.itb "$pkgdir"/usr/lib/esos/esos.itb
+  install -Dm644 output/esos/rt24_os0_rcpu.elf "$pkgdir"/usr/lib/esos/rt24_os0_rcpu.elf
+  install -Dm644 output/esos/rt24_os1_rcpu.elf "$pkgdir"/usr/lib/esos/rt24_os1_rcpu.elf
+
+  install -dm755 "$pkgdir"/usr/lib/firmware
+  ln -s ../esos/rt24_os0_rcpu.elf "$pkgdir"/usr/lib/firmware/rt24_os0_rcpu.elf
+  ln -s ../esos/rt24_os1_rcpu.elf "$pkgdir"/usr/lib/firmware/rt24_os1_rcpu.elf
+
+  install -Dm755 "$srcdir"/esos-spacemit-flash "$pkgdir"/usr/bin/esos-spacemit-flash
+  install -Dm644 "$srcdir"/esos-install "$pkgdir"/usr/lib/initcpio/install/esos
+  install -Dm755 "$srcdir"/module-setup.sh \
+    "$pkgdir"/usr/lib/dracut/modules.d/99esos/module-setup.sh
+
+  install -Dm644 LICENSE "$pkgdir"/usr/share/licenses/$pkgname/esos.LICENSE
+  install -Dm644 debian/copyright "$pkgdir"/usr/share/licenses/$pkgname/esos.debian.copyright
+  install -Dm644 components/esos-lite/LICENSE \
+    "$pkgdir"/usr/share/licenses/$pkgname/esos-lite.LICENSE
+}

--- a/esos-spacemit-k3/esos-install
+++ b/esos-spacemit-k3/esos-install
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+build() {
+    local firmware
+
+    for firmware in rt24_os0_rcpu.elf rt24_os1_rcpu.elf; do
+        add_file "/usr/lib/esos/${firmware}" "/lib/firmware/${firmware}"
+    done
+}
+
+help() {
+    cat <<HELPEOF
+This hook includes SpacemiT ESOS firmware files in the initramfs.
+HELPEOF
+}

--- a/esos-spacemit-k3/esos-spacemit-flash
+++ b/esos-spacemit-k3/esos-spacemit-flash
@@ -1,0 +1,209 @@
+#!/bin/bash
+set -euo pipefail
+
+_esos_itb=/usr/lib/esos/esos.itb
+_dry_run=0
+
+usage() {
+    cat <<USAGE
+Usage: esos-spacemit-flash [--dry-run]
+
+Flash $_esos_itb to the detected SpacemiT boot device.
+USAGE
+}
+
+running_in_chroot() {
+    if [[ "${SYSTEMD_IGNORE_CHROOT:-0}" == "1" ]]; then
+        return 1
+    fi
+    if [[ -e /proc/1/root ]]; then
+        local root_dev_ino proc1_root_dev_ino
+        root_dev_ino=$(stat -c '%d:%i' / 2>/dev/null) || return 0
+        proc1_root_dev_ino=$(stat -L -c '%d:%i' /proc/1/root 2>/dev/null) || return 0
+        [[ "$root_dev_ino" == "$proc1_root_dev_ino" ]] && return 1 || return 0
+    fi
+    if [[ ! -d /proc || ! -r /proc/version ]]; then
+        [[ $$ == 1 ]] && return 1 || return 0
+    fi
+    return 0
+}
+
+boot_device_from_mode() {
+    local mode=$1
+
+    case $mode in
+        emmc) echo /dev/mmcblk2 ;;
+        sdcard) echo /dev/mmcblk0 ;;
+        nor|nand)
+            if [[ -e /dev/mtdblock0 ]]; then
+                echo /dev/mtdblock0
+            fi
+            ;;
+        ufs) echo /dev/sda ;;
+    esac
+}
+
+base_device() {
+    local dev=$1
+
+    case $dev in
+        /dev/mmcblk0*) echo /dev/mmcblk0 ;;
+        /dev/mmcblk2*) echo /dev/mmcblk2 ;;
+        /dev/sda*) echo /dev/sda ;;
+        /dev/nvme0n1*) echo /dev/nvme0n1 ;;
+    esac
+}
+
+resolve_root_device() {
+    local root_spec=$1
+
+    case $root_spec in
+        UUID=*) blkid -U "${root_spec#UUID=}" 2>/dev/null || true ;;
+        /dev/*) echo "$root_spec" ;;
+    esac
+}
+
+detect_target_device() {
+    local boot_mode= root_spec= root= x
+
+    for x in $(cat /proc/cmdline); do
+        case $x in
+            root=*) root_spec=${x#root=} ;;
+            boot_mode=*) boot_mode=${x#boot_mode=} ;;
+        esac
+    done
+
+    if [[ -n $root_spec ]]; then
+        root=$(resolve_root_device "$root_spec")
+    fi
+
+    if [[ -n $boot_mode ]]; then
+        local boot_device
+        boot_device=$(boot_device_from_mode "$boot_mode")
+        if [[ -n $boot_device && -n $root ]]; then
+            local root_base_device
+            root_base_device=$(base_device "$root")
+            if [[ $boot_device != "$root_base_device" ]]; then
+                echo "$boot_device"
+            else
+                echo "$root_base_device"
+            fi
+            return 0
+        elif [[ -n $boot_device ]]; then
+            echo "$boot_device"
+            return 0
+        else
+            echo "Unsupported boot_mode=$boot_mode" >&2
+            return 1
+        fi
+    fi
+
+    if [[ -n $root ]]; then
+        base_device "$root"
+        return 0
+    fi
+
+    echo "Unable to determine target device (missing root= or boot_mode= in cmdline)" >&2
+    return 1
+}
+
+detect_esos_location() {
+    local target_device=$1
+
+    case $target_device in
+        /dev/mmcblk0|/dev/mmcblk2|/dev/sda)
+            echo "$target_device 4096"
+            ;;
+        /dev/mtdblock0)
+            if [[ -f /proc/mtd ]]; then
+                local mtd0_name
+                mtd0_name=$(grep '^mtd0:' /proc/mtd | awk -F'"' '{print $2}')
+                if [[ $mtd0_name == "bootinfo" ]]; then
+                    echo "/dev/mtdblock3 0"
+                else
+                    echo "/dev/mtdblock0 704"
+                fi
+            else
+                echo "/dev/mtdblock0 704"
+            fi
+            ;;
+        /dev/nvme0n1)
+            if [[ -f /proc/mtd ]]; then
+                local mtd0_name
+                mtd0_name=$(grep '^mtd0:' /proc/mtd | awk -F'"' '{print $2}')
+                if [[ $mtd0_name == "bootinfo" ]]; then
+                    echo "/dev/mtdblock3 0"
+                else
+                    echo "/dev/mtdblock0 704"
+                fi
+            elif [[ -e /dev/mtdblock4 ]]; then
+                echo "/dev/mtdblock4 0"
+            elif [[ -e /dev/mtdblock0 ]]; then
+                echo "/dev/mtdblock0 704"
+            else
+                echo "/dev/mmcblk2 704"
+            fi
+            ;;
+        *)
+            echo "Unsupported target device=$target_device" >&2
+            return 1
+            ;;
+    esac
+}
+
+flash_esos() {
+    if ! grep -q 'Spacemit(R) X100' /proc/cpuinfo 2>/dev/null; then
+        echo "Not running on SpacemiT X100, skipping esos.itb flash."
+        return 0
+    fi
+
+    if running_in_chroot; then
+        echo "Running in chroot, skipping esos.itb flash."
+        return 0
+    fi
+
+    if [[ ! -f $_esos_itb ]]; then
+        echo "Missing $_esos_itb" >&2
+        return 1
+    fi
+
+    local target_device esos seek
+    target_device=$(detect_target_device)
+    read -r esos seek < <(detect_esos_location "$target_device")
+
+    if [[ ! -e $esos ]]; then
+        echo "Missing device $esos" >&2
+        return 1
+    fi
+
+    if (( _dry_run )); then
+        echo "Would flash $_esos_itb to $esos at offset ${seek}K."
+        return 0
+    fi
+
+    if (( EUID != 0 )); then
+        echo "Run as root to flash $esos." >&2
+        return 1
+    fi
+
+    echo "Flashing $_esos_itb to $esos at offset ${seek}K ..."
+    dd if="$_esos_itb" of="$esos" seek="$seek" bs=1K && sync
+    echo "Done."
+}
+
+while (( $# )); do
+    case $1 in
+        --dry-run) _dry_run=1 ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            usage >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+flash_esos

--- a/esos-spacemit-k3/esos-spacemit.install
+++ b/esos-spacemit-k3/esos-spacemit.install
@@ -1,0 +1,17 @@
+post_install() {
+    cat <<'EOF'
+:: ESOS firmware was installed to /usr/lib/esos/esos.itb.
+:: To flash it to the detected SpacemiT boot device, run as root:
+::   esos-spacemit-flash
+:: To preview the target without writing, run:
+::   esos-spacemit-flash --dry-run
+:: Rebuild your initramfs after install or upgrade, for example as root:
+::   mkinitcpio -P
+:: or:
+::   dracut -f
+EOF
+}
+
+post_upgrade() {
+    post_install
+}

--- a/esos-spacemit-k3/module-setup.sh
+++ b/esos-spacemit-k3/module-setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+check() {
+    return 0
+}
+
+depends() {
+    return 0
+}
+
+install() {
+    inst_simple /usr/lib/esos/rt24_os0_rcpu.elf /lib/firmware/rt24_os0_rcpu.elf
+    inst_simple /usr/lib/esos/rt24_os1_rcpu.elf /lib/firmware/rt24_os1_rcpu.elf
+}

--- a/newlib/PKGBUILD
+++ b/newlib/PKGBUILD
@@ -1,0 +1,62 @@
+# Maintainer: Felix Yan <felixonmars@archlinux.org>
+
+_target=riscv64-unknown-elf
+pkgname=newlib
+pkgver=4.6.0.20260123
+pkgrel=1
+pkgdesc='C library for bare-metal RISC-V'
+arch=('riscv64')
+url='https://sourceware.org/newlib/'
+license=('LicenseRef-Newlib')
+makedepends=(
+  'texinfo'
+  'xz'
+)
+options=('!emptydirs' '!strip' '!debug' 'staticlibs')
+source=("https://sourceware.org/pub/newlib/newlib-${pkgver}.tar.gz")
+sha512sums=('ffa16d6465c0b429264c46395fa760fbcf072d3ff86e87330ba1f483efcfe66393ef83b03932759444a0ebeaef94d3ca58a59e91ab7b97b2a6ac6be2e7589657')
+
+build() {
+  cd "$srcdir"
+
+  rm -rf build
+  mkdir build
+  cd build
+
+  export CC_FOR_TARGET='gcc'
+  export CXX_FOR_TARGET='g++'
+  export AR_FOR_TARGET='ar'
+  export AS_FOR_TARGET='as'
+  export LD_FOR_TARGET='ld'
+  export NM_FOR_TARGET='nm'
+  export OBJCOPY_FOR_TARGET='objcopy'
+  export OBJDUMP_FOR_TARGET='objdump'
+  export RANLIB_FOR_TARGET='ranlib'
+  export READELF_FOR_TARGET='readelf'
+  export STRIP_FOR_TARGET='strip'
+  export CFLAGS_FOR_TARGET='-Os -ffreestanding -fno-builtin -fno-pie -fno-stack-protector -U__linux__ -U__gnu_linux__ -U__unix__ -Ulinux -Uunix -mcmodel=medany -march=rv64imafdc -mabi=lp64d'
+  export CXXFLAGS_FOR_TARGET="$CFLAGS_FOR_TARGET"
+
+  ../newlib-${pkgver}/configure \
+    --target="${_target}" \
+    --prefix=/usr \
+    --libdir=/usr/${_target}/lib \
+    --enable-newlib-io-long-long \
+    --enable-newlib-register-fini \
+    --disable-newlib-supplied-syscalls \
+    --disable-nls
+  make
+}
+
+package() {
+  cd "$srcdir"/build
+
+  make DESTDIR="$pkgdir" install
+
+  install -Dm644 "$srcdir"/newlib-${pkgver}/COPYING.NEWLIB \
+    "$pkgdir"/usr/share/licenses/$pkgname/COPYING.NEWLIB
+  install -m644 -t "$pkgdir"/usr/share/licenses/$pkgname \
+    "$srcdir"/newlib-${pkgver}/COPYING*
+
+  rm -rf "$pkgdir"/usr/share/info
+}

--- a/opensbi-spacemit-k3/PKGBUILD
+++ b/opensbi-spacemit-k3/PKGBUILD
@@ -1,0 +1,50 @@
+# Maintainer: Felix Yan <felixonmars@archlinux.org>
+
+pkgname=opensbi-spacemit-k3
+pkgver=1.0.0
+_tag=k3-br-v${pkgver}
+pkgrel=1
+pkgdesc='OpenSBI firmware for SpacemiT K3 platforms'
+arch=('riscv64')
+url='https://github.com/spacemit-com/opensbi'
+license=('BSD-2-Clause')
+install=opensbi-spacemit.install
+depends=(
+  'bash'
+)
+makedepends=(
+  'dtc'
+  'git'
+  'python'
+  'uboot-tools'
+)
+options=('!strip' '!debug')
+source=(
+  "git+https://github.com/spacemit-com/opensbi.git#tag=${_tag}"
+  'opensbi-spacemit-flash'
+)
+sha512sums=('SKIP'
+            '4a61f0976e7e2771cb9ee2b6da2c49ae9047b019c33526f225dd548579d803b5bc839cd28a374015a8a2ed78c136c54fab927265a5c1e4498381c64aabee691a')
+
+build() {
+  cd opensbi
+
+  make \
+    PLATFORM=generic \
+    PLATFORM_DEFCONFIG=k3_defconfig
+}
+
+package() {
+  cd opensbi
+
+  local _dest="$pkgdir"/usr/share/opensbi/lp64/spacemit-k3/firmware
+  install -d "$_dest"
+
+  install -Dm644 build/platform/generic/firmware/fw_dynamic.bin \
+    "$_dest"/fw_dynamic.bin
+  install -Dm644 build/platform/generic/firmware/fw_dynamic.itb \
+    "$_dest"/fw_dynamic.itb
+
+  install -Dm755 "$srcdir"/opensbi-spacemit-flash "$pkgdir"/usr/bin/opensbi-spacemit-flash
+  install -Dm644 COPYING.BSD "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
+}

--- a/opensbi-spacemit-k3/opensbi-spacemit-flash
+++ b/opensbi-spacemit-k3/opensbi-spacemit-flash
@@ -1,0 +1,207 @@
+#!/bin/bash
+set -euo pipefail
+
+_opensbi_itb=/usr/share/opensbi/lp64/spacemit-k3/firmware/fw_dynamic.itb
+_dry_run=0
+
+usage() {
+    cat <<USAGE
+Usage: opensbi-spacemit-flash [--dry-run]
+
+Flash $_opensbi_itb to the detected SpacemiT boot device.
+USAGE
+}
+
+running_in_chroot() {
+    if [[ "${SYSTEMD_IGNORE_CHROOT:-0}" == "1" ]]; then
+        return 1
+    fi
+    if [[ -e /proc/1/root ]]; then
+        local root_dev_ino proc1_root_dev_ino
+        root_dev_ino=$(stat -c '%d:%i' / 2>/dev/null) || return 0
+        proc1_root_dev_ino=$(stat -L -c '%d:%i' /proc/1/root 2>/dev/null) || return 0
+        [[ "$root_dev_ino" == "$proc1_root_dev_ino" ]] && return 1 || return 0
+    fi
+    if [[ ! -d /proc || ! -r /proc/version ]]; then
+        [[ $$ == 1 ]] && return 1 || return 0
+    fi
+    return 0
+}
+
+boot_device_from_mode() {
+    local mode=$1
+
+    case $mode in
+        emmc) echo /dev/mmcblk2 ;;
+        sdcard) echo /dev/mmcblk0 ;;
+        nor|nand)
+            if [[ -e /dev/mtdblock0 ]]; then
+                echo /dev/mtdblock0
+            fi
+            ;;
+        ufs) echo /dev/sda ;;
+    esac
+}
+
+base_device() {
+    local dev=$1
+
+    case $dev in
+        /dev/mmcblk0*) echo /dev/mmcblk0 ;;
+        /dev/mmcblk2*) echo /dev/mmcblk2 ;;
+        /dev/sda*) echo /dev/sda ;;
+        /dev/nvme0n1*) echo /dev/nvme0n1 ;;
+    esac
+}
+
+resolve_root_device() {
+    local root_spec=$1
+
+    case $root_spec in
+        UUID=*) blkid -U "${root_spec#UUID=}" 2>/dev/null || true ;;
+        /dev/*) echo "$root_spec" ;;
+    esac
+}
+
+detect_target_device() {
+    local boot_mode='' root_spec='' root='' x
+    local cmdline=()
+
+    read -r -a cmdline < /proc/cmdline
+    for x in "${cmdline[@]}"; do
+        case $x in
+            root=*) root_spec=${x#root=} ;;
+            boot_mode=*) boot_mode=${x#boot_mode=} ;;
+        esac
+    done
+
+    if [[ -n $root_spec ]]; then
+        root=$(resolve_root_device "$root_spec")
+    fi
+
+    if [[ -n $boot_mode ]]; then
+        local boot_device
+        boot_device=$(boot_device_from_mode "$boot_mode")
+        if [[ -n $boot_device && -n $root ]]; then
+            local root_base_device
+            root_base_device=$(base_device "$root")
+            if [[ $boot_device != "$root_base_device" ]]; then
+                echo "$boot_device"
+            else
+                echo "$root_base_device"
+            fi
+            return 0
+        elif [[ -n $boot_device ]]; then
+            echo "$boot_device"
+            return 0
+        else
+            echo "Unsupported boot_mode=$boot_mode" >&2
+            return 1
+        fi
+    fi
+
+    if [[ -n $root ]]; then
+        base_device "$root"
+        return 0
+    fi
+
+    echo "Unable to determine target device (missing root= or boot_mode= in cmdline)" >&2
+    return 1
+}
+
+detect_opensbi_location() {
+    local target_device=$1
+
+    case $target_device in
+        /dev/mmcblk0|/dev/mmcblk2|/dev/sda)
+            echo "$target_device 7168"
+            ;;
+        /dev/mtdblock0)
+            if [[ -f /proc/mtd ]]; then
+                local mtd0_name
+                mtd0_name=$(grep '^mtd0:' /proc/mtd | awk -F'"' '{print $2}')
+                if [[ $mtd0_name == "bootinfo" ]]; then
+                    echo "/dev/mtdblock4 0"
+                else
+                    echo "/dev/mtdblock0 1728"
+                fi
+            else
+                echo "/dev/mtdblock0 1728"
+            fi
+            ;;
+        /dev/nvme0n1)
+            if [[ -f /proc/mtd ]]; then
+                local mtd0_name
+                mtd0_name=$(grep '^mtd0:' /proc/mtd | awk -F'"' '{print $2}')
+                if [[ $mtd0_name == "bootinfo" ]]; then
+                    echo "/dev/mtdblock4 0"
+                else
+                    echo "/dev/mtdblock0 1728"
+                fi
+            else
+                echo "/dev/mmcblk2 1728"
+            fi
+            ;;
+        *)
+            echo "Unsupported target device=$target_device" >&2
+            return 1
+            ;;
+    esac
+}
+
+flash_opensbi() {
+    if ! grep -q 'Spacemit(R) X100' /proc/cpuinfo 2>/dev/null; then
+        echo "Not running on SpacemiT X100, skipping OpenSBI flash."
+        return 0
+    fi
+
+    if running_in_chroot; then
+        echo "Running in chroot, skipping OpenSBI flash."
+        return 0
+    fi
+
+    if [[ ! -f $_opensbi_itb ]]; then
+        echo "Missing $_opensbi_itb" >&2
+        return 1
+    fi
+
+    local target_device opensbi seek
+    target_device=$(detect_target_device)
+    read -r opensbi seek < <(detect_opensbi_location "$target_device")
+
+    if [[ ! -e $opensbi ]]; then
+        echo "Missing device $opensbi" >&2
+        return 1
+    fi
+
+    if (( _dry_run )); then
+        echo "Would flash $_opensbi_itb to $opensbi at offset ${seek}K."
+        return 0
+    fi
+
+    if (( EUID != 0 )); then
+        echo "Run as root to flash $opensbi." >&2
+        return 1
+    fi
+
+    echo "Flashing $_opensbi_itb to $opensbi at offset ${seek}K ..."
+    dd if="$_opensbi_itb" of="$opensbi" seek="$seek" bs=1K && sync
+    echo "Done."
+}
+
+while (( $# )); do
+    case $1 in
+        --dry-run) _dry_run=1 ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            usage >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+flash_opensbi

--- a/opensbi-spacemit-k3/opensbi-spacemit.install
+++ b/opensbi-spacemit-k3/opensbi-spacemit.install
@@ -1,0 +1,13 @@
+post_install() {
+    cat <<'EOF'
+:: OpenSBI firmware was installed to /usr/share/opensbi/lp64/spacemit-k3/firmware.
+:: To flash it to the detected SpacemiT boot device, run as root:
+::   opensbi-spacemit-flash
+:: To preview the target without writing, run:
+::   opensbi-spacemit-flash --dry-run
+EOF
+}
+
+post_upgrade() {
+    post_install
+}

--- a/u-boot-spacemit-k3/PKGBUILD
+++ b/u-boot-spacemit-k3/PKGBUILD
@@ -1,0 +1,70 @@
+# Maintainer: Felix Yan <felixonmars@archlinux.org>
+
+pkgname=u-boot-spacemit-k3
+pkgver=1.0.0
+_tag=k3-br-v${pkgver}
+pkgrel=1
+pkgdesc='U-Boot bootloader for SpacemiT K3 platforms'
+arch=('riscv64')
+url='https://github.com/spacemit-com/uboot-2022.10'
+license=('GPL-2.0-or-later')
+install=u-boot-spacemit.install
+depends=(
+  'bash'
+  'opensbi-spacemit-k3'
+)
+makedepends=(
+  'bc'
+  'bison'
+  'dtc'
+  'flex'
+  'git'
+  'gnutls'
+  'ncurses'
+  'openssl'
+  'python'
+  'python-pyelftools'
+  'python-setuptools'
+  'swig'
+  'util-linux-libs'
+)
+options=('!strip' '!debug')
+source=(
+  "git+https://github.com/spacemit-com/uboot-2022.10.git#tag=${_tag}"
+  'u-boot-spacemit-flash'
+)
+sha512sums=('SKIP'
+            'e93489dc06609873bc2c5cc76fdb184e572865f15960e946e519ccd14c133dadb93a0aac06aef81f441222533ce3181177912944f9296a7b87da22b86545f31b')
+
+build() {
+  cd uboot-2022.10
+
+  local _opensbi=/usr/share/opensbi/lp64/spacemit-k3/firmware/fw_dynamic.bin
+
+  make k3_defconfig
+  sed -i "s/^CONFIG_LOCALVERSION=.*/CONFIG_LOCALVERSION=\"-${pkgrel}\"/" .config
+
+  make OPENSBI="$_opensbi"
+  cp -f u-boot-env-default.bin env.bin
+}
+
+package() {
+  cd uboot-2022.10
+
+  local _dest="$pkgdir"/usr/lib/u-boot/spacemit
+  install -d "$_dest"
+
+  install -Dm644 u-boot.itb "$_dest"/u-boot.itb
+
+  local _artifact
+  for _artifact in FSBL.bin bootinfo*.bin env.bin; do
+    [[ -e $_artifact ]] && install -Dm644 "$_artifact" "$_dest"/"$_artifact"
+  done
+
+  if [[ -f tools/logos/bianbu.bmp ]]; then
+    install -Dm644 tools/logos/bianbu.bmp "$pkgdir"/boot/bianbu.bmp
+  fi
+
+  install -Dm755 "$srcdir"/u-boot-spacemit-flash "$pkgdir"/usr/bin/u-boot-spacemit-flash
+  install -Dm644 Licenses/gpl-2.0.txt "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
+}

--- a/u-boot-spacemit-k3/u-boot-spacemit-flash
+++ b/u-boot-spacemit-k3/u-boot-spacemit-flash
@@ -1,0 +1,228 @@
+#!/bin/bash
+set -euo pipefail
+
+_bin_dir=/usr/lib/u-boot/spacemit
+_dry_run=0
+
+usage() {
+    cat <<USAGE
+Usage: u-boot-spacemit-flash [--dry-run]
+
+Flash U-Boot firmware from $_bin_dir to the detected SpacemiT boot device.
+USAGE
+}
+
+running_in_chroot() {
+    if [[ "${SYSTEMD_IGNORE_CHROOT:-0}" == "1" ]]; then
+        return 1
+    fi
+    if [[ -e /proc/1/root ]]; then
+        local root_dev_ino proc1_root_dev_ino
+        root_dev_ino=$(stat -c '%d:%i' / 2>/dev/null) || return 0
+        proc1_root_dev_ino=$(stat -L -c '%d:%i' /proc/1/root 2>/dev/null) || return 0
+        [[ "$root_dev_ino" == "$proc1_root_dev_ino" ]] && return 1 || return 0
+    fi
+    if [[ ! -d /proc || ! -r /proc/version ]]; then
+        [[ $$ == 1 ]] && return 1 || return 0
+    fi
+    return 0
+}
+
+boot_device_from_mode() {
+    local mode=$1
+
+    case $mode in
+        emmc) echo /dev/mmcblk2 ;;
+        sdcard) echo /dev/mmcblk0 ;;
+        nor|nand)
+            if [[ -e /dev/mtdblock0 ]]; then
+                echo /dev/mtdblock0
+            fi
+            ;;
+        ufs) echo /dev/sda ;;
+    esac
+}
+
+base_device() {
+    local dev=$1
+
+    case $dev in
+        /dev/mmcblk0*) echo /dev/mmcblk0 ;;
+        /dev/mmcblk2*) echo /dev/mmcblk2 ;;
+        /dev/sda*) echo /dev/sda ;;
+        /dev/nvme0n1*) echo /dev/nvme0n1 ;;
+    esac
+}
+
+resolve_root_device() {
+    local root_spec=$1
+
+    case $root_spec in
+        UUID=*) blkid -U "${root_spec#UUID=}" 2>/dev/null || true ;;
+        /dev/*) echo "$root_spec" ;;
+    esac
+}
+
+detect_target_device() {
+    local boot_mode='' root_spec='' root='' x
+    local cmdline=()
+
+    read -r -a cmdline < /proc/cmdline
+    for x in "${cmdline[@]}"; do
+        case $x in
+            root=*) root_spec=${x#root=} ;;
+            boot_mode=*) boot_mode=${x#boot_mode=} ;;
+        esac
+    done
+
+    if [[ -n $root_spec ]]; then
+        root=$(resolve_root_device "$root_spec")
+    fi
+
+    if [[ -n $boot_mode ]]; then
+        local boot_device
+        boot_device=$(boot_device_from_mode "$boot_mode")
+        if [[ -n $boot_device && -n $root ]]; then
+            local root_base_device
+            root_base_device=$(base_device "$root")
+            if [[ $boot_device != "$root_base_device" ]]; then
+                echo "$boot_device"
+            else
+                echo "$root_base_device"
+            fi
+            return 0
+        elif [[ -n $boot_device ]]; then
+            echo "$boot_device"
+            return 0
+        else
+            echo "Unsupported boot_mode=$boot_mode" >&2
+            return 1
+        fi
+    fi
+
+    if [[ -n $root ]]; then
+        base_device "$root"
+        return 0
+    fi
+
+    echo "Unable to determine target device (missing root= or boot_mode= in cmdline)" >&2
+    return 1
+}
+
+detect_flash_layout() {
+    local target_device=$1
+    local boot_mode='' x
+    local cmdline=()
+
+    read -r -a cmdline < /proc/cmdline
+    for x in "${cmdline[@]}"; do
+        case $x in
+            boot_mode=*) boot_mode=${x#boot_mode=} ;;
+        esac
+    done
+
+    case $target_device in
+        /dev/mmcblk0|/dev/mmcblk2|/dev/sda)
+            echo "bootinfo_block.bin $target_device 1048576 1 FSBL.bin $target_device 1572864 1 env.bin $target_device 655360 1 u-boot.itb $target_device 8192 1024"
+            ;;
+        /dev/mtdblock0)
+            local bootinfo_file=bootinfo_spinor.bin
+            if [[ $boot_mode == nand ]]; then
+                bootinfo_file=bootinfo_spinand.bin
+            fi
+            echo "$bootinfo_file /dev/mtdblock0 0 1 FSBL.bin /dev/mtdblock0 131072 1 env.bin /dev/mtdblock0 655360 1 u-boot.itb /dev/mtdblock0 2112 1024"
+            ;;
+        /dev/nvme0n1)
+            if [[ -e /dev/mtdblock6 ]]; then
+                echo "bootinfo_spinor.bin /dev/mtdblock1 0 1 FSBL.bin /dev/mtdblock2 0 1 env.bin /dev/mtdblock3 0 1 u-boot.itb /dev/mtdblock6 0 1024"
+            elif [[ -e /dev/mtdblock0 ]]; then
+                echo "bootinfo_spinor.bin /dev/mtdblock0 0 1 FSBL.bin /dev/mtdblock0 131072 1 env.bin /dev/mtdblock0 655360 1 u-boot.itb /dev/mtdblock0 2112 1024"
+            else
+                echo "bootinfo_block.bin /dev/mmcblk2 1048576 1 FSBL.bin /dev/mmcblk2 1572864 1 env.bin /dev/mmcblk2 655360 1 u-boot.itb /dev/mmcblk2 2112 1024"
+            fi
+            ;;
+        *)
+            echo "Unsupported target device=$target_device" >&2
+            return 1
+            ;;
+    esac
+}
+
+flash_uboot() {
+    if ! grep -q 'Spacemit(R) X100' /proc/cpuinfo 2>/dev/null; then
+        echo "Not running on SpacemiT X100, skipping U-Boot flash."
+        return 0
+    fi
+
+    if running_in_chroot; then
+        echo "Running in chroot, skipping U-Boot flash."
+        return 0
+    fi
+
+    local target_device
+    target_device=$(detect_target_device)
+
+    local layout
+    layout=$(detect_flash_layout "$target_device")
+
+    local words=()
+    read -r -a words <<< "$layout"
+
+    local i file dev seek bs
+    for (( i = 0; i < ${#words[@]}; i += 4 )); do
+        file=${words[i]}
+        dev=${words[i + 1]}
+
+        if [[ ! -e $_bin_dir/$file ]]; then
+            echo "Missing $_bin_dir/$file" >&2
+            return 1
+        fi
+        if [[ ! -e $dev ]]; then
+            echo "Missing device $dev" >&2
+            return 1
+        fi
+    done
+
+    if (( _dry_run )); then
+        for (( i = 0; i < ${#words[@]}; i += 4 )); do
+            file=${words[i]}
+            dev=${words[i + 1]}
+            seek=${words[i + 2]}
+            bs=${words[i + 3]}
+            echo "Would flash $_bin_dir/$file to $dev at seek=$seek bs=$bs."
+        done
+        return 0
+    fi
+
+    if (( EUID != 0 )); then
+        echo "Run as root to flash U-Boot." >&2
+        return 1
+    fi
+
+    echo "Flashing U-Boot to $target_device ..."
+    for (( i = 0; i < ${#words[@]}; i += 4 )); do
+        file=${words[i]}
+        dev=${words[i + 1]}
+        seek=${words[i + 2]}
+        bs=${words[i + 3]}
+        dd if="$_bin_dir/$file" of="$dev" seek="$seek" bs="$bs" 2>/dev/null && sync
+    done
+    echo "U-Boot flash complete."
+}
+
+while (( $# )); do
+    case $1 in
+        --dry-run) _dry_run=1 ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            usage >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+flash_uboot

--- a/u-boot-spacemit-k3/u-boot-spacemit.install
+++ b/u-boot-spacemit-k3/u-boot-spacemit.install
@@ -1,0 +1,13 @@
+post_install() {
+    cat <<'EOF'
+:: U-Boot firmware was installed to /usr/lib/u-boot/spacemit.
+:: To flash it to the detected SpacemiT boot device, run as root:
+::   u-boot-spacemit-flash
+:: To preview the target without writing, run:
+::   u-boot-spacemit-flash --dry-run
+EOF
+}
+
+post_upgrade() {
+    post_install
+}


### PR DESCRIPTION
Package SpacemiT K3 ESOS firmware as a native riscv64 build. The build follows upstream's newlib-based bare-metal flow using the native GNU toolchain and the packaged riscv64-unknown-elf newlib sysroot, with the original flashing behavior exposed as an explicit helper script.