### PR TITLE
updpatch: neovide 0.16.2-2

### DIFF
--- a/neovide/riscv64.patch
+++ b/neovide/riscv64.patch
@@ -1,22 +1,22 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -19,7 +19,7 @@
+@@ -21,7 +21,7 @@
           neovim
           sndio
-          libpng libpng16.so
+          libpng
 -         harfbuzz libharfbuzz.so
 +         harfbuzz libharfbuzz.so libharfbuzz-subset.so
           icu libicuuc.so
-          expat libexpat.so
-          zlib libz.so)
-@@ -34,12 +34,20 @@
+          expat
+          zlib
+@@ -37,12 +37,20 @@
              'libxkbcommon-x11: run on X11 (not needed for wayland)')
  options=(!lto)
  _archive=("$pkgname-$pkgver")
 -source=("$url/archive/$pkgver/$_archive.tar.gz")
 -sha256sums=('a2016cceab3cba50b6a8b2f6787ae9017a85923575e89a83ebb9d428e8f80ca9')
 +source=("$url/archive/$pkgver/$_archive.tar.gz"
-+        "skia-bindings-0.93.1.tar.gz::https://crates.io/api/v1/crates/skia-bindings/0.93.1/download"
++        "skia-bindings-0.93.1.tar.gz::https://static.crates.io/crates/skia-bindings/skia-bindings-0.93.1.crate"
 +        "skia-bindings-riscv.patch")
 +sha256sums=('a2016cceab3cba50b6a8b2f6787ae9017a85923575e89a83ebb9d428e8f80ca9'
 +            '2359f7e30c9da3f322f8ca3d4ec0abbc12a40035ce758309db0cdab07b5d4476'


### PR DESCRIPTION
Refresh patch after Arch's dependency cleanup changed the depends context. Keep the local skia-bindings override because skia-bindings 0.93.1 still misses harfbuzz-subset in its Linux link list and Skia's fetch-gn still lacks a riscv64 mapping.

Use static.crates.io for the skia-bindings crate source because the crates.io API download URL returns HTTP 403 during source retrieval.