### PR TITLE
addpatch: python-pysnmp 7.1.29-1

### DIFF
--- a/python-pysnmp/riscv64.patch
+++ b/python-pysnmp/riscv64.patch
@@ -1,0 +1,17 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -28,6 +28,14 @@
+ source=("https://github.com/lextudio/pysnmp/archive/v$pkgver/${pkgname#python-}-v$pkgver.tar.gz")
+ sha512sums=('53eb9657590fe2fbd3af956177200ee51df7d9f6d1eab51ea689b47a7a4181cc0ff3cfae229be6e8ec5c2ee18acb578ca412c244196ceab410d09413472bd05a')
+ 
++prepare() {
++  cd ${pkgname#python-}-$pkgver
++  # Allow MIB setup and the blocking slow-agent fixture on slower builders.
++  sed -i -e 's/timeout=3/timeout=10/' -e 's/elapsed_time <= 3/elapsed_time <= 10/' \
++    tests/hlapi/v1arch/asyncio/manager/cmdgen/test_v1arch_v1_get.py \
++    tests/hlapi/v3arch/asyncio/manager/cmdgen/test_v1_get.py
++}
++
+ build() {
+   cd ${pkgname#python-}-$pkgver
+   python -m build --wheel --no-isolation


### PR DESCRIPTION
Raise the four GET tests with three-second outer deadlines to ten seconds, including their elapsed-time upper bounds. All four hit asyncio.wait_for timeouts on riscv64 while 244 other tests pass. The timed sections include MIB setup, and the slow-agent fixture blocks the event loop for two seconds.

Keep the one-second SNMP timeout, retry counts, lower timing bounds and result assertions unchanged; no tests are skipped.