### PR TITLE
addpatch: criterion 2.4.3-1

### DIFF
--- a/criterion/boxfort-riscv64-plt.patch
+++ b/criterion/boxfort-riscv64-plt.patch
@@ -1,0 +1,27 @@
+--- a/src/asm/trampoline-riscv64.S
++++ b/src/asm/trampoline-riscv64.S
+@@ -29,17 +29,15 @@
+ #endif
+ .globl MANGLE(bxfi_trampoline)
+ MANGLE(bxfi_trampoline):
++#ifdef __riscv_compressed
++    /* Fit the jump and address into a 16-byte PLT entry. */
++    auipc   a0, 0
++    c.ld    a0, 8(a0)
++    c.jr    a0
++#else
+     ld      a0, addr_data
+     jr      a0
+-
+-/*
+- *  On riscv64gc, these will expand into 3 instructions:
+- *  auipc   a0, 0x0         4 bytes
+- *  ld      a0, offset(a0)  4 bytes
+- *  jr      a0              2 bytes
+- *  <addr_data>
+- *  'offset' is the length between `auipc` and `addr_data`.
+- */
++#endif
+ 
+ .align 1
+ 

--- a/criterion/riscv64.patch
+++ b/criterion/riscv64.patch
@@ -1,0 +1,22 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -26,6 +26,9 @@
+ source=("$pkgname-$pkgver.tar.gz::$url/archive/v$pkgver.tar.gz")
+ sha256sums=('6d924ee5eeaaaed7762ab968f560b9ff543fc3473aa949bf53ac56a2a1a9416c')
+ 
++source+=(boxfort-riscv64-plt.patch)
++sha256sums+=('5943f2747ba527c8c479f69d5b2ef0041f401f9c74d6307d47264f907b2c7d3d')
++
+ prepare() {
+   cd $_pkgname-$pkgver
+   # Use system packages for these instead.
+@@ -37,6 +40,9 @@
+   # file. A meson.build file is not necessary, so ignore the error.
+   meson subprojects download || :
+ 
++  # Keep BoxFort's RISC-V trampoline from overwriting the next PLT entry.
++  patch -Np1 -d subprojects/boxfort -i "$srcdir/boxfort-riscv64-plt.patch"
++
+   # Fix FTBS
+   sed -i '/#ifdef __cplusplus/a # include <cstdint>' include/criterion/alloc.h
+ }

--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -1,5 +1,6 @@
 argocd
 corepack
+criterion
 eslint
 forgejo
 gitea
@@ -14,5 +15,6 @@ prettier
 prometheus
 python-anywidget
 python-esphome-dashboard
+syslog-ng
 typescript-language-server
 vue-language-tools


### PR DESCRIPTION
BoxFort writes an 18-byte RISC-V trampoline into main's 16-byte PLT entry, corrupting the next entry and causing SIGILL in syslog-ng tests on both native and QEMU builders. Use compressed load and jump instructions to fit the trampoline in 16 bytes.

Keep criterion and syslog-ng off Sv39 builders: BoxFort's inheritable arena requires addresses above 32 TiB, outside the Sv39 user address space. Criterion's tests abort with "Could not initialize inheritable arena: Cannot allocate memory" on baxcalibur.

Upstream: https://github.com/Snaipe/BoxFort/issues/44