### PR TITLE
addpatch: rocsolver 7.2.4-1

### DIFF
--- a/rocsolver/riscv64.patch
+++ b/rocsolver/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -29,9 +29,6 @@
+ _dirname="rocm-libraries-rocm-$pkgver/projects/$pkgname"
+ 
+ build() {
+-    # Compile source code for supported GPU archs in parallel
+-    export HIPCC_COMPILE_FLAGS_APPEND="-parallel-jobs=$(nproc)"
+-    export HIPCC_LINK_FLAGS_APPEND="-parallel-jobs=$(nproc)"
+     # -fcf-protection is not supported by HIP, see
+     # https://rocm.docs.amd.com/projects/llvm-project/en/latest/reference/rocmcc.html#support-status-of-other-clang-options
+     local cmake_args=(


### PR DESCRIPTION
Drop the PKGBUILD's hipcc -parallel-jobs=$(nproc) override on riscv64.

rocsolver already builds many HIP source files concurrently through the outer make/CMake jobserver. The extra hipcc override multiplies that parallelism again inside every compiler and linker invocation. On minun, the builder exposes 32 CPUs and makepkg uses MAKEFLAGS=-j16, so up to 16 hipcc commands can run at once and each one is allowed to spawn 32 offload jobs for the 22 AMDGPU targets. The failing log shows those -parallel-jobs=32 commands followed by many killed clang frontend jobs.

That nested fan-out can overwhelm even larger builders; the same package also drove infernape above 5k load. Removing the override leaves ROCm CMake's default HIP_CLANG_NUM_PARALLEL_JOBS=1, preserving source-file parallelism while preventing each hipcc process from spawning dozens of extra compiler/linker workers.