### PR TITLE
addpatch: gotosocial 0.22.1-1

### DIFF
--- a/gotosocial/go1.27-gruf-deps.patch
+++ b/gotosocial/go1.27-gruf-deps.patch
@@ -1,0 +1,114 @@
+--- a/go.mod
++++ b/go.mod
+@@ -29,7 +29,7 @@
+ 	codeberg.org/gruf/go-longdur v0.1.3
+ 	codeberg.org/gruf/go-mempool v0.0.0-20251205182607-a05549c9a993
+ 	codeberg.org/gruf/go-mmap v0.0.0-20251111184116-345a42dab154
+-	codeberg.org/gruf/go-mutexes v1.5.9
++	codeberg.org/gruf/go-mutexes v1.5.10
+ 	codeberg.org/gruf/go-runners v1.7.0
+ 	codeberg.org/gruf/go-sched v1.3.1
+ 	codeberg.org/gruf/go-split v1.2.1
+@@ -106,7 +106,7 @@
+ 	codeberg.org/gruf/go-kv v1.6.5 // indirect
+ 	codeberg.org/gruf/go-mangler/v2 v2.0.9 // indirect
+ 	codeberg.org/gruf/go-maps v1.0.4 // indirect
+-	codeberg.org/gruf/go-xunsafe v0.0.0-20260211121553-1c99e9364fee // indirect
++	codeberg.org/gruf/go-xunsafe v0.0.0-20260820215719-ea52483480e5 // indirect
+ 	dario.cat/mergo v1.0.2 // indirect
+ 	github.com/Masterminds/goutils v1.1.1 // indirect
+ 	github.com/Masterminds/semver/v3 v3.5.0 // indirect
+--- a/go.sum
++++ b/go.sum
+@@ -50,8 +50,8 @@
+ codeberg.org/gruf/go-mempool v0.0.0-20251205182607-a05549c9a993/go.mod h1:761koiXmqfgzvu5mez2Rk7YlwWilpqJ/zv5hIA6NoNI=
+ codeberg.org/gruf/go-mmap v0.0.0-20251111184116-345a42dab154 h1:2SSyx/7XgOOC9nKdlrgpxenz7oZlvUeLR+YEfjM6iS8=
+ codeberg.org/gruf/go-mmap v0.0.0-20251111184116-345a42dab154/go.mod h1:kaHx5xHuLNf13iALbHiFpXmLeO33Ll/aW3mGkW8sI40=
+-codeberg.org/gruf/go-mutexes v1.5.9 h1:sQWz7VwvkAADMY5xHn25ak2hnw0+UhiLR+i/tqVKk2c=
+-codeberg.org/gruf/go-mutexes v1.5.9/go.mod h1:21sy/hWH8dDQBk7ocsxqo2GNpWiIir+e82RG3hjnN20=
++codeberg.org/gruf/go-mutexes v1.5.10 h1:axYkuFrt/wWR7H5L8VjyHnvKtNkd6proQnh3Ik4oTL4=
++codeberg.org/gruf/go-mutexes v1.5.10/go.mod h1:21sy/hWH8dDQBk7ocsxqo2GNpWiIir+e82RG3hjnN20=
+ codeberg.org/gruf/go-runners v1.7.0 h1:Z+8Qne4H9nAdZZbA4cij0PWhhJxtigUGA4Mp7griYes=
+ codeberg.org/gruf/go-runners v1.7.0/go.mod h1:1xBodiyuPfosJga+NYTfeepQYUrlBGCAa4NuQTbtiBw=
+ codeberg.org/gruf/go-sched v1.3.1 h1:9PKL9i9tI+EbIagOZB/2ar54+yEJo5ZPCCIs1+Ylu+E=
+@@ -62,8 +62,8 @@
+ codeberg.org/gruf/go-storage v0.6.1/go.mod h1:Zk/kpUMCikXQNJBHSjxygKwv7N/t8mJvg17sMjl29Xw=
+ codeberg.org/gruf/go-structr v0.9.16 h1:DeVbp4hBunbuDvW43/SYDyaLrlBFeTu5aI5nmh8rpZM=
+ codeberg.org/gruf/go-structr v0.9.16/go.mod h1:h/mxKjJ1o7XoAPNuvkZ56bvqs4ze5tYxSbXnwIiGxKY=
+-codeberg.org/gruf/go-xunsafe v0.0.0-20260211121553-1c99e9364fee h1:ZVGdv6rmXAWiyUJyuOzLdFSJDK9XOsKNr75xi0/zsN4=
+-codeberg.org/gruf/go-xunsafe v0.0.0-20260211121553-1c99e9364fee/go.mod h1:11BPvGfBffTfuv19i0FtxumArfUZJZFrAHAcYgZ0Bvk=
++codeberg.org/gruf/go-xunsafe v0.0.0-20260820215719-ea52483480e5 h1:z8acj6bam04gG1lmiZjkxYYiDcwYFVv5x1o91VZJrlc=
++codeberg.org/gruf/go-xunsafe v0.0.0-20260820215719-ea52483480e5/go.mod h1:11BPvGfBffTfuv19i0FtxumArfUZJZFrAHAcYgZ0Bvk=
+ codeberg.org/superseriousbusiness/gin v1.11.0-array-binding-fix-2 h1:QjlJYZu+TSnTTZZoc9W8iIZ4xl2aSHtsdccpW9FsTqI=
+ codeberg.org/superseriousbusiness/gin v1.11.0-array-binding-fix-2/go.mod h1:+iq/FyxlGzII0KHiBGjuNn4UNENUlKbGlNmc+W50Dls=
+ dario.cat/mergo v1.0.2 h1:85+piFYR1tMbRrLcDwR18y4UKJ3aH1Tbzi24VRW1TK8=
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -291,7 +291,7 @@
+ # codeberg.org/gruf/go-mmap v0.0.0-20251111184116-345a42dab154
+ ## explicit; go 1.20
+ codeberg.org/gruf/go-mmap
+-# codeberg.org/gruf/go-mutexes v1.5.9
++# codeberg.org/gruf/go-mutexes v1.5.10
+ ## explicit; go 1.24.0
+ codeberg.org/gruf/go-mutexes
+ # codeberg.org/gruf/go-runners v1.7.0
+@@ -314,7 +314,7 @@
+ # codeberg.org/gruf/go-structr v0.9.16
+ ## explicit; go 1.24.6
+ codeberg.org/gruf/go-structr
+-# codeberg.org/gruf/go-xunsafe v0.0.0-20260211121553-1c99e9364fee
++# codeberg.org/gruf/go-xunsafe v0.0.0-20260820215719-ea52483480e5
+ ## explicit; go 1.24.6
+ codeberg.org/gruf/go-xunsafe
+ # dario.cat/mergo v1.0.2
+--- a/vendor/codeberg.org/gruf/go-mutexes/map_unsafe.go
++++ b/vendor/codeberg.org/gruf/go-mutexes/map_unsafe.go
+@@ -1,4 +1,4 @@
+-//go:build go1.22 && !go1.27
++//go:build go1.22 && !go1.28
+ 
+ package mutexes
+ 
+@@ -29,7 +29,7 @@
+ 	// NOTE: must remain in
+ 	// sync with sync.Cond{}.
+ 	type syncCond struct {
+-		_ struct{}
++		_ struct{} // nocopy
+ 		L sync.Locker
+ 		n notifyList
+ 		// ... other fields
+--- a/vendor/codeberg.org/gruf/go-xunsafe/abi.go
++++ b/vendor/codeberg.org/gruf/go-xunsafe/abi.go
+@@ -1,4 +1,4 @@
+-//go:build go1.24 && !go1.27
++//go:build go1.24 && !go1.28
+ 
+ package xunsafe
+ 
+--- a/vendor/codeberg.org/gruf/go-xunsafe/abi_type_1_26.go
++++ b/vendor/codeberg.org/gruf/go-xunsafe/abi_type_1_26.go
+@@ -1,4 +1,4 @@
+-//go:build go1.26 && !go1.27
++//go:build go1.26 && !go1.28
+ 
+ package xunsafe
+ 
+--- a/vendor/codeberg.org/gruf/go-xunsafe/reflect.go
++++ b/vendor/codeberg.org/gruf/go-xunsafe/reflect.go
+@@ -1,4 +1,4 @@
+-//go:build go1.24 && !go1.27
++//go:build go1.24 && !go1.28
+ 
+ package xunsafe
+ 
+@@ -47,7 +47,7 @@
+ 		return 0
+ 	}
+ 	f := Reflect_flag(Abi_Type_Kind(elemType))
+-	if Abi_Type_IfaceIndir(elemType) {
++	if !Abi_Type_IsDirectIface(elemType) {
+ 		f |= Reflect_flagIndir
+ 	}
+ 	if f != 0 {

--- a/gotosocial/riscv64.patch
+++ b/gotosocial/riscv64.patch
@@ -1,0 +1,19 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -79,10 +79,16 @@
+         'ccf672731b88fc6700b0b81737790365e1eea0066bad1bbf6b13dac1e5b42af69063838efca47a6d9c16ee3f6308e2e23b92cf79d4226cd88f8551fb7361649b'
+         '6cfdcf5c8814bf1aa20d1f08d89d57e78866142e2d36b7bfc9527a80da163b0765ccc6c78e311c30f47230a680d404b167971ffd1b03ace7314e2284295c55d9'
+         '3671911545d15cc21045b37fbe6983c05499e66b8a6a1e1b3eccbb5c2686914c88b090dec0bfe8e2919d8787e5b4c59bfb1e2c292cad30a8b552ab57e91d5fdf')
++source+=(go1.27-gruf-deps.patch)
++sha512sums+=('35bfd2b8358a04fc4d34197627827e0fb4ed186f6dca09c1d306772d9439b7b4c7b73dcb620a6f73231f2e0a16361a95cb74396fb3033627b3721b84b8a2b130')
++b2sums+=('3cabc90edbee66c2c027692c402235474d936f136c20738ade9c5a392d90501a47f6b563d42c9c34ace2c93bbb0760b51ee562c1673af41ac3bd4e590aa36cd1')
+ 
+ prepare() {
+   cd "$pkgname"
+ 
++  # Backport upstream Go 1.27 dependency fixes for gruf's unsafe helpers.
++  patch -p1 -i "$srcdir/go1.27-gruf-deps.patch"
++
+   # create directory for build output
+   mkdir build
+ 


### PR DESCRIPTION
Backport upstream Go 1.27 support for gruf unsafe helpers and keep vendored metadata/sources in sync. This fixes the riscv64 build failures from undefined Reflect_flag, undefined syncCond_last_ticket, and inconsistent vendoring.