### PR TITLE
qemu-user-blacklist: add python-virtualenv

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -117,6 +117,7 @@ python-filelock
 python-libtmux
 python-prctl
 python-setproctitle
+python-virtualenv
 python-xmlsec
 qalculate-qt
 qbs


### PR DESCRIPTION
The 21.7.8-1 check run on rapidash fails test_run_fail because qemu-user returns status 127 with empty stderr when executing a directory instead of raising OSError. Select a non-qemu-user builder to preserve the existing test coverage.