### PR TITLE
addpatch: libsieve 2.3.1-6

### DIFF
--- a/libsieve/libsieve-header-body-yystype.patch
+++ b/libsieve/libsieve-header-body-yystype.patch
@@ -1,0 +1,21 @@
+--- a/src/sv_parser/header.y
++++ b/src/sv_parser/header.y
+@@ -64,13 +64,14 @@
+                 libsieve_headerentry(context, $1, $3);
+                 };
+ 
+-body: /* empty */ | TEXT                      {
+-                /* Default action is $$ = $1 */
++body: /* empty */		{ $$ = NULL; }
++	| TEXT			{
+                 TRACE_DEBUG( "body: TEXT: %s", $1 );
++                $$ = $1;
+                 }
+         | body WRAP             {
+-                TRACE_DEBUG( "body: body WRAP: %s %s", $1, $2 );
+-                $$ = libsieve_strbuf(context->strbuf, libsieve_strconcat( $1 ? $1 : "", $2, NULL ), strlen($1 ? $1 : "")+strlen($2), FREEME);
++                TRACE_DEBUG( "body: body WRAP: %s %s", $1 ? $1 : "", $2 ? $2 : "" );
++                $$ = libsieve_strbuf(context->strbuf, libsieve_strconcat( $1 ? $1 : "", $2 ? $2 : "", NULL ), strlen($1 ? $1 : "")+strlen($2 ? $2 : ""), FREEME);
+                 };
+ 
+ %%

--- a/libsieve/riscv64.patch
+++ b/libsieve/riscv64.patch
@@ -1,0 +1,22 @@
+diff --git PKGBUILD PKGBUILD
+index 2c1bb45..3217a1f 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -24,6 +24,8 @@
+   rm -f src/sv_parser/{addr,header,sieve}-lex.{c,h}
+   patch -p1 <"$srcdir"/glibc-regex.patch
+   patch -p1 <"$srcdir"/crash-fix.patch
++  patch -p1 <"$srcdir/$pkgname-unsigned-char-lexers.patch"
++  patch -p1 <"$srcdir/$pkgname-header-body-yystype.patch"
+ }
+ 
+ build() {
+@@ -64,3 +66,8 @@
+   cd "$srcdir/$pkgname"
+   make DESTDIR="$pkgdir/" install
+ }
++
++source_riscv64=("$pkgname-unsigned-char-lexers.patch::https://github.com/sodabrew/libsieve/pull/9.patch?full_index=1"
++                "$pkgname-header-body-yystype.patch")
++sha512sums_riscv64=('cb8b1945cbdf16436ce97800c48c557f3546faa0670a07bd598b1158e8b75add0437d93cd8ffd7a4254fbe2c6fff83b4793ccec2953cc79f16668cd090520ccc'
++                    '99bf0a9ccc062665ba71057541827ed6cd45ce91c0c46159a1f9e9e10d7fabe8755699e12377984e19526b35998f5eb94bc763d67e6b2dd6da0b5305f859e662')


### PR DESCRIPTION
https://github.com/sodabrew/libsieve/pull/8
	- This patch cannot be appilied directly so store it here.
https://github.com/sodabrew/libsieve/pull/9