### PR TITLE
addpatch: ipython 9.17.0-1

### DIFF
--- a/ipython/increase-test-timeouts.patch
+++ b/ipython/increase-test-timeouts.patch
@@ -1,0 +1,25 @@
+--- a/tests/test_interactiveshell.py
++++ b/tests/test_interactiveshell.py
+@@ -60,7 +60,7 @@
+     # We try to read as otherwise on failure, pytest will print the 250k lines to stdout.
+     capsys.readouterr()
+     duration = end - start
+-    assert duration < 10
++    assert duration < 30
+ 
+ 
+ def test_naked_string_cells():
+--- a/tests/test_magic.py
++++ b/tests/test_magic.py
+@@ -1593,9 +1593,8 @@
+ @pytest.mark.asyncio
+ async def test_script_streams_continuously(capsys):
+     ip = get_ipython()
+-    # Windows is slow to start up a thread on CI
+-    is_windows = os.name == "nt"
+-    step = 3 if is_windows else 1
++    # Slow platforms can take longer to start the script subprocess.
++    step = 3
+     code = dedent(
+         f"""\
+     import time

--- a/ipython/riscv64.patch
+++ b/ipython/riscv64.patch
@@ -1,0 +1,22 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -58,11 +58,19 @@
+ )
+ b2sums=('714c30ebcc62d5b3a70d0f35caa0cc5f63652f07d782d93573fd06ed78554fd1589b46f1e6bb8946554229b16b6d5694ce7fac43837a10bfeadc5e2da82d9c89'
+         'd445e2bc7a037db8715ea103611720e965987e155c32e445b0ef783e519fca8a0301b16c5763fd9a5d8d169c3b0d7b4db6c0bd0f9772842258b135dcb1d6d5a2')
++source+=(increase-test-timeouts.patch)
++b2sums+=('501052a04161289446663311f133ebb4df08ca4e59b79544dd08de5bfa3d4733ce2499d2cb6cf47de84ec949a52550e099963e74eb18ba8be84ca6b8e44ee1af')
+ validpgpkeys=(
+   99B17F64FD5C94692E9EF8064968B2CC0208DCC8 # Matthias Bussonnier <bussonniermatthias@gmail.com>
+   4D9D285A538F7C2E16D13ACE57982D11F0EA2247 # Michał Krassowski
+ )
+ 
++prepare() {
++  cd $pkgname
++
++  patch -Np1 -i ../increase-test-timeouts.patch
++}
++
+ build() {
+   cd $pkgname
+   python -m build --wheel --skip-dependency-check --no-isolation


### PR DESCRIPTION
Increase two timing-sensitive stream tests: the riscv64 log shows test_stream_performance taking 10.36s against a 10s limit, and test_script_streams_continuously producing reordered output with the 1s step.