### PR TITLE
sv39-blacklist: remove nodejs

### DIFF
--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -6,7 +6,6 @@ gitea
 grafana
 grafana-agent
 navidrome
-nodejs
 openbao
 phpldapadmin
 prettier


### PR DESCRIPTION
The previous nodejs patch already addresses the sv39 failure, and forcing Node onto scarce sv48/non-sv39 builders risks OOM. Let it schedule on sv39-capable native builders again while keeping the qemu-user blacklist in place.