### PR TITLE
updpatch: python-llvmlite 0.49.0-1

### DIFF
--- a/python-llvmlite/riscv64.patch
+++ b/python-llvmlite/riscv64.patch
@@ -1,16 +1,18 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -44,7 +44,12 @@
+@@ -38,7 +38,14 @@
  
  check() {
      cd $_name
 -    pytest -vv $_name/tests
 +    # Skip MCJIT related failures, as it's known to be broken on RISC-V
 +    # Skip OrcLLJIT tests on non-x86 platforms
++    # test_optsize_minsize assumes O3 creates a vector loop on every target.
 +    pytest -vv $_name/tests --deselect llvmlite/tests/test_binding.py::TestMCJit \
 +                            --deselect llvmlite/tests/test_binding.py::TestGlobalConstructors \
 +                            --deselect llvmlite/tests/test_binding.py::TestObjectFile::test_add_object_file \
-+                            --deselect llvmlite/tests/test_binding.py::TestOrcLLJIT
++                            --deselect llvmlite/tests/test_binding.py::TestOrcLLJIT \
++                            --deselect llvmlite/tests/test_binding.py::TestNewModulePassManager::test_optsize_minsize
  }
  
  package() {


### PR DESCRIPTION
Deselect test_optsize_minsize because LLVM does not vectorize its sample loop on riscv64, matching the logged missing vector.body failure.