### PR TITLE
updpatch: meson 1.12.0-1

### DIFF
--- a/meson/riscv64.patch
+++ b/meson/riscv64.patch
@@ -1,24 +1,24 @@
-diff --git PKGBUILD PKGBUILD
-index 94643a7..c7c1a64 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -28,7 +28,6 @@ checkdepends=(
-   boost
+@@ -30,9 +30,7 @@
+   byacc
    clang
    cmake
 -  cuda
    cython
+-  dmd
    doxygen
    gcc-fortran
-@@ -42,7 +41,6 @@ checkdepends=(
+   gcc-objc
+@@ -45,7 +43,6 @@
    graphviz
    gtest
    gtk-doc
 -  gtk-sharp-3
    gtk3
    gtkmm3
-   hdf5
-@@ -54,7 +52,6 @@ checkdepends=(
+   hotdoc
+@@ -56,7 +53,6 @@
    libwmf
    llvm
    mercurial

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -80,6 +80,7 @@ mdbook
 meilisearch
 memcached
 menyoki
+meson
 mkvtoolnix
 mold
 mongo-c-driver


### PR DESCRIPTION
The riscv64 build first fails while resolving checkdepends because dmd is unavailable; drop it with the other unavailable checkdepends.

The next log reaches check() and fails in ASan/LeakSanitizer tests because LSan's ptrace-based stop-the-world handling does not work under qemu-user, so add meson to qemu-user-blacklist.txt.