### PR TITLE
addpatch: nodejs-lts-jod 22.23.2-1

### DIFF
--- a/nodejs-lts-jod/riscv64.patch
+++ b/nodejs-lts-jod/riscv64.patch
@@ -1,0 +1,45 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -32,6 +32,17 @@
+
+ prepare() {
+   cd node-v${pkgver}
++  # Compare only the low 32 bits of Wasm values, even with stale upper bits.
++  # https://github.com/v8/v8/commit/1f69656648fc23f5d1d4d4c38904b76d8feceee8
++  patch -Np1 -i ../v8-riscv-word32-compare.patch
++  # Wasm zero checks must ignore stale upper bits in i32 arguments too.
++  patch -Np1 -i ../v8-riscv-word32-zero.patch
++  # Fix inverted floating-point branches in V8's RISC-V backend.
++  patch -Np1 -i ../v8-riscv-float-branch.patch
++  # Allow slow watch restarts, Sv39 Wasm, and expected closed-pipe errors.
++  patch -Np1 -i ../test-resource-limits.patch
++  # Accept both old and new OpenSSL CCM finalization behavior.
++  patch -Np1 -i ../openssl-ccm-final.patch
+   # Update ICU tests https://github.com/nodejs/node/pull/60523
+   patch -Np1 -i ../update-icu-tests.patch
+ }
+@@ -81,7 +92,8 @@
+   # https://github.com/nodejs/node/issues/63914
+   rm test/parallel/test-snapshot-reproducible.js
+
+-  make test-only
++  # The test runner otherwise uses all CPUs, ignoring MAKEFLAGS.
++  make test-only JOBS=8
+ }
+
+ package() {
+@@ -90,3 +102,14 @@
+   make DESTDIR="${pkgdir}" install
+   install -Dm644 LICENSE -t "${pkgdir}"/usr/share/licenses/${pkgname}/
+ }
++
++source+=(v8-riscv-word32-compare.patch
++         v8-riscv-word32-zero.patch
++         v8-riscv-float-branch.patch
++         test-resource-limits.patch
++         "openssl-ccm-final.patch::https://github.com/nodejs/node/commit/40eac4a32f3676b286fd44435be4514962a40b79.patch")
++sha256sums+=('1b12913fa8dc965815751629773d91bc3c9c9844e7dc7a7d982b73b756fd0342'
++             'a208e39a506ae4e4b6eeba2435d706092d28992aa83d9b245888ea4cac39a3c0'
++             '7ea4fb5985fcf5c5a1ecc07f71ce1ae0147f173ba3576b45098e83dcf4fe06fc'
++             '3f459ab8e8345cc1e7e18fab6bbe3aa7cdedd06a95b0952ec076bf114c07a28f'
++             'a264e9b41d6956450de7e31400398f81d98ff7e56e08f583020c8cd6b7a39e2b')

