### PR TITLE
addpatch: python-anywidget 0.11.0-1

### DIFF
--- a/python-anywidget/riscv64.patch
+++ b/python-anywidget/riscv64.patch
@@ -1,0 +1,22 @@
+--- PKGBUILD.orig
++++ PKGBUILD
+@@ -37,14 +37,17 @@
+ 
+ prepare() {
+   cd $_name-$_name-$pkgver
++  # Vite+ has no riscv64 binary; invoke pnpm directly.
++  sed -i 's/^npm = "vp"$/npm = "pnpm"/' pyproject.toml
++  # Enable Rspack's WASM fallback for both pnpm 9 and pnpm 11.
++  sed -i '/"packageManager":/i\  "pnpm": {"supportedArchitectures": {"cpu": ["current", "wasm32"]}},' package.json
++  printf '\nsupportedArchitectures:\n  cpu: [current, wasm32]\n' >> pnpm-workspace.yaml
+   # install required npm packages for building the frontend
+   pnpm install --frozen-lockfile
+ }
+ 
+ build() {
+   cd $_name-$_name-$pkgver
+-  # build system expects `vp` on PATH
+-  PATH="$PWD/node_modules/.bin:$PATH" \
+   python -m build --wheel --no-isolation
+ }
+ 

--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -10,6 +10,7 @@ openbao
 phpldapadmin
 prettier
 prometheus
+python-anywidget
 python-esphome-dashboard
 typescript-language-server
 vue-language-tools


### PR DESCRIPTION
Use pnpm directly for the wheel build because Vite+ lacks a riscv64 native binding. Enable the locked Rspack WASM fallback in both package.json (pnpm 9) and pnpm-workspace.yaml (pnpm 11), preventing the second install from pruning it. Blacklist sv39 builders so the frontend build can execute WASM.