### PR TITLE
addpatch: lua-lut 1.2.1-3

### DIFF
--- a/lua-lut/lua55.patch
+++ b/lua-lut/lua55.patch
@@ -1,0 +1,14 @@
+--- a/lut/Test.lua
++++ b/lut/Test.lua
+@@ -467,9 +467,9 @@
+       for k, info in pairs(coverage) do
+         if info ~= true and not self.ignore[k] then
+           if lib.mock then
+-            k = string.upper(string.sub(k, 1, 1))..string.sub(k, 2, -1)
++            local _k = string.upper(string.sub(k, 1, 1))..string.sub(k, 2, -1)
+             lub.insertSorted(not_tested, {
+-              text = 'function should.respondTo'..k..'()\n'..lib.mock..'end',
++              text = 'function should.respondTo'.._k..'()\n'..lib.mock..'end',
+               line = tonumber(debug.getinfo(info).linedefined),
+             }, 'line')
+           else

--- a/lua-lut/riscv64.patch
+++ b/lua-lut/riscv64.patch
@@ -1,0 +1,23 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -23,6 +23,13 @@
+ source=("https://github.com/lubyk/$_rockname/archive/REL-$pkgver/$_archive.tar.gz")
+ sha256sums=('6f7fbe620995b49d59127cf354d9100c218744b91327345c2fa7777fb9871413')
+ 
++prepare() {
++	cd "$_archive"
++	# Lua 5.5 makes loop control variables read-only.
++	# https://github.com/lubyk/lut/pull/2
++	patch -Np1 -i ../lua55.patch
++}
++
+ check() {
+ 	cd "$_archive"
+ 	lua test/all.lua
+@@ -55,3 +62,6 @@
+ package_lua51-lut() {
+ 	_package 5.1
+ }
++
++source+=(lua55.patch)
++sha256sums+=('921826845a9fdd95b108795cc825cc458eaf1ec00637f35e3b0ae5bcd92995c1')


### PR DESCRIPTION
Lua 5.5 makes loop control variables read-only, so lut.Test fails to load with "attempt to assign to const variable 'k'". Backport the upstream fix to use a separate local variable for the formatted test name, preserving the coverage checks and compatibility with older Lua versions.

Omit the upstream PR's rockspec change for the newer 1.2.2 release.

Upstream: https://github.com/lubyk/lut/pull/2