### PR TITLE
addpatch: python-hatch 1.17.0-1

### DIFF
--- a/python-hatch/riscv64.patch
+++ b/python-hatch/riscv64.patch
@@ -1,0 +1,25 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -90,6 +90,22 @@
+     # Broken, likely because newer flit-core in repos not compatible
+     --deselect="tests/project/test_frontend.py::TestPrepareMetadata::test_wheel[flit-core]"
+     --deselect="tests/project/test_frontend.py::TestPrepareMetadata::test_editable[flit-core]"
++
++    # No default Python distributions exist for these targets on riscv64.
++    --deselect="tests/python/test_core.py::test_custom_source[3.7]"
++    --deselect="tests/python/test_core.py::test_custom_source[3.8]"
++    --deselect="tests/python/test_core.py::test_custom_source[pypy2.7]"
++    --deselect="tests/python/test_core.py::test_custom_source[pypy3.9]"
++    --deselect="tests/python/test_core.py::test_custom_source[pypy3.10]"
++    --deselect="tests/python/test_core.py::test_custom_source[pypy3.11]"
++    --deselect="tests/python/test_core.py::test_installation[3.7]"
++    --deselect="tests/python/test_core.py::test_installation[3.8]"
++    --deselect="tests/python/test_core.py::test_installation[pypy2.7]"
++    --deselect="tests/python/test_core.py::test_installation[pypy3.9]"
++    --deselect="tests/python/test_core.py::test_installation[pypy3.10]"
++    --deselect="tests/python/test_core.py::test_installation[pypy3.11]"
++    --deselect="tests/python/test_resolve.py::TestDistributionVersions::test_pypy_custom"
++    --deselect="tests/python/test_resolve.py::TestDistributionPaths::test_pypy_custom"
+   )
+   test-env/bin/python -m pytest --ignore=tests/backend "${pytest_args[@]}"
+ }


### PR DESCRIPTION
Deselect Python distribution tests for targets that have no default linux/riscv64 source in Hatch's distribution table.