### PR TITLE
addpatch: memcached 1.6.42-1

### DIFF
--- a/memcached/riscv64.patch
+++ b/memcached/riscv64.patch
@@ -1,0 +1,24 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -25,17 +25,20 @@
+   memcached.sysusers
+   0001-tests-enable-drop_privileges-by-default-for-better-s.patch
+   0001-seccomp-extend-syscalls-tested-on-Linux-6.1-with-gli.patch
++  seccomp-allow-ppoll-in-worker-sandbox.patch::https://github.com/memcached/memcached/commit/822fa941b3a7e8ea48396e04f800db529327218a.patch
+ )
+ b2sums=('43b445521045b2593fdb18bf47268074794d8ac0ae803ad5a398f8ad725ef23a502b8e121afdd0d946ece1e21658961cd8f1373df683af171e0310603a077343'
+         'ab94a7a7b94d210ad145d88dbc3ed6ba52c4bf7564490aacc94016b8b0681636bf0996deb37f433e962346c7e1cd7775c66cd3f23b7c9623e24a6fb60e3c66c5'
+         '8c008783c4580e07463524c50ee7251cd9828c41d7e98f7516b1500ac538bc3ed0b42ce98987c6852475f0e9fbe135a5168c853626a98d2a021462b01c2dcbe8'
+         '9ff28a3bebf84a14afb6413febefd346ec72401dce0ec3330fb0adb23682d89da576f9ef7d0387debabbe548c9386d373cb0d9e340bea039dc6c630db15f50df'
+         'c7339653dd4e170c793f3c1e53f035f2bbc41a1a622b91fc31a6eebe7bd177b9173c50d8879b5c6a090f836fba50eeefcaaa867a39daad83e9ef8a7b30bb1888'
+-        '4db74ac2babe2a725f1b5de2b2ba43e650966ae528a3bd4beef4dcc781d1802a6a82cc814936cb9abfbd4fc23c4e0d399d6b801a03601e41e9bd0b57565012e4')
++        '4db74ac2babe2a725f1b5de2b2ba43e650966ae528a3bd4beef4dcc781d1802a6a82cc814936cb9abfbd4fc23c4e0d399d6b801a03601e41e9bd0b57565012e4'
++        '362e17b12a526ad9b6ff228d6d3f7f2ec71654a227385bd2f95c447e3b76644755c9e96baab0b1bfdcce4f4a116902e61b03b1c1196e3a31690a8c072030c1b0')
+ 
+ prepare() {
+   cd ${pkgname}
+   patch -Np1 < ../0001-seccomp-extend-syscalls-tested-on-Linux-6.1-with-gli.patch
++  patch -Np1 < ../seccomp-allow-ppoll-in-worker-sandbox.patch
+   patch -Np1 < ../0001-tests-enable-drop_privileges-by-default-for-better-s.patch
+   patch -Np1 < ../memcached.service.patch
+   sed -e 's/^##safer##//g' -i scripts/*.service


### PR DESCRIPTION
Backport upstream seccomp ppoll allowlist fix so riscv64 worker threads are not trapped by syscall 73 during t/lru-crawler.t.