### PR TITLE
updpatch: vector 0.57.0-1

### DIFF
--- a/vector/databricks-zerobus-ingest-sdk-honor-protoc.patch
+++ b/vector/databricks-zerobus-ingest-sdk-honor-protoc.patch
@@ -1,0 +1,13 @@
+--- a/build.rs
++++ b/build.rs
+@@ -5,7 +5,9 @@
+ mod zeroparser_proto_build;
+ 
+ fn main() {
+-    env::set_var("PROTOC", protoc_bin_vendored::protoc_bin_path().unwrap());
++    if env::var_os("PROTOC").is_none() {
++        env::set_var("PROTOC", protoc_bin_vendored::protoc_bin_path().unwrap());
++    }
+     tonic_prost_build::compile_protos("zerobus_service.proto")
+         .unwrap_or_else(|e| panic!("Failed to compile protos {:?}", e));
+ 

--- a/vector/fix-memory-table-flush-interval.patch
+++ b/vector/fix-memory-table-flush-interval.patch
@@ -1,0 +1,20 @@
+--- a/src/enrichment_tables/memory/table.rs
++++ b/src/enrichment_tables/memory/table.rs
+@@ -424,12 +424,11 @@
+     async fn run(mut self: Box<Self>, mut input: BoxStream<'_, Event>) -> Result<(), ()> {
+         let events_sent = register!(EventsSent::from(Output(None)));
+         let bytes_sent = register!(BytesSent::from(Protocol("memory_enrichment_table".into(),)));
+-        let mut flush_interval = IntervalStream::new(interval(
+-            self.config
+-                .flush_interval
+-                .map(Duration::from_secs)
+-                .unwrap_or(Duration::MAX),
+-        ));
++        let mut flush_interval = self
++            .config
++            .flush_interval
++            .map(|secs| IntervalStream::new(interval(Duration::from_secs(secs))).boxed())
++            .unwrap_or_else(|| futures::stream::empty().boxed());
+         let mut scan_interval = IntervalStream::new(interval(Duration::from_secs(
+             self.config.scan_interval.into(),
+         )));

--- a/vector/fix-unused-trace-stream-ext-import.patch
+++ b/vector/fix-unused-trace-stream-ext-import.patch
@@ -1,0 +1,11 @@
+--- a/src/trace.rs
++++ b/src/trace.rs
+@@ -421,8 +421,6 @@
+     use tracing::info;
+     use tracing_subscriber::layer::SubscriberExt;
+ 
+-    use futures::StreamExt as _;
+-
+     use super::*;
+ 
+     /// Verifies that `RateLimitedLayer<BroadcastLayer>` — the configuration produced by

--- a/vector/increase-backpressure-test-timeout.patch
+++ b/vector/increase-backpressure-test-timeout.patch
@@ -1,0 +1,15 @@
+--- a/src/topology/test/backpressure.rs
++++ b/src/topology/test/backpressure.rs
+@@ -170,6 +170,11 @@
+ // Wait until the source has sent at least the expected number of events, plus a small additional
+ // margin to ensure we allow it to run over the expected amount if it's going to.
+ async fn wait_until_expected(source_counter: impl AsRef<AtomicUsize>, expected: usize) {
+-    crate::test_util::wait_for_atomic_usize(source_counter, |count| count >= expected).await;
++    crate::test_util::wait_for_atomic_usize_timeout_ms(
++        source_counter,
++        |count| count >= expected,
++        30_000,
++    )
++    .await;
+     tokio::time::sleep(Duration::from_millis(100)).await;
+ }

--- a/vector/riscv64.patch
+++ b/vector/riscv64.patch
@@ -1,20 +1,53 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -5,7 +5,7 @@ pkgver=0.28.2
- pkgrel=1
- pkgdesc="A high-performance observability data pipeline"
- arch=("x86_64")
--_target="x86_64-unknown-linux-gnu"
-+_target="riscv64gc-unknown-linux-gnu"
- url="https://vector.dev"
- license=("MPL2")
- options=(!lto) # TODO: Build with LTO
-@@ -38,6 +38,8 @@ sha512sums=('5326f333a560bcb06a4eb048b6d950dfaa5e512abae0d74d439ab7f2cbdb2e0f70b
- prepare() {
-     cd "${pkgname}-${pkgver}"
+@@ -45,8 +45,18 @@
+ }
  
-+    sed -i "/\[patch.crates-io\]/a ring = { git = 'https://github.com/felixonmars/ring', branch = '0.16.20' }" Cargo.toml
-+    cargo update -p ring
+ prepare() {
++    patch -d databricks-zerobus-ingest-sdk-2.3.0 -p1 -i "$srcdir/databricks-zerobus-ingest-sdk-honor-protoc.patch"
++
+     cd "${pkgname}"
+ 
++    patch -p1 -i "$srcdir/fix-unused-trace-stream-ext-import.patch"
++    # Avoid timer overflow when periodic memory-table flushing is disabled.
++    # https://github.com/vectordotdev/vector/commit/6d4ee78ad843340b58be6fa7b929001a0d059ea2
++    patch -p1 -i "$srcdir/fix-memory-table-flush-interval.patch"
++    # Allow CPU-scaled backpressure buffers to fill on slower builders.
++    patch -p1 -i "$srcdir/increase-backpressure-test-timeout.patch"
++    sed -i '/^\[patch\.crates-io\]$/a databricks-zerobus-ingest-sdk = { path = "../databricks-zerobus-ingest-sdk-2.3.0" }' Cargo.toml
++    cargo update -p databricks-zerobus-ingest-sdk
      cargo fetch \
          --locked
  }
+@@ -59,6 +69,7 @@
+ 
+     # https://github.com/vectordotdev/vector/issues/22888
+     export CFLAGS="${CFLAGS} -std=gnu17"
++    export PROTOC=/usr/bin/protoc
+ 
+     cargo build \
+         --frozen \
+@@ -73,6 +84,8 @@
+ check() {
+     cd "${pkgname}"
+ 
++    export PROTOC=/usr/bin/protoc
++
+     # Unit-Tests only, integration tests require services.
+     # UDP syslog/socket sources currently take too long, so we skip them.
+     # Test sources::file::tests::file_start_position_server_restart_unfinalized is flaky,
+@@ -119,3 +132,14 @@
+     install -Dm644 "distribution/systemd/hardened-vector.service" "${pkgdir}/usr/lib/systemd/system/hardened-vector.service"
+     install -Dm644 "distribution/systemd/vector.default" "${pkgdir}/etc/default/vector"
+ }
++
++source+=("databricks-zerobus-ingest-sdk-2.3.0.tar.gz::https://static.crates.io/crates/databricks-zerobus-ingest-sdk/databricks-zerobus-ingest-sdk-2.3.0.crate"
++         "databricks-zerobus-ingest-sdk-honor-protoc.patch"
++         "fix-unused-trace-stream-ext-import.patch"
++         "fix-memory-table-flush-interval.patch"
++         "increase-backpressure-test-timeout.patch")
++sha512sums+=('f220200b85e5ed029a4f700ec70eb13a3f53989571e1d170f35ffdd10eefb0408b9622e58f38cba8a52de48131dae0edf52ff63908f820cbd1f8f3cf03ebb85f'
++             '819f00f9d3224ffb9c5120a942c432aeff4a781845f29c3b419d65a958eab39e5a00a06349b65b2e8d9321d950b981d7486b170c87e7a7237d2cfa8e7b2d74a2'
++             'a5f8fa046b7b7da4aad2caaf83d8e68ec9ad94b5a48b8bafe6a9dcc07743e7f45a1b6f9067bdc4d545a09683d0dc3582fd93ab1efbb4ae230415602c8a8e61e0'
++             '75da613c711e8eb58bf87a1cc24ab0caceb959c9afaee65acd520edf21b9344373c42b369712546c3b02dc0d8edaefa25409cacf713e44ef738c76aabc653692'
++             'bee99c6157709f304db10ffe44d9b3db4e473f4c5d2f477c0a89f3ca04b2ebd104fa4f314616e7e7178f50c20428c1b7a2d1bbbe6394f1933a6a5178abef1f50')


### PR DESCRIPTION
Refresh the patch for the current PKGBUILD, dropping the stale _target override and obsolete ring 0.16.20 workaround. The package now builds with --target host-tuple, and 0.57.0 locks ring 0.17.14.

The build log first fails in databricks-zerobus-ingest-sdk 2.3.0 because protoc-bin-vendored has no linux/riscv64 binary, so patch the crate to honor PROTOC and use protobuf's system protoc. The next log reaches check() and fails because deny(warnings) rejects an unused futures::StreamExt import in src/trace.rs, so remove that test-only import.

Extract the upstream memory-table timer fix: use an empty stream when periodic flushing is disabled instead of Duration::MAX, which panics with "overflow when adding duration to instant" in the enrichment-table reload tests.

Increase the backpressure-test wait from five to 30 seconds so CPU-scaled buffers can fill on slower builders, keeping the event-count assertions unchanged.

Upstream: https://github.com/vectordotdev/vector/commit/6d4ee78ad843340b58be6fa7b929001a0d059ea2