### PR TITLE
addpatch: python-httpx-ws 0.9.0-1

### DIFF
--- a/python-httpx-ws/riscv64.patch
+++ b/python-httpx-ws/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -21,6 +21,7 @@
+               python-pytest-cov
+               python-starlette
+               python-trio
++              python-websockets
+               uvicorn)
+ source=(git+https://github.com/frankie567/httpx-ws#tag=v$pkgver
+         no-regex-commit.patch)


### PR DESCRIPTION
Add python-websockets to checkdepends now that uvicorn only lists it as an optional dependency. Without it, the websockets test server fails to import its backend and the fixture waits forever for startup.

Upstream report: https://gitlab.archlinux.org/archlinux/packaging/packages/python-httpx-ws/-/work_items/5