### PR TITLE
updpatch: protobuf 36.0-1

### DIFF
--- a/protobuf/riscv64.patch
+++ b/protobuf/riscv64.patch
@@ -15,10 +15,10 @@
 +  # Keep it here instead of bottom of the file because this file updates along with the package
 +  "$pkgbase-$pkgver-python.tar.gz::https://files.pythonhosted.org/packages/source/${pkgbase::1}/${pkgbase//-/_}/${pkgbase//-/_}-7.$pkgver.tar.gz"
  )
- sha512sums=('70104fd3ae0d13fc5afc2d2835d10d4a45949d528ecb15b88dc29cc6e52ecea1d62dbbcb17a49fd129a53bb78243051b4f10e6b90552146403898d517272df68'
+ sha512sums=('e1ebed47daa921e304a038e0b90412cda2d4614d3add0f70ce5e17553623b2aabd739b0aa7c134f78e0fe901b7afb037c1a7656046de79e3f6ff5b284ab5dedf'
 -            '18bc71031bbcbc3810a9985fa670465040f06a6c104ab8079b56bdfc499bb6cec40805a0cefd455031142490a576dc60aa8000523877ac0353b93558e9beabbd')
 +            '18bc71031bbcbc3810a9985fa670465040f06a6c104ab8079b56bdfc499bb6cec40805a0cefd455031142490a576dc60aa8000523877ac0353b93558e9beabbd'
-+            'f732067c69921340aaf295e2b55c21d244e60f59430379c0dbda3657bcd104a094c8747f64bbc692ce6d2e2ee6593c587f04d42369d11f97cc2fd27d03864a1d')
++            'e6ac5262d0ed06a1b646e21618b83641101b2e16b2c431a9ae165af62e2c8a062e93589784e46dab8255fc925f42eac9e2246f281ae628f0b95f8fb2bf9dfe13')
  
  options=(!lto)
  


### PR DESCRIPTION
Refresh the PyPI sdist workaround against current Arch checksums after protobuf 36.0-1 failed during patch application.