### PR TITLE
addpatch: python-openai 2.53.0-1

### DIFF
--- a/python-openai/riscv64.patch
+++ b/python-openai/riscv64.patch
@@ -1,0 +1,45 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -32,8 +32,8 @@
+   'python-wheel'
+ )
+ checkdepends=(
++  'deno'
+   'nodejs-lts-jod'
+-  'npm'
+   'procps-ng'
+   'python-dirty-equals'
+   'python-httpx-aiohttp'
+@@ -70,6 +70,12 @@
+   cd "${_name}-${pkgver}"
+   grep -q "openai-$_openai_openapi_spec.yml" .stats.yml \
+     || { echo "Update _openai_openapi_spec"; exit 1; }
++
++  # Steady's npm package has no riscv64 binary; run the same release from source.
++  sed -i 's|npm exec --package=@stdy/cli@0.22.1 -- steady|deno run -A --config=../steady-0.22.1/deno.json ../steady-0.22.1/cmd/steady.ts|g' scripts/mock
++
++  # Allow more time for mTLS example subprocesses on slow builders.
++  sed -i 's/timeout=15,/timeout=60,/' tests/test_mtls_http_client.py
+ }
+ 
+ build() {
+@@ -83,9 +89,10 @@
+   local site_packages=$(python -c "import site; print(site.getsitepackages()[0])")
+   export PYTHONPATH="$PWD/tmp_install/${site_packages}"
+ 
++  # Deno 2.2 requires opting into Steady's v5 lockfile.
++  export DENO_UNSTABLE_LOCKFILE_V5=1
+   # Start mock server and make sure it's cleaned up on exit
+-  export npm_config_yes=true
+-  trap 'pkill "npm exec steady"' EXIT
++  trap 'pkill -f "^deno run .*steady"' EXIT
+   ./scripts/mock --daemon "${srcdir}/openai-${_openai_openapi_spec}.yml"
+ 
+   # Randomly generated mock API key
+@@ -105,3 +112,6 @@
+   python -m installer --destdir="${pkgdir}" dist/*.whl
+   install -vDm644 LICENSE -t "${pkgdir}/usr/share/licenses/${pkgname}/"
+ }
++
++source+=("steady-0.22.1.tar.gz::https://github.com/dgellow/steady/archive/refs/tags/v0.22.1.tar.gz")
++b2sums+=('f90f9a5ce968e2a88b9392ded27982c5cb7a0062deef1b40990acc924fb1be042a3b724e04b56c326090a81b51d4a149d483326703ee10c3f53a56ec9057f088')


### PR DESCRIPTION
check() aborts before pytest because @stdy/cli@0.22.1 reports "Unsupported platform: linux-riscv64". Its npm launcher only provides precompiled binaries for x86_64 and aarch64.

Run the same Steady release from source with system Deno, preserving mock-server options and test selection. Fetch the release tarball because 0.22.1 is not published on JSR. Enable v5 lockfile support for the Deno 2.2.9 package in Arch Linux RISC-V and update daemon cleanup.

Upstream: https://github.com/dgellow/steady/blob/v0.22.1/scripts/build_npm.ts

Raise the mTLS example subprocess timeout from 15 to 60 seconds. With Steady running, three examples hit TimeoutExpired during the 128-worker check run. Allow more time on slower builders while retaining all four examples and the certificate-chain assertions.