### PR TITLE
qemu-user-blacklist: add util-linux

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -144,6 +144,7 @@ tpm2-tss
 tracexec
 ty
 upower
+util-linux
 uutils-coreutils
 valkey
 vim


### PR DESCRIPTION
The 2.42.3-1 check run on rapidash fails kill/decode, kill/name_to_number and lsfd/mkfds-signalfd because QEMU user emulation remaps signals and exposes host signal state. setarch also reports the QEMU minimum kernel release 4.15.0 instead of 2.6. Select a non-qemu-user builder to retain full test coverage.