### PR TITLE
addpatch: python-progressbar 4.6.0-1

### DIFF
--- a/python-progressbar/riscv64.patch
+++ b/python-progressbar/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -33,6 +33,12 @@
+ b2sums=('de2e70d74c7b2a9946b5d0572b475ad27b8e25d55d402048a071520369c9cd87c2f2dda9eabe95b8971cf3a81794c281452fa20566a4d1a4125b1413c5b516e2')
+ validpgpkeys=('149325FD15904E9C4EB89E95E81444E9CE1F695D') # Rick van Hattem <wolph@wol.ph>
+ 
++prepare() {
++  cd $pkgname
++  # Allow a 5us smoke-test limit on slower riscv64 builders.
++  sed -i 's/assert ns < 200,/assert ns < 5000,/' tests/test_fastpath.py
++}
++
+ build() {
+   cd $pkgname
+   SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver python -m build --wheel --no-isolation


### PR DESCRIPTION
Raise the iterator smoke-test limit from 200ns to 5000ns. The riscv64 builders measured 485.9ns and 2350.0ns per iteration, so the initial 1000ns allowance was still too tight on the slower builder. Keep every test enabled, including the separate machine-calibrated performance budget, which passes in both logs.

https://github.com/WoLpH/python-progressbar/blob/v4.6.0/tests/test_perf_budget.py