### PR TITLE
addpatch: fprintd 1.94.5-2

### DIFF
--- a/fprintd/riscv64.patch
+++ b/fprintd/riscv64.patch
@@ -1,6 +1,23 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -59,7 +59,7 @@ build() {
+@@ -38,12 +38,16 @@
+ validpgpkeys=(
+   D4C501DA48EB797A081750939449C2F50996635F # Marco Trevisan (Treviño) <mail@3v1n0.net>
+ )
++source+=(slow-delete-storage-error-test.patch)
++b2sums+=('fae2d1a119853b83a0af035d62e59f7e2eabace489c03a831c9a4c34d5b54e82331c374be1d960842b5ef7b47b37b8286aa5f752fae564ed3e423ea546260e5d')
+ 
+ prepare() {
+   cd fprintd
+ 
+   # Fix tests
+   git cherry-pick -n ec2a995c36f0757e1f5c695a80d89f41d2fa03bb
++  # Slow riscv64 builders can miss the legacy API test's async race window.
++  patch -Np1 -i ../slow-delete-storage-error-test.patch
+ }
+ 
+ build() {
+@@ -57,7 +61,7 @@
  }
  
  check() {

--- a/fprintd/slow-delete-storage-error-test.patch
+++ b/fprintd/slow-delete-storage-error-test.patch
@@ -1,0 +1,19 @@
+--- a/tests/fprintd.py
++++ b/tests/fprintd.py
+@@ -2641,11 +2641,14 @@
+ 
+     def test_delete_enrolled_fingers_storage_error_has_higher_priority(self):
+         self.enroll_print('deleted-print', finger='left-thumb')
+-        self.send_sleep(get_timeout('device_sleep'))
++        # The legacy API does extra async authorization/logging before the
++        # daemon reaches device-side deletion, so keep a wider race window.
++        device_sleep = get_timeout('device_sleep') * 4
++        self.send_sleep(device_sleep)
+         self.send_error(FPrint.DeviceError.BUSY)
+ 
+         self.call_device_method_async('DeleteEnrolledFingers', '(s)', ['testuser'])
+-        self.wait_for_result(max_wait=get_timeout('device_sleep') / 2)
++        self.wait_for_result(max_wait=device_sleep / 2)
+         self.assertFalse(self.get_all_async_replies())
+ 
+         self.set_print_not_writable('testuser', FPrint.Finger.LEFT_THUMB)


### PR DESCRIPTION
The latest riscv64 check log fails in FPrintdVirtualDeviceStorageClaimedTest.test_delete_enrolled_fingers_storage_error_has_higher_priority because the legacy DeleteEnrolledFingers path misses its short async race window and teardown Release sees the queued BUSY command. Widen only that legacy test's device sleep window while keeping the Meson timeout workaround.