### PR TITLE
addpatch: drminfo 8.1-2

### DIFF
--- a/drminfo/riscv64.patch
+++ b/drminfo/riscv64.patch
@@ -1,0 +1,17 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -30,6 +30,7 @@
+ 
+ prepare() {
+   cd "${pkgname}-${_tag}"
++  patch -Np1 -i "../$pkgname-fix-virtgpu-resource-info-stride.patch"
+   meson build --prefix=/usr
+ }
+ 
+@@ -44,3 +45,6 @@
+ }
+ 
+ # vim: ts=2 sw=2 et:
++
++source_riscv64=("$pkgname-fix-virtgpu-resource-info-stride.patch::https://github.com/kraxel/drminfo/commit/13c09aebb679b155bc5aad0bba7c5fd6d16da599.patch")
++sha256sums_riscv64=('91be48f662304b909339bcfa045b01fc65220f45a18336edffda688aa56ff41f')


### PR DESCRIPTION
Apply upstream fix for libdrm dropping drm_virtgpu_resource_info.stride; otherwise virtiotest.c fails to compile on current riscv64.