### PR TITLE
addpatch: mypy 2.1.0-2

### DIFF
--- a/mypy/riscv64-timeouts.patch
+++ b/mypy/riscv64-timeouts.patch
@@ -1,0 +1,38 @@
+--- a/mypy/defaults.py
++++ b/mypy/defaults.py
+@@ -47,12 +47,12 @@
+ 
+ RECURSION_LIMIT: Final = 2**14
+ 
+-# It looks like Windows is slow with processes, causing test flakiness even
+-# with our generous timeouts, so we set them higher.
++# Process startup can be slow on Windows and heavily loaded builders, so use
++# generous timeouts for worker startup and IPC connection setup.
+ WORKER_START_INTERVAL: Final = 0.01 if sys.platform != "win32" else 0.03
+-WORKER_START_TIMEOUT: Final = 3 if sys.platform != "win32" else 10
++WORKER_START_TIMEOUT: Final = 30
+ WORKER_SHUTDOWN_TIMEOUT: Final = 1 if sys.platform != "win32" else 3
+ 
+-WORKER_CONNECTION_TIMEOUT: Final = 10
++WORKER_CONNECTION_TIMEOUT: Final = 60
+ WORKER_IDLE_TIMEOUT: Final = 600
+ WORKER_DONE_TIMEOUT: Final = 600
+--- a/mypy/test/config.py
++++ b/mypy/test/config.py
+@@ -28,4 +28,4 @@
+ # Ref. https://github.com/python/mypy/issues/12615
+ # Ref. mypy/test/testpep561.py
+ pip_lock = os.path.join(package_path, ".pip_lock")
+-pip_timeout = 60
++pip_timeout = 300
+--- a/mypyc/test/librt_cache.py
++++ b/mypyc/test/librt_cache.py
+@@ -162,7 +162,7 @@
+ 
+     os.makedirs(cache_root, exist_ok=True)
+ 
+-    with filelock.FileLock(lock_file, timeout=300):  # 5 min timeout
++    with filelock.FileLock(lock_file, timeout=1200):  # 20 min timeout
+         if os.path.exists(marker):
+             return build_dir
+ 

--- a/mypy/riscv64.patch
+++ b/mypy/riscv64.patch
@@ -1,0 +1,23 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -43,15 +43,19 @@
+ source=(
+   "$pkgname-$pkgver.tar.gz::https://github.com/python/mypy/archive/v$pkgver.tar.gz"
+   "$pkgname-exclude-tests.patch"
++  'riscv64-timeouts.patch'
+ )
+ b2sums=('37bf2f6d79377ebde68537119c0b58ae9cf6868421329b1d5b814e48788749e53cd34053bb5472385881b167cc8af7fdd85cef3c63792868668286516fe27462'
+-        '83b6d12dac919b917ba13c6a5b6da6e4cd6dc517f85b4f8e81d793d9c0e871af5a48708c4a5a54c45c7be89c5ed394b2f77007be89420fea4a1f3ca1efb04c0d')
++        '83b6d12dac919b917ba13c6a5b6da6e4cd6dc517f85b4f8e81d793d9c0e871af5a48708c4a5a54c45c7be89c5ed394b2f77007be89420fea4a1f3ca1efb04c0d'
++        'fba73dd5d8d533bfed85b7f965141e33795d6625a40231643491745758f92d1398525878b38dfc6d534306c98abc1122e40306bca5328eb8b844457357908dc7')
+ 
+ prepare() {
+   cd "$pkgname-$pkgver"
+   # -Werror, not even once
+   sed -e '/Werror/d' -i mypyc/build.py
+   patch -Np1 < ../$pkgname-exclude-tests.patch
++  # RISC-V builders can exceed upstream's short lock and worker timeouts.
++  patch -Np1 < ../riscv64-timeouts.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
Increase RISC-V test timeouts for serialized pip/librt cache locks and mypy worker startup/IPC. The failing log shows filelock timeouts and worker connection failures rather than bad test assertions.