### PR TITLE
addpatch: hyprtoolkit 0.5.4-5

### DIFF
--- a/hyprtoolkit/riscv64.patch
+++ b/hyprtoolkit/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -26,7 +26,7 @@
+          pixman libpixman-1.so
+          wayland libwayland-client.so
+ )
+-makedepends=(cmake)
++makedepends=(cmake hyprwayland-scanner)
+ provides=(libhyprtoolkit.so)
+ _archive="$pkgname-$pkgver"
+ source=("$url/archive/v$pkgver/$_archive.tar.gz")


### PR DESCRIPTION
Add hyprwayland-scanner to makedepends. Aquamarine 0.15.0-2 moved it to a build dependency, so it no longer enters the build environment transitively and CMake fails to find it for protocol generation.

Upstream report: https://gitlab.archlinux.org/archlinux/packaging/packages/hyprtoolkit/-/work_items/14