### PR TITLE
addpatch: python-hypothesis 6.165.10-1

### DIFF
--- a/python-hypothesis/riscv64.patch
+++ b/python-hypothesis/riscv64.patch
@@ -1,0 +1,19 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -66,9 +66,15 @@
+ source=("$pkgname::git+$_url#tag=v$pkgver")
+ sha512sums=('5151fda34e809961810624d7e6f14746ff9725300c2b8b91b2c6bf4c1cc5512a4429db559b4d69c3009daa1970ee7f3981d6cdee64833d1775313f5e475ebca9')
+ b2sums=('7fb47487897630ae64d3cb09fa6d4228c3952d782a2118b801a677ba17ee1857c58fbfc437c39455861c6b5ceed1d451b44c77c9332bfc2722014edd462376d5')
++source+=(suppress-stateful-too-slow-healthcheck.patch)
++sha512sums+=('e8df90b55134bfde8a24f7f0513b2f9d39b4c237c34a95fd74787a83f2196d70229d8d9d7ee6dfdb7a01fcb8a1767124772ac22f95fb1b09aacc51f4ec449070')
++b2sums+=('afcaae1f8513549a99d26f16a6e345c19080cc085aad19ed29fcc40b37f56156c5aa80696a9d63e47b5939ea35c833d87986b8b54b7e09b100bd73634ae3346d')
+ 
+ prepare() {
+-  cd $pkgname/$_name/rust/
++  cd $pkgname
++  patch -Np1 -i ../suppress-stateful-too-slow-healthcheck.patch
++
++  cd $_name/rust/
+   cargo fetch --locked --target host-tuple
+ }
+ 

--- a/python-hypothesis/suppress-stateful-too-slow-healthcheck.patch
+++ b/python-hypothesis/suppress-stateful-too-slow-healthcheck.patch
@@ -1,0 +1,27 @@
+--- a/hypothesis/tests/nocover/test_stateful.py
++++ b/hypothesis/tests/nocover/test_stateful.py
+@@ -13,7 +13,7 @@
+ 
+ import pytest
+ 
+-from hypothesis import Phase, settings as Settings, strategies as st
++from hypothesis import HealthCheck, Phase, settings as Settings, strategies as st
+ from hypothesis.stateful import (
+     Bundle,
+     RuleBasedStateMachine,
+@@ -28,8 +28,13 @@
+ 
+ def run_to_notes(TestClass):
+     TestCase = TestClass.TestCase
+-    # don't add explain phase notes to the error
+-    TestCase.settings = Settings(phases=set(Phase) - {Phase.explain}, max_examples=500)
++    # This helper checks shrink output, not generation speed; slow builders may
++    # otherwise hit the health check before reaching the expected assertion.
++    TestCase.settings = Settings(
++        phases=set(Phase) - {Phase.explain},
++        max_examples=500,
++        suppress_health_check=[HealthCheck.too_slow],
++    )
+     try:
+         TestCase().runTest()
+     except AssertionError as err:


### PR DESCRIPTION
Patch the stateful-output helper to suppress only HealthCheck.too_slow. On slow riscv64 builders the helper can otherwise fail with FailedHealthCheck before it reaches the expected assertion output.