### PR TITLE
updpatch: opensearch-sql-plugin 3.8.0.0-1

### DIFF
--- a/opensearch-sql-plugin/riscv64.patch
+++ b/opensearch-sql-plugin/riscv64.patch
@@ -1,10 +1,10 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -29,6 +29,7 @@ build() {
+@@ -29,6 +29,7 @@
      --exclude-task ":doctest:doctest" \
      --exclude-task ":jacocoTestReport" \
      --exclude-task ":sql:build" \
 +    --exclude-task ":integ-test:yamlRestTest" \
-     --exclude-task ":integ-test:integTest"
+     --exclude-task ":integ-test:integTest" \
+     --exclude-task ":prometheus:test"
  }
- 

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -99,6 +99,7 @@ nushell
 odin2-synthesizer
 openh264
 openldap
+opensearch-sql-plugin
 pangomm-2.48
 percona-server
 perl


### PR DESCRIPTION
Keep the yaml REST exclusion because it tries to fetch an official OpenSearch binary release tarball, which is unavailable for riscv64.

The latest 3.8.0.0-1 failure was on magby qemu-user. It is not a SQL test failure: core reported 9/9 passing tests and protocol records the Gradle test run itself failing while stopping worker services. The stack reaches OpenJDK NativeThread.signal0 from Gradle ServerSocketChannel worker IPC cleanup; on Linux OpenJDK uses SIGRTMAX-2, and qemu-riscv64 cannot map guest signal 62. Blacklist this package from qemu-user instead of carrying a Gradle worker-count hack.