### PR TITLE
addpatch: jupyter-nbclassic 1.3.3-4

### DIFF
--- a/jupyter-nbclassic/riscv64.patch
+++ b/jupyter-nbclassic/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -41,7 +41,8 @@
+ 
+ build() {
+   cd $_pyname
+-  python -m build --wheel --no-isolation --skip-dependency-check
++  # npx downloads patch-package during postinstall; allow it without prompting.
++  npm_config_yes=true python -m build --wheel --no-isolation --skip-dependency-check
+ }
+ 
+ check() {

--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -5,6 +5,7 @@ forgejo
 gitea
 grafana
 grafana-agent
+jupyter-nbclassic
 navidrome
 openbao
 phpldapadmin


### PR DESCRIPTION
Set npm_config_yes=true for the wheel build so npx can install the undeclared patch-package dependency without waiting at "Ok to proceed?" when stdin is a terminal.

Add jupyter-nbclassic to the sv39 blacklist because Webpack uses WebAssembly for hashing.