### PR TITLE
addpatch: rsync 3.5.0-1

### DIFF
--- a/rsync/riscv64.patch
+++ b/rsync/riscv64.patch
@@ -1,0 +1,18 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -21,6 +21,15 @@
+             '733ccb571721433c3a6262c58b658253ca6553bec79c2bdd0011810bb4f2156b')
+ 
+ _backports=(
++  # Recognize /dev/fd pins, required by the process-substitution fix below.
++  # https://github.com/RsyncProject/rsync/pull/1048
++  324a1f0716aa75d311f879864f48408d5723d963
++  # Fix process-substitution filter files (/dev/fd/*), used by PCP packaging.
++  # https://github.com/RsyncProject/rsync/pull/1054
++  a68b32cd5c3a28fe7f752977a1e85b828d227ba6
++  # Avoid hanging on captured output from the protected-regular unshare probe.
++  # https://github.com/RsyncProject/rsync/pull/1049
++  3d2caaa0cb1b316f60b57a4036b42cd687eea561
+ )
+ 
+ _reverts=(


### PR DESCRIPTION
Backport the upstream fix for process-substitution filter files through _backports. Rsync 3.5.0 resolves /dev/fd symlink targets such as pipe:[...] as filesystem paths, causing PCP 7.2.0-2 packaging to fail with "failed to open exclude file /dev/fd/63: No such file or directory (2)".

Handle kernel pseudo-paths correctly in rsync instead of working around the architecture-independent regression in PCP.

Include the prerequisite that teaches fd_pin_tail() to recognize /dev/fd. Without it, the pseudo-path fix never activates for Bash's descriptor paths, and pseudo-paths still fails to open /dev/fd/63 with ENOENT.

Backport the protected-regular unshare probe fix. Helpers can retain the captured output pipes after unshare exits, hanging the test until its 300-second timeout. Redirect the probe's streams to /dev/null and bound it to five seconds, as upstream does for this chroot-related failure.

Upstream:
https://github.com/RsyncProject/rsync/commit/a68b32cd5c3a28fe7f752977a1e85b828d227ba6 https://github.com/RsyncProject/rsync/commit/324a1f0716aa75d311f879864f48408d5723d963 https://github.com/RsyncProject/rsync/commit/3d2caaa0cb1b316f60b57a4036b42cd687eea561