### PR TITLE
addpatch: bear 4.2.2-1

### DIFF
--- a/bear/riscv64.patch
+++ b/bear/riscv64.patch
@@ -1,0 +1,13 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -34,6 +34,10 @@
+   # fix install script
+   patch -p1 -i "$srcdir/avoid-libexec.patch"
+ 
++  # Allow the same five-second startup window as the other signal tests.
++  sed -i '/^fn signal_tears_down_build_process_tree()/,/assert!(is_alive(gpid)/s/from_secs(2)/from_secs(5)/' \
++    tests/integration/tests/cases/exit_codes.rs
++
+   # download dependencies
+   cargo fetch --locked --target host-tuple
+ }


### PR DESCRIPTION
Extend the process-tree signal test startup wait from 2s to 5s, matching the readiness window used by the other signal tests. The riscv64 log fails with "build never recorded its grandchild pid" before SIGTERM is sent. Leave the 2s teardown deadline and all signal assertions unchanged; keep the test enabled.

https://github.com/rizsotto/Bear/blob/4.2.2/tests/integration/tests/cases/exit_codes.rs#L602