### PR TITLE
updpatch: python-hypothesis 6.167.1-1

### DIFF
--- a/python-hypothesis/riscv64.patch
+++ b/python-hypothesis/riscv64.patch
@@ -1,18 +1,22 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -69,6 +69,7 @@
+@@ -69,6 +69,8 @@
  
  prepare() {
    cd $pkgname/$_name/rust/
 +  patch -Np1 -d ../.. -i "$srcdir/suppress-stateful-too-slow-healthcheck.patch"
++  patch -Np1 -d ../.. -i "$srcdir/wait-for-test-threads.patch"
    cargo fetch --locked --target host-tuple
  }
  
-@@ -108,3 +109,7 @@
+@@ -108,3 +110,10 @@
    cd $pkgname/$_name
    python -m installer --destdir="$pkgdir" dist/*.whl
  }
 +
-+source+=(suppress-stateful-too-slow-healthcheck.patch)
-+sha512sums+=('e8df90b55134bfde8a24f7f0513b2f9d39b4c237c34a95fd74787a83f2196d70229d8d9d7ee6dfdb7a01fcb8a1767124772ac22f95fb1b09aacc51f4ec449070')
-+b2sums+=('afcaae1f8513549a99d26f16a6e345c19080cc085aad19ed29fcc40b37f56156c5aa80696a9d63e47b5939ea35c833d87986b8b54b7e09b100bd73634ae3346d')
++source+=(suppress-stateful-too-slow-healthcheck.patch
++         wait-for-test-threads.patch)
++sha512sums+=('e8df90b55134bfde8a24f7f0513b2f9d39b4c237c34a95fd74787a83f2196d70229d8d9d7ee6dfdb7a01fcb8a1767124772ac22f95fb1b09aacc51f4ec449070'
++             'ec2b8b191956ef7cf41358fa61e77444d7f288d7c2c340db63c72329a4cd4b55e94af4d7558c85f9b4a51f3cbaa6dad92caf7ff443bfcfaa9458ddfdf43568a9')
++b2sums+=('afcaae1f8513549a99d26f16a6e345c19080cc085aad19ed29fcc40b37f56156c5aa80696a9d63e47b5939ea35c833d87986b8b54b7e09b100bd73634ae3346d'
++         'd9e15eb941261e60b7da5d990eb10273eeac038250abaa6fe84abf3eec9538fca0ae22e19d34a64ee7bacd04cea05e8116a7688a5c9e2347e53d839703d6fc5f')

--- a/python-hypothesis/wait-for-test-threads.patch
+++ b/python-hypothesis/wait-for-test-threads.patch
@@ -1,0 +1,34 @@
+--- a/hypothesis/tests/common/utils.py
++++ b/hypothesis/tests/common/utils.py
+@@ -330,8 +330,10 @@
+     for thread in threads:
+         thread.start()
+ 
++    # Do not leave threads running into later tests: they may still hold
++    # temporary process-wide state such as the recursion limit.
+     for thread in threads:
+-        thread.join(timeout=10)
++        thread.join()
+ 
+ 
+ def wait_for(condition, *, timeout=1, interval=0.01):
+--- a/hypothesis/tests/nocover/test_threading.py
++++ b/hypothesis/tests/nocover/test_threading.py
+@@ -150,7 +150,7 @@
+     for thread in threads:
+         thread.start()
+     for thread in threads:
+-        thread.join(timeout=10)
++        thread.join()
+ 
+     assert sys.getrecursionlimit() == original_recursionlimit
+ 
+@@ -194,7 +194,7 @@
+ 
+     thread = Thread(target=target)
+     thread.start()
+-    thread.join(timeout=10)
++    thread.join()
+ 
+ 
+ def test_deadline_exceeded_not_raised_under_concurrent_threads():


### PR DESCRIPTION
The riscv64 check fails test_stackframes_restores_original_recursion_limit with 2014 != 2023. Unchecked Thread.join(timeout=10) calls can return while threads still hold temporary process-wide recursion limits.

Wait for completion in run_concurrently and the direct threaded tests, so threads cannot leak state into later tests or outlive the restoration assertion. Keep all assertions and runtime behavior unchanged.