### PR TITLE
addpatch: atuin 18.21.0-1

### DIFF
--- a/atuin/riscv64.patch
+++ b/atuin/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -50,6 +50,8 @@
+ 
+ check() {
+ 	_srcenv
++	# SQLite pool setup can exceed upstream's 2s test default on slower builders.
++	export ATUIN_TEST_LOCAL_TIMEOUT=30.0
+ 	cargo test --frozen --all-features --workspace --lib
+ }
+ 


### PR DESCRIPTION
Raise the SQLite test local timeout on riscv64. The latest log shows many atuin-client SQLite tests failing during pool setup with 'pool timed out while waiting for an open connection' under the upstream 2s test default.