### PR TITLE
updpatch: java8-openjdk 8.504.u01-1

### DIFF
--- a/java8-openjdk/jdk8-riscv.patch
+++ b/java8-openjdk/jdk8-riscv.patch
@@ -1,55 +1,39 @@
-diff --git a/jdk8u-jdk8u482-b08/common/autoconf/build-aux/autoconf-config.guess b/jdk8u-jdk8u482-b08/common/autoconf/build-aux/autoconf-config.guess
-index 15ee438..c7355c3 100644
---- a/jdk8u-jdk8u482-b08/common/autoconf/build-aux/autoconf-config.guess
-+++ b/jdk8u-jdk8u482-b08/common/autoconf/build-aux/autoconf-config.guess
-@@ -1000,6 +1000,9 @@ EOF
+diff -urN a/jdk8u-jdk8u504-b01/common/autoconf/build-aux/autoconf-config.guess b/jdk8u-jdk8u504-b01/common/autoconf/build-aux/autoconf-config.guess
+--- a/jdk8u-jdk8u504-b01/common/autoconf/build-aux/autoconf-config.guess	2026-08-10 15:49:49.000000000 +0000
++++ b/jdk8u-jdk8u504-b01/common/autoconf/build-aux/autoconf-config.guess	2026-08-24 15:32:56.455255309 +0000
+@@ -1000,6 +1000,9 @@
      ppc:Linux:*:*)
-	echo powerpc-unknown-linux-gnu
-	exit ;;
+ 	echo powerpc-unknown-linux-gnu
+ 	exit ;;
 +    riscv64:Linux:*:*)
 +	echo riscv64-unknown-linux-gnu
 +	exit ;;
      s390:Linux:*:* | s390x:Linux:*:*)
-	echo ${UNAME_MACHINE}-ibm-linux
-	exit ;;
-diff --git a/jdk8u-jdk8u482-b08/common/autoconf/build-aux/autoconf-config.sub b/jdk8u-jdk8u482-b08/common/autoconf/build-aux/autoconf-config.sub
-index 1aab2b3..662b002 100644
---- a/jdk8u-jdk8u482-b08/common/autoconf/build-aux/autoconf-config.sub
-+++ b/jdk8u-jdk8u482-b08/common/autoconf/build-aux/autoconf-config.sub
-@@ -302,6 +302,7 @@ case $basic_machine in
-	| pdp10 | pdp11 | pj | pjl \
-	| powerpc | powerpc64 | powerpc64le | powerpcle | ppcbe \
-	| pyramid \
+ 	echo ${UNAME_MACHINE}-ibm-linux
+ 	exit ;;
+diff -urN a/jdk8u-jdk8u504-b01/common/autoconf/build-aux/autoconf-config.sub b/jdk8u-jdk8u504-b01/common/autoconf/build-aux/autoconf-config.sub
+--- a/jdk8u-jdk8u504-b01/common/autoconf/build-aux/autoconf-config.sub	2026-08-10 15:49:49.000000000 +0000
++++ b/jdk8u-jdk8u504-b01/common/autoconf/build-aux/autoconf-config.sub	2026-08-24 15:32:56.455356856 +0000
+@@ -302,6 +302,7 @@
+ 	| pdp10 | pdp11 | pj | pjl \
+ 	| powerpc | powerpc64 | powerpc64le | powerpcle | ppcbe \
+ 	| pyramid \
 +	| riscv32 | riscv64 \
-	| score \
-	| sh | sh[1234] | sh[24]a | sh[23]e | sh[34]eb | sheb | shbe | shle | sh[1234]le | sh3ele \
-	| sh64 | sh64le \
-@@ -383,6 +384,7 @@ case $basic_machine in
-	| pdp10-* | pdp11-* | pj-* | pjl-* | pn-* | power-* \
-	| powerpc-* | powerpc64-* | powerpc64le-* | powerpcle-* | ppcbe-* \
-	| pyramid-* \
+ 	| score \
+ 	| sh | sh[1234] | sh[24]a | sh[23]e | sh[34]eb | sheb | shbe | shle | sh[1234]le | sh3ele \
+ 	| sh64 | sh64le \
+@@ -383,6 +384,7 @@
+ 	| pdp10-* | pdp11-* | pj-* | pjl-* | pn-* | power-* \
+ 	| powerpc-* | powerpc64-* | powerpc64le-* | powerpcle-* | ppcbe-* \
+ 	| pyramid-* \
 +	| riscv32-* | riscv64-* \
