### PR TITLE
addpatch: gmt 6.7.0-1

### DIFF
--- a/gmt/riscv64.patch
+++ b/gmt/riscv64.patch
@@ -1,0 +1,19 @@
+diff --git PKGBUILD PKGBUILD
+index 65b5de6..f27e210 100644
+--- PKGBUILD
++++ PKGBUILD
+@@ -48,3 +48,14 @@
+   install -d "${pkgdir}"/usr/share/
+   mv doc "${pkgdir}"/usr/share/
+ }
++
++source_riscv64=(gmt-optional-gmt-update.patch::https://github.com/GenericMappingTools/gmt/commit/a22977e0e1ebd31bc52861e09e2dfac96830f2de.patch?full_index=1
++                gmt-msvc-only-gmt-update.patch::https://github.com/GenericMappingTools/gmt/commit/d52a1e5825b73c3ad6948efce1ac8eeff01c2c93.patch?full_index=1)
++sha256sums_riscv64=('3981a9c0a07fc96771e579e0029cf0cd26af29046350645f98306e4f7c37edef'
++                    'f55f13d6fee4632b2e10abe8dd35e57f21e9593e011771b37668af13d570c5d7')
++
++prepare() {
++  cd ${pkgname}-${pkgver}
++  patch -Np1 -i ../gmt-optional-gmt-update.patch
++  patch -Np1 -i ../gmt-msvc-only-gmt-update.patch
++}


### PR DESCRIPTION
Backport two commits to skip gmt_update on riscv64.