### PR TITLE
addpatch: ruby-sinatra 4.2.1-1

### DIFF
--- a/ruby-sinatra/riscv64.patch
+++ b/ruby-sinatra/riscv64.patch
@@ -1,0 +1,19 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -46,6 +46,9 @@
+ prepare() {
+   cd "sinatra-${pkgver}"
+ 
++  # Haml 7 changed the default attribute quoting in rendered HTML.
++  patch -Np1 -i "$srcdir/fix-haml-7-tests.patch"
++
+   # update gemspec to allow newer version of the dependencies
+   sed --in-place --regexp-extended 's|~>|>=|g' sinatra.gemspec */*.gemspec
+ 
+@@ -226,3 +229,6 @@
+   install --verbose -D --mode=0644 "${_licensefile}" --target-directory "${pkgdir}/usr/share/licenses/ruby-${_gemname}/"
+   install --verbose -D --mode=0644 *.md --target-directory "${pkgdir}/usr/share/doc/ruby-${_gemname}"
+ }
++
++source+=("fix-haml-7-tests.patch::https://github.com/sinatra/sinatra/commit/0135c85402f08e8a82dc3d270d9ba5a87b13aa40.patch?full_index=1")
++sha512sums+=('c222feaac12d823363fe7b90042843d2898b78ae8cc4f9eca7cbd540345a9b5a8fe2c07a790d60d8294de71bc76d908c8c1a6bcdcff2a01703da3976fa7e4a4f')


### PR DESCRIPTION
Backport the upstream Haml 7 test compatibility fix. The riscv64 builder has Haml 7.2.0, whose double-quoted HTML attributes fail the single-quote expectation in HAMLTest. Adjust the Sinatra and sinatra-contrib expectations for the Haml version, keeping all tests enabled.

Upstream: https://github.com/sinatra/sinatra/commit/0135c85402f08e8a82dc3d270d9ba5a87b13aa40