### PR TITLE
updpatch: pnpm 11.3.0-1

### DIFF
--- a/pnpm/riscv64.patch
+++ b/pnpm/riscv64.patch
@@ -1,17 +1,16 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -21,7 +21,13 @@
+@@ -21,7 +21,12 @@
  
  prepare() {
    cd $pkgname/$pkgname
 -  pnpm install --frozen-lockfile
 +  rm -r artifacts
-+  sed -i '/@yao-pkg\/pkg/d' ../package.json
-+  sed -i '/@yao-pkg\/pkg/d' ../pnpm-workspace.yaml
-+  sed -i '/patchedDependencies/d' ../pnpm-workspace.yaml
-+  sed -i '/__patches__/d' ../pnpm-workspace.yaml
-+  sed -i '/patchesDir/d' ../pnpm-workspace.yaml
-+  pnpm install
++
++  # Upstream Node.js and tsgo binaries are unavailable for riscv64.
++  sed -i '/"runtime": {/,/^    }/s/"download"/"ignore"/' ../package.json
++  sed -i 's/tsgo --build/tsc --build/; s/pnx node@runtime:24.6.0/node/' package.json
++  pnpm install --no-frozen-lockfile
  }
  
  build() {


### PR DESCRIPTION
Use system Node.js for installation and bundling to avoid ERR_PNPM_NO_RESOLUTION_MATCHED from the pinned runtime, which has no riscv64 download. Use the workspace TypeScript compiler instead of the unavailable tsgo binary and explicitly allow lockfile updates.

Drop obsolete @yao-pkg/pkg edits and preserve dependency patches now that bootstrap pnpm 10.33.4 isolates self-installation from workspace settings.

Bootstrap reference: https://github.com/pnpm/pnpm/blob/v10.33.4/tools/plugin-commands-self-updater/src/installPnpmToTools.ts