### PR TITLE
addpatch: deja-dup 50.2-1

### DIFF
--- a/deja-dup/fix-recursive-delete-error.patch
+++ b/deja-dup/fix-recursive-delete-error.patch
@@ -1,0 +1,11 @@
+--- a/libdeja/RecursiveOp.vala
++++ b/libdeja/RecursiveOp.vala
+@@ -11,7 +11,7 @@
+ public abstract class RecursiveOp : Object
+ {
+   public signal void done();
+-  public signal void raise_error(File src, File dst, string errstr);
++  public signal void raise_error(File src, File? dst, string errstr);
+ 
+   public File src {get; construct;}
+   public File dst {get; construct;}

--- a/deja-dup/riscv64.patch
+++ b/deja-dup/riscv64.patch
@@ -1,0 +1,22 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -39,6 +39,12 @@
+ b2sums=(58a8e9b98cb03dbcb6c8bc88f2f99de5e008ba43523af5881334244e1fe4d40d1bfa1a8fa16aeb430a609d323e7dcd60f6ed5e32037d9065e782c58e06358843)
+ validpgpkeys=(A3A5C2FC56AE7341D308D8571B50ECA373F3F233) # Michael Terry <mike@mterry.name>
+ 
++prepare() {
++  cd $pkgname
++  # RecursiveDelete reports errors without a destination file.
++  patch -Np1 -i ../fix-recursive-delete-error.patch
++}
++
+ build() {
+   arch-meson $pkgname build \
+     -D packagekit=disabled
+@@ -53,3 +59,6 @@
+ package() {
+   meson install -C build --destdir "$pkgdir"
+ }
++
++source+=(fix-recursive-delete-error.patch)
++b2sums+=(3ad28f860682705bc9719d88e40b916e89adc8de88b20edcfc0d1128995e3b6daa98d418d76ad2e47d4cd64e999ea2ed65d41dde248fd6cb212f55f0ff4a0a37)


### PR DESCRIPTION
Allow a null destination in RecursiveOp.raise_error. RecursiveDelete has no destination, so forwarding a child error otherwise aborts with "__lambda11_: assertion 'd != NULL' failed".

The custom-tool-wrapper-bad test hits this path when cleanup races with GVfs renaming a temporary metadata file and unlink returns ENOENT. The same guard exists on x86_64; fix the error-reporting contract rather than blacklisting qemu-user or skipping the test.