### PR TITLE
updpatch: qemu 11.1.1-1

### DIFF
--- a/qemu/riscv64.patch
+++ b/qemu/riscv64.patch
@@ -1,22 +1,6 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -23,7 +23,6 @@ pkgname=(
-   qemu-ui-{curses,dbus,egl-headless,gtk,opengl,sdl,spice-{app,core}}
-   qemu-user{,-static}{,-binfmt}
-   qemu-vhost-user-gpu
--  qemu-vmsr-helper
-   qemu-{base,desktop,emulators-full,full}
- )
- pkgver=10.1.0
-@@ -126,6 +125,7 @@ makedepends=(
-   zlib
-   zstd
- )
-+options=(!lto)
- source=(
-   https://download.qemu.org/qemu-$pkgver.tar.xz{,.sig}
-   bridge.conf
-@@ -212,7 +212,7 @@ _qemu_desktop_optdepends=(
+@@ -203,7 +203,7 @@
    'qemu-system-mips: for MIPS system emulator'
    'qemu-system-or1k: for OpenRisc32 system emulator'
    'qemu-system-ppc: for PPC system emulator'
@@ -25,90 +9,36 @@
    'qemu-system-rx: for RX system emulator'
    'qemu-system-s390x: for S390 system emulator'
    'qemu-system-sh4: for SH4 system emulator'
-@@ -443,13 +443,6 @@ package_qemu-common() {
+@@ -425,9 +425,6 @@
    # remove unneeded files
    find "$pkgdir" -name .buildinfo -delete
  
 -  # remove files provided by seabios
 -  rm -fv "$pkgdir/usr/share/$pkgbase/"{bios,vgabios}*
 -
--  # remove files provided by edk2-{aarch64,arm,ovmf}
--  rm -fv "$pkgdir/usr/share/$pkgbase/"edk2-*
--  rm -frv "$pkgdir/usr/share/$pkgbase/firmware"
--
    (
      # create man page symlinks for all system emulators
      cd "$pkgdir/usr/share/man/man1"
-@@ -515,6 +508,9 @@ package_qemu-common() {
+@@ -580,6 +577,9 @@
  
-     _pick qemu-system-aarch64 usr/bin/qemu-system-aarch64
-     _pick qemu-system-aarch64 usr/share/man/man1/qemu-system-aarch64.1*
-+    # NOTE: needs to be replaced by edk2, not buildable on riscv64 yet
-+    _pick qemu-system-aarch64 usr/share/qemu/firmware/*-aarch64*
-+    _pick qemu-system-aarch64 usr/share/qemu/edk2-aarch64-*
- 
-     _pick qemu-system-alpha usr/bin/qemu-system-alpha
-     _pick qemu-system-alpha usr/share/man/man1/qemu-system-alpha.1*
-@@ -523,6 +519,9 @@ package_qemu-common() {
- 
-     _pick qemu-system-arm usr/bin/qemu-system-arm
-     _pick qemu-system-arm usr/share/man/man1/qemu-system-arm.1*
-+    # NOTE: needs to be replaced by edk2, not buildable on riscv64 yet
-+    _pick qemu-system-arm-firmware usr/share/qemu/firmware/*-arm*
-+    _pick qemu-system-arm-firmware usr/share/qemu/edk2-arm-*
- 
-     _pick qemu-system-arm-firmware usr/share/qemu/{ast27x0,npcm{7,8}xx}_bootrom.bin
- 
-@@ -596,6 +595,13 @@ package_qemu-common() {
- 
-     _pick qemu-system-x86-firmware usr/share/qemu/{kvmvapic,linuxboot,multiboot{,_dma},pvh}.bin
+     _pick qemu-system-x86-firmware usr/share/qemu/{kvmvapic,{linuxboot,multiboot}_dma,pvh}.bin
      _pick qemu-system-x86-firmware usr/share/qemu/qboot.rom
-+    # NOTE: needs to be replaced by seabios/edk2, not buildable on riscv64 yet
-+    _pick qemu-system-x86-firmware usr/share/qemu/firmware/*-i386*
-+    _pick qemu-system-x86-firmware usr/share/qemu/firmware/*-x86_64*
-+    _pick qemu-system-x86-firmware usr/share/qemu/edk2-i386-*
-+    _pick qemu-system-x86-firmware usr/share/qemu/edk2-x86_64-*
++    # NOTE: needs to be replaced by seabios, not available on riscv64 yet
 +    _pick qemu-system-x86-firmware usr/share/qemu/bios*
 +    _pick qemu-system-x86-firmware usr/share/qemu/vgabios*
  
      _pick qemu-system-xtensa usr/bin/qemu-system-xtensa{,eb}
      _pick qemu-system-xtensa usr/share/man/man1/qemu-system-xtensa{,eb}.1*
-@@ -623,7 +629,6 @@ package_qemu-common() {
-     _pick qemu-vhost-user-gpu usr/lib/qemu/vhost-user-gpu
-     _pick qemu-vhost-user-gpu usr/share/qemu/vhost-user/50-qemu-gpu.json
- 
--    _pick qemu-vmsr-helper usr/bin/qemu-vmsr-helper
-   )
- }
- 
-@@ -841,7 +846,7 @@ package_qemu-hw-s390x-virtio-gpu-ccw() {
- 
- package_qemu-system-aarch64() {
-   pkgdesc="QEMU system emulator for AARCH64"
--  depends=("${_qemu_system_deps[@]}" dtc edk2-aarch64 systemd-libs libudev.so)
-+  depends=("${_qemu_system_deps[@]}" dtc systemd-libs libudev.so)
-   mv -v $pkgname/* "$pkgdir"
-   _install_licenses
- }
-@@ -862,7 +867,7 @@ package_qemu-system-alpha-firmware() {
- 
- package_qemu-system-arm() {
-   pkgdesc="QEMU system emulator for ARM"
--  depends=("${_qemu_system_deps[@]}" dtc edk2-arm qemu-system-arm-firmware=$pkgver-$pkgrel systemd-libs libudev.so)
-+  depends=("${_qemu_system_deps[@]}" dtc qemu-system-arm-firmware=$pkgver-$pkgrel systemd-libs libudev.so)
-   mv -v $pkgname/* "$pkgdir"
-   _install_licenses
- }
-@@ -1017,7 +1022,7 @@ package_qemu-system-tricore() {
+@@ -1010,7 +1010,7 @@
  
  package_qemu-system-x86() {
    pkgdesc="QEMU system emulator for x86"
 -  depends=("${_qemu_system_deps[@]}" dtc edk2-ovmf libcbor libcbor.so qemu-system-x86-firmware=$pkgver-$pkgrel seabios systemd-libs libudev.so)
-+  depends=("${_qemu_system_deps[@]}" dtc libcbor libcbor.so qemu-system-x86-firmware=$pkgver-$pkgrel systemd-libs libudev.so)
++  depends=("${_qemu_system_deps[@]}" dtc edk2-ovmf libcbor libcbor.so qemu-system-x86-firmware=$pkgver-$pkgrel systemd-libs libudev.so)
    mv -v $pkgname/* "$pkgdir"
    _install_licenses
  }
-@@ -1219,7 +1224,7 @@ package_qemu-base() {
+@@ -1215,7 +1215,7 @@
    depends=(
      qemu-common=$pkgver-$pkgrel
      qemu-img=$pkgver-$pkgrel
@@ -117,11 +47,3 @@
      virtiofsd
    )
    optdepends=("${_qemu_base_optdepends[@]}")
-@@ -1269,7 +1274,6 @@ package_qemu-full() {
-     qemu-tests=$pkgver-$pkgrel
-     qemu-tools=$pkgver-$pkgrel
-     qemu-user=$pkgver-$pkgrel
--    qemu-vmsr-helper=$pkgver-$pkgrel
-   )
-   optdepends=("${_qemu_full_optdepends[@]}")
-   provides=(qemu=$pkgver)


### PR DESCRIPTION
Refresh patch against current PKGBUILD. Keep qemu-base on qemu-system-riscv and keep bundled SeaBIOS files in qemu-system-x86-firmware because seabios is not available on riscv64.

Drop stale qemu-vmsr-helper, edk2, and LTO workarounds now handled by current packaging or riscv64 deps.