### PR TITLE
addpatch: wf-config 0.11.0-1

### DIFF
--- a/wf-config/riscv64.patch
+++ b/wf-config/riscv64.patch
@@ -1,0 +1,20 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -21,8 +21,15 @@
+   glm
+   meson
+ )
+-source=("git+https://github.com/WayfireWM/wf-config.git#tag=v$pkgver")
+-b2sums=(d74cf44a8a33bd8225f2c6342e6536a4996aa55d3d2d6935f8d133b51b420294c6e8f7ab583dbc8f7c9536afb159ad885a543aba2ab8f413325edf771e5aae58)
++source=("git+https://github.com/WayfireWM/wf-config.git#tag=v$pkgver"
++        widen-simple-animation-timing.patch)
++b2sums=(d74cf44a8a33bd8225f2c6342e6536a4996aa55d3d2d6935f8d133b51b420294c6e8f7ab583dbc8f7c9536afb159ad885a543aba2ab8f413325edf771e5aae58
++        952701135865692bacdbdfac904b04d592fb5495f8aae80a071be93679e2c3167ec61e044ce949bbe2775ac52b86dc9a8d617bc482e5c299cd05fc9959d90e49)
++
++prepare() {
++  cd $pkgname
++  patch -Np1 -i ../widen-simple-animation-timing.patch
++}
+ 
+ build() {
+   arch-meson $pkgname build

--- a/wf-config/widen-simple-animation-timing.patch
+++ b/wf-config/widen-simple-animation-timing.patch
@@ -1,0 +1,24 @@
+--- a/test/duration_test.cpp
++++ b/test/duration_test.cpp
+@@ -126,7 +126,7 @@
+ 
+ TEST_CASE("wf::animation::simple_animation_t")
+ {
+-    auto length = std::make_shared<option_t<int>>("length", 10);
++    auto length = std::make_shared<option_t<int>>("length", 100);
+     simple_animation_t anim{length, smoothing::linear};
+ 
+     auto cycle_through = [&] (double s, double e, bool x1, bool x2)
+@@ -144,10 +144,10 @@
+ 
+         CHECK(anim.running());
+         CHECK((double)anim == doctest::Approx(s));
+-        usleep(5000);
++        usleep(50000);
+         CHECK((double)anim == doctest::Approx((s + e) / 2).epsilon(0.1));
+         CHECK(anim.running());
+-        usleep(5500);
++        usleep(60000);
+         CHECK((double)anim == doctest::Approx(e));
+         CHECK(anim.running());
+         CHECK(!anim.running());


### PR DESCRIPTION
Widen the simple_animation_t timing test: the 10 ms window is too tight on riscv64, where the latest log overshot the midpoint and finished before running() checks. Keep the same proportions with a 100 ms window.