### PR TITLE
addpatch: python-threat9-test-bed 0.6.0+2+g1ed61b3-13

### DIFF
--- a/python-threat9-test-bed/riscv64.patch
+++ b/python-threat9-test-bed/riscv64.patch
@@ -1,0 +1,19 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -27,6 +27,8 @@
+   cd ${pkgname}
+   # not sure why this works lol
+   patch -Np1 -i ../http-service-async-mock.patch
++  # setuptools-scm 10 rejects absolute version-file paths.
++  patch -Np1 -i ../setuptools-scm-relative-version-file.patch
+ }
+ 
+ build() {
+@@ -46,4 +48,7 @@
+   install -Dm 644 README.md -t "${pkgdir}/usr/share/doc/${pkgname}"
+ }
+ 
++source+=(setuptools-scm-relative-version-file.patch)
++sha512sums+=('b382dab8ec591ec5236f60f135fed821a9028c774390a7141b4fc15d6b8d496c651d813896bf9ea1d67113f2b73b9af2df55207d4de01ec63df245e51b21bee7')
++
+ # vim: ts=2 sw=2 et:

--- a/python-threat9-test-bed/setuptools-scm-relative-version-file.patch
+++ b/python-threat9-test-bed/setuptools-scm-relative-version-file.patch
@@ -1,0 +1,11 @@
+--- a/setup.py
++++ b/setup.py
+@@ -12,7 +12,7 @@
+     name="threat9-test-bed",
+     use_scm_version={
+         "root": str(HERE),
+-        "write_to": str(HERE / "threat9_test_bed" / "_version.py"),
++        "write_to": "threat9_test_bed/_version.py",
+     },
+     url="http://threat9.com",
+     author="Mariusz Kupidura",


### PR DESCRIPTION
setuptools-scm 10.2.1 rejects upstream's absolute use_scm_version.write_to path during build_wheel. Patch setup.py to write threat9_test_bed/_version.py relative to the project root.