### PR TITLE
addpatch: docker-compose 5.5.1-1

### DIFF
--- a/docker-compose/riscv64.patch
+++ b/docker-compose/riscv64.patch
@@ -1,0 +1,18 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,6 +17,15 @@
+ source=("$pkgname-$pkgver.tar.gz::https://github.com/docker/compose/archive/v$pkgver.tar.gz")
+ b2sums=('2156a68670c96560f10e1b65abb0568b182f0c5a71a1fd3239e589b31bc38af3add5e194943b7001ff334cfdf64e0adbb3730d080c1930eb2a4fc8c448c6db91')
+ 
++prepare() {
++  cd "compose-$pkgver"
++
++  # The fixture uses riscv64 as a non-host platform; on riscv64 it is native.
++  sed -i \
++    '/imageManifest("sha256:s390x", "s390x", true)/,+1 s/"sha256:riscv64", "riscv64"/"sha256:arm64", "arm64"/' \
++    pkg/compose/images_test.go
++}
++
+ build() {
+   cd "compose-$pkgver"
+   export CGO_CPPFLAGS="${CPPFLAGS}"


### PR DESCRIPTION
The latest riscv64 check log fails TestPlatformPinnedDigest because the test fixture uses riscv64 as one of two supposedly non-native platforms. On a riscv64 builder, platforms.Default() matches that fixture and the shared digest becomes sha256:riscv64 instead of the expected index digest.

Rewrite only that fixture platform to arm64 in prepare() so the test keeps exercising the same non-native-platform behavior on riscv64.