### PR TITLE
updpatch: sequoia-sq 1.4.0-2

### DIFF
--- a/sequoia-sq/riscv64.patch
+++ b/sequoia-sq/riscv64.patch
@@ -1,11 +1,11 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -40,7 +40,7 @@ prepare() {
-   # update sequoia-openpgp and buffered-reader: https://gitlab.com/sequoia-pgp/sequoia-sq/-/merge_requests/25
-   git cherry-pick -n cd8ef12ef413d9dd3beefb1102b86aa323513ba8 58ee3380565879a05f20882107d580bfadcf3b4a
-   export RUSTUP_TOOLCHAIN=stable
+@@ -40,7 +40,7 @@
+ 
+ prepare() {
+   cd $pkgname
 -  cargo fetch --locked --target "$CARCH-unknown-linux-gnu"
 +  cargo fetch --locked
  }
-
+ 
  build() {


### PR DESCRIPTION
Refresh the cargo fetch target workaround against the current PKGBUILD. The latest riscv64 log fails while applying the old patch; keep dropping the derived $CARCH target because Arch Rust uses riscv64gc-unknown-linux-gnu on riscv64.