### PR TITLE
addpatch: haskell-primitive 0.9.1.0-209

### DIFF
--- a/haskell-primitive/fix-signed-memset.patch
+++ b/haskell-primitive/fix-signed-memset.patch
@@ -1,0 +1,47 @@
+--- a/Data/Primitive/Internal/Operations.hs
++++ b/Data/Primitive/Internal/Operations.hs
+@@ -71,10 +71,16 @@
+
+ #if __GLASGOW_HASKELL__ >= 902
+-foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word8"
+-  setInt8Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int8# -> IO ()
+-foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word16"
+-  setInt16Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int16# -> IO ()
+-foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word32"
+-  setInt32Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int32# -> IO ()
++-- Match the unsigned C arguments to avoid incorrect sign extension.
++setInt8Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int8# -> IO ()
++setInt8Array# arr off n x = setWord8Array# arr off n (int8ToWord8# x)
++{-# INLINE setInt8Array# #-}
++
++setInt16Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int16# -> IO ()
++setInt16Array# arr off n x = setWord16Array# arr off n (int16ToWord16# x)
++{-# INLINE setInt16Array# #-}
++
++setInt32Array# :: MutableByteArray# s -> CPtrdiff -> CSize -> Int32# -> IO ()
++setInt32Array# arr off n x = setWord32Array# arr off n (int32ToWord32# x)
++{-# INLINE setInt32Array# #-}
+ #else
+ foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word8"
+@@ -124,10 +130,15 @@
+
+ #if __GLASGOW_HASKELL__ >= 902
+-foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word8"
+-  setInt8OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int8# -> IO ()
+-foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word16"
+-  setInt16OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int16# -> IO ()
+-foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word32"
+-  setInt32OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int32# -> IO ()
++setInt8OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int8# -> IO ()
++setInt8OffAddr# addr off n x = setWord8OffAddr# addr off n (int8ToWord8# x)
++{-# INLINE setInt8OffAddr# #-}
++
++setInt16OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int16# -> IO ()
++setInt16OffAddr# addr off n x = setWord16OffAddr# addr off n (int16ToWord16# x)
++{-# INLINE setInt16OffAddr# #-}
++
++setInt32OffAddr# :: Addr# -> CPtrdiff -> CSize -> Int32# -> IO ()
++setInt32OffAddr# addr off n x = setWord32OffAddr# addr off n (int32ToWord32# x)
++{-# INLINE setInt32OffAddr# #-}
+ #else
+ foreign import ccall unsafe "primitive-memops.h hsprimitive_memset_Word8"

--- a/haskell-primitive/riscv64.patch
+++ b/haskell-primitive/riscv64.patch
@@ -1,0 +1,13 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,6 +17,10 @@
+ sha512sums=('e57face42b62a6ae552ad2f3a20251bc7e4913d7114355535f1581899da9c45d33b27976fc09670452dbe870b3bac00d0831c0556756ae831c9121769b7e6a05')
+
++source+=(fix-signed-memset.patch)
++sha512sums+=('bfcb2ce78fb63d2e1ba7ae0082e538184bf6de37951deb482c7446fceab4b08b5f4ec85b1341fd55231886390a6dd60d549b2b843aef15c62c04296f8ee1b2ed')
++
+ prepare() {
+   cd primitive-$pkgver
++  patch -p1 -i ../fix-signed-memset.patch
+   gen-setup
+ }


### PR DESCRIPTION
Convert narrow signed fill arguments to their unsigned equivalents before calling the C helpers. The mismatched FFI declarations sign-extend negative Int16 values on riscv64, making a fill with -2 produce [-2,-1,-1,-1] and causing 13 test failures. Apply the conversion to arrays and pointers.