### PR TITLE
addpatch: edk2 202605-1

### DIFF
--- a/edk2/riscv64.patch
+++ b/edk2/riscv64.patch
@@ -1,0 +1,26 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -20,7 +20,7 @@
+   util-linux-libs
+   nasm
+   python
+-  riscv64-linux-gnu-gcc
++  x86_64-linux-gnu-gcc
+ )
+ options=(!makeflags)
+ source=(
+@@ -190,12 +190,9 @@
+   )
+ 
+   cd $pkgbase
+-  # This is used as the prefix for both gcc and objcopy
+-  # so it cannot be set to x86_64-linux-gnu-
+-  # (binutils does not provide x86_64-linux-gnu-objcopy)
+-  export GCC_BIN=""
++  # Cross-compile IA32/X64 binaries on non-x86 hosts.
++  export GCC_BIN="x86_64-linux-gnu-"
+   export GCC_AARCH64_PREFIX="aarch64-linux-gnu-"
+-  export GCC_RISCV64_PREFIX="riscv64-linux-gnu-"
+   echo "Building base tools"
+   make -C BaseTools
+   # expose build tooling in PATH


### PR DESCRIPTION
Add a RISC-V overlay patch that uses the native compiler for RiscV64 while adding the x86_64 cross compiler and GCC_BIN prefix needed for IA32/X64 firmware targets.