### PR TITLE
addpatch: prometheus 3.14.0-1

### DIFF
--- a/prometheus/riscv64.patch
+++ b/prometheus/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -72,7 +72,7 @@
+   cd prometheus-$pkgver
+ 
+   # TestHeadCompactionWhileScraping: https://github.com/prometheus/prometheus/issues/17956
+-  GODEBUG=x509sha1=1 go test -short -skip TestHeadCompactionWhileScraping ./...
++  go test -short -skip TestHeadCompactionWhileScraping ./...
+ }
+ 
+ package() {


### PR DESCRIPTION
Remove GODEBUG=x509sha1=1 from check(). Go 1.27 aborts before running tests because the setting was removed in Go 1.24. Prometheus 3.14.0 already requires Go 1.25.8 or newer, so this override is obsolete.

https://go.dev/doc/godebug#go-124