### PR TITLE
addpatch: marksman 20260208-3

### DIFF
--- a/marksman/riscv64.patch
+++ b/marksman/riscv64.patch
@@ -1,0 +1,23 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -20,11 +20,18 @@
+   export DOTNET_CLI_TELEMETRY_OPTOUT=1
+ 
+   make build
+-  make publish
++  dotnet publish -c Release --no-self-contained \
++    -p:DebugType=embedded \
++    -p:UseAppHost=false \
++    -o publish \
++    Marksman/Marksman.fsproj
+ }
+ 
+ package() {
+   cd "marksman"
+-  install -Dm755 Marksman/bin/Release/net*/linux-*/publish/marksman $pkgdir/usr/bin/marksman
++  install -dm755 "$pkgdir/usr/lib/$pkgname" "$pkgdir/usr/bin"
++  cp -dr --no-preserve=ownership publish/* "$pkgdir/usr/lib/$pkgname/"
++  printf '#!/bin/sh\nexec dotnet /usr/lib/%s/marksman.dll "$@"\n' "$pkgname" > "$pkgdir/usr/bin/marksman"
++  chmod 755 "$pkgdir/usr/bin/marksman"
+   install -Dm644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+ }

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -77,6 +77,7 @@ libvirt
 lksctp-tools
 lmdb
 m4
+marksman
 mdbook
 meilisearch
 memcached


### PR DESCRIPTION
Avoid self-contained publish on riscv64. The RID now reaches linux-riscv64, but dotnet cannot restore Microsoft.NETCore.App.Runtime.linux-riscv64 or Microsoft.AspNetCore.App.Runtime.linux-riscv64 runtime packs, so publish a framework-dependent app and install a dotnet wrapper.

Also add marksman to the qemu-user blacklist: dotnet can fail first-run NuGet migrations with pthread_mutex_init returning ENOTSUP/EOPNOTSUPP under qemu-user.