### PR TITLE
addpatch: nginx-mainline 1.31.5-1

### DIFF
--- a/nginx-mainline/h3_limit_req-fix-spurious-failures.patch
+++ b/nginx-mainline/h3_limit_req-fix-spurious-failures.patch
@@ -1,0 +1,46 @@
+
+# HG changeset patch
+# User Maxim Dounin <mdounin@mdounin.ru>
+# Date 1710372349 -10800
+# Node ID 1867428f1673214f6e2bb647a2bba0ae3a77bcb7
+# Parent  e0b55129fbbf0411524ab3436fbe08f4f6c0505a
+Tests: fixed h3_limit_req.t spurious failures.
+
+In the "reset stream - cancellation" test, HTTP/3 stream is closed without
+sending the request body when the request is waiting in the limit_req
+module, and this results in error 444.  However, when the request is received
+with some minor delay due to system load, it is not delayed by limit_req,
+and the stream is closed during reading the request body, which results
+in error 400 instead, breaking the test.
+
+Fix is to introduce yet another request before the "reset stream" test,
+so the stream in question is always delayed by limit_req.
+
+diff --git a/h3_limit_req.t b/h3_limit_req.t
+--- a/h3_limit_req.t
++++ b/h3_limit_req.t
+@@ -24,7 +24,7 @@ select STDERR; $| = 1;
+ select STDOUT; $| = 1;
+ 
+ my $t = Test::Nginx->new()->has(qw/http http_v3 proxy limit_req cryptx/)
+-	->has_daemon('openssl')->plan(6);
++	->has_daemon('openssl')->plan(7);
+ 
+ $t->write_file_expand('nginx.conf', <<'EOF');
+ 
+@@ -131,6 +131,14 @@ select undef, undef, undef, 1.1;
+ ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
+ is($frame->{headers}->{':status'}, 200, 'request body - limit req - empty');
+ 
++# another request
++
++$sid = $s->new_stream({ path => '/' });
++$frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
++
++($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
++is($frame->{headers}->{':status'}, '200', 'request body - limit req - next');
++
+ # detect RESET_STREAM while request is delayed
+ 
+ $s = Test::Nginx::HTTP3->new();
+

--- a/nginx-mainline/riscv64.patch
+++ b/nginx-mainline/riscv64.patch
@@ -1,0 +1,29 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -55,6 +55,7 @@
+   nginx.service
+   logrotate
+   perl-io-socket-ssl-2.094-tests-fix.patch
++  h3_limit_req-fix-spurious-failures.patch
+ )
+ # https://nginx.org/en/pgp_keys.html
+ validpgpkeys=(
+@@ -67,7 +68,8 @@
+             'c175c6ebee041c53ff1f93c173b64ff306ea692d04a7f94b8bc9794cc1be2e4c46351a9bad859fac107bbdc53707b8af3eb0051fa5042317ce1e4545c0f773b1'
+             'f469b3b14def666e955abf6f2d3c68a47631cad7bee90c92039ffe5bf629aa7e32bb4250844d52c0f963740fb07bf7fea5f8887cc1d5199403f07be6214fcb8d'
+             '2f4dfcfa711b8bcbc5918ba635f5e430ef7132e66276261ade62bb1cba016967432c8dce7f84352cb8b07dc7c6b18f09177aa3eb92c8e358b2a106c8ca142fe9'
+-            '2d4ba6e53ee078bbf0921d0221ea7c7acf5a391ce8b3dc9d135cc4c68c1508569a00dedcfaca382f0f912d97e3ced71691573e0aef3b62b124099b33554fbdde')
++            '2d4ba6e53ee078bbf0921d0221ea7c7acf5a391ce8b3dc9d135cc4c68c1508569a00dedcfaca382f0f912d97e3ced71691573e0aef3b62b124099b33554fbdde'
++            '166b876529fad57c691c2d8c174340d15323aad6d4cafa00023d77d25bdce221c8fd82d4d1f795569455f1f68f3be586d25652302e86013c90ac8925d6a78ba6')
+ 
+ prepare() {
+   cp -r $_pkgbase{,-src}
+@@ -79,6 +81,8 @@
+   # the tests are still passing correctly with perl-io-socket-ssl-2.089
+   cd nginx-tests
+   patch -p1 -i ../perl-io-socket-ssl-2.094-tests-fix.patch
++  # Fix h3_limit_req.t logging 400 instead of 499 if RESET_STREAM races limit_req.
++  patch -p1 -i ../h3_limit_req-fix-spurious-failures.patch
+ }
+ 
+ build() {


### PR DESCRIPTION
Add upstream h3_limit_req.t spurious-failure fix. The riscv64 logs hit the race where RESET_STREAM can be logged as 400 instead of 499.