### PR TITLE
updpatch: cockatrice 3.0.2-2

### DIFF
--- a/cockatrice/increase-deck-hash-test-timeout.patch
+++ b/cockatrice/increase-deck-hash-test-timeout.patch
@@ -5,7 +5,7 @@
  
  add_test(NAME deck_hash_performance_test COMMAND deck_hash_performance_test)
 -set_tests_properties(deck_hash_performance_test PROPERTIES TIMEOUT 5)
-+set_tests_properties(deck_hash_performance_test PROPERTIES TIMEOUT 30)
++set_tests_properties(deck_hash_performance_test PROPERTIES TIMEOUT 120)
  
  # Find GTest
  

--- a/cockatrice/riscv64.patch
+++ b/cockatrice/riscv64.patch
@@ -9,12 +9,12 @@
 +source=("git+https://github.com/Cockatrice/Cockatrice.git#tag=$_tag"
 +        "increase-deck-hash-test-timeout.patch")
 +sha512sums=('c99f6e8852a055237dccd0370cf70e5da9170818fed7ca2d7e0f4d1e1c1ec6a58e148037badb3a62af3f87e5f36eaa7f3821463922718a9bbd48b35305358e90'
-+            '2a0e24ab8a7558b8ac0bf970975878b67aa1623299056f66bc2bc9adde86ac5c22b81367d44fcdbecbbbd1acaa4f483e8ba4331255b332ff0729178ce7446bf1')
++            '83dcc8844af638b5c50750b60612b5bc08cf10c7b0598166d269aa35e1499ac3e5dbd62075a80ab231d0eb351d68eadafa465721cf6e745b8bfdf5497063884f')
 +
 +prepare() {
 +  cd $_pkgname
 +
-+  # The deck hash performance test exceeds its 5s timeout on riscv64 builders.
++  # The deck hash performance test timed out after 30s on a native riscv64 builder.
 +  patch -Np1 -i ../increase-deck-hash-test-timeout.patch
 +}
  


### PR DESCRIPTION
Raise deck_hash_performance_test timeout from 30s to 120s after it still timed out at 30.04s on a native sg2042 riscv64 builder.

Upstream also raised this timeout due to platform variance in https://github.com/Cockatrice/Cockatrice/commit/cf8e5858, but only to 15s.