### PR TITLE
qemu-user-blacklist: add plantuml

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -105,6 +105,7 @@ pangomm-2.48
 percona-server
 perl
 perl-par-packer
+plantuml
 pueue
 pyqt6
 pyqt6-3d


### PR DESCRIPTION
All 13 PicowebTest cases in 1.2026.5-1 fail during ServerSocket.close() on minun with IOException: Operation now in progress. OpenJDK uses SIGRTMAX-2 (62) to wake blocked socket threads, but the default QEMU user signal mapping cannot deliver it. Select a non-qemu-user builder to preserve the full test suite.

References:
https://github.com/openjdk/jdk26u/blob/jdk-26.0.2.1%2B1/src/java.base/unix/native/libnio/ch/NativeThread.c#L39 https://github.com/qemu/qemu/blob/v11.0.3/linux-user/signal.c#L574