### PR TITLE
addpatch: python-httpretty 1.1.4-14

### DIFF
--- a/python-httpretty/increase-test-timeouts.patch
+++ b/python-httpretty/increase-test-timeouts.patch
@@ -1,0 +1,62 @@
+--- a/tests/functional/test_bypass.py
++++ b/tests/functional/test_bypass.py
+@@ -52,7 +52,7 @@
+     context.server = TornadoServer(context.http_port)
+     context.server.start()
+     ready = False
+-    timeout = 2
++    timeout = 10
+     started_at = time.time()
+     while not ready:
+         httpretty.disable()
+--- a/tests/functional/test_httplib2.py
++++ b/tests/functional/test_httplib2.py
+@@ -165,7 +165,7 @@
+ 
+ 
+ @httprettified
+-@within(two=miliseconds)
++@within(twelve=miliseconds)
+ def test_rotating_responses_with_httplib2(now):
+     "HTTPretty should support rotating responses with httplib2"
+ 
+@@ -222,7 +222,7 @@
+ 
+ 
+ @httprettified
+-@within(two=miliseconds)
++@within(twelve=miliseconds)
+ def test_can_inspect_last_request_with_ssl(now):
+     "HTTPretty.last_request is recorded even when mocking 'https' (SSL)"
+ 
+@@ -263,7 +263,7 @@
+ 
+ 
+ @httprettified
+-@within(two=miliseconds)
++@within(twelve=miliseconds)
+ def test_callback_response(now):
+     ("HTTPretty should call a callback function to be set as the body with"
+      " httplib2")
+--- a/tests/functional/test_requests.py
++++ b/tests/functional/test_requests.py
+@@ -366,7 +366,7 @@
+     )
+ 
+     twitter_expected_response_body = b''.join(twitter_response_lines)
+-    with in_time(0.02, 'Iterating by char is taking forever!'):
++    with in_time(0.1, 'Iterating by char is taking forever!'):
+         twitter_body = b''.join(c for c in response.iter_content(chunk_size=1))
+ 
+     expect(twitter_body).to.equal(twitter_expected_response_body)
+--- a/tests/functional/testserver.py
++++ b/tests/functional/testserver.py
+@@ -128,7 +128,7 @@
+         args = [self.port]
+         self.process = Process(target=subprocess_server_tcp, args=args)
+         self.process.start()
+-        time.sleep(1)
++        time.sleep(3)
+ 
+     def stop(self):
+         try:

--- a/python-httpretty/riscv64.patch
+++ b/python-httpretty/riscv64.patch
@@ -1,0 +1,28 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -38,13 +38,15 @@
+         "$pkgname-fix-failing-requests-tests.patch::$url/commit/929cc89c2afced0c42bd08e3b9440ab1f4ec22a8.patch"
+         # https://github.com/gabrielfalcao/HTTPretty/pull/485
+         "$pkgname-urllib3-2.3-compatibility.patch::$url/commit/8e96b1e312d473429fbd08bc867376e9932ad42a.patch"
+-         python-3.14.patch)
++         python-3.14.patch
++        increase-test-timeouts.patch)
+ sha512sums=('58c733ba4719f97e06e2313bb6b94f1c6609d3facb2e0262ac37be97f1c3430eac661611ba9b3712c9c1809846e177b61f3fc2945f3770d475f70b81bea2aced'
+             '5520594ddb2e73d75c6eb8476dc1984464306614d915627c0c9e69815a5671d65e286e90f3ee926daa040f9f24a81835eb5c7993e620a5b67aaaefa06571dcb2'
+             'c9f1668be03210ef5efc7fe6f4783af31549aa812ebb32154a27034b88866e7e81df59648a3bb68f8f6c08c2734abc4b012c9e8b90d19d8570940c20391294e9'
+             '0b890bfd1dad70cf27aef5720e3158225697a4ccbe735fd7dd7e2b0887b60cc158750b9724d3e192311a6f32400480ce6ded4b01f01ed885085753ef13fc939e'
+             '483cb20c64872b68dbef35a3325fc7f93d5e550c3e4cb266425a0d0ecac172b97674de8f837b2b48d63145ff0a24d3a89af1871cb84bfec9eeb70b1bea803a34'
+-            '1c05ee336e3d0f039699d633a02eeeef62cf4fcba2bdbd9ec35d65d1480390337bcf64111cfa6019a546ca0f7aac8fe6d3d44892e446ef18203337791ce528ed')
++            '1c05ee336e3d0f039699d633a02eeeef62cf4fcba2bdbd9ec35d65d1480390337bcf64111cfa6019a546ca0f7aac8fe6d3d44892e446ef18203337791ce528ed'
++            '1856426410ce7af9810db5e1e20295bed24fc2404789e612f136757c02f0d2f059496edfe4d7ae56fdda1c7c478acf1bad14c3c000d363cfaf657ec93b436c34')
+ 
+ prepare() {
+   cd HTTPretty-$pkgver
+@@ -54,6 +56,7 @@
+   patch -p1 -i ../$pkgname-urllib3-2.3-compatibility.patch
+   sed -i -e '/rednose/d' -e '/cover/d' setup.cfg
+   patch -p1 -i ../python-3.14.patch # Fedora patch
++  patch -p1 -i ../increase-test-timeouts.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
Relax brittle timing assumptions in functional tests: the riscv64 log shows local test servers were not ready after the fixed waits, httplib2 checks exceeded the 2ms limit, and streaming-by-char hit its watchdog.

Use twelve milliseconds for sure-based checks because the packaged sure only accepts number words through twelve.