### PR TITLE
addpatch: yaml-language-server 1.23.0-1

### DIFF
--- a/yaml-language-server/riscv64.patch
+++ b/yaml-language-server/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -29,7 +29,7 @@
+ 
+ check() {
+   cd $pkgname
+-  npm test
++  npm test -- --timeout 60000
+ }
+ 
+ package() {


### PR DESCRIPTION
Raise the Mocha timeout for riscv64 checks. The 1.23.0 log, like the previous 1.21.0 and 1.22.0 logs, gets through the suite and then fails only with 10000ms Mocha timeouts in completion and Kubernetes schema resolution tests, with no assertion failures. Append a larger timeout to the upstream npm test command for the slower RISC-V builders.