### PR TITLE
updpatch: libnids 1.26-6

### DIFF
--- a/libnids/riscv64.patch
+++ b/libnids/riscv64.patch
@@ -1,10 +1,6 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -19,6 +19,7 @@ sha256sums=('3f3e9f99a83cd37bc74af83d415c5e3a7505f5b190dfaf456b0849e0054f6733'
- prepare() {
-   cd $pkgname-$pkgver
-   patch -p1 -i ../38336d55.patch # Honor LDFLAGS
+@@ -30,2 +30,3 @@
+   patch -p1 -i "$srcdir/gcc15.patch"
 +  cp /usr/share/autoconf/build-aux/config.{guess,sub} .
  }
- 
- build() {


### PR DESCRIPTION
Refresh patch for the current PKGBUILD, which now applies gcc15.patch from $srcdir before configure.

The config.{guess,sub} refresh is still needed because libnids 1.26 ships config.sub from 2000, which rejects riscv64-unknown-linux-gnu; upstream PR 12 refreshes these files.