### PR TITLE
addpatch: limesuite 23.11.0-9

### DIFF
--- a/limesuite/riscv64.patch
+++ b/limesuite/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -25,7 +25,9 @@
+   mkdir -p LimeSuite-$pkgver/build
+   cd LimeSuite-$pkgver/build
+ 
++  # FLTK's public headers include cairo.h, but LimeSuite's CMake misses cairo cflags.
+   CFLAGS+=" -std=gnu17" \
++  CXXFLAGS+=" $(pkg-config --cflags cairo)" \
+   cmake .. \
+     -DCMAKE_INSTALL_PREFIX=/usr \
+     -DCMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
Add cairo cflags for the QuickTest build. The latest riscv64 log fails in TestGUI.cpp because FLTK's Fl_Cairo.H includes cairo.h, but LimeSuite's CMake only passes FLTK include paths.