--- a/nodejs-lts-jod/test-resource-limits.patch
+++ b/nodejs-lts-jod/test-resource-limits.patch
@@ -1,0 +1,29 @@
+--- a/test/parallel/test-worker-messaging.js
++++ b/test/parallel/test-worker-messaging.js
+@@ -1,4 +1,5 @@
+ 'use strict';
++// Flags: --disable-wasm-trap-handler
+ 
+ const common = require('../common');
+ const Countdown = require('../common/countdown');
+--- a/test/sequential/test-watch-mode.mjs
++++ b/test/sequential/test-watch-mode.mjs
+@@ -73,7 +73,7 @@
+       future.resolve();
+       return { stdout, stderr };
+     },
+-    restart(timeout = 1000) {
++    restart(timeout = 4000) {
+       if (!child) {
+         run();
+       }
+--- a/test/parallel/test-child-process-fork-closed-channel-segfault.js
++++ b/test/parallel/test-child-process-fork-closed-channel-segfault.js
+@@ -78,6 +78,7 @@
+           // may already have exited.
+           if (err && err.code !== 'ERR_IPC_CHANNEL_CLOSED' &&
+                      err.code !== 'ECONNRESET' &&
++                     err.code !== 'EPIPE' &&
+                      err.code !== 'ECONNREFUSED' &&
+                      err.code !== 'EMFILE') {
+             throw err;

--- a/nodejs-lts-jod/v8-riscv-float-branch.patch
+++ b/nodejs-lts-jod/v8-riscv-float-branch.patch
@@ -1,0 +1,60 @@
+--- a/deps/v8/src/compiler/backend/riscv/code-generator-riscv.cc
++++ b/deps/v8/src/compiler/backend/riscv/code-generator-riscv.cc
+@@ -324,8 +324,8 @@
+       *predicate = true;
+       return GE;
+     case kFloatLessThanOrUnordered:
+-      *predicate = true;
+-      return LT;
++      *predicate = false;
++      return GE;
+     case kFloatGreaterThanOrUnordered:
+       *predicate = false;
+       return LE;
+@@ -333,8 +333,8 @@
+       *predicate = false;
+       return LT;
+     case kFloatLessThanOrEqualOrUnordered:
+-      *predicate = true;
+-      return LE;
++      *predicate = false;
++      return GT;
+     default:
+       *predicate = true;
+       break;
+--- /dev/null
++++ b/deps/v8/test/mjsunit/wasm/regress-riscv-float-branch.js
+@@ -0,0 +1,33 @@
++// Copyright 2026 the V8 project authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++// Flags: --no-liftoff --no-wasm-loop-unrolling
++
++d8.file.execute('test/mjsunit/wasm/wasm-module-builder.js');
++
++// A zero left operand is commuted during instruction selection. When the
++// back-edge becomes the branch target, code generation must invert the
++// emitted comparison's result, not just swap the branch labels.
++for (const [comparison, expected] of [[kExprF32Gt, 1], [kExprF32Ge, 0]]) {
++  const builder = new WasmModuleBuilder();
++  builder.addFunction('loop', makeSig([kWasmF32], [kWasmF32]))
++      .addBody([
++        kExprBlock, kWasmVoid,
++          kExprLoop, kWasmVoid,
++            kExprLocalGet, 0,
++            ...wasmF32Const(1),
++            kExprF32Add,
++            kExprLocalTee, 0,
++            ...wasmF32Const(0),
++            comparison,
++            kExprBrIf, 1,
++            kExprBr, 0,
++          kExprEnd,
++        kExprEnd,
++        kExprLocalGet, 0,
++      ])
++      .exportFunc();
++  const instance = builder.instantiate();
++  assertEquals(expected, instance.exports.loop(-10));
++}

--- a/nodejs-lts-jod/v8-riscv-word32-compare.patch
+++ b/nodejs-lts-jod/v8-riscv-word32-compare.patch
@@ -1,0 +1,109 @@
+--- a/deps/v8/src/compiler/backend/riscv/instruction-selector-riscv64.cc
++++ b/deps/v8/src/compiler/backend/riscv/instruction-selector-riscv64.cc
+@@ -2009,26 +2009,6 @@
+ 
+ namespace {
+ 
+-#ifndef V8_COMPRESS_POINTERS
+-bool IsNodeUnsigned(Node* n) {
+-  NodeMatcher m(n);
+-
+-  if (m.IsLoad() || m.IsUnalignedLoad() || m.IsProtectedLoad()) {
+-    LoadRepresentation load_rep = LoadRepresentationOf(n->op());
+-    return load_rep.IsUnsigned();
+-  } else if (m.IsWord32AtomicLoad() || m.IsWord64AtomicLoad()) {
+-    AtomicLoadParameters atomic_load_params = AtomicLoadParametersOf(n->op());
+-    LoadRepresentation load_rep = atomic_load_params.representation();
+-    return load_rep.IsUnsigned();
+-  } else {
+-    return m.IsUint32Div() || m.IsUint32LessThan() ||
+-           m.IsUint32LessThanOrEqual() || m.IsUint32Mod() ||
+-           m.IsUint32MulHigh() || m.IsChangeFloat64ToUint32() ||
+-           m.IsTruncateFloat64ToUint32() || m.IsTruncateFloat32ToUint32();
+-  }
+-}
+-#endif
+-
+ // Shared routine for multiple word compare operations.
+ template <typename Adapter>
+ void VisitFullWord32Compare(InstructionSelectorT<Adapter>* selector,
+@@ -2049,78 +2029,11 @@
+   VisitCompare(selector, opcode, leftOp, rightOp, cont);
+ }
+ 
+-#ifndef V8_COMPRESS_POINTERS
+-template <typename Adapter>
+-void VisitOptimizedWord32Compare(InstructionSelectorT<Adapter>* selector,
+-                                 Node* node, InstructionCode opcode,
+-                                 FlagsContinuationT<Adapter>* cont) {
+-  if (v8_flags.debug_code) {
+-    RiscvOperandGeneratorT<Adapter> g(selector);
+-    InstructionOperand leftOp = g.TempRegister();
+-    InstructionOperand rightOp = g.TempRegister();
+-    InstructionOperand optimizedResult = g.TempRegister();
+-    InstructionOperand fullResult = g.TempRegister();
+-    FlagsCondition condition = cont->condition();
+-    InstructionCode testOpcode = opcode |
+-                                 FlagsConditionField::encode(condition) |
+-                                 FlagsModeField::encode(kFlags_set);
+-
+-    selector->Emit(testOpcode, optimizedResult, g.UseRegister(node->InputAt(0)),
+-                   g.UseRegister(node->InputAt(1)));
+-
+-    selector->Emit(kRiscvShl64, leftOp, g.UseRegister(node->InputAt(0)),
+-                   g.TempImmediate(32));
+-    selector->Emit(kRiscvShl64, rightOp, g.UseRegister(node->InputAt(1)),
+-                   g.TempImmediate(32));
+-    selector->Emit(testOpcode, fullResult, leftOp, rightOp);
+-
+-    selector->Emit(kRiscvAssertEqual, g.NoOutput(), optimizedResult, fullResult,
+-                   g.TempImmediate(static_cast<int>(
+-                       AbortReason::kUnsupportedNonPrimitiveCompare)));
+-  }
+-
+-  VisitWordCompare(selector, node, opcode, cont, false);
+-}
+-#endif
+ template <typename Adapter>
+ void VisitWord32Compare(InstructionSelectorT<Adapter>* selector,
+                         typename Adapter::node_t node,
+                         FlagsContinuationT<Adapter>* cont) {
+-  if constexpr (Adapter::IsTurboshaft) {
+-    VisitFullWord32Compare(selector, node, kRiscvCmp, cont);
+-  } else {
+-    // RISC-V doesn't support Word32 compare instructions. Instead it relies
+-    // that the values in registers are correctly sign-extended and uses
+-    // Word64 comparison instead. This behavior is correct in most cases,
+-    // but doesn't work when comparing signed with unsigned operands.
+-    // We could simulate full Word32 compare in all cases but this would
+-    // create an unnecessary overhead since unsigned integers are rarely
+-    // used in JavaScript.
+-    // The solution proposed here tries to match a comparison of signed
+-    // with unsigned operand, and perform full Word32Compare only
+-    // in those cases. Unfortunately, the solution is not complete because
+-    // it might skip cases where Word32 full compare is needed, so
+-    // basically it is a hack.
+-    // When call to a host function in simulator, if the function return a
+-    // int32 value, the simulator do not sign-extended to int64 because in
+-    // simulator we do not know the function whether return a int32 or int64.
+-    // so we need do a full word32 compare in this case.
+-#ifndef V8_COMPRESS_POINTERS
+-#ifndef USE_SIMULATOR
+-    if (IsNodeUnsigned(node->InputAt(0)) != IsNodeUnsigned(node->InputAt(1))) {
+-#else
+-    if (IsNodeUnsigned(node->InputAt(0)) != IsNodeUnsigned(node->InputAt(1)) ||
+-        node->InputAt(0)->opcode() == IrOpcode::kCall ||
+-        node->InputAt(1)->opcode() == IrOpcode::kCall) {
+-#endif
+-      VisitFullWord32Compare(selector, node, kRiscvCmp, cont);
+-    } else {
+-      VisitOptimizedWord32Compare(selector, node, kRiscvCmp, cont);
+-    }
+-#else
+-    VisitFullWord32Compare(selector, node, kRiscvCmp, cont);
+-#endif
+-  }
++  VisitFullWord32Compare(selector, node, kRiscvCmp, cont);
+ }
+ 
+ template <typename Adapter>

--- a/nodejs-lts-jod/v8-riscv-word32-zero.patch
+++ b/nodejs-lts-jod/v8-riscv-word32-zero.patch
@@ -1,0 +1,49 @@
+--- a/deps/v8/src/compiler/backend/riscv/instruction-selector-riscv64.cc
++++ b/deps/v8/src/compiler/backend/riscv/instruction-selector-riscv64.cc
+@@ -2037,6 +2037,18 @@
+ }
+
+ template <typename Adapter>
++void VisitWord32CompareZero(InstructionSelectorT<Adapter>* selector,
++                           typename Adapter::node_t value,
++                           FlagsContinuationT<Adapter>* cont) {
++  // Wasm i32 stack arguments can have unspecified upper bits.
++  RiscvOperandGeneratorT<Adapter> g(selector);
++  InstructionOperand input = g.TempRegister();
++  selector->Emit(kRiscvSignExtendWord, input, g.UseRegister(value),
++                 g.TempImmediate(0));
++  selector->EmitWithContinuation(kRiscvCmpZero, input, cont);
++}
++
++template <typename Adapter>
+ void VisitWord64Compare(InstructionSelectorT<Adapter>* selector,
+                         typename Adapter::node_t node,
+                         FlagsContinuationT<Adapter>* cont) {
+@@ -2410,7 +2422,11 @@
+
+     // Continuation could not be combined with a compare, emit compare against
+     // 0.
+-    EmitWordCompareZero(this, value, cont);
++    if (user->opcode() == IrOpcode::kWord64Equal) {
++      EmitWordCompareZero(this, value, cont);
++    } else {
++      VisitWord32CompareZero(this, value, cont);
++    }
+ }
+
+ template <>
+@@ -2511,7 +2527,13 @@
+
+   // Continuation could not be combined with a compare, emit compare against
+   // 0.
+-  EmitWordCompareZero(this, value, cont);
++  const ComparisonOp* comparison = Get(user).TryCast<ComparisonOp>();
++  if (comparison &&
++      comparison->rep.value() == RegisterRepresentation::Word64()) {
++    EmitWordCompareZero(this, value, cont);
++  } else {
++    VisitWord32CompareZero(this, value, cont);
++  }
+ }
+
+ template <typename Adapter>


### PR DESCRIPTION
Backport the V8 fix to compare the low 32 bits on riscv64. Stale upper
bits in Wasm stack arguments make TurboFan miscompare loop limits,
causing SWC to panic with an out-of-bounds index during the Grafana build.
Omit unit-test hunks for files absent from Node's release tarball.

Also truncate i32 values before zero checks in both instruction selectors.
The comparison backport leaves this path untouched, so stale upper
bits can make an empty SWC list appear nonempty. Preserve explicit
64-bit zero comparisons.

Apply the floating-point branch fix from nodejs: lower
less-than-or-unordered and less-than-or-equal-or-unordered as negated
GE and GT predicates. This keeps branch inversion consistent with the
emitted comparison, including NaNs. Include its regression test.

Backport the upstream CCM test fix to accept both old and new OpenSSL
finalization behavior. Disable the Wasm trap handler in the worker
messaging test to avoid exhausting Sv39 address space, and increase the
watch restart timeout from one to four seconds for slower builders.

Limit the test runner to eight jobs. It ignores MAKEFLAGS and otherwise
starts 128 tests at once on glalie, causing widespread timeouts.
Accept EPIPE when the closed-channel test sends to an exited worker.

Upstream:
https://github.com/v8/v8/commit/1f69656648fc23f5d1d4d4c38904b76d8feceee8
https://github.com/nodejs/node/commit/40eac4a32f3676b286fd44435be4514962a40b79
https://github.com/nodejs/node/issues/38392