### PR TITLE
addpatch: bpftrace 0.26.1-1

### DIFF
--- a/bpftrace/riscv64.patch
+++ b/bpftrace/riscv64.patch
@@ -1,0 +1,13 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -63,7 +63,9 @@
+ }
+ 
+ check() {
+-  ctest --test-dir build --output-on-failure
++  # The single GoogleTest binary is serial and exceeds CTest's 25m default
++  # timeout on riscv64 while still making progress.
++  ctest --test-dir build --output-on-failure --timeout 7200
+ }
+ 
+ package() {

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -6,6 +6,7 @@ aws-sdk-cpp
 bat
 bear
 bmake
+bpftrace
 breezy
 caps
 cargo-audit


### PR DESCRIPTION
Raise CTest's timeout because the single bpftrace_test binary runs past the default 1500s on riscv64 while still making progress.

Also blacklist qemu-user builds because qemu-user does not implement the ptrace syscall path needed by the childproc.ptrace_* tests.