### PR TITLE
addpatch: urh 2.10.0-2

### DIFF
--- a/urh/riscv64.patch
+++ b/urh/riscv64.patch
@@ -1,0 +1,35 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -54,12 +54,22 @@
+ )
+ source=(
+   "$url/archive/v$pkgver/$pkgname-$pkgver.tar.gz"
++  'signed-iq-samples.patch'
++  'wait-for-continuous-modulator.patch'
+ )
+-b2sums=('4d68080279dea9763180a586169b07279fecd9b2df98a509db5e578432f1082a20b94e04fae3f2ed1f32621b4c683bde546e158d9ca369e2bc68c061e473b9ea')
++b2sums=('4d68080279dea9763180a586169b07279fecd9b2df98a509db5e578432f1082a20b94e04fae3f2ed1f32621b4c683bde546e158d9ca369e2bc68c061e473b9ea'
++        'ec34e21af64c0eff188bba2792403b126e1d7a53546501e727138df54fcf95519443d1576b35f769b32454cc424812048761a8b5983d4b89dce7c5d825f6e91e'
++        'bdf1569edc3d7a6a1ff2197245b3e7c5f9f75a00b6e61e0ad938481b911798bb2385a457dd70e69b962e3f7e901165babe9ccd8212fd51986d07b1e70f7a892a')
+
+ prepare() {
+   cd $pkgname-$pkgver
+
++  # Signed 8-bit IQ samples must not depend on the platform char signedness.
++  patch -Np1 -i ../signed-iq-samples.patch
++
++  # Allow more time for spawned modulation and receiver startup.
++  patch -Np1 -i ../wait-for-continuous-modulator.patch
++
+   # No need to package this build script.
+   rm -v src/urh/cythonext/build.py
+
+@@ -70,6 +80,8 @@
+
+ build() {
+   cd $pkgname-$pkgver
++  # FMA rounding can turn zero FSK phase differences into positive values.
++  export CXXFLAGS="$CXXFLAGS -ffp-contract=off"
+   python -m build --wheel --no-isolation --skip-dependency-check
+ }
+

--- a/urh/signed-iq-samples.patch
+++ b/urh/signed-iq-samples.patch
@@ -1,0 +1,58 @@
+--- a/src/urh/cythonext/util.pxd
++++ b/src/urh/cythonext/util.pxd
+@@ -1,5 +1,5 @@
+ ctypedef fused iq:
+-    char
++    signed char
+     unsigned char
+     short
+     unsigned short
+--- a/src/urh/cythonext/signal_functions.pyx
++++ b/src/urh/cythonext/signal_functions.pyx
+@@ -44,7 +44,7 @@
+         return 0
+ 
+ cdef get_numpy_dtype(iq cython_type):
+-    if str(cython.typeof(cython_type)) == "char":
++    if str(cython.typeof(cython_type)) == "signed char":
+         return np.int8
+     elif str(cython.typeof(cython_type)) == "short":
+         return np.int16
+@@ -62,7 +62,7 @@
+     if dtype == np.int8:
+         return __modulate(
+             bits, samples_per_symbol, modulation_type, parameters, bits_per_symbol, carrier_amplitude,
+-            carrier_frequency, carrier_phase, sample_rate, pause, start, <char>0, gauss_bt, filter_width
++            carrier_frequency, carrier_phase, sample_rate, pause, start, <signed char>0, gauss_bt, filter_width
+         )
+     elif dtype == np.int16:
+         return __modulate(
+@@ -264,7 +264,7 @@
+ 
+     cdef float[::1] result = np.empty(num_samples, dtype=np.float32)
+ 
+-    if str(cython.typeof(samples)) == "char[:, ::1]":
++    if str(cython.typeof(samples)) == "signed char[:, ::1]":
+         scale = 127.5
+         shift = 0.5
+     elif str(cython.typeof(samples)) == "unsigned char[:, ::1]":
+@@ -340,7 +340,7 @@
+     cdef float noise_sqrd = noise_mag * noise_mag, real = 0, imag = 0, magnitude = 0, max_magnitude
+     cdef float complex tmp
+ 
+-    if str(cython.typeof(samples)) == "char[:, ::1]":
++    if str(cython.typeof(samples)) == "signed char[:, ::1]":
+         max_magnitude = sqrt(127*127 + 128*128)
+     elif str(cython.typeof(samples)) == "unsigned char[:, ::1]":
+         max_magnitude = sqrt(255*255)
+--- a/src/urh/cythonext/path_creator.pyx
++++ b/src/urh/cythonext/path_creator.pyx
+@@ -25,7 +25,7 @@
+     cdef long long i,j,index, chunk_end, num_samples, pixels_on_path, samples_per_pixel
+     num_samples = end - start
+ 
+-    cdef dict type_lookup = {"char[:]": np.int8, "unsigned char[:]": np.uint8,
++    cdef dict type_lookup = {"signed char[:]": np.int8, "unsigned char[:]": np.uint8,
+                              "short[:]": np.int16, "unsigned short[:]": np.uint16,
+                              "float[:]": np.float32, "double[:]": np.float64}
+ 

--- a/urh/wait-for-continuous-modulator.patch
+++ b/urh/wait-for-continuous-modulator.patch
@@ -1,0 +1,22 @@
+--- a/tests/test_continuous_modulator.py
++++ b/tests/test_continuous_modulator.py
+@@ -22,7 +22,7 @@
+         self.assertTrue(continuous_modulator.ring_buffer.is_empty)
+         continuous_modulator.start()
+         self.assertTrue(continuous_modulator.process.is_alive())
+-        time.sleep(2)
++        time.sleep(10)
+         self.assertFalse(continuous_modulator.ring_buffer.is_empty)
+         continuous_modulator.stop()
+         self.assertFalse(continuous_modulator.process.is_alive())
+--- a/tests/test_send_recv_dialog_gui.py
++++ b/tests/test_send_recv_dialog_gui.py
+@@ -267,7 +267,7 @@
+         process.daemon = True
+         process.start()
+         n = 0
+-        while ready.value == 0 and n < 50:  # ensure server is up
++        while ready.value == 0 and n < 300:  # ensure server is up
+             time.sleep(0.1)
+             n += 1
+ 


### PR DESCRIPTION
Use explicit signed char for 8-bit IQ samples and update the matching Cython type checks. Plain char is unsigned on riscv64, corrupting signal demodulation and causing test_auto_detect_button to block on an "Autodetection failed" modal dialog.

Disable FP contraction so FMA rounding does not turn zero phase differences into positive values and change the decoded FSK bits.

Increase the continuous modulator test's startup delay from 2 to 10 seconds to allow more time for the child process on slower builders. Raise the continuous-send receiver's readiness limit from 5 to 30 seconds: its ready flag is still unset when the test checks it on centiskorch. The spawned child must import NumPy, Qt, and URH before opening its socket.