### PR TITLE
addpatch: python-openapi-core 0.23.1-1

### DIFF
--- a/python-openapi-core/jsonschema-path-0.5.patch
+++ b/python-openapi-core/jsonschema-path-0.5.patch
@@ -1,0 +1,66 @@
+--- a/openapi_core/templating/paths/finders.py
++++ b/openapi_core/templating/paths/finders.py
+@@ -18,6 +18,8 @@
+ from openapi_core.templating.paths.protocols import PathsIterator
+ from openapi_core.templating.paths.protocols import ServersIterator
+ 
++DEFAULT_SERVER = SchemaPath.from_dict({"url": "/"})
++
+ 
+ class BasePathFinder:
+     paths_iterator: PathsIterator = NotImplemented
+@@ -63,7 +65,7 @@
+ class APICallPathFinder(BasePathFinder):
+     paths_iterator: PathsIterator = TemplatePathsIterator("paths")
+     operations_iterator: OperationsIterator = SimpleOperationsIterator()
+-    servers_iterator: ServersIterator = TemplateServersIterator()
++    servers_iterator: ServersIterator = TemplateServersIterator(DEFAULT_SERVER)
+ 
+ 
+ class WebhookPathFinder(APICallPathFinder):
+--- a/openapi_core/templating/paths/iterators.py
++++ b/openapi_core/templating/paths/iterators.py
+@@ -122,6 +122,9 @@
+ 
+ 
+ class TemplateServersIterator:
++    def __init__(self, default_server: SchemaPath):
++        self.default_server = default_server
++
+     def __call__(
+         self,
+         name: str,
+@@ -136,7 +139,7 @@
+                 or spec.get("servers", None)
+             )
+             if not servers:
+-                servers = [SchemaPath.from_dict({"url": "/"})]
++                servers = [self.default_server]
+             for server in servers:
+                 server_url_pattern = name.rsplit(path_result.resolved, 1)[0]
+                 server_url = server["url"]
+--- a/tests/unit/templating/test_paths_finders.py
++++ b/tests/unit/templating/test_paths_finders.py
+@@ -6,6 +6,7 @@
+ from openapi_core.templating.paths.exceptions import PathNotFound
+ from openapi_core.templating.paths.exceptions import PathsNotFound
+ from openapi_core.templating.paths.exceptions import ServerNotFound
++from openapi_core.templating.paths.finders import DEFAULT_SERVER
+ from openapi_core.templating.paths.finders import APICallPathFinder
+ 
+ 
+@@ -195,13 +196,12 @@
+ 
+         path = spec / "paths" / self.path_name
+         operation = spec / "paths" / self.path_name / method
+-        server = SchemaPath.from_dict({"url": "/"})
+         path_result = TemplateResult(self.path_name, {})
+         server_result = TemplateResult("/", {})
+         assert result == (
+             path,
+             operation,
+-            server,
++            DEFAULT_SERVER,
+             path_result,
+             server_result,
+         )

--- a/python-openapi-core/riscv64.patch
+++ b/python-openapi-core/riscv64.patch
@@ -1,0 +1,32 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -43,7 +43,7 @@
+   python-falcon
+   python-fastapi
+   python-flask
+-  python-httpx
++  python-httpx2
+   python-multidict
+   python-pytest
+   python-pytest-aiohttp
+@@ -55,6 +55,20 @@
+ source=("git+$url#tag=$pkgver")
+ b2sums=('54bf2eea1c57779ea9144bbc56af2cd0ece68a6ef76a9d4057e251947d4a5e1f031949721deb8b2a46e3a7e5b0e9e70de23ddc8bf1256ae2bdfc2bb3c3554a6f')
+ 
++source+=(jsonschema-path-0.5.patch
++         "$pkgname-pytest-9.1.patch::https://github.com/python-openapi/openapi-core/commit/0cbab14e03c6a9f64be2df51e0c86401f791feca.patch")
++b2sums+=('279bbaf7c3f4252e7723305e9ede15c60ce2c64021d1e2a8d3b62307a5b4aae34d62896f0c1188b107d4db7d7065369cd7dc4b841aa85c5b496fa9fe99b03608'
++         '88da06ab456e4c1753f606cceb963cd1fe04a89b6df64639f3b2068ed67c3153a57410fd07b4aed4fff729d54b01cbce2b965becee028e5ce79d7dcf1d700b2f')
++
++prepare() {
++  cd "${pkgname#python-}"
++  # Use a shared default server for jsonschema-path 0.5.
++  # https://github.com/python-openapi/openapi-core/pull/1189
++  patch -Np1 -i ../jsonschema-path-0.5.patch
++  # pytest 9.1 deprecates class-scoped instance fixtures.
++  patch -Np1 -i ../$pkgname-pytest-9.1.patch
++}
++
+ build() {
+   cd "${pkgname#python-}"
+   python -m build --wheel --no-isolation


### PR DESCRIPTION
Use python-httpx2 in checkdepends to avoid Starlette's httpx fallback warning being treated as an error during test collection.

Backport the shared default-server fix for jsonschema-path 0.5's accessor identity checks, which break six path-finder tests. Convert class-scoped fixtures to class methods for pytest 9.1, fixing twelve test setup errors without suppressing warnings.

Upstream: https://gitlab.archlinux.org/archlinux/packaging/packages/python-openapi-core/-/work_items/6
Upstream: https://github.com/python-openapi/openapi-core/pull/1189
Upstream: https://github.com/python-openapi/openapi-core/pull/1207