### PR TITLE
qemu-user-blacklist: add python-filelock

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -112,6 +112,7 @@ pyqt6-datavisualization
 pyqt6-networkauth
 pyqt6-webengine
 python
+python-filelock
 python-libtmux
 python-prctl
 python-setproctitle


### PR DESCRIPTION
The 3.31.0-1 check run under qemu-user fails all three SoftFileLock thread-pool thrashing tests with empty reads inside the protected section. QEMU synthesizes /proc/<pid>/stat using the calling task start time, initialized separately for each thread. FileLock interprets the differing start tokens for the same live PID as PID reuse and removes a held lock. Select a non-qemu-user builder to retain the full locking tests.

QEMU references:
https://github.com/qemu/qemu/blob/v11.0.0/linux-user/syscall.c#L8521 https://github.com/qemu/qemu/blob/v11.0.0/linux-user/main.c#L211