### PR TITLE
addpatch: afl++ 5.00c-1

### DIFF
--- a/afl++/fix-riscv64-tests.patch
+++ b/afl++/fix-riscv64-tests.patch
@@ -1,0 +1,38 @@
+--- a/test/test-bug-pass.sh
++++ b/test/test-bug-pass.sh
+@@ -852,7 +852,10 @@
+ # --- ALLOCSIZE stack-alloca: catches OOB on stack arrays.  Registers
+ #     entry-block allocas (size multiple of 64 bytes, alignment 64) so
+ #     the existing store oracle's shadow lookup finds them.
+-AFL_QUIET=1 AFL_LLVM_BUG_ALLOCSIZE=1 "$CC" -O0 \
++# -fno-stack-protector: isolate the ALLOCSIZE oracle from the compiler's own
++# stack-canary, which (on macOS/arm64, unlike glibc/x86) independently aborts
++# on this overflow and would otherwise mask what the oracle does.
++AFL_QUIET=1 AFL_LLVM_BUG_ALLOCSIZE=1 "$CC" -O0 -fno-stack-protector \
+   "$SCRIPT_DIR/test-bug-allocsize-stack-oob.c" -o "$TMP/aso"
+ set +e
+ printf '\x00\x00\x00\x00' | "$TMP/aso" 2>"$TMP/aso.err"
+@@ -918,7 +921,9 @@
+ 
+ # Gating: AFL_LLVM_BUG_ALLOCSIZE_STACK=0 must restore pre-fix behavior.
+ # Rebuild the TP source with the opt-out; OOB must slip past silently.
+-AFL_QUIET=1 AFL_LLVM_BUG_ALLOCSIZE=1 AFL_LLVM_BUG_ALLOCSIZE_STACK=0 "$CC" -O0 \
++# -fno-stack-protector: see the TP build above - without it the stack canary,
++# not AFL, aborts the STACK=0 binary on macOS and the opt-out looks broken.
++AFL_QUIET=1 AFL_LLVM_BUG_ALLOCSIZE=1 AFL_LLVM_BUG_ALLOCSIZE_STACK=0 "$CC" -O0 -fno-stack-protector \
+   "$SCRIPT_DIR/test-bug-allocsize-stack-oob.c" -o "$TMP/aso_off"
+ set +e
+ printf '\x00\x00\x00\x00' | "$TMP/aso_off" 2>"$TMP/aso_off.err"
+--- a/test/test-qemu-mode.sh
++++ b/test/test-qemu-mode.sh
+@@ -43,6 +43,10 @@
+       }
+       rm -f errors
+ 
++      # AFL_ENTRYPOINT reuses the probed absolute address; make it stable on riscv64.
++      if test "$SYS" = "riscv64"; then
++        ${CPU_TARGET_CC} -no-pie -o test-instr ../test-instr.c
++      fi
+       $ECHO "$GREY[*] running afl-fuzz for qemu_mode AFL_ENTRYPOINT, this will take approx 6 seconds"
+       {
+         {

--- a/afl++/riscv64.patch
+++ b/afl++/riscv64.patch
@@ -1,0 +1,26 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -50,9 +50,12 @@
+ options=(!lto)
+ source=(
+   "https://github.com/AFLplusplus/AFLplusplus/archive/refs/tags/v${pkgver}/${pkgname}-${pkgver}.tar.gz"
++  fix-riscv64-tests.patch
+ )
+-sha256sums=('b0c005a1d28883ad1cad17ac01837d5c6b0cc7a72d19db700823e42ce3848534')
+-b2sums=('88fe7ebc95d4f116eb2ed183bc92d6d90fbb2cab03fc12132a5c1c5eabe057deb7dc710cd538159ffe7d1c1f38f05f497e08afa64e69912d9137ff0937cbb0dc')
++sha256sums=('b0c005a1d28883ad1cad17ac01837d5c6b0cc7a72d19db700823e42ce3848534'
++            'bcf8ac617dac641cc616d5feaf29f71d36b2d612d2aa23c1917c5f7082dfad44')
++b2sums=('88fe7ebc95d4f116eb2ed183bc92d6d90fbb2cab03fc12132a5c1c5eabe057deb7dc710cd538159ffe7d1c1f38f05f497e08afa64e69912d9137ff0937cbb0dc'
++        '5385446940e7f09003a0284cec5cd98fd8ee861e0e81dc60d4441f05939002629b21226cc7f62b9614c3ae41f50620afd0a46ba0e83c1a606d4607cc3e047672')
+ 
+ prepare() {
+   # https://github.com/AFLplusplus/AFLplusplus/issues/2643
+@@ -83,7 +86,7 @@
+   rm -v test/test-performance.sh
+   # Unset our CFLAGS/CXXFLAGS for the tests since these may
+   # interact in unexpected ways with afl-cc instrumentation.
+-  CFLAGS= CXXFLAGS= make ARCH= test
++  CFLAGS= CXXFLAGS= make ARCH= NO_UNICORN=1 test
+ }
+ 
+ package() {


### PR DESCRIPTION
Backport the ALLOCSIZE stack test fix and rebuild the qemu_mode AFL_ENTRYPOINT target as non-PIE on riscv64 so the probed absolute entrypoint is reusable across qemuafl runs.

Disable unicorn_mode during check(): the optional unicornafl build fails on riscv64, leaving no C headers for the persistent sample.