### PR TITLE
updpatch: maxima 5.50.0-2

### DIFF
--- a/maxima/riscv64.patch
+++ b/maxima/riscv64.patch
@@ -6,10 +6,10 @@
  pkgbase=maxima
 -pkgname=($pkgbase{,-sbcl,-ecl,-fas})
 +pkgname=($pkgbase{,-ecl,-fas})
- pkgver=5.49.0
- _sbclver=2.6.2
- _eclver=24.5.10
-@@ -15,8 +15,7 @@ url='http://maxima.sourceforge.net'
+ pkgver=5.50.0
+ _sbclver=2.6.8
+ _eclver=26.5.5
+@@ -15,8 +15,7 @@
  makedepends=(ecl
               emacs
               git
@@ -19,7 +19,7 @@
  # needs rebuild when bash changes version
  # needs a rebuild when ecl or sbcl changes version
  options=(!zipman) # don't zip info pages or they won't work inside maxima
-@@ -46,9 +45,8 @@ build() {
+@@ -43,9 +42,8 @@
      --mandir=/usr/share/man \
      --infodir=/usr/share/info \
      --libexecdir=/usr/lib \


### PR DESCRIPTION
Refresh the SBCL-disable patch for the current PKGBUILD. The latest build failed while applying stale patch context before it could build.