### PR TITLE
addpatch: jitterentropy 3.7.0-1

### DIFF
--- a/jitterentropy/jitterentropy-riscv-use-rdtime.patch
+++ b/jitterentropy/jitterentropy-riscv-use-rdtime.patch
@@ -1,0 +1,43 @@
+diff --git a/jitterentropy-base-user.h b/jitterentropy-base-user.h
+index ad160df..f9d4d55 100644
+--- a/jitterentropy-base-user.h
++++ b/jitterentropy-base-user.h
+@@ -231,7 +231,37 @@ static inline void jent_get_nstime(uint64_t *out)
+ 	*out = result;
+ }
+ 
+-#else /* (__x86_64__) || (__i386__) || (__aarch64__) || (__s390x__) || (__powerpc) */
++#elif defined(__riscv)
++
++#ifndef RISCV_NSTIME_INSN
++#define RISCV_NSTIME_INSN "rdtime"
++#endif
++#if __riscv_xlen < 64
++#ifndef RISCV_NSTIME_INSN_HI
++#define RISCV_NSTIME_INSN_HI "rdtimeh"
++#endif
++#endif
++
++static inline void jent_get_nstime(uint64_t *out)
++{
++#if __riscv_xlen >= 64
++	uint64_t ctr_val;
++	__asm__ __volatile__(RISCV_NSTIME_INSN " %0" : "=r" (ctr_val));
++	*out = ctr_val;
++#else
++	uint32_t hi, lo, hi2;
++	__asm__ __volatile__(
++		"1:\n\t"
++		RISCV_NSTIME_INSN_HI " %0\n\t"
++		RISCV_NSTIME_INSN    " %1\n\t"
++		RISCV_NSTIME_INSN_HI " %2\n\t"
++		"bne %0, %2, 1b"
++		: "=&r" (hi), "=&r" (lo), "=&r" (hi2));
++	*out = ((uint64_t)hi << 32) | (uint64_t)lo;
++#endif
++}
++
++#else /* (__x86_64__) || (__i386__) || (__aarch64__) || (__s390x__) || (__powerpc) || (__riscv) */
+ 
+ static inline void jent_get_nstime(uint64_t *out)
+ {

--- a/jitterentropy/riscv64.patch
+++ b/jitterentropy/riscv64.patch
@@ -1,0 +1,21 @@
+diff --git PKGBUILD PKGBUILD
+index 425c4b9..69a2e40 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -19,6 +19,8 @@
+ prepare() {
+   cd "$_pkgname-$pkgver"
+ 
++  patch -Np1 -i "../$pkgname-riscv-use-rdtime.patch"
++
+   # Disable man page compression on install
+   sed -e '/\tgzip .*\/man\// d' -i Makefile
+   # Let the package manager handle stripping
+@@ -38,4 +40,7 @@
+   install -Dm644 LICENSE.bsd "$pkgdir/usr/share/licenses/$pkgname/LICENSE.bsd"
+ }
+ 
++source_riscv64=("$pkgname-riscv-use-rdtime.patch")
++sha256sums_riscv64=('9bbe5ba93cbda062866ec51347b64f9ed746015166764d6dfe0e74ad723f04f1')
++
+ # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
Backport https://github.com/smuellerDD/jitterentropy-library/commit/59dc5997905ff757bba24a023d7e636b6fe66b48, which cannot be applied directly.