### PR TITLE
addpatch: brial 1.2.15-3

### DIFF
--- a/brial/riscv64.patch
+++ b/brial/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -18,6 +18,8 @@
+ 
+ prepare() {
+   cd BRiAl
++  # Fix C++20 accumulation and recursive comparisons with GCC 16.
++  git cherry-pick -n df5b4fd300cdbdd4cda920a27fdc5257f3cfea26
+   autoreconf -vi
+ }
+ 


### PR DESCRIPTION
Backport the upstream C++20 fix for GCC 16. std::accumulate now moves its accumulator, which cannot bind to AddEliminationDegrees' lvalue reference; take and return it by value. Call the polynomial comparison members explicitly to avoid recursive reversed comparisons in C++20.

Upstream: https://github.com/BRiAl/BRiAl/commit/df5b4fd300cdbdd4cda920a27fdc5257f3cfea26