-	| romp-* | rs6000-* \
-	| sh-* | sh[1234]-* | sh[24]a-* | sh[23]e-* | sh[34]eb-* | sheb-* | shbe-* \
-	| shle-* | sh[1234]le-* | sh3ele-* | sh64-* | sh64le-* \
-diff --git a/jdk8u-jdk8u482-b08/common/autoconf/platform.m4 b/jdk8u-jdk8u482-b08/common/autoconf/platform.m4
-index f54942a..e70c159 100644
---- a/jdk8u-jdk8u482-b08/common/autoconf/platform.m4
-+++ b/jdk8u-jdk8u482-b08/common/autoconf/platform.m4
-@@ -102,6 +102,12 @@ AC_DEFUN([PLATFORM_EXTRACT_VARS_FROM_CPU],
-       VAR_CPU_BITS=64
-       VAR_CPU_ENDIAN=little
-       ;;
-+    riscv64)
-+      VAR_CPU=riscv64
-+      VAR_CPU_ARCH=riscv
-+      VAR_CPU_BITS=64
-+      VAR_CPU_ENDIAN=little
-+      ;;
-     *)
-       AC_MSG_ERROR([unsupported cpu $1])
-       ;;
-@@ -387,6 +393,7 @@ AC_DEFUN([PLATFORM_SETUP_LEGACY_VARS],
+ 	| romp-* | rs6000-* \
+ 	| sh-* | sh[1234]-* | sh[24]a-* | sh[23]e-* | sh[34]eb-* | sheb-* | shbe-* \
+ 	| shle-* | sh[1234]le-* | sh3ele-* | sh64-* | sh64le-* \
+diff -urN a/jdk8u-jdk8u504-b01/common/autoconf/platform.m4 b/jdk8u-jdk8u504-b01/common/autoconf/platform.m4
+--- a/jdk8u-jdk8u504-b01/common/autoconf/platform.m4	2026-08-10 15:49:49.000000000 +0000
++++ b/jdk8u-jdk8u504-b01/common/autoconf/platform.m4	2026-08-24 15:33:26.380554511 +0000
+@@ -393,6 +393,7 @@
      sparc*)  ZERO_ARCHDEF=SPARC ;;
      x86_64*) ZERO_ARCHDEF=AMD64 ;;
      x86)     ZERO_ARCHDEF=IA32  ;;
@@ -57,53 +41,21 @@ index f54942a..e70c159 100644
      *)      ZERO_ARCHDEF=$(echo "${OPENJDK_TARGET_CPU_LEGACY_LIB}" | tr a-z A-Z)
    esac
    AC_SUBST(ZERO_ARCHDEF)
-diff --git a/jdk8u-jdk8u482-b08/hotspot/src/os/linux/vm/os_linux.cpp b/jdk8u-jdk8u482-b08/hotspot/src/os/linux/vm/os_linux.cpp
-index 5629a64..77fde84 100644
---- a/jdk8u-jdk8u482-b08/hotspot/src/os/linux/vm/os_linux.cpp
-+++ b/jdk8u-jdk8u482-b08/hotspot/src/os/linux/vm/os_linux.cpp
-@@ -363,8 +363,8 @@
+diff -urN a/jdk8u-jdk8u504-b01/hotspot/src/os/linux/vm/os_linux.cpp b/jdk8u-jdk8u504-b01/hotspot/src/os/linux/vm/os_linux.cpp
+--- a/jdk8u-jdk8u504-b01/hotspot/src/os/linux/vm/os_linux.cpp	2026-08-10 15:49:49.000000000 +0000
++++ b/jdk8u-jdk8u504-b01/hotspot/src/os/linux/vm/os_linux.cpp	2026-08-24 15:33:26.470554436 +0000
+@@ -363,7 +363,7 @@
    //        1: ...
    //        ...
    //        7: The default directories, normally /lib and /usr/lib.
 -#if defined(AMD64) || defined(_LP64) && (defined(SPARC) || defined(PPC) || defined(S390))
--  #define DEFAULT_LIBPATH "/usr/lib64:/lib64:/lib:/usr/lib"
 +#if defined(AMD64) || defined(_LP64) && (defined(SPARC) || defined(PPC) || defined(S390) || defined(RISCV))
-+  #define DEFAULT_LIBPATH "/usr/lib64:/lib64:/lib:/usr/lib"
+   #define DEFAULT_LIBPATH "/usr/lib64:/lib64:/lib:/usr/lib"
  #else
  #if defined(AARCH64)
-   // Use 32-bit locations first for AARCH64 (a 64-bit architecture), since some systems
-@@ -1959,6 +1959,9 @@
-   #ifndef EM_LOONGARCH
-   #define EM_LOONGARCH  258               /* LoongArch */
-   #endif
-+  #ifndef EM_RISCV
-+  #define EM_RISCV      243               /* RISC-V */
-+  #endif
+@@ -2058,10 +2058,12 @@
+   }
  
