### PR TITLE
addpatch: sbt 2.0.8-1

### DIFF
--- a/sbt/riscv64.patch
+++ b/sbt/riscv64.patch
@@ -1,0 +1,22 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -30,6 +30,7 @@
+   ./sbt \
+     -Dsbt.build.version=${pkgver} \
+     -Dsbt.build.offline=false \
++    -Dsbt.build.includesbtn=false \
+     clean \
+     launcherPackage/Universal/packageBin \
+     launcherPackage/Universal/packageZipTarball
+@@ -48,9 +49,9 @@
+ 
+   mkdir -p "${pkgdir}"/usr/share/${pkgname}
+   cp -r bin "${pkgdir}"/usr/share/${pkgname}
+-  rm "${pkgdir}"/usr/share/${pkgname}/bin/*{.bat,.exe,-darwin}
++  rm -f "${pkgdir}"/usr/share/${pkgname}/bin/*{.bat,.exe,-darwin}
+   chmod -x "${pkgdir}"/usr/share/${pkgname}/bin/*
+-  chmod +x "${pkgdir}"/usr/share/${pkgname}/bin/{sbt,sbtn-${CARCH}-pc-linux}
++  chmod +x "${pkgdir}"/usr/share/${pkgname}/bin/sbt
+   mkdir -p "${pkgdir}"/usr/bin
+   ln -s /usr/share/${pkgname}/bin/sbt "${pkgdir}"/usr/bin/sbt
+ 


### PR DESCRIPTION
Disable bundled native sbtn on riscv64. The upstream sbtn-dist release used by sbt 2.0.8 does not ship sbtn-riscv64-pc-linux, so package() fails when chmod tries to mark it executable; the shell launcher can fall back to the JVM client when no native client is available.