### PR TITLE
qemu-user-blacklist: add python-libtmux

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -112,6 +112,7 @@ pyqt6-datavisualization
 pyqt6-networkauth
 pyqt6-webengine
 python
+python-libtmux
 python-prctl
 python-setproctitle
 python-xmlsec


### PR DESCRIPTION
The 0.62.0-1 check run under qemu-user reports qemu-riscv64-static instead of sleep as the pane name, and missing executables return status 127 instead of FileNotFoundError. Select a non-qemu-user builder to retain the existing test coverage.