### PR TITLE
addpatch: python-cachecontrol 1:0.14.4-3

### DIFF
--- a/python-cachecontrol/riscv64.patch
+++ b/python-cachecontrol/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -36,6 +36,11 @@
+ sha256sums=('d862b0f313c852c618510fbce464b5eb58b02dbe3a146952c5a7b7cb4957431d')
+ b2sums=('ee12d64ec215714b376ac48eeb07d4861f8221755d7f016c5a48970bdacc85d01209d845984e344d9a0b6a1fa9a42dc24e2bb383d136f18c5e2ff440dee87ddc')
+ 
++prepare() {
++  cd $_name-$pkgver
++  sed -i 's/,<0\.10\.0//' pyproject.toml
++}
++
+ build() {
+   cd $_name-$pkgver
+   python -m build --wheel --no-isolation


### PR DESCRIPTION
Build fails because pyproject.toml caps uv_build below Archs packaged backend. Remove only the stale <0.10.0 cap in prepare() so dependency checks continue normally.