### PR TITLE
addpatch: js140 140.14.0-1

### DIFF
--- a/js140/riscv64.patch
+++ b/js140/riscv64.patch
@@ -1,0 +1,22 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -59,6 +59,9 @@
+         'ae4d401c7375737b394654ab6d7cb9e61e34013f583ef05c57e74c6f6e9700ed6787afb83fab88e826e0f086e5e079258f0c1cdddf89b3e792ff67611e781052'
+         'e2421669901b4549700ec5abccd07a169fe0a3d2c5ddadecf55bc911f68df64ce6154431f01e1ad16c4af0299b029f6df787bf74b3070fece270cec9b74c907d'
+         '3d51383d407f7d9c5da8df55899e2ff6a0fdbbf07583af0e06c8bcefda73b1fcecd89ffea52f822ae605a14d498f11b0e492b686ad711d0e3dc97a2c601fdaa0')
++source+=(rust-1.98-riscv64-target-detection.patch)
++sha256sums+=('0236d5a8cc339096f287790f4f5015a79bd0a7f92477450b11eab88123afe142')
++b2sums+=('d47df95569d0fbc907fc631af56ca2ead47c06da533adcbc3b29ab9fa77faae0f1218884ca265a3dce6ce4c007f896eadb3739f45257066ee090b01a91dba522')
+ 
+ # Make sure the duplication between bin and lib is found
+ COMPRESSZST+=(--long)
+@@ -76,6 +79,9 @@
+   patch -Np1 -i ../0004-Bug-1983736-Patch-jsonschema-to-work-with-Python-3.1.patch
+   patch -Np1 -i ../0005-Bug-1993797-Fix-AST-parsing-in-DecoratorVisitor-for-.patch
+ 
++  # https://bugzilla.mozilla.org/show_bug.cgi?id=2053518
++  patch -Np1 -i ../rust-1.98-riscv64-target-detection.patch
++
+   cat >../mozconfig <<END
+ ac_add_options --enable-application=js
+ mk_add_options MOZ_OBJDIR=${PWD@Q}/obj

--- a/js140/rust-1.98-riscv64-target-detection.patch
+++ b/js140/rust-1.98-riscv64-target-detection.patch
@@ -1,0 +1,29 @@
+--- a/build/moz.configure/rust.configure
++++ b/build/moz.configure/rust.configure
+@@ -302,6 +302,10 @@
+         elif not candidates:
+             return None
+ 
++        # config.guess uses the "pc" vendor for x86/x86_64 where rust uses its
++        # generic "unknown" vendor; normalize so we correlate on the right one.
++        vendor = "unknown" if host_or_target.vendor == "pc" else host_or_target.vendor
++
+         # We have multiple candidates. There are two cases where we can try to
+         # narrow further down using extra information from the build system.
+         # - For windows targets, correlate with the C compiler type
+@@ -402,6 +406,15 @@
+             elif narrowed:
+                 candidates = narrowed
+ 
++        # Correlate on the (normalized) vendor, so vendor-specific targets (e.g.
++        # the *-oe-linux-gnu targets added in rust 1.98) don't shadow the
++        # generic ones for aliases whose vendor doesn't match a rust target.
++        narrowed = [c for c in candidates if c.target.vendor == vendor]
++        if len(narrowed) == 1:
++            return narrowed[0].rust_target
++        elif narrowed:
++            candidates = narrowed
++
+         # See if we can narrow down with the raw OS and raw CPU
+         narrowed = [
+             c


### PR DESCRIPTION
Backport Mozilla's Rust 1.98 target detection fix so the new vendor-specific riscv64-oe-linux-gnu target does not shadow the matching riscv64gc-unknown-linux-gnu host and abort configure.