### PR TITLE
addpatch: numactl 2.0.19-1

### DIFF
--- a/numactl/riscv64.patch
+++ b/numactl/riscv64.patch
@@ -1,0 +1,9 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -21,4 +21,6 @@
+ prepare(){
+   cd $pkgname-$pkgver
++  # Keep the highest node in memhog's mask: the kernel subtracts one from maxnode.
++  sed -i '/if (mbind(/s/nodes->size/nodes->size + 1/' memhog.c
+   autoreconf -fiv
+ }

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -96,6 +96,7 @@ nodejs
 nodejs-lts-iron
 nodejs-lts-jod
 nodejs-lts-krypton
+numactl
 nushell
 odin2-synthesizer
 openh264


### PR DESCRIPTION
Pass nodes->size + 1 to memhog's mbind call. The kernel subtracts one from maxnode, so glalie's eight-bit mask loses node 7. This causes "mbind: Invalid argument" and the remaining test/regress failure.

Route builds away from QEMU user mode, whose missing get_mempolicy syscall and synthetic CPU field in /proc/self/stat cause six checks to fail on magby.

https://github.com/numactl/numactl/issues/194#issuecomment-1759081492 https://github.com/qemu/qemu/blob/v11.0.3/linux-user/syscall.c