### PR TITLE
addpatch: linuxwave 0.3.0-1

### DIFF
--- a/linuxwave/linuxwave-zig-0.16.patch
+++ b/linuxwave/linuxwave-zig-0.16.patch
@@ -1,0 +1,560 @@
+diff -urN linuxwave.orig/build.zig linuxwave.new/build.zig
+--- linuxwave.orig/build.zig	2026-08-24 21:05:14.664222703 +0000
++++ linuxwave.new/build.zig	2026-08-24 21:05:14.664259443 +0000
+@@ -6,18 +6,12 @@
+ /// Version.
+ const version = "0.3.0"; // managed by release.sh
+ 
+-/// Adds the required packages to the given executable.
++/// Adds the required packages to the given module.
+ ///
+ /// This is used for providing the dependencies for main executable as well as the tests.
+-fn addPackages(b: *std.Build, exe: *std.Build.Step.Compile) !void {
++fn addPackages(b: *std.Build, mod: *std.Build.Module) !void {
+     const clap = b.dependency("clap", .{}).module("clap");
+-    exe.root_module.addImport("clap", clap);
+-    for ([_][]const u8{ "file", "gen", "wav" }) |package| {
+-        const path = b.fmt("src/{s}.zig", .{package});
+-        exe.root_module.addImport(package, b.createModule(.{
+-            .root_source_file = b.path(path),
+-        }));
+-    }
++    mod.addImport("clap", clap);
+ }
+ 
+ pub fn build(b: *std.Build) void {
+@@ -31,18 +25,25 @@
+     // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
+     const optimize = b.standardOptimizeOption(.{});
+ 
++    const root = b.createModule(.{
++        .root_source_file = b.path("src/main.zig"),
++        .target = target,
++        .optimize = optimize,
++    });
++
+     // Add custom options.
+     const pie = b.option(bool, "pie", "Build a Position Independent Executable") orelse true;
+     const relro = b.option(bool, "relro", "Force all relocations to be read-only after processing") orelse true;
+     const coverage = b.option(bool, "test-coverage", "Generate test coverage") orelse false;
+     const documentation = b.option(bool, "docs", "Generate documentation") orelse false;
+ 
++    // Add packages.
++    try addPackages(b, root);
++
+     // Add main executable.
+     const exe = b.addExecutable(.{
+         .name = exe_name,
+-        .root_source_file = b.path("src/main.zig"),
+-        .target = target,
+-        .optimize = optimize,
++        .root_module = root,
+     });
+     if (documentation) {
+         const install_docs = b.addInstallDirectory(.{
+@@ -56,12 +57,9 @@
+     exe.link_z_relro = relro;
+     b.installArtifact(exe);
+ 
+-    // Add packages.
+-    try addPackages(b, exe);
+-
+     // Add executable options.
+     const exe_options = b.addOptions();
+-    exe.root_module.addOptions("build_options", exe_options);
++    root.addOptions("build_options", exe_options);
+     exe_options.addOption([]const u8, "version", version);
+     exe_options.addOption([]const u8, "exe_name", exe_name);
+ 
+@@ -80,13 +78,17 @@
+     const test_step = b.step("test", "Run tests");
+     for ([_][]const u8{ "main", "file", "gen", "wav" }) |module| {
+         const test_name = b.fmt("{s}-tests", .{module});
+-        const test_module = b.fmt("src/{s}.zig", .{module});
+-        var exe_tests = b.addTest(.{
+-            .name = test_name,
+-            .root_source_file = b.path(test_module),
++        const test_filepath = b.fmt("src/{s}.zig", .{module});
++        const test_module = b.createModule(.{
++            .root_source_file = b.path(test_filepath),
+             .target = target,
+             .optimize = optimize,
+         });
++        try addPackages(b, test_module);
++        var exe_tests = b.addTest(.{
++            .name = test_name,
++            .root_module = test_module,
++        });
+         if (coverage) {
+             exe_tests.setExecCmd(&[_]?[]const u8{
+                 "kcov",
+@@ -94,8 +96,7 @@
+                 null,
+             });
+         }
+-        try addPackages(b, exe_tests);
+-        exe_tests.root_module.addOptions("build_options", exe_options);
++        test_module.addOptions("build_options", exe_options);
+         const run_unit_tests = b.addRunArtifact(exe_tests);
+         test_step.dependOn(&run_unit_tests.step);
+     }
+diff -urN linuxwave.orig/build.zig.zon linuxwave.new/build.zig.zon
+--- linuxwave.orig/build.zig.zon	2026-08-24 21:05:14.668682420 +0000
++++ linuxwave.new/build.zig.zon	2026-08-24 21:05:14.668682420 +0000
+@@ -2,7 +2,7 @@
+     .name = .linuxwave,
+     .version = "0.1.5",
+     .fingerprint = 0x217eafdf4732b5f9,
+-    .minimum_zig_version = "0.14.0",
++    .minimum_zig_version = "0.16.0",
+     .paths = .{
+         "build.zig",
+         "build.zig.zon",
+@@ -12,8 +12,8 @@
+     },
+     .dependencies = .{
+         .clap = .{
+-            .url = "https://github.com/Hejsil/zig-clap/archive/refs/tags/0.10.0.tar.gz",
+-            .hash = "clap-0.10.0-oBajB434AQBDh-Ei3YtoKIRxZacVPF1iSwp3IX_ZB8f0",
++            .url = "https://github.com/Hejsil/zig-clap/archive/refs/tags/0.12.0.tar.gz",
++            .hash = "clap-0.12.0-oBajB7foAQDqlSwaSG5g0yq7xGbQARUsBk5T64gAOqP5",
+         },
+     },
+ }
+diff -urN linuxwave.orig/src/args.zig linuxwave.new/src/args.zig
+--- linuxwave.orig/src/args.zig	2026-08-24 21:05:14.673160840 +0000
++++ linuxwave.new/src/args.zig	2026-08-24 21:05:14.673259434 +0000
+@@ -1,4 +1,4 @@
+-const wav = @import("wav");
++const wav = @import("wav.zig");
+ const clap = @import("clap");
+ 
+ // Banner text.
+diff -urN linuxwave.orig/src/defaults.zig linuxwave.new/src/defaults.zig
+--- linuxwave.orig/src/defaults.zig	2026-08-24 21:05:14.677706298 +0000
++++ linuxwave.new/src/defaults.zig	2026-08-24 21:05:14.677706298 +0000
+@@ -1,4 +1,4 @@
+-const wav = @import("wav");
++const wav = @import("wav.zig");
+ 
+ // Default input file.
+ pub const input = "/dev/urandom";
+diff -urN linuxwave.orig/src/file.zig linuxwave.new/src/file.zig
+--- linuxwave.orig/src/file.zig	2026-08-24 21:05:14.681259425 +0000
++++ linuxwave.new/src/file.zig	2026-08-24 21:05:14.682259424 +0000
+@@ -4,30 +4,34 @@
+ 
+ /// Reads the given file and returns a byte array with the length of `len`.
+ pub fn readBytes(
++    io: std.Io,
+     allocator: std.mem.Allocator,
+     path: []const u8,
+     len: usize,
+ ) ![]u8 {
+-    const file = try std.fs.cwd().openFile(path, .{});
+-    defer file.close();
+-    var list = try std.ArrayList(u8).initCapacity(allocator, len);
+-    var buffer = list.allocatedSlice();
+-    const bytes_read = try file.read(buffer);
+-    return buffer[0..bytes_read];
++    const file = try std.Io.Dir.cwd().openFile(io, path, .{});
++    defer file.close(io);
++    var read_buffer: [1024]u8 = undefined;
++    var file_reader = file.reader(io, &read_buffer);
++    const reader = &file_reader.interface;
++    return reader.readAlloc(allocator, len);
+ }
+ 
+ test "read bytes from the file" {
++    const allocator = std.testing.allocator;
++    const io = std.testing.io;
++
+     // Get the current directory.
+     var cwd_buffer: [std.fs.max_path_bytes]u8 = undefined;
+-    const cwd = try std.posix.getcwd(&cwd_buffer);
++    const cwd_len = try std.process.currentPath(io, &cwd_buffer);
++    const cwd = cwd_buffer[0..cwd_len];
+ 
+     // Concatenate the current directory with the builder file.
+-    const allocator = std.testing.allocator;
+     const path = try std.fs.path.join(allocator, &.{ cwd, "build.zig" });
+     defer allocator.free(path);
+ 
+     // Read the contents of the file and compare.
+-    const bytes = try readBytes(allocator, path, 9);
++    const bytes = try readBytes(io, allocator, path, 9);
+     try std.testing.expectEqualStrings("const std", bytes);
+     defer allocator.free(bytes);
+ }
+diff -urN linuxwave.orig/src/gen.zig linuxwave.new/src/gen.zig
+--- linuxwave.orig/src/gen.zig	2026-08-24 21:05:14.686699779 +0000
++++ linuxwave.new/src/gen.zig	2026-08-24 21:05:14.686699779 +0000
+@@ -31,7 +31,7 @@
+     ///
+     /// Returns an array that contains the amplitudes of the sound wave at a given point in time.
+     pub fn generate(self: Generator, allocator: std.mem.Allocator, sample: u8) ![]u8 {
+-        var buffer = std.ArrayList(u8).init(allocator);
++        var buffer: std.ArrayList(u8) = .empty;
+         var i: usize = 0;
+         while (i < sample_count) : (i += 1) {
+             // Calculate the frequency according to the equal temperament.
+@@ -45,9 +45,9 @@
+             // Apply the volume control.
+             const volume: f32 = @floatFromInt(self.config.volume);
+             amp = amp * volume / 100;
+-            try buffer.append(@intFromFloat(amp));
++            try buffer.append(allocator, @trunc(amp));
+         }
+-        return buffer.toOwnedSlice();
++        return buffer.toOwnedSlice(allocator);
+     }
+ };
+ 
+diff -urN linuxwave.orig/src/main.zig linuxwave.new/src/main.zig
+--- linuxwave.orig/src/main.zig	2026-08-24 21:05:14.691178651 +0000
++++ linuxwave.new/src/main.zig	2026-08-24 21:05:14.691259414 +0000
+@@ -1,27 +1,31 @@
+ const std = @import("std");
+-const wav = @import("wav");
+-const gen = @import("gen");
+-const file = @import("file");
++const wav = @import("wav.zig");
++const gen = @import("gen.zig");
++const file = @import("file.zig");
+ const args = @import("args.zig");
+ const defaults = @import("defaults.zig");
+ const build_options = @import("build_options");
+ const clap = @import("clap");
+ 
+ /// Runs `linuxwave`.
+-fn run(allocator: std.mem.Allocator, output: anytype) !void {
++fn run(io: std.Io, allocator: std.mem.Allocator, output: *std.Io.Writer, argv: std.process.Args) !void {
+     // Parse command-line arguments.
+-    const cli = try clap.parse(clap.Help, &args.params, args.parsers, .{ .allocator = allocator });
++    const cli = try clap.parse(clap.Help, &args.params, args.parsers, argv, .{ .allocator = allocator });
+     defer cli.deinit();
+     if (cli.args.help != 0) {
+         try output.print("{s}\n", .{args.banner});
+-        return clap.help(output, clap.Help, &args.params, args.help_options);
+-    } else if (cli.args.version != 0) {
++        try clap.help(output, clap.Help, &args.params, args.help_options);
++        try output.flush();
++        return;
++    }
++    if (cli.args.version != 0) {
+         try output.print("{s} {s}\n", .{ build_options.exe_name, build_options.version });
++        try output.flush();
+         return;
+     }
+ 
+     // Create encoder configuration.
+-    const encoder_config = wav.EncoderConfig{
++    const encoder_config: wav.EncoderConfig = .{
+         .num_channels = if (cli.args.channels) |channels| channels else defaults.channels,
+         .sample_rate = if (cli.args.rate) |rate| @intFromFloat(rate) else defaults.sample_rate,
+         .format = if (cli.args.format) |format| format else defaults.format,
+@@ -29,12 +33,12 @@
+ 
+     // Create generator configuration.
+     const scale = s: {
+-        var scale = std.ArrayList(u8).init(allocator);
++        var scale: std.ArrayList(u8) = .empty;
+         var splits = std.mem.splitAny(u8, if (cli.args.scale) |s| s else defaults.scale, ",");
+         while (splits.next()) |chunk| {
+-            try scale.append(try std.fmt.parseInt(u8, chunk, 0));
++            try scale.append(allocator, try std.fmt.parseInt(u8, chunk, 0));
+         }
+-        break :s try scale.toOwnedSlice();
++        break :s try scale.toOwnedSlice(allocator);
+     };
+     defer allocator.free(scale);
+     const generator_config = gen.GeneratorConfig{
+@@ -50,63 +54,76 @@
+     const buffer = b: {
+         if (std.mem.eql(u8, input_file, "-")) {
+             try output.print("Reading {d} bytes from stdin\n", .{data_len});
+-            var list = try std.ArrayList(u8).initCapacity(allocator, data_len);
+-            const buffer = list.allocatedSlice();
+-            const stdin = std.io.getStdIn().reader();
+-            try stdin.readNoEof(buffer);
+-            break :b buffer;
+-        } else {
+-            try output.print("Reading {d} bytes from {s}\n", .{ data_len, input_file });
+-            break :b try file.readBytes(allocator, input_file, data_len);
++            try output.flush();
++            var read_buffer: [1024]u8 = undefined;
++            var stdin_reader = std.Io.File.stdin().reader(io, &read_buffer);
++            const stdin = &stdin_reader.interface;
++            break :b try stdin.readAlloc(allocator, data_len);
+         }
++
++        try output.print("Reading {d} bytes from {s}\n", .{ data_len, input_file });
++        try output.flush();
++        break :b try file.readBytes(io, allocator, input_file, data_len);
+     };
+     defer allocator.free(buffer);
+ 
+     // Generate music.
+-    const generator = gen.Generator.init(generator_config);
+-    var data = std.ArrayList(u8).init(allocator);
++    const generator: gen.Generator = .init(generator_config);
++    var data: std.ArrayList(u8) = .empty;
+     for (buffer) |v| {
+         const gen_data = try generator.generate(allocator, v);
+         defer allocator.free(gen_data);
+-        try data.appendSlice(gen_data);
++        try data.appendSlice(allocator, gen_data);
+     }
+ 
+     // Encode WAV.
+     const out = if (cli.args.output) |out| out else defaults.output;
+-    const writer = w: {
++    var write_buffer: [1024]u8 = undefined;
++    var fhandle: ?std.Io.File = null;
++    defer if (fhandle) |f| {
++        f.close(io);
++    };
++    var file_writer = w: {
+         if (std.mem.eql(u8, out, "-")) {
+             try output.print("Writing to stdout\n", .{});
+-            break :w std.io.getStdOut().writer();
+-        } else {
+-            try output.print("Saving to {s}\n", .{out});
+-            const out_file = try std.fs.cwd().createFile(out, .{});
+-            break :w out_file.writer();
++            try output.flush();
++            break :w std.Io.File.stdout().writer(io, &write_buffer);
+         }
++
++        try output.print("Saving to {s}\n", .{out});
++        try output.flush();
++        fhandle = try std.Io.Dir.cwd().createFile(io, out, .{});
++        break :w fhandle.?.writer(io, &write_buffer);
+     };
+-    const wav_data = try data.toOwnedSlice();
++    const wav_data = try data.toOwnedSlice(allocator);
+     defer allocator.free(wav_data);
+-    try wav.Encoder(@TypeOf(writer)).encode(writer, wav_data, encoder_config);
++    try wav.encode(&file_writer.interface, wav_data, encoder_config);
+ }
+ 
+ /// Entry-point.
+-pub fn main() !void {
+-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+-    const allocator = gpa.allocator();
+-    const stderr = std.io.getStdErr().writer();
+-    run(allocator, stderr) catch |err| {
++pub fn main(init: std.process.Init) !void {
++    const allocator = init.gpa;
++    const io = init.io;
++    var stderr_buffer: [1024]u8 = undefined;
++    var stderr_writer = std.Io.File.stderr().writer(io, &stderr_buffer);
++    const stderr = &stderr_writer.interface;
++    run(io, allocator, stderr, init.minimal.args) catch |err| {
+         try stderr.print("Error occurred: {}\n", .{err});
++        try stderr.flush();
+     };
+ }
+ 
+ test "run" {
+     const allocator = std.testing.allocator;
+-    var buffer = std.ArrayList(u8).init(allocator);
+-    const output = buffer.writer();
+-    run(allocator, output) catch |err| {
++    const io = std.testing.io;
++
++    const fake_args: std.process.Args = .{ .vector = &[_][*:0]const u8{} };
++    var allocating: std.Io.Writer.Allocating = .init(allocator);
++    run(io, allocator, &allocating.writer, fake_args) catch |err| {
+         std.debug.print("Error occurred: {s}\n", .{@errorName(err)});
+         return;
+     };
+-    const result = buffer.toOwnedSlice() catch |err| {
++    const result = allocating.toOwnedSlice() catch |err| {
+         std.debug.print("Error occurred: {s}\n", .{@errorName(err)});
+         return;
+     };
+diff -urN linuxwave.orig/src/wav.zig linuxwave.new/src/wav.zig
+--- linuxwave.orig/src/wav.zig	2026-08-24 21:05:14.695639533 +0000
++++ linuxwave.new/src/wav.zig	2026-08-24 21:05:14.695639533 +0000
+@@ -14,6 +14,7 @@
+ const DATA = [4]u8{ 'd', 'a', 't', 'a' };
+ // Total length of the header.
+ const header_len: u32 = 44;
++const data_chunk_pos: u32 = 36;
+ 
+ /// Format of the waveform data.
+ pub const Format = enum {
+@@ -52,113 +53,72 @@
+     }
+ };
+ 
+-/// WAV encoder implementation.
+-pub fn Encoder(comptime Writer: type) type {
+-    // Position of the data chunk.
+-    const data_chunk_pos: u32 = 36;
+-
+-    return struct {
+-        // Encode WAV.
+-        pub fn encode(writer: Writer, data: []const u8, config: EncoderConfig) !void {
+-            try writeChunks(writer, config, data);
+-        }
+-
+-        /// Writes the headers with placeholder values for length.
+-        ///
+-        /// This can be used while streaming the WAV file i.e. when the total length is unknown.
+-        pub fn writeHeader(writer: Writer, config: EncoderConfig) !void {
+-            try writeChunks(writer, config, null);
+-        }
+-
+-        /// Patches the headers to seek back and patch the headers for length values.
+-        pub fn patchHeader(writer: Writer, seeker: anytype, data_len: u32) !void {
+-            const endian = std.builtin.Endian.little;
+-            try seeker.seekTo(4);
+-            try writer.writeInt(u32, data_chunk_pos + 8 + data_len - 8, endian);
+-            try seeker.seekTo(data_chunk_pos + 4);
+-            try writer.writeInt(u32, data_len, endian);
+-        }
+-
+-        /// Writes the WAV chunks with optional data.
+-        ///
+-        /// <WAVE-form> → RIFF('WAVE'
+-        ///                    <fmt-ck>            // Format
+-        ///                    [<fact-ck>]         // Fact chunk
+-        ///                    [<cue-ck>]          // Cue points
+-        ///                    [<playlist-ck>]     // Playlist
+-        ///                    [<assoc-data-list>] // Associated data list
+-        ///                    <wave-data> )       // Wave data
+-        fn writeChunks(writer: Writer, config: EncoderConfig, opt_data: ?[]const u8) !void {
+-            // Chunk configuration.
+-            const bytes_per_sample = config.format.getNumBytes();
+-            const num_channels: u16 = @intCast(config.num_channels);
+-            const sample_rate: u32 = @intCast(config.sample_rate);
+-            const byte_rate = sample_rate * @as(u32, num_channels) * bytes_per_sample;
+-            const block_align: u16 = num_channels * bytes_per_sample;
+-            const bits_per_sample: u16 = bytes_per_sample * 8;
+-            const data_len: u32 = if (opt_data) |data| @intCast(data.len) else 0;
+-            const endian = std.builtin.Endian.little;
+-            // Write the file header.
+-            try writer.writeAll(&RIFF);
+-            if (opt_data != null) {
+-                try writer.writeInt(u32, data_chunk_pos + 8 + data_len - 8, endian);
+-            } else {
+-                try writer.writeInt(u32, 0, endian);
+-            }
+-            try writer.writeAll(&WAVE);
+-            // Write the format chunk.
+-            try writer.writeAll(&FMT_);
+-            // Encode with pulse-code modulation (LPCM).
+-            try writer.writeInt(u32, 16, endian);
+-            // Uncompressed.
+-            try writer.writeInt(u16, 1, endian);
+-            try writer.writeInt(u16, num_channels, endian);
+-            try writer.writeInt(u32, sample_rate, endian);
+-            try writer.writeInt(u32, byte_rate, endian);
+-            try writer.writeInt(u16, block_align, endian);
+-            try writer.writeInt(u16, bits_per_sample, endian);
+-            // Write the data chunk.
+-            try writer.writeAll(&DATA);
+-            if (opt_data) |data| {
+-                try writer.writeInt(u32, data_len, endian);
+-                try writer.writeAll(data);
+-            } else {
+-                try writer.writeInt(u32, 0, endian);
+-            }
+-        }
+-    };
++pub fn encode(writer: *std.Io.Writer, data: []const u8, config: EncoderConfig) !void {
++    try writeChunks(writer, config, data);
+ }
+ 
+-test "encode WAV" {
+-    var buffer: [1000]u8 = undefined;
+-    var stream = std.io.fixedBufferStream(&buffer);
+-    const writer = stream.writer();
+-    try Encoder(@TypeOf(writer)).encode(writer, &[_]u8{ 0, 0, 0, 0, 0, 0, 0, 0 }, .{
+-        .num_channels = 1,
+-        .sample_rate = 44100,
+-        .format = .S16_LE,
+-    });
+-    try std.testing.expectEqualSlices(u8, "RIFF", buffer[0..4]);
++/// Writes the headers with placeholder values for length.
++///
++/// This can be used while streaming the WAV file i.e. when the total length is unknown.
++pub fn writeHeader(writer: *std.Io.Writer, config: EncoderConfig) !void {
++    try writeChunks(writer, config, null);
+ }
+ 
+-test "stream out WAV" {
+-    var buffer: [1000]u8 = undefined;
+-    var fbs = std.io.fixedBufferStream(&buffer);
++/// Writes the WAV chunks with optional data.
++///
++/// <WAVE-form> → RIFF('WAVE'
++///                    <fmt-ck>            // Format
++///                    [<fact-ck>]         // Fact chunk
++///                    [<cue-ck>]          // Cue points
++///                    [<playlist-ck>]     // Playlist
++///                    [<assoc-data-list>] // Associated data list
++///                    <wave-data> )       // Wave data
++fn writeChunks(writer: *std.Io.Writer, config: EncoderConfig, opt_data: ?[]const u8) !void {
++    // Chunk configuration.
++    const bytes_per_sample = config.format.getNumBytes();
++    const num_channels: u16 = @intCast(config.num_channels);
++    const sample_rate: u32 = @intCast(config.sample_rate);
++    const byte_rate = sample_rate * @as(u32, num_channels) * bytes_per_sample;
++    const block_align: u16 = num_channels * bytes_per_sample;
++    const bits_per_sample: u16 = bytes_per_sample * 8;
++    const data_len: u32 = if (opt_data) |data| @intCast(data.len) else 0;
+     const endian = std.builtin.Endian.little;
+-    const WavEncoder = Encoder(@TypeOf(fbs).Writer);
+-    try WavEncoder.writeHeader(fbs.writer(), .{
++    // Write the file header.
++    try writer.writeAll(&RIFF);
++    if (opt_data != null) {
++        try writer.writeInt(u32, data_chunk_pos + 8 + data_len - 8, endian);
++    } else {
++        try writer.writeInt(u32, 0, endian);
++    }
++    try writer.writeAll(&WAVE);
++    // Write the format chunk.
++    try writer.writeAll(&FMT_);
++    // Encode with pulse-code modulation (LPCM).
++    try writer.writeInt(u32, 16, endian);
++    // Uncompressed.
++    try writer.writeInt(u16, 1, endian);
++    try writer.writeInt(u16, num_channels, endian);
++    try writer.writeInt(u32, sample_rate, endian);
++    try writer.writeInt(u32, byte_rate, endian);
++    try writer.writeInt(u16, block_align, endian);
++    try writer.writeInt(u16, bits_per_sample, endian);
++    // Write the data chunk.
++    try writer.writeAll(&DATA);
++    if (opt_data) |data| {
++        try writer.writeInt(u32, data_len, endian);
++        try writer.writeAll(data);
++    } else {
++        try writer.writeInt(u32, 0, endian);
++    }
++}
++
++test "encode WAV" {
++    var buffer: [1000]u8 = undefined;
++    var writer: std.Io.Writer = .fixed(&buffer);
++    try encode(&writer, &[_]u8{ 0, 0, 0, 0, 0, 0, 0, 0 }, .{
+         .num_channels = 1,
+         .sample_rate = 44100,
+         .format = .S16_LE,
+     });
+-    try std.testing.expectEqual(@as(u64, 44), try fbs.getPos());
+-    try std.testing.expectEqual(@as(u32, 0), std.mem.readInt(u32, buffer[4..8], endian));
+-    try std.testing.expectEqual(@as(u32, 0), std.mem.readInt(u32, buffer[40..44], endian));
+-
+-    const data = &[_]u8{ 0, 0, 0, 0, 0, 0, 0, 0 };
+-    try fbs.writer().writeAll(data);
+-    try std.testing.expectEqual(@as(u64, 52), try fbs.getPos());
+-    try WavEncoder.patchHeader(fbs.writer(), fbs.seekableStream(), data.len);
+-    try std.testing.expectEqual(@as(u32, 44), std.mem.readInt(u32, buffer[4..8], endian));
+-    try std.testing.expectEqual(@as(u32, 8), std.mem.readInt(u32, buffer[40..44], endian));
++    try std.testing.expectEqualSlices(u8, "RIFF", buffer[0..4]);
+ }

--- a/linuxwave/riscv64.patch
+++ b/linuxwave/riscv64.patch
@@ -1,0 +1,16 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -13,6 +13,13 @@
+   "${pkgname}::git+$url#commit=$_gitcommit"
+ )
+ sha256sums=('95a2061038060651b53479e9cd4df79d9401530fd94effdd0f55e5df4d117d08')
++source_riscv64=("$pkgname-zig-0.16.patch")
++sha256sums_riscv64=('12de2626573d5454b7a86e3f88494927a22221a1ebc4cb62d0bf3cefef7efccd')
++
++prepare() {
++  cd "$pkgname"
++  patch -Np1 -i "../$pkgname-zig-0.16.patch"
++}
+ 
+ build() {
+   cd "$pkgname"


### PR DESCRIPTION
Backport upstream Zig 0.16 compatibility changes. The packaged 0.3.0 sources still use the old build.zig executable API, and current Zig 0.16 rejects Build.ExecutableOptions.root_source_file.