### PR TITLE
addpatch: pixi 0.78.0-1

### DIFF
--- a/pixi/riscv64.patch
+++ b/pixi/riscv64.patch
@@ -1,0 +1,13 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -58,6 +58,10 @@
+     source_package_tests::locked_accepts_branch_build_source_after_upstream_moves
+     source_package_tests::test_abbreviated_git_rev_build_source_keeps_lock_satisfied
+     source_package_tests::test_git_path_lock_behaviour
++    # static dummy channel has no linux-riscv64 packages
++    install_filter_tests::install_subset_e2e_skip_with_deps
++    # mutates PIXI_OVERRIDE_PLATFORM process-wide and can race other integration tests
++    lock_v6_platform_tests::v6_lock_resolves_for_current_machine
+     # https://github.com/prefix-dev/pixi/issues/5383
+     tests::test_env_vars_are_set
+     tests::test_rust_is_in_build_requirements


### PR DESCRIPTION
Skip the install-filter e2e test because its static dummy channel has no linux-riscv64 packages. Also skip the lock_v6 platform test because its async PIXI_OVERRIDE_PLATFORM mutation can race other integration tests and produce spurious current-system platform mismatches.