### PR TITLE
addpatch: gimp 3.2.4-2

### DIFF
--- a/gimp/riscv64.patch
+++ b/gimp/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -131,7 +131,8 @@
+ }
+
+ check() {
+-  meson test -C build --print-errorlogs
++  # Plug-in discovery for each fresh test instance is slow on riscv64.
++  meson test -C build --print-errorlogs --timeout-multiplier 2
+ }
+
+ package() {


### PR DESCRIPTION
Double the Meson test timeout to allow for plug-in discovery in each fresh GIMP instance on riscv64. Four tests reach the 90-second limit, while passing tests take 81-86 seconds.