### PR TITLE
addpatch: oxyromon 0.21.0-2

### DIFF
--- a/oxyromon/riscv64.patch
+++ b/oxyromon/riscv64.patch
@@ -1,0 +1,59 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -24,7 +24,6 @@
+   qt6-base
+   rust
+   wit
+-  yarn
+ )
+ optdepends=(
+   'bchunk: BIN to ISO support'
+@@ -43,8 +42,20 @@
+
+ prepare() {
+   cd oxyromon
+-  yarn install \
+-    --frozen-lockfile
++  # Use the packaged maxcso instead of the bundled x86_64 test binary.
++  rm tests/maxcso
++  # Use upstream WASM bindings where native riscv64 bindings are unavailable.
++  cat > pnpm-workspace.yaml <<'EOF'
++overrides:
++  lightningcss: npm:lightningcss-wasm@1.30.2
++supportedArchitectures:
++  cpu: [current, wasm32]
++allowBuilds:
++  esbuild: true
++  svelte-preprocess: false # Only prints an optional-dependency reminder.
++EOF
++  pnpm install \
++    --no-frozen-lockfile
+   cargo fetch \
+     --locked
+ }
+@@ -53,7 +64,8 @@
+   cd oxyromon
+   export CARGO_PROFILE_RELEASE_LTO=true
+   export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
+-  yarn build
++  export SKIP_PNPM=true
++  pnpm build
+   cargo build \
+     --features server \
+     --release \
+@@ -61,6 +73,7 @@
+ }
+
+ check() {
++  export SKIP_PNPM=true
+   cargo test \
+     --features server \
+     --release \
+@@ -69,6 +82,7 @@
+ }
+
+ package() {
++  export SKIP_PNPM=true
+   cargo install \
+     --features server \
+     --frozen \

--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -7,6 +7,7 @@ grafana
 grafana-agent
 navidrome
 openbao
+oxyromon
 phpldapadmin
 prettier
 prometheus


### PR DESCRIPTION
Fix the missing lightningcss.linux-riscv64-gnu.node binding with upstream Lightning CSS WASM and Tailwind WASI packages. Use pnpm with the upstream lockfile and skip build.rs's redundant UI installation and build.

Explicitly disable svelte-preprocess's informational postinstall to avoid ERR_PNPM_IGNORED_BUILDS.

Remove the bundled x86_64 tests/maxcso so CSO/ZSO tests use the packaged native executable instead of failing to spawn it.

Add oxyromon to the sv39 blacklist because the UI build executes WebAssembly.