### PR TITLE
addpatch: bcachefs-tools 3:1.39.2-1

### DIFF
--- a/bcachefs-tools/riscv64.patch
+++ b/bcachefs-tools/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -58,6 +58,9 @@
+   export CFLAGS="${CFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
+   export CXXFLAGS="${CXXFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
+ 
++  # Rust uses riscv*gc triples, but clang expects canonical riscv* triples.
++  export BINDGEN_EXTRA_CLANG_ARGS="$BINDGEN_EXTRA_CLANG_ARGS --target=riscv64-unknown-linux-gnu -march=rv64gc"
++
+   make \
+     LIBEXECDIR=/usr/lib \
+     DESTDIR="${pkgdir}" \


### PR DESCRIPTION
libclang rejects Rust's riscv64gc target triple when bindgen is run by bcachefs-tools. Pass the canonical RISC-V clang target while preserving the Rust build target.