### PR TITLE
updpatch: python-llvmlite 0.49.0-1

### DIFF
--- a/python-llvmlite/fix-optsize-minsize-test.patch
+++ b/python-llvmlite/fix-optsize-minsize-test.patch
@@ -1,0 +1,44 @@
+--- a/llvmlite/tests/test_binding.py
++++ b/llvmlite/tests/test_binding.py
+@@ -2810,10 +2810,24 @@
+         self.assertIn("alloca", optimized_asm_optnone)
+ 
+     def test_optsize_minsize(self):
+-        pb = self.pb(speed_level=3)
++        # This test only inspects IR. Use a vector-capable target instead of
++        # relying on the host's default CPU (issue #1449).
++        llvm.initialize_all_targets()
++        triple = "x86_64-unknown-linux-gnu"
++        try:
++            target = llvm.Target.from_triple(triple)
++        except RuntimeError as e:
++            if "No available targets are compatible with triple" in str(e):
++                self.skipTest("X86 target unsupported by linked LLVM.")
++            else:
++                raise
++        tm = target.create_target_machine()
++        pto = llvm.create_pipeline_tuning_options(speed_level=3)
++        pb = llvm.create_pass_builder(tm, pto)
+ 
+         # Without optsize: O3 vectorises the loop
+         mod = self.module(asm_vectorize)
++        mod.triple = triple
+         mpm = pb.getModulePassManager()
+         mpm.run(mod, pb)
+         optimized = str(mod)
+@@ -2821,6 +2835,7 @@
+ 
+         # With optsize: vectorisation is suppressed
+         mod_optsize = self.module(asm_vectorize)
++        mod_optsize.triple = triple
+         fn = mod_optsize.get_function("stride1")
+         fn.add_function_attribute("optsize")
+         self.assertIn(b"optsize", list(fn.attributes))
+@@ -2832,6 +2847,7 @@
+ 
+         # With minsize: vectorisation is suppressed
+         mod_minsize = self.module(asm_vectorize)
++        mod_minsize.triple = triple
+         fn = mod_minsize.get_function("stride1")
+         fn.add_function_attribute("minsize")
+         self.assertIn(b"minsize", list(fn.attributes))

--- a/python-llvmlite/riscv-jit-symbols.patch
+++ b/python-llvmlite/riscv-jit-symbols.patch
@@ -1,0 +1,107 @@
+--- a/ffi/targets.cpp
++++ b/ffi/targets.cpp
+@@ -209,6 +209,13 @@
+     opt.MCOptions.ShowMCInst = PrintMC;
+     opt.MCOptions.ABIName = ABIName;
+ 
++    // RISC-V ELF relocations can reference unnamed temporary symbols, all
++    // emitted as ".L0 ". RuntimeDyld looks up symbols by name, so these
++    // relocations can resolve to the wrong address. Preserve unique names
++    // even for non-JIT target machines: their objects can be loaded by MCJIT.
++    if (llvm::Triple(TripleStr).isRISCV())
++        opt.MCOptions.MCSaveTempLabels = true;
++
+     bool jit = JIT;
+ 
+     return wrap(unwrap(T)->createTargetMachine(
+--- a/llvmlite/tests/test_binding.py
++++ b/llvmlite/tests/test_binding.py
+@@ -115,6 +115,42 @@
+     }}
+     """
+ 
++asm_switch = r"""
++    target triple = "{triple}"
++
++    define i32 @switch_func(i32 %index, i32 %value) {{
++    entry:
++        switch i32 %index, label %default [
++            i32 0, label %case0
++            i32 1, label %case1
++            i32 2, label %case2
++            i32 3, label %case3
++            i32 4, label %case4
++            i32 5, label %case5
++        ]
++    case0:
++        %v0 = add i32 %value, 17
++        ret i32 %v0
++    case1:
++        %v1 = mul i32 %value, 7
++        ret i32 %v1
++    case2:
++        %v2 = xor i32 %value, 15
++        ret i32 %v2
++    case3:
++        %v3 = or i32 %value, 64
++        ret i32 %v3
++    case4:
++        %v4 = sub i32 %value, 12
++        ret i32 %v4
++    case5:
++        %v5 = and i32 %value, 37
++        ret i32 %v5
++    default:
++        ret i32 -1
++    }}
++    """
++
+ asm_square_sum = r"""
+     ; ModuleID = '<string>'
+     target triple = "{triple}"
+@@ -1405,6 +1441,17 @@
+             target_machine = self.target_machine(jit=True)
+         return llvm.create_mcjit_compiler(mod, target_machine)
+ 
++    def test_switch(self):
++        # Duplicate temporary symbol names can make every jump-table entry
++        # resolve to the same basic block on RISC-V.
++        with self.jit(self.module(asm_switch)) as ee:
++            cfunc = self.get_sum(ee, "switch_func")
++            for index, expected in enumerate((140, 861, 116, 123, 111, 33)):
++                with self.subTest(index=index):
++                    self.assertEqual(cfunc(index, 123), expected)
++            self.assertEqual(cfunc(-1, 123), -1)
++            self.assertEqual(cfunc(6, 123), -1)
++
+ 
+ # There are some memory corruption issues with OrcJIT on AArch64 - see Issue
+ # #1000. Since OrcJIT is experimental, and we don't test regularly during
+@@ -2539,6 +2586,27 @@
+ 
+         self.assertEqual(sum_twice(2, 3), 10)
+ 
++    def test_switch_object_file(self):
++        # Emitted objects need unique temporary symbols too, regardless of
++        # whether the target machine was created with jit=True.
++        for jit in (False, True):
++            with self.subTest(jit=jit):
++                tm = self.target_machine(jit=jit)
++                obj_bin = tm.emit_object(self.module(asm_switch))
++                with llvm.create_mcjit_compiler(
++                        self.module(asm_sum_declare), tm) as ee:
++                    ee.add_object_file(llvm.ObjectFileRef.from_data(obj_bin))
++                    ee.finalize_object()
++                    address = ee.get_function_address("switch_func")
++                    self.assertTrue(address)
++                    cfunc = CFUNCTYPE(c_int, c_int, c_int)(address)
++                    for index, expected in enumerate(
++                            (140, 861, 116, 123, 111, 33)):
++                        with self.subTest(index=index):
++                            self.assertEqual(cfunc(index, 123), expected)
++                    self.assertEqual(cfunc(-1, 123), -1)
++                    self.assertEqual(cfunc(6, 123), -1)
++
+     def test_add_object_file_from_filesystem(self):
+         target_machine = self.target_machine(jit=False)
+         mod = self.module()

