### PR TITLE
addpatch: corepack 0.36.0-1

### DIFF
--- a/corepack/riscv64.patch
+++ b/corepack/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -21,6 +21,8 @@
+   mkdir bin
+   corepack enable --install-directory bin yarn
+   yes | bin/yarn set version stable
++  # Install Rolldown's WASM fallback; no native riscv64 binding is available.
++  bin/yarn config set supportedArchitectures.cpu --json '["current", "wasm32"]'
+   yes | bin/yarn install --immutable
+ }
+


### PR DESCRIPTION
Enable wasm32 in Yarn's supported architectures so it installs the locked Rolldown WASM fallback. Rolldown has no native riscv64 binding, causing Vitest to abort before running tests in check().