### PR TITLE
addpatch: python-soxr 1.1.0-2

### DIFF
--- a/python-soxr/riscv64.patch
+++ b/python-soxr/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -32,6 +32,7 @@
+ prepare() {
+   cd python-soxr
+   rm -rf libsoxr
++  sed -i 's/nanobind >=2, <3/nanobind >=2, <4/' pyproject.toml
+ }
+
+ build() {


### PR DESCRIPTION
Raise the nanobind upper bound to <4. The <3 constraint rejects the installed nanobind 3.0.1 before compilation. The bindings do not use the APIs affected by nanobind 3 breaking changes.