### PR TITLE
addpatch: brltty 6.9.1-3

### DIFF
--- a/brltty/riscv64.patch
+++ b/brltty/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -97,7 +97,7 @@
+   CFLAGS+=" -ffat-lto-objects"
+ 
+   cd $pkgbase-${pkgbase^^}-$pkgver
+-  ./configure "${configure_options[@]}"
++  JAVA_JAR_DIR=/usr/share/java ./configure "${configure_options[@]}"
+   make
+   # make brlapi.jar deterministic
+   find . -type f -iname "*.jar" -exec strip-nondeterminism {} \;


### PR DESCRIPTION
Set JAVA_JAR_DIR explicitly so configure enables jar installation even when no dependency has pre-created /usr/share/java. The riscv64 log shows no commonly used jar installation directory, then jar not installed, causing package_brltty() to fail moving usr/share/java/brlapi.jar.