### PR TITLE
addpatch: python-pydantic 2.13.4-1

### DIFF
--- a/python-pydantic/riscv64.patch
+++ b/python-pydantic/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -70,6 +70,7 @@
+     -vv
+     --deselect tests/test_docs.py  # we are not interested in code formatting
+     --deselect tests/pydantic_core/test_docstrings.py::test_readme  # we are not interested in code formatting
++    --deselect tests/pydantic_core/test_docstrings.py::test_docstrings  # we are not interested in code formatting
+     --deselect tests/test_types.py::test_string_fails
+     --deselect 'tests/test_networks.py::test_address_invalid[foobar-An email address must have an @-sign.]'
+   )


### PR DESCRIPTION
Deselect the pydantic-core docstring formatting checks that fail under current ruff. Arch's testing package already carries the same deselect in 2.13.5-1; add it here for the logged 2.13.4-1 build.