### PR TITLE
addpatch: ruby-ethon 0.18.0-1

### DIFF
--- a/ruby-ethon/check-ntlm-support.patch
+++ b/ruby-ethon/check-ntlm-support.patch
@@ -1,0 +1,11 @@
+--- a/spec/ethon/easy/operations_spec.rb
++++ b/spec/ethon/easy/operations_spec.rb
+@@ -179,7 +179,7 @@
+         end
+       end
+ 
+-      context "when ntlm" do
++      context "when ntlm", :if => (Ethon::Curl.version_info[:features] & Ethon::Curl::VERSION_NTLM) != 0 do
+         let(:url) { "http://localhost:3001/auth_ntlm" }
+         let(:http_auth) { :ntlm }
+ 

--- a/ruby-ethon/riscv64.patch
+++ b/ruby-ethon/riscv64.patch
@@ -1,0 +1,19 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -36,6 +36,9 @@
+     -e 's|~>|>=|g' \
+     -e '/curb/d' \
+     Gemfile
++
++  # Arch's curl build no longer enables the optional NTLM feature.
++  patch -Np1 -i ../check-ntlm-support.patch
+ }
+ 
+ build() {
+@@ -99,3 +102,6 @@
+ }
+ 
+ # vim: tabstop=2 shiftwidth=2 expandtab:
++
++source+=("check-ntlm-support.patch")
++sha256sums+=('14a371dc608851e8760071a30889cfaf387e6799f5f5b3076221cd2a952f83c7')


### PR DESCRIPTION
Gate the NTLM specs on the libcurl VERSION_NTLM feature bit. The check fails with HTTP 401 instead of 200 because the Arch curl 8.21.0 build lacks NTLM, which curl now disables by default. Keep the specs enabled when NTLM is available and leave runtime code unchanged.

The official package .BUILDINFO records an x86_64 build on 2026-03-14 with curl 8.19.0, before the 2026-03-21 default change. The difference is dependency age, not CPU architecture.

Curl change: https://github.com/curl/curl/commit/cc0c83c5f853c41fca6880c5dcd6745da9353434