### PR TITLE
updpatch: nodejs 26.8.1-2

### DIFF
--- a/nodejs/riscv64.patch
+++ b/nodejs/riscv64.patch
@@ -10,7 +10,7 @@
  }
  
  prepare() {
-@@ -64,6 +67,15 @@
+@@ -64,6 +67,18 @@
    # Fix the CCM empty-message test with newer OpenSSL behavior:
    # https://github.com/nodejs/node/commit/7e2254fc8ba5ac88fe6f35715e7bb6e78597846b
    git cherry-pick -n 7e2254fc8ba5ac88fe6f35715e7bb6e78597846b
@@ -21,12 +21,15 @@
 +  # Disable Highway RVV code; Arch RISC-V targets rv64gc, not RVV.
 +  patch -Np1 -i ../hwy-broken-rvv.diff
 +
++  # Fix inverted floating-point branches in V8's RISC-V backend.
++  patch -Np1 -i ../v8-riscv-float-branch.patch
++
 +  # Ten WPT workers still exhaust Node.js worker heaps on riscv64 builders.
 +  sed -i 's/concurrency = Math.min(10, concurrency);/concurrency = Math.min(2, concurrency);/' test/common/wpt.js
  }
  
  build() {
-@@ -112,6 +124,9 @@
+@@ -112,6 +127,9 @@
    # https://github.com/nodejs/node/issues/63914
    rm test/parallel/test-snapshot-reproducible.js
  
@@ -36,15 +39,17 @@
    make test-only
  }
  
-@@ -122,4 +137,11 @@
+@@ -122,4 +140,13 @@
    install -Dm644 LICENSE -t "$pkgdir"/usr/share/licenses/$pkgname
  }
  
 +
 +makedepends+=(clang)
 +source+=("hwy-broken-rvv.diff"
-+         "v8-wasm-lazy-jump.patch::https://github.com/v8/v8/commit/def38dd3f8726ed595932624ee5d681a3f02ed4a.patch")
++         "v8-wasm-lazy-jump.patch::https://github.com/v8/v8/commit/def38dd3f8726ed595932624ee5d681a3f02ed4a.patch"
++         "v8-riscv-float-branch.patch")
 +sha512sums+=('b4f21e06bef85f8eba9536e9a110d4aec3d230f9f3e76ee3d98a8cd88086c77f8593427c6379de51e5e7fe668273803f8e9ea8c30ab225010186dcb404c0b164'
-+            '1743a2759134a32324e0b271fd99a246cfd3540ccf7b1dc3011ab76f0843181366b7b749e52331c5ea41d68949cc5cfd280a3929f90ef68df9f9ffe5d2dcd2f3')
++            '1743a2759134a32324e0b271fd99a246cfd3540ccf7b1dc3011ab76f0843181366b7b749e52331c5ea41d68949cc5cfd280a3929f90ef68df9f9ffe5d2dcd2f3'
++            'e7943296c30c8089c5ca5d536373bffca72f73024b8b0294e7bd133bb9af1742e849835d2ab5782ab1b594bb5671095de6be9d6749b8de87e7ec9fa55be599f5')
 +
  # vim:set ts=2 sw=2 et:

--- a/nodejs/v8-riscv-float-branch.patch
+++ b/nodejs/v8-riscv-float-branch.patch
@@ -1,0 +1,60 @@
+--- a/deps/v8/src/compiler/backend/riscv/code-generator-riscv.cc
++++ b/deps/v8/src/compiler/backend/riscv/code-generator-riscv.cc
+@@ -433,8 +433,8 @@
+       *predicate = true;
+       return GE;
+     case kFloatLessThanOrUnordered:
+-      *predicate = true;
+-      return LT;
++      *predicate = false;
++      return GE;
+     case kFloatGreaterThanOrUnordered:
+       *predicate = false;
+       return LE;
+@@ -442,8 +442,8 @@
+       *predicate = false;
+       return LT;
+     case kFloatLessThanOrEqualOrUnordered:
+-      *predicate = true;
+-      return LE;
++      *predicate = false;
++      return GT;
+     default:
+       *predicate = true;
+       break;
+--- /dev/null
++++ b/deps/v8/test/mjsunit/wasm/regress-riscv-float-branch.js
+@@ -0,0 +1,33 @@
++// Copyright 2026 the V8 project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++// Flags: --no-liftoff --no-wasm-loop-unrolling
++
++d8.file.execute('test/mjsunit/wasm/wasm-module-builder.js');
++
++// A zero left operand is commuted during instruction selection. When the
++// back-edge becomes the branch target, code generation must invert the
++// emitted comparison's result, not just swap the branch labels.
++for (const [comparison, expected] of [[kExprF32Gt, 1], [kExprF32Ge, 0]]) {
++  const builder = new WasmModuleBuilder();
++  builder.addFunction('loop', makeSig([kWasmF32], [kWasmF32]))
++      .addBody([
++        kExprBlock, kWasmVoid,
++          kExprLoop, kWasmVoid,
++            kExprLocalGet, 0,
++            ...wasmF32Const(1),
++            kExprF32Add,
++            kExprLocalTee, 0,
++            ...wasmF32Const(0),
++            comparison,
++            kExprBrIf, 1,
++            kExprBr, 0,
++          kExprEnd,
++        kExprEnd,
++        kExprLocalGet, 0,
++      ])
++      .exportFunc();
++  const instance = builder.instantiate();
++  assertEquals(expected, instance.exports.loop(-10));
++}


### PR DESCRIPTION
Fix V8's RISC-V lowering of the less-than-or-unordered and less-than-or-equal-or-unordered conditions as negated GE and GT results. Branch layout can negate a condition after emitting its comparison; the complementary conditions must share that comparison and invert its predicate, preserving NaN behavior as well.

This explains Yoga 3.2.1 collapsing flex-grow widths from 78 to 0 after Wasm optimization in gemini-cli 0.50.0, while Liftoff remains correct. Add regression coverage for both conditions: optimized RISC-V loops return -9 instead of 1 or 0 with loop unrolling disabled.

Introduced by V8 d76fd9ca2f18:
https://chromium-review.googlesource.com/c/v8/v8/+/5364233

Reproducer (Node only): "use asm" makes V8 translate this JavaScript subset to Wasm; Math.fround keeps the arithmetic in float32.

```
node --no-liftoff --no-wasm-loop-unrolling <<'JS'
function Module(stdlib) {
  'use asm';
  var f32 = stdlib.Math.fround;
  function f(x) {
    x = f32(x);
    do { x = f32(x + f32(1.0)); } while (!(x > f32(0.0)));
    return x;
  }
  return f;
}
console.log(process.arch, Module(globalThis)(-10));
JS
```

With Node 26.8.1, x86_64 prints "x64 1" and affected RISC-V prints "riscv64 -9". Adding --no-validate-asm runs the same source as ordinary JavaScript and prints "riscv64 1". The correct result is always 1.