### PR TITLE
updpatch: dart 3.13.2-1

### DIFF
--- a/dart/HACK-gclient-fix-dep.diff
+++ b/dart/HACK-gclient-fix-dep.diff
@@ -1,12 +1,12 @@
---- gclient.py.orig	2025-11-01 08:31:34.496028596 +0000
-+++ gclient.py	2025-11-01 08:32:52.295977141 +0000
-@@ -79,6 +79,9 @@
- #   To specify a target CPU, the variables target_cpu and target_cpu_only
- #   are available and are analogous to target_os and target_os_only.
- 
-+import os, sys
+--- gclient.py.orig
++++ gclient.py
+@@ -91,6 +91,9 @@
+ import pprint
+ import re
+ import sys
++
 +os.system(f"{sys.executable} -m pip install httplib2==0.13.1 six==1.10.0 requests==2.31.0")
 +
- __version__ = '0.7'
- 
- import copy
+ import shutil
+ import tarfile
+ import tempfile

--- a/dart/dart-riscv-no-cross.patch
+++ b/dart/dart-riscv-no-cross.patch
@@ -1,6 +1,6 @@
 --- a/build/toolchain/linux/BUILD.gn
 +++ b/build/toolchain/linux/BUILD.gn
-@@ -276,10 +276,8 @@ gcc_toolchain_suite("clang_riscv32") {
+@@ -246,10 +246,8 @@
  }
  
  gcc_toolchain_suite("riscv64") {

--- a/dart/gcc-warning-errors.patch
+++ b/dart/gcc-warning-errors.patch
@@ -1,12 +1,11 @@
 --- a/build/config/compiler/BUILD.gn
 +++ b/build/config/compiler/BUILD.gn
-@@ -680,6 +680,9 @@
+@@ -671,6 +671,8 @@
      ]
    } else {
      default_warning_flags += [
 +      "-Wno-error=array-bounds",
-+      "-Wno-error=tsan",
 +      "-Wno-error=unused-but-set-variable",
        "-Wno-ignored-qualifiers",  # Warnings in BoringSSL headers
+       "-Wno-stringop-overflow",  # ICU in gcc 16
      ]
-   }

--- a/dart/riscv64.patch
+++ b/dart/riscv64.patch
@@ -1,6 +1,6 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -57,8 +57,17 @@
+@@ -58,8 +58,17 @@
  
    export PATH+=":$PWD/depot_tools" DEPOT_TOOLS_UPDATE=0
  
@@ -16,9 +16,9 @@
 +  patch -Np 1 --input=$srcdir/gcc-warning-errors.patch
 +
    patch -Np 1 --input="$srcdir/DEPS.patch"
-   patch -Np 1 --input="$srcdir/0001-fix-gcc-build-fails-with-msan-enabled.patch"
  
-@@ -80,7 +89,7 @@
+   # Fix for https://github.com/dart-lang/sdk/issues/63406
+@@ -82,7 +91,7 @@
    # gn args --list out
  
    /usr/bin/gn gen -qv out --args='
@@ -27,7 +27,7 @@
                          is_debug = false
                          is_release = true
                          is_clang = false
-@@ -112,3 +121,10 @@
+@@ -113,3 +122,10 @@
  }
  
  # vim:set ts=2 sw=2 et:
@@ -35,6 +35,6 @@
 +source+=("dart-riscv-no-cross.patch"
 +         "gcc-warning-errors.patch"
 +         "HACK-gclient-fix-dep.diff")
-+sha256sums+=('8c0d3a27a86aea34d7b932181111a9f660d2e7bf67d5e45055163e6b980b187f'
-+             'e3c43e1db6826f35c76a78db49d83b72a5296eb833ad616d6f4f8c02895e0e61'
-+             'ba4ac7e5c41c4d4a20f3fa420af99e844c69255ce1472436568a1fdf77785104')
++sha256sums+=('22430d5b1369357bc741de4a53a42d8c3dc6b2944eea349314f8ed69e8f5682c'
++             'c3bac7dfdc594e53b6b29525b2df88f91774d2c65b2047d941a6db81a32577e3'
++             'd42dd77c9ea37ea7bf7ad454a7879090a8d506894d20be4f92483e51e7a92fdd')


### PR DESCRIPTION
Refresh patch for Dart 3.13.2 and the pinned depot_tools commit. The latest riscv64 log fails because HACK-gclient-fix-dep.diff no longer applies to gclient.py; move the hack to the current import block, refresh source patch context, and drop the tsan suppression now covered upstream.