### PR TITLE
addpatch: python-pydicom 3.0.2-1

### DIFF
--- a/python-pydicom/riscv64.patch
+++ b/python-pydicom/riscv64.patch
@@ -1,0 +1,16 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -19,6 +19,13 @@
+ source=("$pkgname-$pkgver.tar.gz::https://github.com/pydicom/pydicom/archive/v$pkgver.tar.gz")
+ sha256sums=('76f95d03cba3e978dc19470c0907c6ad8ca68e72311137622e5fe5e8f594d67f')
+ 
++prepare()
++{
++	cd "$srcdir/pydicom-$pkgver"
++	# Arch ships flit_core 4, which supports PEP 621 metadata.
++	sed -i -e '/flit_core/s/,<4//' pyproject.toml
++}
++
+ build()
+ {
+ 	cd "$srcdir/pydicom-$pkgver"


### PR DESCRIPTION
Relax the flit_core upper bound so the package can build with Arch's flit_core 4.