-   static const arch_t arch_array[]={
-     {EM_386,         EM_386,     ELFCLASS32, ELFDATA2LSB, (char*)"IA 32"},
-@@ -1986,6 +1989,7 @@
-     {EM_68K,         EM_68K,     ELFCLASS32, ELFDATA2MSB, (char*)"M68k"},
-     {EM_AARCH64,     EM_AARCH64, ELFCLASS64, ELFDATA2LSB, (char*)"AARCH64"},
-     {EM_LOONGARCH,   EM_LOONGARCH, ELFCLASS64, ELFDATA2LSB, (char*)"LoongArch"},
-+    {EM_RISCV,       EM_RISCV,   ELFCLASS64, ELFDATA2LSB, (char*)"RISCV"},
-   };
- 
-   #if  (defined IA32)
-@@ -2021,9 +2025,11 @@
-     static  Elf32_Half running_arch_code=EM_AARCH64;
-   #elif  (defined LOONGARCH64)
-     static  Elf32_Half running_arch_code=EM_LOONGARCH;
-+  #elif  (defined RISCV)
-+    static  Elf32_Half running_arch_code=EM_RISCV;
-   #else
-     #error Method os::dll_load requires that one of following is defined:\
--         IA32, AMD64, IA64, __sparc, __powerpc__, ARM, S390, ALPHA, MIPS, MIPSEL, PARISC, M68K, AARCH64, LOONGARCH64
-+         IA32, AMD64, IA64, __sparc, __powerpc__, ARM, S390, ALPHA, MIPS, MIPSEL, PARISC, M68K, AARCH64, LOONGARCH64, RISCV
-   #endif
- 
-   // Identify compatability class for VM's architecture and library's architecture
-@@ -2054,6 +2060,8 @@
  #ifndef S390
 +#ifndef RISCV
    if (lib_arch.elf_class != arch_array[running_arch_index].elf_class) {
@@ -113,12 +65,11 @@ index 5629a64..77fde84 100644
 +#endif // RISCV
  #endif // !S390
  
-  if (lib_arch.compat_class != arch_array[running_arch_index].compat_class) {
-diff --git a/jdk8u-jdk8u482-b08/jdk/src/share/bin/java.c b/jdk8u-jdk8u482-b08/jdk/src/share/bin/java.c
-index 9e579e6..65daf0d 100644
---- a/jdk8u-jdk8u482-b08/jdk/src/share/bin/java.c
-+++ b/jdk8u-jdk8u482-b08/jdk/src/share/bin/java.c
-@@ -145,7 +145,7 @@ static struct vmdesc *knownVMs = NULL;
+   if (lib_arch.compat_class != arch_array[running_arch_index].compat_class) {
+diff -urN a/jdk8u-jdk8u504-b01/jdk/src/share/bin/java.c b/jdk8u-jdk8u504-b01/jdk/src/share/bin/java.c
+--- a/jdk8u-jdk8u504-b01/jdk/src/share/bin/java.c	2026-08-10 15:49:49.000000000 +0000
++++ b/jdk8u-jdk8u504-b01/jdk/src/share/bin/java.c	2026-08-24 15:32:56.456166513 +0000
+@@ -145,7 +145,7 @@
  static int knownVMsCount = 0;
  static int knownVMsLimit = 0;
  
@@ -127,12 +78,10 @@ index 9e579e6..65daf0d 100644
  static int  KnownVMIndex(const char* name);
  static void FreeKnownVMs();
  static jboolean IsWildCardEnabled();
-diff --git a/jdk8u-jdk8u482-b08/jdk/src/share/native/common/jni_util.h b/jdk8u-jdk8u482-b08/jdk/src/share/native/common/jni_util.h
-index a51a6a1..24ee536 100644
---- a/jdk8u-jdk8u482-b08/jdk/src/share/native/common/jni_util.h
-+++ b/jdk8u-jdk8u482-b08/jdk/src/share/native/common/jni_util.h
-@@ -407,7 +407,7 @@ char* nativeGetStringPlatformChars(JNIEnv *env, jstring jstr, jboolean *isCopy);
- char* nativeGetStringPlatformChars(JNIEnv *env, jstring jstr, jboolean *isCopy);
+diff -urN a/jdk8u-jdk8u504-b01/jdk/src/share/native/common/jni_util.h b/jdk8u-jdk8u504-b01/jdk/src/share/native/common/jni_util.h
+--- a/jdk8u-jdk8u504-b01/jdk/src/share/native/common/jni_util.h	2026-08-10 15:49:49.000000000 +0000
++++ b/jdk8u-jdk8u504-b01/jdk/src/share/native/common/jni_util.h	2026-08-24 15:32:56.456268668 +0000
+@@ -407,7 +407,7 @@
  
  int getFastEncoding();
  
@@ -140,86 +89,87 @@ index a51a6a1..24ee536 100644
 +void initializeEncoding(JNIEnv *env);
  
  void* getProcessHandle();
-diff --git a/jdk8u-jdk8u482-b08/jdk/src/solaris/native/sun/awt/awt_GraphicsEnv.h b/jdk8u-jdk8u482-b08/jdk/src/solaris/native/sun/awt/awt_GraphicsEnv.h
-index 5b1f84d..72cdb56 100644
---- a/jdk8u-jdk8u482-b08/jdk/src/solaris/native/sun/awt/awt_GraphicsEnv.h
-+++ b/jdk8u-jdk8u482-b08/jdk/src/solaris/native/sun/awt/awt_GraphicsEnv.h
-@@ -50,8 +50,6 @@
- #define MITSHM_PERM_COMMON (0666)
- #define MITSHM_PERM_OWNER  (0600)
  
--extern int XShmQueryExtension();
--
- void TryInitMITShm(JNIEnv *env, jint *shmExt, jint *shmPixmaps);
- void resetXShmAttachFailed();
- jboolean isXShmAttachFailed();
-diff --git a/jdk8u-jdk8u482-b08/jdk/src/solaris/native/sun/awt/gtk2_interface.c b/jdk8u-jdk8u482-b08/jdk/src/solaris/native/sun/awt/gtk2_interface.c
-index 6db1fb9..cb85cde 100644
---- a/jdk8u-jdk8u482-b08/jdk/src/solaris/native/sun/awt/gtk2_interface.c
-+++ b/jdk8u-jdk8u482-b08/jdk/src/solaris/native/sun/awt/gtk2_interface.c
-@@ -1468,7 +1468,7 @@ gtk2_get_widget(GtkWidgetType widget_type)
-             if (init_result = (NULL == gtk2_widgets[_GTK_NOTEBOOK_TYPE]))
-             {
-                 gtk2_widgets[_GTK_NOTEBOOK_TYPE] =
--                    (*fp_gtk_notebook_new)(NULL);
-+                    (*fp_gtk_notebook_new)();
+diff -urN a/jdk8u-jdk8u504-b01/jdk/src/share/native/sun/awt/medialib/awt_ImagingLib.c b/jdk8u-jdk8u504-b01/jdk/src/share/native/sun/awt/medialib/awt_ImagingLib.c
+--- a/jdk8u-jdk8u504-b01/jdk/src/share/native/sun/awt/medialib/awt_ImagingLib.c	2026-08-10 15:49:49.000000000 +0000
++++ b/jdk8u-jdk8u504-b01/jdk/src/share/native/sun/awt/medialib/awt_ImagingLib.c	2026-08-24 15:32:56.456868818 +0000
+@@ -427,7 +427,7 @@
+         return 0;
+     }
+ 
+-    if ((*sMlibFns[MLIB_CONVKERNCVT].fptr)(kdata, &scale, dkern, w, h,
++    if (((MlibConvKernelConvertFP_t)sMlibFns[MLIB_CONVKERNCVT].fptr)(kdata, &scale, dkern, w, h,
+                                     mlib_ImageGetType(src)) != MLIB_SUCCESS) {
+         freeArray(env, srcImageP, src, sdata, dstImageP, dst, ddata);
+         awt_freeParsedImage(srcImageP, TRUE);
+@@ -455,7 +455,7 @@
+     }
+ 
+     cmask = (1<<src->channels)-1;
+-    status = (*sMlibFns[MLIB_CONVMxN].fptr)(dst, src, kdata, w, h,
++    status = ((MlibConvMxNFP_t)sMlibFns[MLIB_CONVMxN].fptr)(dst, src, kdata, w, h,
+                                (w-1)/2, (h-1)/2, scale, cmask,
+                                getMlibEdgeHint(edgeHint));
+ 
+@@ -674,7 +674,7 @@
+         return 0;
+     }
+ 
+-    if ((*sMlibFns[MLIB_CONVKERNCVT].fptr)(kdata, &scale, dkern, w, h,
++    if (((MlibConvKernelConvertFP_t)sMlibFns[MLIB_CONVKERNCVT].fptr)(kdata, &scale, dkern, w, h,
+                                     mlib_ImageGetType(src)) != MLIB_SUCCESS) {
+         freeDataArray(env, srcRasterP->jdata, src, sdata,
+                       dstRasterP->jdata, dst, ddata);
+@@ -703,7 +703,7 @@
+     }
+ 
+     cmask = (1<<src->channels)-1;
+-    status = (*sMlibFns[MLIB_CONVMxN].fptr)(dst, src, kdata, w, h,
++    status = ((MlibConvMxNFP_t)sMlibFns[MLIB_CONVMxN].fptr)(dst, src, kdata, w, h,
+                                (w-1)/2, (h-1)/2, scale, cmask,
+                                getMlibEdgeHint(edgeHint));
+ 
+@@ -919,7 +919,7 @@
+                mlib_ImageGetWidth(dst)*mlib_ImageGetHeight(dst));
+     }
+     /* Perform the transformation */
+-    if ((status = (*sMlibFns[MLIB_AFFINE].fptr)(dst, src, mtx, filter,
++    if ((status = ((MlibAffineFP_t)sMlibFns[MLIB_AFFINE].fptr)(dst, src, mtx, filter,
+                                   MLIB_EDGE_SRC_EXTEND) != MLIB_SUCCESS))
+     {
+         printMedialibError(status);
+@@ -1136,7 +1136,7 @@
+     }
+ 
+     /* Perform the transformation */
+-    if ((status = (*sMlibFns[MLIB_AFFINE].fptr)(dst, src, mtx, filter,
++    if ((status = ((MlibAffineFP_t)sMlibFns[MLIB_AFFINE].fptr)(dst, src, mtx, filter,
+                                   MLIB_EDGE_SRC_EXTEND) != MLIB_SUCCESS))
+     {
+         printMedialibError(status);
+@@ -1493,8 +1493,7 @@
              }
-             result = gtk2_widgets[_GTK_NOTEBOOK_TYPE];
-             break;
-@@ -1476,7 +1476,7 @@ gtk2_get_widget(GtkWidgetType widget_type)
-             if (init_result = (NULL == gtk2_widgets[_GTK_TOGGLE_BUTTON_TYPE]))
-             {
-                 gtk2_widgets[_GTK_TOGGLE_BUTTON_TYPE] =
--                    (*fp_gtk_toggle_button_new)(NULL);
-+                    (*fp_gtk_toggle_button_new)();
+         }
+         /* How about ddata == null? */
+-    }
+-    else if ((status = (*sMlibFns[MLIB_LOOKUP].fptr)(dst, src,
++    } else if ((status = ((MlibLookUpFP_t)sMlibFns[MLIB_LOOKUP].fptr)(dst, src,
+                                       (void **)tbl) != MLIB_SUCCESS)) {
+         printMedialibError(status);
+         retStatus = 0;
+@@ -1732,7 +1731,7 @@
              }
-             result = gtk2_widgets[_GTK_TOGGLE_BUTTON_TYPE];
-             break;
-@@ -1485,7 +1485,7 @@ gtk2_get_widget(GtkWidgetType widget_type)
-             if (init_result = (NULL == gtk2_widgets[_GTK_TOOLBAR_TYPE]))
-             {
-                 gtk2_widgets[_GTK_TOOLBAR_TYPE] =
--                    (*fp_gtk_toolbar_new)(NULL);
-+                    (*fp_gtk_toolbar_new)();
-             }
-             result = gtk2_widgets[_GTK_TOOLBAR_TYPE];
-             break;
-diff --git a/jdk8u-jdk8u482-b08/jdk/src/solaris/native/sun/awt/gtk3_interface.c b/jdk8u-jdk8u482-b08/jdk/src/solaris/native/sun/awt/gtk3_interface.c
-index c0d1445..59af4eb 100644
---- a/jdk8u-jdk8u482-b08/jdk/src/solaris/native/sun/awt/gtk3_interface.c
-+++ b/jdk8u-jdk8u482-b08/jdk/src/solaris/native/sun/awt/gtk3_interface.c
-@@ -1241,7 +1241,7 @@ gtk3_get_widget(GtkWidgetType widget_type)
-             if (init_result = (NULL == gtk3_widgets[_GTK_NOTEBOOK_TYPE]))
-             {
-                 gtk3_widgets[_GTK_NOTEBOOK_TYPE] =
--                    (*fp_gtk_notebook_new)(NULL);
-+                    (*fp_gtk_notebook_new)();
-             }
-             result = gtk3_widgets[_GTK_NOTEBOOK_TYPE];
-             break;
-@@ -1249,7 +1249,7 @@ gtk3_get_widget(GtkWidgetType widget_type)
-             if (init_result = (NULL == gtk3_widgets[_GTK_TOGGLE_BUTTON_TYPE]))
-             {
-                 gtk3_widgets[_GTK_TOGGLE_BUTTON_TYPE] =
--                    (*fp_gtk_toggle_button_new)(NULL);
-+                    (*fp_gtk_toggle_button_new)();
-             }
-             result = gtk3_widgets[_GTK_TOGGLE_BUTTON_TYPE];
-             break;
-@@ -1258,7 +1258,7 @@ gtk3_get_widget(GtkWidgetType widget_type)
-             if (init_result = (NULL == gtk3_widgets[_GTK_TOOLBAR_TYPE]))
-             {
-                 gtk3_widgets[_GTK_TOOLBAR_TYPE] =
--                    (*fp_gtk_toolbar_new)(NULL);
-+                    (*fp_gtk_toolbar_new)();
-             }
-             result = gtk3_widgets[_GTK_TOOLBAR_TYPE];
-             break;
-diff --git a/jdk8u-jdk8u482-b08/jdk/src/share/native/sun/awt/medialib/awt_ImagingLib.h b/jdk8u-jdk8u482-b08/jdk/src/share/native/sun/awt/medialib/awt_ImagingLib.h
-index a2ff6bd..d015510 100644
---- a/jdk8u-jdk8u482-b08/jdk/src/share/native/sun/awt/medialib/awt_ImagingLib.h
-+++ b/jdk8u-jdk8u482-b08/jdk/src/share/native/sun/awt/medialib/awt_ImagingLib.h
-@@ -32,9 +32,20 @@
+         }
+         /* How about ddata == null? */
+-    } else if ((status = (*sMlibFns[MLIB_LOOKUP].fptr)(dst, src,
++    } else if ((status = ((MlibLookUpFP_t)sMlibFns[MLIB_LOOKUP].fptr)(dst, src,
+                                       (void **)mlib_lookupTable) != MLIB_SUCCESS)) {
+         printMedialibError(status);
+         retStatus = 0;
+diff -urN a/jdk8u-jdk8u504-b01/jdk/src/share/native/sun/awt/medialib/awt_ImagingLib.h b/jdk8u-jdk8u504-b01/jdk/src/share/native/sun/awt/medialib/awt_ImagingLib.h
+--- a/jdk8u-jdk8u504-b01/jdk/src/share/native/sun/awt/medialib/awt_ImagingLib.h	2026-08-10 15:49:49.000000000 +0000
++++ b/jdk8u-jdk8u504-b01/jdk/src/share/native/sun/awt/medialib/awt_ImagingLib.h	2026-08-24 15:32:56.456736868 +0000
+@@ -32,10 +32,21 @@
  
  /* Struct that holds the mlib function ptrs and names */
  typedef struct {
@@ -241,52 +191,83 @@ index a2ff6bd..d015510 100644
 +
  typedef mlib_image *(*MlibCreateFP_t)(mlib_type, mlib_s32, mlib_s32,
                                         mlib_s32);
-diff --git a/jdk8u-jdk8u482-b08/jdk/src/share/native/sun/awt/medialib/awt_ImagingLib.c b/jdk8u-jdk8u482-b08/jdk/src/share/native/sun/awt/medialib/awt_ImagingLib.c
-index 77d82f1..f25d6eb 100644
---- a/jdk8u-jdk8u482-b08/jdk/src/share/native/sun/awt/medialib/awt_ImagingLib.c
-+++ b/jdk8u-jdk8u482-b08/jdk/src/share/native/sun/awt/medialib/awt_ImagingLib.c
-@@ -430,2 +430,2 @@ Java_sun_awt_image_ImagingLib_convolveBI(JNIEnv *env, jobject this,
--    if ((*sMlibFns[MLIB_CONVKERNCVT].fptr)(kdata, &scale, dkern, w, h,
-+    if (((MlibConvKernelConvertFP_t)sMlibFns[MLIB_CONVKERNCVT].fptr)(kdata, &scale, dkern, w, h,
-                                     mlib_ImageGetType(src)) != MLIB_SUCCESS) {
-@@ -458,3 +458,3 @@ Java_sun_awt_image_ImagingLib_convolveBI(JNIEnv *env, jobject this,
--    status = (*sMlibFns[MLIB_CONVMxN].fptr)(dst, src, kdata, w, h,
-+    status = ((MlibConvMxNFP_t)sMlibFns[MLIB_CONVMxN].fptr)(dst, src, kdata, w, h,
-                                (w-1)/2, (h-1)/2, scale, cmask,
-                                getMlibEdgeHint(edgeHint));
-@@ -677,2 +677,2 @@ Java_sun_awt_image_ImagingLib_convolveRaster(JNIEnv *env, jobject this,
--    if ((*sMlibFns[MLIB_CONVKERNCVT].fptr)(kdata, &scale, dkern, w, h,
-+    if (((MlibConvKernelConvertFP_t)sMlibFns[MLIB_CONVKERNCVT].fptr)(kdata, &scale, dkern, w, h,
-                                     mlib_ImageGetType(src)) != MLIB_SUCCESS) {
-@@ -706,3 +706,3 @@ Java_sun_awt_image_ImagingLib_convolveRaster(JNIEnv *env, jobject this,
--    status = (*sMlibFns[MLIB_CONVMxN].fptr)(dst, src, kdata, w, h,
-+    status = ((MlibConvMxNFP_t)sMlibFns[MLIB_CONVMxN].fptr)(dst, src, kdata, w, h,
-                                (w-1)/2, (h-1)/2, scale, cmask,
-                                getMlibEdgeHint(edgeHint));
-@@ -922,2 +922,2 @@ Java_sun_awt_image_ImagingLib_transformBI(JNIEnv *env, jobject this,
--    if ((status = (*sMlibFns[MLIB_AFFINE].fptr)(dst, src, mtx, filter,
-+    if ((status = ((MlibAffineFP_t)sMlibFns[MLIB_AFFINE].fptr)(dst, src, mtx, filter,
-                                   MLIB_EDGE_SRC_EXTEND) != MLIB_SUCCESS))
-@@ -1139,2 +1139,2 @@ Java_sun_awt_image_ImagingLib_transformRaster(JNIEnv *env, jobject this,
--    if ((status = (*sMlibFns[MLIB_AFFINE].fptr)(dst, src, mtx, filter,
-+    if ((status = ((MlibAffineFP_t)sMlibFns[MLIB_AFFINE].fptr)(dst, src, mtx, filter,
-                                   MLIB_EDGE_SRC_EXTEND) != MLIB_SUCCESS))
-@@ -1496,3 +1496,2 @@ Java_sun_awt_image_ImagingLib_lookupByteBI(JNIEnv *env,
--    }
--    else if ((status = (*sMlibFns[MLIB_LOOKUP].fptr)(dst, src,
-+    } else if ((status = ((MlibLookUpFP_t)sMlibFns[MLIB_LOOKUP].fptr)(dst, src,
-                                       (void **)tbl) != MLIB_SUCCESS)) {
-@@ -1733,3 +1733,3 @@ Java_sun_awt_image_ImagingLib_lookupByteRaster(JNIEnv *env,
--        /* How about ddata == null? */
--    } else if ((status = (*sMlibFns[MLIB_LOOKUP].fptr)(dst, src,
-+        /* How about ddata == null? */
-+    } else if ((status = ((MlibLookUpFP_t)sMlibFns[MLIB_LOOKUP].fptr)(dst, src,
-                                       (void **)mlib_lookupTable) != MLIB_SUCCESS)) {
-diff --git a/jdk8u-jdk8u482-b08/jdk/src/solaris/native/sun/net/spi/DefaultProxySelector.c b/jdk8u-jdk8u482-b08/jdk/src/solaris/native/sun/net/spi/DefaultProxySelector.c
-index fa90dff..b5a7656 100644
---- a/jdk8u-jdk8u482-b08/jdk/src/solaris/native/sun/net/spi/DefaultProxySelector.c
-+++ b/jdk8u-jdk8u482-b08/jdk/src/solaris/native/sun/net/spi/DefaultProxySelector.c
-@@ -95,11 +95,11 @@ typedef struct _GProxyResolver GProxyResolver;
+ typedef mlib_image *(*MlibCreateStructFP_t)(mlib_type, mlib_s32, mlib_s32,
+diff -urN a/jdk8u-jdk8u504-b01/jdk/src/solaris/native/sun/awt/awt_GraphicsEnv.h b/jdk8u-jdk8u504-b01/jdk/src/solaris/native/sun/awt/awt_GraphicsEnv.h
+--- a/jdk8u-jdk8u504-b01/jdk/src/solaris/native/sun/awt/awt_GraphicsEnv.h	2026-08-10 15:49:49.000000000 +0000
++++ b/jdk8u-jdk8u504-b01/jdk/src/solaris/native/sun/awt/awt_GraphicsEnv.h	2026-08-24 15:32:56.456322414 +0000
+@@ -50,8 +50,6 @@
+ #define MITSHM_PERM_COMMON (0666)
+ #define MITSHM_PERM_OWNER  (0600)
+ 
+-extern int XShmQueryExtension();
+-
+ void TryInitMITShm(JNIEnv *env, jint *shmExt, jint *shmPixmaps);
+ void resetXShmAttachFailed();
+ jboolean isXShmAttachFailed();
+diff -urN a/jdk8u-jdk8u504-b01/jdk/src/solaris/native/sun/awt/gtk2_interface.c b/jdk8u-jdk8u504-b01/jdk/src/solaris/native/sun/awt/gtk2_interface.c
+--- a/jdk8u-jdk8u504-b01/jdk/src/solaris/native/sun/awt/gtk2_interface.c	2026-08-10 15:49:49.000000000 +0000
++++ b/jdk8u-jdk8u504-b01/jdk/src/solaris/native/sun/awt/gtk2_interface.c	2026-08-24 15:32:56.456419410 +0000
+@@ -1468,7 +1468,7 @@
+             if (init_result = (NULL == gtk2_widgets[_GTK_NOTEBOOK_TYPE]))
+             {
+                 gtk2_widgets[_GTK_NOTEBOOK_TYPE] =
+-                    (*fp_gtk_notebook_new)(NULL);
++                    (*fp_gtk_notebook_new)();
+             }
+             result = gtk2_widgets[_GTK_NOTEBOOK_TYPE];
+             break;
+@@ -1476,7 +1476,7 @@
+             if (init_result = (NULL == gtk2_widgets[_GTK_TOGGLE_BUTTON_TYPE]))
+             {
+                 gtk2_widgets[_GTK_TOGGLE_BUTTON_TYPE] =
+-                    (*fp_gtk_toggle_button_new)(NULL);
++                    (*fp_gtk_toggle_button_new)();
+             }
+             result = gtk2_widgets[_GTK_TOGGLE_BUTTON_TYPE];
+             break;
+@@ -1485,7 +1485,7 @@
+             if (init_result = (NULL == gtk2_widgets[_GTK_TOOLBAR_TYPE]))
+             {
+                 gtk2_widgets[_GTK_TOOLBAR_TYPE] =
+-                    (*fp_gtk_toolbar_new)(NULL);
++                    (*fp_gtk_toolbar_new)();
+             }
+             result = gtk2_widgets[_GTK_TOOLBAR_TYPE];
+             break;
+diff -urN a/jdk8u-jdk8u504-b01/jdk/src/solaris/native/sun/awt/gtk3_interface.c b/jdk8u-jdk8u504-b01/jdk/src/solaris/native/sun/awt/gtk3_interface.c
+--- a/jdk8u-jdk8u504-b01/jdk/src/solaris/native/sun/awt/gtk3_interface.c	2026-08-10 15:49:49.000000000 +0000
++++ b/jdk8u-jdk8u504-b01/jdk/src/solaris/native/sun/awt/gtk3_interface.c	2026-08-24 15:32:56.456605382 +0000
+@@ -1241,7 +1241,7 @@
+             if (init_result = (NULL == gtk3_widgets[_GTK_NOTEBOOK_TYPE]))
+             {
+                 gtk3_widgets[_GTK_NOTEBOOK_TYPE] =
+-                    (*fp_gtk_notebook_new)(NULL);
++                    (*fp_gtk_notebook_new)();
+             }
+             result = gtk3_widgets[_GTK_NOTEBOOK_TYPE];
+             break;
+@@ -1249,7 +1249,7 @@
+             if (init_result = (NULL == gtk3_widgets[_GTK_TOGGLE_BUTTON_TYPE]))
+             {
+                 gtk3_widgets[_GTK_TOGGLE_BUTTON_TYPE] =
+-                    (*fp_gtk_toggle_button_new)(NULL);
++                    (*fp_gtk_toggle_button_new)();
+             }
+             result = gtk3_widgets[_GTK_TOGGLE_BUTTON_TYPE];
+             break;
+@@ -1258,7 +1258,7 @@
+             if (init_result = (NULL == gtk3_widgets[_GTK_TOOLBAR_TYPE]))
+             {
+                 gtk3_widgets[_GTK_TOOLBAR_TYPE] =
+-                    (*fp_gtk_toolbar_new)(NULL);
++                    (*fp_gtk_toolbar_new)();
+             }
+             result = gtk3_widgets[_GTK_TOOLBAR_TYPE];
+             break;
+diff -urN a/jdk8u-jdk8u504-b01/jdk/src/solaris/native/sun/net/spi/DefaultProxySelector.c b/jdk8u-jdk8u504-b01/jdk/src/solaris/native/sun/net/spi/DefaultProxySelector.c
+--- a/jdk8u-jdk8u504-b01/jdk/src/solaris/native/sun/net/spi/DefaultProxySelector.c	2026-08-10 15:49:49.000000000 +0000
++++ b/jdk8u-jdk8u504-b01/jdk/src/solaris/native/sun/net/spi/DefaultProxySelector.c	2026-08-24 15:32:56.457051175 +0000
+@@ -95,11 +95,11 @@
  typedef struct _GSocketConnectable GSocketConnectable;
  typedef struct GError GError;
  typedef GProxyResolver* g_proxy_resolver_get_default_func();

--- a/java8-openjdk/riscv64.patch
+++ b/java8-openjdk/riscv64.patch
@@ -1,8 +1,6 @@
-diff --git PKGBUILD PKGBUILD
-index 42de797..e65b9bd 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -49,6 +49,7 @@ b2sums=('baad344bcb29c35f6f01a1af2285cc3e1f0d075b78ae341e8f4d63f001636a96359fcab
+@@ -49,6 +49,7 @@
  case "${CARCH}" in
    'x86_64'  ) _JARCH=amd64   ; _DOC_ARCH=x86_64  ;;
    'aarch64' ) _JARCH=aarch64 ; _DOC_ARCH=aarch64 ;;
@@ -10,7 +8,7 @@ index 42de797..e65b9bd 100644
  esac
  
  _jdkname=openjdk8
-@@ -65,6 +66,10 @@ _nonheadless=(
+@@ -65,6 +66,10 @@
  prepare() {
    cd jdk8u-jdk${_majorver}u${_minorver}-b${_updatever}
  
@@ -21,7 +19,7 @@ index 42de797..e65b9bd 100644
    # Do not treats warnings as errors
    sed -E -i 's/(^WARNINGS_ARE_ERRORS = -W)(error)/\1no-\2/' \
      hotspot/make/linux/makefiles/gcc.make
-@@ -111,7 +116,9 @@ build() {
+@@ -111,7 +116,9 @@
      --with-extra-cflags="${CFLAGS}" \
      --with-extra-cxxflags="${CXXFLAGS}" \
      --with-extra-ldflags="${LDFLAGS}" \
@@ -32,7 +30,7 @@ index 42de797..e65b9bd 100644
  
    # These help to debug builds: LOG=trace HOTSPOT_BUILD_JOBS=1
    # Without 'DEBUG_BINARIES', i686 won't build: http://mail.openjdk.java.net/pipermail/core-libs-dev/2013-July/019203.html
-@@ -337,8 +345,11 @@ package_openjdk8-doc() {
+@@ -337,8 +344,11 @@
    pkgdesc='OpenJDK Java 8 documentation'
  
    install -d -m 755 "${pkgdir}/usr/share/doc/${pkgbase}/"
@@ -42,6 +40,6 @@ index 42de797..e65b9bd 100644
  }
  
 +source+=(jdk8-riscv.patch)
-+b2sums+=('6098f770f42620e40177eb2a07b93d54672231b034bbed7148a03b41da7a8195477a6199cdf1a8944ac7703266bac01bd8b841551601a55190273d9ebbe61fe3')
++b2sums+=('272740b2cfaaf3ddcc26051154abba72765c988cf8661c3e1662bf66b00b69b2336b5c9fd73bf960931771c54b000f9de3d501fece670913385eeb4905bfa809')
 +
  # vim: ts=2 sw=2 et:


### PR DESCRIPTION
Refresh patch for 8.504.u01-1. Upstream jdk8u504-b01 already contains the RISC-V CPU extraction and os_linux architecture-code pieces, so drop those stale hunks and update the patch checksum.