### PR TITLE
addpatch: libkrun 1.19.4-1

### DIFF
--- a/libkrun/fix-riscv64-non-tee-memory-region-setup.patch
+++ b/libkrun/fix-riscv64-non-tee-memory-region-setup.patch
@@ -1,0 +1,220 @@
+--- a/src/vmm/src/linux/vstate.rs
++++ b/src/vmm/src/linux/vstate.rs
+@@ -49,14 +49,16 @@
+     KVM_CLOCK_TSC_STABLE, KVM_IRQCHIP_IOAPIC, KVM_IRQCHIP_PIC_MASTER, KVM_IRQCHIP_PIC_SLAVE,
+     KVM_MAX_CPUID_ENTRIES,
+ };
+-use kvm_bindings::{
+-    kvm_create_guest_memfd, kvm_userspace_memory_region, kvm_userspace_memory_region2,
+-    KVM_API_VERSION, KVM_MEM_GUEST_MEMFD, KVM_SYSTEM_EVENT_RESET, KVM_SYSTEM_EVENT_SHUTDOWN,
+-};
++#[cfg(not(feature = "tee"))]
++use kvm_bindings::kvm_userspace_memory_region;
++use kvm_bindings::{KVM_API_VERSION, KVM_SYSTEM_EVENT_RESET, KVM_SYSTEM_EVENT_SHUTDOWN};
+ #[cfg(feature = "tee")]
+ use kvm_bindings::{kvm_enable_cap, KVM_CAP_EXIT_HYPERCALL, KVM_MEMORY_EXIT_FLAG_PRIVATE};
+-#[cfg(not(target_arch = "riscv64"))]
+-use kvm_bindings::{kvm_memory_attributes, KVM_MEMORY_ATTRIBUTE_PRIVATE};
++#[cfg(all(feature = "tee", target_arch = "x86_64"))]
++use kvm_bindings::{
++    kvm_create_guest_memfd, kvm_memory_attributes, kvm_userspace_memory_region2,
++    KVM_MEM_GUEST_MEMFD, KVM_MEMORY_ATTRIBUTE_PRIVATE,
++};
+ use kvm_ioctls::{Cap::*, *};
+ use utils::eventfd::EventFd;
+ use utils::signal::{register_signal_handler, sigrtmin, Killable};
+@@ -661,90 +663,120 @@
+         None
+     }
+ 
+-    #[allow(unused_mut)]
+-    fn memory_region_set(
++    // GuestMemfd is generally intended for either of two purposes:
++    // * sharing the memory with out-of-process components, and conversely,
++    // * hiding the memory completely from the VMM process (Confidential Computing).
++    //
++    // We only use it for the second use case currently, so don't even try to use it
++    // outside of TEE builds. Software-protected VMs are only available on x86_64 and
++    // are marked with strongly-worded warnings about them being for development only,
++    // as of late 2025. Also, on other architectures like aarch64, guest_memfd in
++    // general is unstable for now, so don't try to use it without a reason.
++
++    #[cfg(not(feature = "tee"))]
++    fn create_guest_physical_memory_slot(
+         &mut self,
+-        guest_mem: &GuestMemoryMmap,
++        host_addr: u64,
++        start: u64,
+         region: &GuestRegionMmap,
+     ) -> Result<()> {
+-        let host_addr = guest_mem.get_host_address(region.start_addr()).unwrap();
+-        let start = region.start_addr().raw_value();
+-        let end = start + region.len();
++        let memory_region = kvm_userspace_memory_region {
++            slot: self.next_mem_slot,
++            guest_phys_addr: start,
++            memory_size: region.len(),
++            userspace_addr: host_addr,
++            flags: 0,
++        };
+ 
+-        // GuestMemfd is generally intended for either of two purposes:
+-        // * sharing the memory with out-of-process components, and conversely,
+-        // * hiding the memory completely from the VMM process (Confidential Computing).
+-        //
+-        // We only use it for the second use case currently, so don't even try to use it
+-        // outside of TEE builds. Software-protected VMs are only available on x86_64 and
+-        // are marked with strongly-worded warnings about them being for development only,
+-        // as of late 2025. Also, on other architectures like aarch64, guest_memfd in
+-        // general is unstable for now, so don't try to use it without a reason.
+-
+-        if cfg!(not(feature = "tee")) {
+-            let memory_region = kvm_userspace_memory_region {
+-                slot: self.next_mem_slot,
+-                guest_phys_addr: start,
+-                memory_size: region.len(),
+-                userspace_addr: host_addr as u64,
+-                flags: 0,
+-            };
++        // Safe because we mapped the memory region, we made sure that the regions
++        // are not overlapping.
++        unsafe {
++            self.fd
++                .set_user_memory_region(memory_region)
++                .map_err(Error::SetUserMemoryRegion)?;
++        };
+ 
+-            // Safe because we mapped the memory region, we made sure that the regions
+-            // are not overlapping.
+-            unsafe {
+-                self.fd
+-                    .set_user_memory_region(memory_region)
+-                    .map_err(Error::SetUserMemoryRegion)?;
+-            };
+-        } else {
+-            if !self.fd.check_extension(GuestMemfd) {
+-                return Err(Error::KvmCap(GuestMemfd));
+-            }
++        Ok(())
++    }
++
++    #[cfg(all(feature = "tee", target_arch = "x86_64"))]
++    fn create_guest_physical_memory_slot(
++        &mut self,
++        host_addr: u64,
++        start: u64,
++        region: &GuestRegionMmap,
++    ) -> Result<()> {
++        let end = start + region.len();
++
++        if !self.fd.check_extension(GuestMemfd) {
++            return Err(Error::KvmCap(GuestMemfd));
++        }
+ 
+-            // Create a guest_memfd and set the region.
+-            let guest_memfd = self
+-                .fd
+-                .create_guest_memfd(kvm_create_guest_memfd {
+-                    size: region.size() as u64,
+-                    flags: 0,
+-                    reserved: [0; 6],
+-                })
+-                .map_err(Error::CreateGuestMemfd)?;
+-
+-            let memory_region = kvm_userspace_memory_region2 {
+-                slot: self.next_mem_slot,
+-                flags: KVM_MEM_GUEST_MEMFD,
+-                guest_phys_addr: start,
+-                memory_size: region.len(),
+-                userspace_addr: host_addr as u64,
+-                guest_memfd_offset: 0,
+-                guest_memfd: guest_memfd as u32,
+-                pad1: 0,
+-                pad2: [0; 14],
+-            };
+-
+-            // Safe because we mapped the memory region, we made sure that the regions
+-            // are not overlapping.
+-            unsafe {
+-                self.fd
+-                    .set_user_memory_region2(memory_region)
+-                    .map_err(Error::SetUserMemoryRegion)?;
+-            };
+-
+-            let attr = kvm_memory_attributes {
+-                address: start,
+-                size: region.len(),
+-                attributes: KVM_MEMORY_ATTRIBUTE_PRIVATE as u64,
++        // Create a guest_memfd and set the region.
++        let guest_memfd = self
++            .fd
++            .create_guest_memfd(kvm_create_guest_memfd {
++                size: region.size() as u64,
+                 flags: 0,
+-            };
++                reserved: [0; 6],
++            })
++            .map_err(Error::CreateGuestMemfd)?;
++
++        let memory_region = kvm_userspace_memory_region2 {
++            slot: self.next_mem_slot,
++            flags: KVM_MEM_GUEST_MEMFD,
++            guest_phys_addr: start,
++            memory_size: region.len(),
++            userspace_addr: host_addr,
++            guest_memfd_offset: 0,
++            guest_memfd: guest_memfd as u32,
++            pad1: 0,
++            pad2: [0; 14],
++        };
+ 
++        // Safe because we mapped the memory region, we made sure that the regions
++        // are not overlapping.
++        unsafe {
+             self.fd
+-                .set_memory_attributes(attr)
+-                .map_err(Error::SetMemoryAttributes)?;
++                .set_user_memory_region2(memory_region)
++                .map_err(Error::SetUserMemoryRegion)?;
++        };
+ 
+-            self.guest_memfds.push((Range { start, end }, guest_memfd));
+-        }
++        let attr = kvm_memory_attributes {
++            address: start,
++            size: region.len(),
++            attributes: KVM_MEMORY_ATTRIBUTE_PRIVATE as u64,
++            flags: 0,
++        };
++
++        self.fd
++            .set_memory_attributes(attr)
++            .map_err(Error::SetMemoryAttributes)?;
++
++        self.guest_memfds.push((Range { start, end }, guest_memfd));
++
++        Ok(())
++    }
++
++    #[cfg(all(feature = "tee", not(target_arch = "x86_64")))]
++    fn create_guest_physical_memory_slot(
++        &mut self,
++        _host_addr: u64,
++        _start: u64,
++        _region: &GuestRegionMmap,
++    ) -> Result<()> {
++        Err(Error::InvalidTee)
++    }
++
++    fn memory_region_set(
++        &mut self,
++        guest_mem: &GuestMemoryMmap,
++        region: &GuestRegionMmap,
++    ) -> Result<()> {
++        let host_addr = guest_mem.get_host_address(region.start_addr()).unwrap() as u64;
++        let start = region.start_addr().raw_value();
++
++        self.create_guest_physical_memory_slot(host_addr, start, region)?;
+ 
+         self.next_mem_slot += 1;
+ 

--- a/libkrun/riscv64.patch
+++ b/libkrun/riscv64.patch
@@ -1,0 +1,21 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -11,12 +11,16 @@
+ license=('Apache-2.0')
+ makedepends=('cargo' 'patchelf' 'clang')
+ depends=('glibc' 'libgcc' 'zstd' 'bzip2' 'libkrunfw' 'libpipewire' 'virglrenderer')
+-source=("https://github.com/containers/libkrun/archive/refs/tags/v$pkgver/$pkgname-$pkgver.tar.gz")
+-sha256sums=('e8775fab2b460972a67ca6cd936296bb79cdb078d852d712a283cb290dd0b284')
++source=("https://github.com/containers/libkrun/archive/refs/tags/v$pkgver/$pkgname-$pkgver.tar.gz"
++        "fix-riscv64-non-tee-memory-region-setup.patch")
++sha256sums=('e8775fab2b460972a67ca6cd936296bb79cdb078d852d712a283cb290dd0b284'
++            '6a3bde92bd2ae6d518907a68b1c659126db309badec4e945aceb31bfa242a752')
+ 
+ prepare() {
+   cd "$pkgname-$pkgver"
+ 
++  # Backport upstream d4bb6e0 for cfg! type-checking TEE-only memory attributes on riscv64.
++  patch -Np1 -i ../fix-riscv64-non-tee-memory-region-setup.patch
+   cargo fetch --locked --target "$(rustc --print host-tuple)"
+ }
+ 


### PR DESCRIPTION
Backport upstream d4bb6e0 so non-TEE riscv64 builds do not type-check TEE-only KVM memory attribute setup; the log fails on missing kvm_memory_attributes, KVM_MEMORY_ATTRIBUTE_PRIVATE, and VmFd::set_memory_attributes.