### PR TITLE
updpatch: clpeak 2.1.4-1

### DIFF
--- a/clpeak/riscv64.patch
+++ b/clpeak/riscv64.patch
@@ -4,17 +4,17 @@
  # Maintainer: Sven-Hendrik Haase <svenstaro@archlinux.org>
 -pkgname=(clpeak clpeak-cuda)
 +pkgname=(clpeak)
- pkgver=2.0.12
+ pkgver=2.1.4
  pkgrel=1
  pkgdesc="A tool which profiles OpenCL devices to find their peak capacities (OpenCL/Vulkan support)"
 @@ -7,7 +7,7 @@
  url="https://github.com/krrishnarraj/clpeak"
  license=("Unlicense")
  depends=('ocl-icd' 'libgcc' 'libstdc++' 'glibc' 'vulkan-icd-loader')
--makedepends=('cmake' 'opencl-headers' 'ninja' 'git' 'vulkan-headers' 'shaderc' 'cuda')
-+makedepends=('cmake' 'opencl-headers' 'ninja' 'git' 'vulkan-headers' 'shaderc')
+-makedepends=('cmake' 'opencl-headers' 'ninja' 'git' 'vulkan-headers' 'shaderc' 'cuda' 'clang')
++makedepends=('cmake' 'opencl-headers' 'ninja' 'git' 'vulkan-headers' 'shaderc' 'clang')
  source=(git+https://github.com/krrishnarraj/clpeak#tag=$pkgver)
- sha512sums=('12e1410645e16ddd298336e90792551e79ea1f2e6e7401eb625d1916e7bd07b238a2e17aaa72f44e4708c2622b6c120b61f1e6aacec0545bff185c405720430f')
+ sha512sums=('c68a63ae2ac9b22fe239d8aca16fe9f3c62da007a27acf3669ac0b618fb91e4b4e2f8c6c44e676cf3ccc046e7e5150d56998637baedba7ea65253aeedce40691')
  
 @@ -21,13 +21,6 @@
      -DCLPEAK_ENABLE_CUDA=OFF


### PR DESCRIPTION
Refresh the riscv64 CUDA split-package workaround for the 2.1.4 PKGBUILD. cuda is still x86_64-only, so keep dropping clpeak-cuda, the cuda makedep, and the CUDA build block while preserving the new clang makedep.