### PR TITLE
updpatch: java11-openjdk 11.0.32.1.u1-1

### DIFF
--- a/java11-openjdk/java11-riscv64.patch
+++ b/java11-openjdk/java11-riscv64.patch
@@ -40,14 +40,7 @@ Index: jdk11u-jdk-11.0.21-9/make/autoconf/platform.m4
 ===================================================================
 --- jdk11u-jdk-11.0.21-9.orig/make/autoconf/platform.m4
 +++ jdk11u-jdk-11.0.21-9/make/autoconf/platform.m4
-@@ -1,5 +1,5 @@
- #
--# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
-+# Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
- # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
- #
- # This code is free software; you can redistribute it and/or modify it
-@@ -554,6 +554,8 @@ AC_DEFUN([PLATFORM_SETUP_LEGACY_VARS_HEL
+@@ -560,6 +560,8 @@ AC_DEFUN([PLATFORM_SETUP_LEGACY_VARS_HEL
      HOTSPOT_$1_CPU_DEFINE=PPC64
    elif test "x$OPENJDK_$1_CPU" = xppc64le; then
      HOTSPOT_$1_CPU_DEFINE=PPC64
@@ -54299,12 +54292,12 @@ Index: jdk11u-jdk-11.0.21-9/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDe
  static jfieldID p_ps_prochandle_ID = 0;
  static jfieldID threadList_ID = 0;
  static jfieldID loadObjectList_ID = 0;
-@@ -397,7 +401,7 @@ JNIEXPORT jbyteArray JNICALL Java_sun_jv
+@@ -401,7 +405,7 @@ JNIEXPORT jbyteArray JNICALL Java_sun_jv
    return (err == PS_OK)? array : 0;
  }
  
--#if defined(i386) || defined(amd64) || defined(sparc) || defined(sparcv9) | defined(ppc64) || defined(ppc64le) || defined(aarch64)
-+#if defined(i386) || defined(amd64) || defined(sparc) || defined(sparcv9) | defined(ppc64) || defined(ppc64le) || defined(aarch64) || defined(riscv64)
+-#if defined(i586) || defined(amd64) || defined(sparc) || defined(sparcv9) | defined(ppc64) || defined(ppc64le) || defined(aarch64)
++#if defined(i586) || defined(amd64) || defined(sparc) || defined(sparcv9) | defined(ppc64) || defined(ppc64le) || defined(aarch64) || defined(riscv64)
  JNIEXPORT jlongArray JNICALL Java_sun_jvm_hotspot_debugger_linux_LinuxDebuggerLocal_getThreadIntegerRegisterSet0
    (JNIEnv *env, jobject this_obj, jint lwp_id) {
  

--- a/java11-openjdk/riscv64.patch
+++ b/java11-openjdk/riscv64.patch
@@ -1,14 +1,14 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -68,6 +68,7 @@
+@@ -67,6 +67,7 @@
+ case "${CARCH}" in
    x86_64) _JARCH='x86_64';;
-   i686)   _JARCH='x86';;
    aarch64)_JARCH='aarch64';;
 +  riscv64)_JARCH='riscv64';;
  esac
  
  _jvmdir=/usr/lib/jvm/java-${_majorver}-openjdk
-@@ -97,6 +98,11 @@
+@@ -96,6 +97,11 @@
    nss
  )
  
@@ -20,12 +20,12 @@
  build() {
    cd ${_jdkdir}
  
-@@ -442,4 +448,8 @@
+@@ -435,4 +441,8 @@
    ln -s ${pkgbase} "${pkgdir}/usr/share/licenses/${pkgname}"
  }
  
 +# see https://build.opensuse.org/package/show/home:Andreas_Schwab:riscv:java/java-11-openjdk
 +source+=(java11-riscv64.patch)
-+sha256sums+=('862b3b865da51a210d0d1c83be7912e23246c99397b27ea312566be35f510499')
++sha256sums+=('244847ec6ea172f54bed88be14ce4e877ea931e78a8e60aa7d96f37fd7b9743e')
 +
  # vim: ts=2 sw=2 et:


### PR DESCRIPTION
Refresh patch so prepare() applies to 11.0.32.1. The current source already has the platform.m4 copyright update and now uses i586 in LinuxDebuggerLocal.c.