### PR TITLE
addpatch: p2pool 4.18-1

### DIFF
--- a/p2pool/riscv64.patch
+++ b/p2pool/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -122,7 +122,7 @@
+ build() {
+   cd ${pkgname}/build
+   # -DCMAKE_POLICY_VERSION_MINIMUM=3.5 can be removed as soon as the project builds without
+-  cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5
++  cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_CXX_FLAGS="$CXXFLAGS -Wno-error=stringop-overflow"
+   make -j$(nproc)
+ }
+ 


### PR DESCRIPTION
GCC 16 on riscv64 reports `writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]` from libstdc++ vector::shrink_to_fit after p2pool clears m_hashingBlob; keep the warning but stop upstream -Werror from making it fatal.