### PR TITLE
updpatch: conky 1.22.3-3

### DIFF
--- a/conky/riscv64.patch
+++ b/conky/riscv64.patch
@@ -1,16 +1,14 @@
-diff --git PKGBUILD PKGBUILD
-index ad9508b..51f0ac3 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -44,7 +44,6 @@ depends=(
+@@ -34,7 +34,6 @@
    'libxft'
    'libxinerama'
    'libxml2'
 -  'libxnvctrl' libXNVCtrl.so
-   'lua'
+   'lua54'
    'ncurses' libncursesw.so
    'pango'
-@@ -87,7 +86,7 @@ build() {
+@@ -92,7 +91,7 @@
      -D BUILD_IMLIB2=ON \
      -D BUILD_CURL=ON \
      -D BUILD_RSS=ON \


### PR DESCRIPTION
Refresh patch after the dependency context changed from lua to lua54. Keep NVIDIA support disabled because libxnvctrl/proprietary NVIDIA support is not usable on riscv64.