--- a/python-llvmlite/riscv64.patch
+++ b/python-llvmlite/riscv64.patch
@@ -1,18 +1,23 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -38,7 +38,14 @@
+@@ -28,8 +28,18 @@
+ checkdepends=(
+     python-pytest
+ )
+-source=(git+https://github.com/numba/llvmlite.git#tag=v$pkgver)
+-b2sums=('9a46ebc71dc74aa206f79b23dbacb3de3ba564776fc92e88b4cf43c4e18f9a29bcad80bd5bb4b024e5410da4596f3c44b069ba9a85be2ef9d8ab5028cf409db7')
++source=(git+https://github.com/numba/llvmlite.git#tag=v$pkgver
++        riscv-jit-symbols.patch
++        fix-optsize-minsize-test.patch)
++b2sums=('9a46ebc71dc74aa206f79b23dbacb3de3ba564776fc92e88b4cf43c4e18f9a29bcad80bd5bb4b024e5410da4596f3c44b069ba9a85be2ef9d8ab5028cf409db7'
++        '0eeead26455607d7f0ecf0adb3019832796448e2f7b14862c0f8c92acc710a6b207c01a2f7eecbda2d114738deb4c3c0fd4548a9f9dbb84609f5f852deefc786'
++        'd8afe9a8332329978eb30c3d589204ae860f36afc5d85876bc47b6cd99307d34a3d316fb2089cb3f01b89827e75a5b74dfabace501b96629a1cbe66b127f3821')
++
++prepare() {
++    cd $_name
++    patch -Np1 -i ../riscv-jit-symbols.patch
++    patch -Np1 -i ../fix-optsize-minsize-test.patch
++}
  
- check() {
+ build() {
      cd $_name
--    pytest -vv $_name/tests
-+    # Skip MCJIT related failures, as it's known to be broken on RISC-V
-+    # Skip OrcLLJIT tests on non-x86 platforms
-+    # test_optsize_minsize assumes O3 creates a vector loop on every target.
-+    pytest -vv $_name/tests --deselect llvmlite/tests/test_binding.py::TestMCJit \
-+                            --deselect llvmlite/tests/test_binding.py::TestGlobalConstructors \
-+                            --deselect llvmlite/tests/test_binding.py::TestObjectFile::test_add_object_file \
-+                            --deselect llvmlite/tests/test_binding.py::TestOrcLLJIT \
-+                            --deselect llvmlite/tests/test_binding.py::TestNewModulePassManager::test_optsize_minsize
- }
- 
- package() {


### PR DESCRIPTION
Enable MCSaveTempLabels for RISC-V. LLVM emits distinct temporary symbols as ".L0 ", while RuntimeDyld resolves relocations by name. The collision corrupts jump tables, producing wrong results and Numba 0.67.0 segfaults. Add regressions for direct MCJIT execution and emitted-object loading.

Remove obsolete MCJIT, global-constructor and object-loading exclusions; the existing cases pass with LLVM 22. OrcLLJIT is already skipped upstream.

Replace the optsize/minsize skip with an explicit vector-capable x86_64 target for this IR-only test. Keep its vectorization assertions without assuming the native default CPU has vector registers. https://github.com/numba/llvmlite/issues/1449