### PR TITLE
addpatch: python-sybil 10.1.0-1

### DIFF
--- a/python-sybil/riscv64.patch
+++ b/python-sybil/riscv64.patch
@@ -1,0 +1,20 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -10,8 +10,15 @@
+ depends=('python')
+ makedepends=('git' 'python-build' 'python-hatchling' 'python-installer')
+ checkdepends=('python-pytest' 'python-seedir' 'python-testfixtures' 'python-yaml')
+-source=("git+https://github.com/simplistix/sybil.git#tag=$pkgver")
+-sha512sums=('e3280fe7fcd08a3e9158ba9d5e7f6a845a3c55e85224dac95bf6ca63b29e37edf0f8c47b746068594240234385276e60343d68e4bec21dc111a2b77c80fd28f5')
++source=("git+https://github.com/simplistix/sybil.git#tag=$pkgver"
++        "testfixtures-12.patch::$url/commit/b1c31ce0818cfa7953a61b3b391a88cd5620f9dd.patch")
++sha512sums=('e3280fe7fcd08a3e9158ba9d5e7f6a845a3c55e85224dac95bf6ca63b29e37edf0f8c47b746068594240234385276e60343d68e4bec21dc111a2b77c80fd28f5'
++            '462bc0174112f2605fb00c506d53f7073a0afce93c4fee8e5db96776b6bfdb11f40c92467d84e21f021711d56565a60d9bab110d8d317ea0bbb887dc4f133e68')
++
++prepare() {
++  cd sybil
++  patch -Np1 -i ../testfixtures-12.patch
++}
+ 
+ build() {
+   cd sybil


### PR DESCRIPTION
Backport upstream b1c31ce to follow the testfixtures 12 compare_text/compare_dict move. The riscv64 log has python-testfixtures 12.3.0 and fails test collection while importing those helpers from testfixtures.comparison.