### PR TITLE
blacklist: add nsight-compute

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -17,6 +17,7 @@ intel-oneapi-openmp
 intel-oneapi-tbb
 intel-oneapi-tcm
 intel-oneapi-umf
+nsight-compute
 nvidia
 nvidia-cg-toolkit
 nvidia-dkms


### PR DESCRIPTION
NVIDIA only ships nsight-compute binary archives for x86_64 and aarch64/SBSA. On riscv64 no archive is downloaded, so package() fails to cd into nsight_compute-linux-*-2026.2.1.5-archive.