### PR TITLE
updpatch: libtool 2.6.2-5

### DIFF
--- a/libtool/riscv64.patch
+++ b/libtool/riscv64.patch
@@ -6,15 +6,6 @@
  pkgbase=libtool
 -pkgname=(libtool lib32-libltdl)
 +pkgname=(libtool)
- pkgver=2.6.1
- _commit=79de7bb71bc0a1167f4c4ae8bd897976a0ff2b51
- pkgrel=1
-@@ -24,8 +24,6 @@
-   "gcc>=$_gccver"
-   git
-   glibc
--  lib32-gcc-libs
--  lib32-glibc
-   help2man
- )
- checkdepends=(
+ pkgver=2.6.2
+ _commit=309bb53a8adfb22c6e5869cc8da049bf123e5438
+ pkgrel=5


### PR DESCRIPTION
Refresh the riscv64 patch after the 2.6.2 update.

Arch now scopes lib32 makedepends to x86_64, so the overlay only needs to remove the lib32-libltdl output.