### PR TITLE
addpatch: libvips 8.18.5-1

### DIFF
--- a/libvips/riscv64.patch
+++ b/libvips/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -30,7 +30,7 @@
+ 
+ check() {
+   export LD_LIBRARY_PATH="$srcdir/build/libvips"
+-  meson test -C build
++  meson test -C build --timeout-multiplier 5
+   pytest -k "not test_text" -sv --log-cli-level=WARNING vips-$pkgver/test/test-suite
+ }
+ 


### PR DESCRIPTION
RISC-V builds repeatedly time out in Meson vips:fuzz at the upstream 120s limit. Keep the test enabled but use Meson timeout scaling so it can complete on slower builders.