### PR TITLE
qemu-user-blacklist: add aquamarine

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -1,4 +1,5 @@
 abseil-cpp
+aquamarine
 arrow
 arti
 asio


### PR DESCRIPTION
The 0.15.0-2 build aborts with cc1plus SIGSEGV while compiling DRM.cpp under qemu-user, matching the 0.12.1-1 and 0.14.0-2 failures on other qemu-user builders. No retained core identifies the exact GCC or emulator fault. Route builds to a non-qemu-user worker while keeping the package sources, LTO and optimization flags unchanged.