### PR TITLE
updpatch: nodejs-lts-krypton 24.20.0-1

### DIFF
--- a/nodejs-lts-krypton/fix-wasi-thread-spawn.patch
+++ b/nodejs-lts-krypton/fix-wasi-thread-spawn.patch
@@ -1,0 +1,31 @@
+--- a/test/fixtures/wasi-preview-1.js
++++ b/test/fixtures/wasi-preview-1.js
+@@ -68,6 +68,9 @@
+       const name = `pthread-${tid}`;
+       const sab = new SharedArrayBuffer(8 + 8192);
+       const result = new Int32Array(sab);
++      // The thread stores 0 once it has loaded or 1 with an error; wait on a
++      // value neither of them writes so an early notify cannot be missed.
++      Atomics.store(result, 0, -1);
+ 
+       const workerData = {
+         name,
+@@ -106,7 +109,7 @@
+         throw new Error(e);
+       });
+ 
+-      const r = Atomics.wait(result, 0, 0, 1000);
++      const r = Atomics.wait(result, 0, -1, common.platformTimeout(30_000));
+       if (r === 'timed-out') {
+         workers[tid].terminate();
+         delete workers[tid];
+--- a/test/wasi/wasi.status
++++ b/test/wasi/wasi.status
+@@ -14,7 +14,3 @@
+ [$system==win32 || $system==android]
+ # Unsupported on Windows and Android
+ test-wasi-readdir: SKIP
+-
+-[$system==linux]
+-# https://github.com/nodejs/node/issues/59146
+-test-wasi-pthread: PASS, FLAKY

--- a/nodejs-lts-krypton/hwy-broken-rvv.diff
+++ b/nodejs-lts-krypton/hwy-broken-rvv.diff
@@ -1,8 +1,6 @@
-diff --git a/tools/v8_gypfiles/v8.gyp b/tools/v8_gypfiles/v8.gyp
-index 3ea5564d54..a09ca8d798 100644
 --- a/tools/v8_gypfiles/v8.gyp
 +++ b/tools/v8_gypfiles/v8.gyp
-@@ -2284,6 +2284,9 @@
+@@ -2387,6 +2387,9 @@
            ['v8_target_arch=="arm64"', {
              'defines': ['HWY_BROKEN_TARGETS=HWY_ALL_SVE',],
            }],
@@ -12,7 +10,7 @@ index 3ea5564d54..a09ca8d798 100644
            ['v8_target_arch=="ppc64" or v8_target_arch=="s390x"', {
              'defines': ['TOOLCHAIN_MISS_ASM_HWCAP_H',],
            }],
-@@ -2308,6 +2311,9 @@
+@@ -2411,6 +2414,9 @@
          ['v8_target_arch=="arm64"', {
            'defines': ['HWY_BROKEN_TARGETS=HWY_ALL_SVE',],
          }],

--- a/nodejs-lts-krypton/riscv64.patch
+++ b/nodejs-lts-krypton/riscv64.patch
@@ -1,6 +1,6 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -61,6 +61,16 @@
+@@ -65,12 +65,24 @@
    # /usr/lib/libnode.so uses malloc_usable_size, which is incompatible with fortification level 3
    CFLAGS="${CFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
    CXXFLAGS="${CXXFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
@@ -8,16 +8,24 @@
 +  # https://github.com/riscv-forks/electron/issues/7
 +  export CC=/usr/bin/clang
 +  export CXX=/usr/bin/clang++
-+}
-+
-+prepare() {
-+  cd node
-+
+ }
+ 
+ prepare() {
+   cd node
+   # test: account for varied OpenSSL CCM final behaviours
+   patch --forward --strip=1 --input=../0001-test-account-for-varied-OpenSSL-CCM-final-behaviours.patch
 +  patch -Np1 -i ../hwy-broken-rvv.diff
++
++  # Fix missed WASI worker notifications and the short startup timeout.
++  # https://github.com/nodejs/node/commit/bb8f1148c4437eabf9ab568dc5b199cac0b2ae93
++  patch -Np1 -i ../fix-wasi-thread-spawn.patch
++
++  # Ten WPT workers can exhaust the Wasm address space available on Sv39.
++  sed -i 's/concurrency = Math.min(10, concurrency);/concurrency = Math.min(2, concurrency);/' test/common/wpt.js
  }
  
  build() {
-@@ -94,6 +104,8 @@
+@@ -105,6 +117,8 @@
  check() {
    _set_flags
    cd node
@@ -26,12 +34,13 @@
    rm test/parallel/test-http2-client-set-priority.js
    rm test/parallel/test-http2-client-unescaped-path.js
    rm test/parallel/test-http2-max-invalid-frames.js
-@@ -114,4 +126,8 @@
+@@ -124,3 +138,9 @@
+   make DESTDIR="$pkgdir" install
    install -Dm644 LICENSE -t "$pkgdir"/usr/share/licenses/$pkgname
  }
- 
 +
 +makedepends+=(clang)
-+source+=("hwy-broken-rvv.diff")
-+b2sums+=('4e770adcd1d4edc71f1ebced7573ca61b6e7424f780baa15bd12aae8f37656ce518fe5b1a9cc4c838f41464421a25490d4d3c8c88b441a8dab50481df94f08d5')
- # vim:set ts=2 sw=2 et:
++source+=("hwy-broken-rvv.diff"
++         "fix-wasi-thread-spawn.patch")
++b2sums+=('4717b78b17b63195ee6c4f3b989e52aa6cabb2ed565945371774d643faa235f14fd315df5eac2800709b95b5e6ba889d60410f6242e11873a995e2a78e37d5cc'
++         'f4392dd1649f9f3e041890ca74b434f5f560a46b54ef6994826c35e5852c11897c85563504434cc03e9163049e328a7cc93162a53cc9e96a4de18611fae38131')


### PR DESCRIPTION
Refresh hwy-broken-rvv.diff against Node v24.19.0 and update its checksum.

Also add nodejs-lts-krypton to the qemu-user blacklist: the latest log reaches check() but fails with qemu-user runtime/environment issues, including RSS reported as 0, watch-mode restart timeouts, and profiler children ending with SIGILL/SIGSEGV.