### PR TITLE
addpatch: wireplumber 0.5.17-1

### DIFF
--- a/wireplumber/riscv64.patch
+++ b/wireplumber/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -54,7 +54,8 @@
+ }
+ 
+ check() {
+-  meson test -C build --print-errorlogs
++  # Avoid parallel test contention against the fixture's 8-second watchdog.
++  meson test -C build --print-errorlogs --max-lines 0 --num-processes 1
+ }
+ 
+ _pick() {


### PR DESCRIPTION
Run tests serially to avoid contention against the eight-second fixture watchdog. All seven failing script tests report "test timed out" while still processing node and link events. Keep the watchdog and test coverage unchanged.

Print complete failure logs so the initial diagnostic is not truncated.