### PR TITLE
addpatch: python-rich-click 1.9.7-1

### DIFF
--- a/python-rich-click/fix-test-width.patch
+++ b/python-rich-click/fix-test-width.patch
@@ -1,0 +1,11 @@
+--- a/tests/conftest.py
++++ b/tests/conftest.py
+@@ -75,6 +75,8 @@
+ def default_config(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+     # Isolate rich_click global config module for each test:
+     monkeypatch.delenv("RICH_CLICK_THEME", raising=False)
++    # Rich 15 treats TERM=dumb as an 80-column terminal, ignoring WIDTH.
++    monkeypatch.setenv("TERM", "xterm-256color")
+     reload(rc)
+ 
+     # Default config settings

--- a/python-rich-click/riscv64.patch
+++ b/python-rich-click/riscv64.patch
@@ -1,0 +1,34 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -12,14 +12,17 @@
+ checkdepends=(python-pytest python-typer python-inline-snapshot ruff)
+ license=(MIT)
+ source=(git+$url.git#tag=v$pkgver
+-  coverage.patch)
++  coverage.patch
++  fix-test-width.patch)
+ b2sums=('22bd625411379fd1ee34f19097cc4b2d2cc652aabcf9d8d9b468902827392664f7bb1d52d0daf3403e3a14a2511b61721c31a7b1527f907e8d54b997baf19275'
+-        'ce76531f596c44b9da8b5ae0b462a9a41e1003f46a2b8b7141f75ae127e0c285dcf0ae4cc0655381f839c196f8097789e83c6f236c5661d8cf30b20c455329d8')
++        'ce76531f596c44b9da8b5ae0b462a9a41e1003f46a2b8b7141f75ae127e0c285dcf0ae4cc0655381f839c196f8097789e83c6f236c5661d8cf30b20c455329d8'
++        '36cffbe295cbf040a911440bc5fb7faebdbc5573c0ef0209ab45d914dd2adac179b124768d2c9a565d225b6612dc8bcef38be52c17633f4d1392eebe3734821d')
+ 
+ prepare() {
+   cd $_name
+   # patch pytest command line args for a newer version
+   patch -p1 <../coverage.patch
++  patch -Np1 -i ../fix-test-width.patch
+ }
+ 
+ build() {
+@@ -31,7 +34,10 @@
+   cd $_name
+   python -m venv --system-site-packages test-env
+   test-env/bin/python -m installer dist/*.whl
+-  test-env/bin/python -P -m pytest -k "not test_markdown_help_rich_12 and not test_markdown_help_text_markup_field_rich_12"
++  # Upstream currently caps Typer below 0.26 because patch_typer is incompatible.
++  test-env/bin/python -P -m pytest \
++    --ignore=tests/typer_help \
++    -k "not test_markdown_help_rich_12 and not test_markdown_help_text_markup_field_rich_12"
+ }
+ 
+ package() {


### PR DESCRIPTION
Set TERM during tests so Rich 15 honors the 100-column snapshots instead of treating TERM=dumb as 80 columns.

Ignore Typer help tests because upstream caps Typer below 0.26 and Arch currently carries a newer Typer.