### PR TITLE
addpatch: ruby-maxitest 6.2.0-1

### DIFF
--- a/ruby-maxitest/interrupt-test-startup.patch
+++ b/ruby-maxitest/interrupt-test-startup.patch
@@ -1,0 +1,20 @@
+--- a/spec/maxitest_spec.rb
++++ b/spec/maxitest_spec.rb
+@@ -238,7 +238,7 @@
+   describe "Interrupts" do
+     it "stops on ctrl+c and prints errors" do
+       t = Thread.new { run_cmd("ruby spec/cases/cltr_c.rb", fail: true) }
+-      sleep 1 # let thread start
++      sleep 3 # let the child finish loading Bundler and Maxitest
+       kill_process_with_name("spec/cases/cltr_c.rb")
+       output = t.value
+       output.should include "4 runs, 1 assertions, 1 failures, 1 errors, 2 skips" # failed, error from interrupt (so you see a backtrace), rest skipped
+@@ -262,7 +262,7 @@
+ 
+     it "shows backtraces when in verbose mode" do
+       t = Thread.new { run_cmd("ruby spec/cases/cltr_c.rb -v", fail: true) }
+-      sleep 1 # let thread start
++      sleep 3 # let the child finish loading Bundler and Maxitest
+       kill_process_with_name("spec/cases/cltr_c.rb")
+       output = t.value
+       output.gsub(/:\d+:in/, ":D:in").should match /cltr_c.rb:D:in (`|'Kernel#)sleep'/ # let you know where it happened

--- a/ruby-maxitest/riscv64.patch
+++ b/ruby-maxitest/riscv64.patch
@@ -1,0 +1,16 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -27,8 +27,13 @@
+ source=("git+https://github.com/grosser/maxitest.git#tag=v$pkgver")
+ sha512sums=('429c7d10557ac25a1c615a1441e9a48b253fc4f12255c4edf615b0c494894b56c1bde26aa103e1fab8c4d8f1219ab47ba9ccab7855e83b1aa1ff65a3c8331e67')
+ 
++source+=(interrupt-test-startup.patch)
++sha512sums+=('be4b55f3774ee2e305a956c377278b9e60911b2a769ddd546218848a8c5b6a1add0aa8148e5fcfde657b409dcd1e27253cd9b531fd6d9f3b4f2c7b692540b718')
++
+ prepare() {
+   cd "$_pkgname"
++  # Allow Ruby and Bundler to load before the interrupt tests send SIGINT.
++  patch -Np1 -i ../interrupt-test-startup.patch
+   git rm Gemfile.lock
+ 
+   # Remove dependency on bump and debug


### PR DESCRIPTION
Increase the two interrupt tests' startup delays from one to three seconds. On electivire, SIGINT arrives while Ruby is still loading Bundler, producing startup backtraces instead of Maxitest's interrupt report. Keep the delay below Maxitest's five-second test timeout.