### PR TITLE
updpatch: opensearch 3.8.0-1

### DIFF
--- a/opensearch/riscv64.patch
+++ b/opensearch/riscv64.patch
@@ -1,6 +1,6 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -31,10 +31,11 @@ pkgrel=1
+@@ -31,10 +31,11 @@
  # See https://github.com/opensearch-project/OpenSearch/blob/main/.ci/java-versions.properties
  _jrever=21
  _jdkver=21
@@ -13,15 +13,15 @@
  source=(
    "OpenSearch-${pkgver}.tar.gz::https://github.com/opensearch-project/OpenSearch/archive/${pkgver}.tar.gz"
    opensearch.service
-@@ -44,6 +45,7 @@ source=(
+@@ -44,6 +45,7 @@
    opensearch-user.conf
    opensearch-tmpfile.conf
    opensearch.default
 +  "protobuf-${_protobuf_ver}.tar.gz::https://github.com/protocolbuffers/protobuf/archive/v${_protobuf_ver}.tar.gz"
  )
- sha256sums=('fae7017afdaacb2fecad097cc224a4259a379665d45c468da6a2c6c56afa0507'
+ sha256sums=('779b19116c5ac1549c6115a78d88313790fde38da43fce5874c070af38e4c738'
              'b59d064ce8e348f22b969cc2b7522a1c7b64d4b4e3fd98d9ad1f01d842e94d46'
-@@ -52,7 +54,18 @@ sha256sums=('fae7017afdaacb2fecad097cc224a4259a379665d45c468da6a2c6c56afa0507'
+@@ -52,7 +54,23 @@
              'a133b8944d57d81224caf03f8d0e5b127f2570123b2a1e2d2f6eb199446448ae'
              '515e509f811a367cfd0a6cbafb3f8f472276410d53df7957aa878d8047a3cfc6'
              'eb1ea6146d2bd16eeb63061dfcdb7ebed55da556397c7d6c924941b1564f1f72'
@@ -31,9 +31,14 @@
 +
 +prepare() {
 +  cd "protobuf-${_protobuf_ver}"
++  # protobuf 3.25.5 misses the header for memcpy with current GCC.
++  sed -i '/#include <cstdint>/a #include <cstring>' third_party/utf8_range/utf8_validity.cc
 +  cmake . -DCMAKE_CXX_STANDARD=17 -Dprotobuf_BUILD_TESTS=OFF -Dprotobuf_ABSL_PROVIDER=package
 +  make $MAKEFLAGS
 +  cd "${srcdir}/OpenSearch-${pkgver}"
++  # RISC-V builders can take longer than the default two minutes to start testclusters.
++  sed -i 's/private static final int NODE_UP_TIMEOUT = 2;/private static final int NODE_UP_TIMEOUT = 5;/' \
++    buildSrc/src/main/java/org/opensearch/gradle/testclusters/OpenSearchNode.java
 +  sed -i -e '/artifact = "com.google.protobuf:protoc/d' \
 +    -e "\|protoc {|apath = '$(realpath ${srcdir}/protobuf-${_protobuf_ver}/protoc)'" \
 +    server/build.gradle
@@ -41,7 +46,7 @@
  
  build() {
    cd "OpenSearch-${pkgver}"
-@@ -66,7 +79,7 @@ build() {
+@@ -66,7 +84,7 @@
  
    # OpenSearch
    ./gradlew :distribution:buildSystemdModule
@@ -50,7 +55,7 @@
  
    # Plugins
    for p in \
-@@ -151,7 +164,7 @@ package_opensearch() {
+@@ -151,7 +169,7 @@
    install -dm755 "${pkgdir}"/{usr/share,var/lib,var/log}/opensearch
    install -dm755 "${pkgdir}/usr/bin"
  


### PR DESCRIPTION
Refresh the protoc vendoring patch for the current PKGBUILD and add the missing <cstring> include to protobuf 3.25.5, matching the logged utf8_validity.cc memcpy failure with current GCC.

The next log reaches :plugins:analysis-icu:yamlRestTest, starts the testcluster, then stops it after failing to wait for ports files after 150000 ms while the node was still initializing. Raise the buildSrc testcluster node startup timeout from 2 to 5 minutes on riscv64.