### PR TITLE
addpatch: rocblas 7.2.4-3

### DIFF
--- a/rocblas/riscv64.patch
+++ b/rocblas/riscv64.patch
@@ -1,0 +1,13 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -60,10 +60,6 @@
+ }
+ 
+ build() {
+-  # Compile source code for supported GPU archs in parallel
+-  export HIPCC_COMPILE_FLAGS_APPEND="-parallel-jobs=$(nproc)"
+-  export HIPCC_LINK_FLAGS_APPEND="-parallel-jobs=$(nproc)"
+-
+   # Reduce massive spam in log files
+   CXXFLAGS+=" -Wno-unused"
+ 


### PR DESCRIPTION
The latest monferno log reaches TensileCreateLibrary and is killed while generating kernels with 32 threads over 118768 tasks. Upstream already drives the build through Ninja, but the PKGBUILD also exports hipcc -parallel-jobs=$(nproc) for compile and link steps, which adds per-compiler nested parallelism on top of the build host job limit.

Drop those hipcc-wide parallel job overrides on riscv64 so rocBLAS uses the outer build scheduler concurrency instead of multiplying it inside each hipcc invocation.