### PR TITLE
addpatch: vlc 3.0.23_2-13

### DIFF
--- a/vlc/riscv64.patch
+++ b/vlc/riscv64.patch
@@ -1,0 +1,32 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -778,20 +778,23 @@
+     _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libgrey_yuv_plugin.so
+     _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi420_10_p010_plugin.so
+     _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi420_nv12_plugin.so
+-    _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi420_rgb_mmx_plugin.so
+     _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi420_rgb_plugin.so
+-    _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi420_rgb_sse2_plugin.so
+-    _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi420_yuy2_mmx_plugin.so
+     _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi420_yuy2_plugin.so
+-    _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi420_yuy2_sse2_plugin.so
+     _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi422_i420_plugin.so
+-    _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi422_yuy2_mmx_plugin.so
+     _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi422_yuy2_plugin.so
+-    _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi422_yuy2_sse2_plugin.so
+     _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/librv32_plugin.so
+     _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libyuvp_plugin.so
+     _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libyuy2_i420_plugin.so
+     _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libyuy2_i422_plugin.so
++    # VLC only installs MMX/SSE2 chroma plugins when building for x86.
++    if [[ $CARCH == x86_64 ]]; then
++      _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi420_rgb_mmx_plugin.so
++      _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi420_rgb_sse2_plugin.so
++      _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi420_yuy2_mmx_plugin.so
++      _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi420_yuy2_sse2_plugin.so
++      _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi422_yuy2_mmx_plugin.so
++      _pick vlc-plugins-base usr/lib/vlc/plugins/video_chroma/libi422_yuy2_sse2_plugin.so
++    fi
+     _pick vlc-plugins-base usr/lib/vlc/plugins/video_filter/libadjust_plugin.so
+     _pick vlc-plugins-base usr/lib/vlc/plugins/video_filter/libalphamask_plugin.so
+     _pick vlc-plugins-base usr/lib/vlc/plugins/video_filter/libanaglyph_plugin.so


### PR DESCRIPTION
Move x86-only MMX/SSE2 chroma plugins only on x86_64; riscv64 builds do not install them and package_vlc() failed when moving libi420_rgb_mmx_plugin.so.