### PR TITLE
addpatch: python-falcon 4.3.1-1

### DIFF
--- a/python-falcon/riscv64.patch
+++ b/python-falcon/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -58,6 +58,9 @@
+
+ prepare() {
+   cd $_name-$pkgver
++  # Hypercorn startup can exceed five seconds on riscv64 builders.
++  sed -i 's/Give up after 5 seconds/Give up after 30 seconds/; s/start_ts) < 5:/start_ts) < 30:/' \
++    tests/asgi/test_asgi_servers.py
+ }
+
+ build() {


### PR DESCRIPTION
Increase the ASGI test server startup window from 5 to 30 seconds. Five Hypercorn fixtures hit "Server is not responding to requests" while their processes were still alive on the riscv64 builder; allow more startup time while retaining the readiness check and all tests.