### PR TITLE
addpatch: gnome-calendar 50.0-2

### DIFF
--- a/gnome-calendar/fix-event-tzid-test-libical-system-tzdata.patch
+++ b/gnome-calendar/fix-event-tzid-test-libical-system-tzdata.patch
@@ -1,0 +1,32 @@
+--- a/tests/test-event.c
++++ b/tests/test-event.c
+@@ -310,10 +310,13 @@
+   g_autoptr (GDateTime) datetime = NULL;
+   g_autoptr (GTimeZone) tz = NULL;
+   g_autofree gchar *ical_string = NULL;
++  g_autofree gchar *unfolded_ical_string = NULL;
++  g_auto (GStrv) folded_lines = NULL;
+ 
+   ECalComponent *comp = NULL;
+   ICalComponent *ical_comp = NULL;
+   ECalComponentDateTime *dt_end = NULL;
++  const gchar *dtend_line = NULL;
+ 
+   g_test_bug ("172");
+ 
+@@ -340,8 +343,14 @@
+   gcal_event_set_date_end (event, datetime);
+ 
+   ical_string = i_cal_component_as_ical_string (ical_comp);
++  /* Unfold the line before checking it, since libical may fold long TZIDs. */
++  folded_lines = g_strsplit (ical_string, "\r\n ", -1);
++  unfolded_ical_string = g_strjoinv ("", folded_lines);
++  dtend_line = strstr (unfolded_ical_string, "DTEND;TZID=");
++
+   g_assert_true (strstr (ical_string, "DTSTART;TZID=Europe/London:20170818T010000\r\n") != NULL);
+-  g_assert_true (strstr (ical_string, "DTEND;TZID=/freeassociation.sourceforge.net/Europe/London:\r\n 20170818T030000\r\n") != NULL);
++  g_assert_nonnull (dtend_line);
++  g_assert_true (strstr (dtend_line, "Europe/London:20170818T030000\r\n") != NULL);
+   g_clear_pointer (&ical_string, g_free);
+ 
+   g_setenv ("TZ", "UTC", TRUE);

--- a/gnome-calendar/riscv64.patch
+++ b/gnome-calendar/riscv64.patch
@@ -1,0 +1,23 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -39,13 +39,18 @@
+ )
+ groups=(gnome)
+ source=("git+https://gitlab.gnome.org/GNOME/gnome-calendar.git#tag=${pkgver/[a-z]/.&}"
+-         libical-4.patch)
++         libical-4.patch
++         fix-event-tzid-test-libical-system-tzdata.patch)
+ b2sums=('d56765b7cd680fc1e3b324b7820dea56f7dc0c32059fc5f6ea3f1dcc735100ef83990f232129f62d992766a923e6fef8dd8c58e3fca531574b922de683f037fd'
+-        '6cfe91eda112dad310903cde4e6d31b013e231886d56a46177a7c1c0c8bf64057d95009c1ffd2d8ef95b85405ca431efa1c6a7dc694d618efb850027916c7a43')
++        '6cfe91eda112dad310903cde4e6d31b013e231886d56a46177a7c1c0c8bf64057d95009c1ffd2d8ef95b85405ca431efa1c6a7dc694d618efb850027916c7a43'
++        'f6ff41055dbe2130b9d13075a762ec342a0dfdf3c72aae3fa36d59506a1fc879bb9dccb23557545a2d6bcc5b4c9c713629ad0e9d0d9ebda62080a7ade5a665c6')
+ 
+ prepare() {
+   cd $pkgname
+   patch -p1 -i ../libical-4.patch # Fix build with libical 4.0
++
++  # libical can fold system-zone TZIDs differently, e.g. with a Tzfile prefix.
++  patch -Np1 -i ../fix-event-tzid-test-libical-system-tzdata.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
Patch the brittle create-tzid test to unfold iCalendar output before checking DTEND. The RISC-V log fails because libical may fold system-zone TZIDs, including compatible Tzfile-prefixed forms, while preserving the event semantics.

Ref: https://gitlab.gnome.org/GNOME/gnome-calendar/-/work_items/172