### PR TITLE
updpatch: keycloak 26.7.3-1

### DIFF
--- a/keycloak/riscv64.patch
+++ b/keycloak/riscv64.patch
@@ -1,19 +1,29 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -34,6 +34,7 @@ prepare() {
+@@ -34,11 +34,17 @@
    cd $pkgname-$pkgver
  
    patch -Np1 -i "$srcdir"/pin-java-version.patch
 +  patch -Np1 -i "$srcdir"/use-system-node.patch
++  # Use Rollup's parser instead of ast-grep's unavailable riscv64 bindings.
++  cp "$srcdir"/use-rollup-parser.patch js/
  }
  
  build() {
-@@ -83,4 +84,8 @@ package() {
-   install -Dm 644 LICENSE.txt "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE.txt"
+   cd $pkgname-$pkgver
+ 
++  # Use Kiota's managed .NET tool; its npm wrapper rejects riscv64.
++  dotnet tool install --local --create-manifest-if-needed Microsoft.OpenApi.Kiota --version 1.32.4
++
+   export PATH="/usr/lib/jvm/java-${_java}-openjdk/bin:$PATH"
+   mvn -am \
+     -s maven-settings.xml \
+@@ -84,3 +90,8 @@
  }
  
-+makedepends+=('nodejs' 'npm' 'pnpm')
-+source+=(use-system-node.patch)
-+sha512sums+=('444c7b4b729abbfb11d18a3b12de51afdc67c2fb405be55d4de8e99fe33a8dab93b2c02773ecd4bef9a392696fd1a5169712faffae75d09095452844f70db757')
-+
  # vim: ts=2 sw=2 et:
++
++makedepends+=('nodejs' 'npm' 'pnpm' 'dotnet-sdk')
++source+=(use-system-node.patch use-rollup-parser.patch)
++sha512sums+=('1d994bfba2a3972f0924d184d8e2b67f20d18717a0ade4265f1d888d3f9fcf84048c6864e5558fb928ac69dc6a8ced80d164b4e0ab675a12d8a12da85904dbba'
++            '5753aabc3a4fc533dedb2f353049116eb69675c06db81ebe3d73f1790c985ae9341acf8f39aecd75b32432275b0f8571b66097d4652e794b5a6f795a0f0da737')

--- a/keycloak/use-rollup-parser.patch
+++ b/keycloak/use-rollup-parser.patch
@@ -1,0 +1,55 @@
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -1,11 +1,10 @@
+ // src/index.ts
+ import path from "node:path";
+-import { Lang, parse } from "@ast-grep/napi";
+ import MagicString from "magic-string";
+ import color from "picocolors";
+ var excludeTokens = [
+-  "import_statement",
+-  "expression_statement"
++  "ImportDeclaration",
++  "ExpressionStatement"
+ ];
+ var pluginName = "vite:lib-inject-css";
+ function libInjectCss() {
+@@ -69,8 +68,8 @@
+         if (chunk.type !== "chunk" || !chunk.viteMetadata?.importedCss.size) {
+           continue;
+         }
+-        const node = parse(Lang.JavaScript, chunk.code).root().children().find((node2) => !excludeTokens.includes(node2.kind()));
+-        const position = node?.range().start.index ?? 0;
++        const node = this.parse(chunk.code).body.find((node2) => !excludeTokens.includes(node2.type));
++        const position = node?.start ?? 0;
+         let code = chunk.code;
+         for (const cssFileName of chunk.viteMetadata.importedCss) {
+           let cssFilePath = path.relative(path.dirname(chunk.fileName), cssFileName).replaceAll(/[\\/]+/g, "/");
+--- a/dist/index.cjs
++++ b/dist/index.cjs
+@@ -34,12 +34,11 @@
+ });
+ module.exports = __toCommonJS(index_exports);
+ var import_node_path = __toESM(require("path"), 1);
+-var import_napi = require("@ast-grep/napi");
+ var import_magic_string = __toESM(require("magic-string"), 1);
+ var import_picocolors = __toESM(require("picocolors"), 1);
+ var excludeTokens = [
+-  "import_statement",
+-  "expression_statement"
++  "ImportDeclaration",
++  "ExpressionStatement"
+ ];
+ var pluginName = "vite:lib-inject-css";
+ function libInjectCss() {
+@@ -103,8 +102,8 @@
+         if (chunk.type !== "chunk" || !chunk.viteMetadata?.importedCss.size) {
+           continue;
+         }
+-        const node = (0, import_napi.parse)(import_napi.Lang.JavaScript, chunk.code).root().children().find((node2) => !excludeTokens.includes(node2.kind()));
+-        const position = node?.range().start.index ?? 0;
++        const node = this.parse(chunk.code).body.find((node2) => !excludeTokens.includes(node2.type));
++        const position = node?.start ?? 0;
+         let code = chunk.code;
+         for (const cssFileName of chunk.viteMetadata.importedCss) {
+           let cssFilePath = import_node_path.default.relative(import_node_path.default.dirname(chunk.fileName), cssFileName).replaceAll(/[\\/]+/g, "/");

--- a/keycloak/use-system-node.patch
+++ b/keycloak/use-system-node.patch
@@ -1,371 +1,106 @@
-diff --git a/.mvn/maven-build-cache-config.xml b/.mvn/maven-build-cache-config.xml
-index fc667dca1a..b1dcb12e3e 100644
---- a/.mvn/maven-build-cache-config.xml
-+++ b/.mvn/maven-build-cache-config.xml
-@@ -27,22 +27,11 @@
-             <!-- matching all files, as there is no good file pattern to match files in META-INF/services by their file name -->
-             <glob>{*}</glob>
-         </global>
--        <plugins>
--            <plugin groupId="com.github.eirslett" artifactId="frontend-maven-plugin">
--                <dirScan>
--                    <excludes>
--                        <exclude tagName="installDirectory" />
--                    </excludes>
--                </dirScan>
--            </plugin>
--        </plugins>
-     </input>
-     <executionControl>
-         <runAlways>
-             <plugins>
-                 <plugin artifactId="maven-failsafe-plugin"/>
--                <!-- The Maven Frontend plugin will build all JS parts in the subfolders, and has its own caching, therefore, run it always -->
--                <plugin groupId="com.github.eirslett" artifactId="frontend-maven-plugin"/>
-             </plugins>
-             <goalsLists>
-                 <goalsList artifactId="maven-install-plugin">
-@@ -66,4 +55,4 @@
-             </plugins>
-         </reconcile>
-     </executionControl>
--</cache>
-\ No newline at end of file
-+</cache>
-diff --git a/js/apps/account-ui/pom.xml b/js/apps/account-ui/pom.xml
-index bec5ec69b4..0d7026aa04 100644
---- a/js/apps/account-ui/pom.xml
-+++ b/js/apps/account-ui/pom.xml
-@@ -37,26 +37,33 @@
-             <build>
-                 <plugins>
-                     <plugin>
--                        <groupId>com.github.eirslett</groupId>
--                        <artifactId>frontend-maven-plugin</artifactId>
-+                        <groupId>org.codehaus.mojo</groupId>
-+                        <artifactId>exec-maven-plugin</artifactId>
-                         <executions>
-                             <execution>
-                                 <id>pnpm-build-lib</id>
-                                 <goals>
--                                    <goal>pnpm</goal>
-+                                    <goal>exec</goal>
-                                 </goals>
-                                 <configuration>
--                                    <arguments>build-lib</arguments>
-+                                    <executable>pnpm</executable>
-+                                    <arguments>
-+                                        <argument>build-lib</argument>
-+                                    </arguments>
-                                 </configuration>
-                             </execution>
-                             <execution>
-                                 <id>pnpm-pack</id>
-                                 <phase>package</phase>
-                                 <goals>
--                                    <goal>pnpm</goal>
-+                                    <goal>exec</goal>
-                                 </goals>
-                                 <configuration>
--                                    <arguments>pack --pack-destination=target</arguments>
-+                                    <executable>pnpm</executable>
-+                                    <arguments>
-+                                        <argument>pack</argument>
-+                                        <argument>--pack-destination=target</argument>
-+                                    </arguments>
-                                 </configuration>
-                             </execution>
-                         </executions>
-@@ -81,4 +88,4 @@
-             </plugin>
-         </plugins>
-     </build>
--</project>
-\ No newline at end of file
-+</project>
-diff --git a/js/apps/admin-ui/pom.xml b/js/apps/admin-ui/pom.xml
-index 7cc0f8988a..39497063f8 100644
---- a/js/apps/admin-ui/pom.xml
-+++ b/js/apps/admin-ui/pom.xml
-@@ -37,26 +37,33 @@
-             <build>
-                 <plugins>
-                     <plugin>
--                        <groupId>com.github.eirslett</groupId>
--                        <artifactId>frontend-maven-plugin</artifactId>
-+                        <groupId>org.codehaus.mojo</groupId>
-+                        <artifactId>exec-maven-plugin</artifactId>
-                         <executions>
-                             <execution>
-                                 <id>pnpm-build-lib</id>
-                                 <goals>
--                                    <goal>pnpm</goal>
-+                                    <goal>exec</goal>
-                                 </goals>
-                                 <configuration>
--                                    <arguments>build-lib</arguments>
-+                                    <executable>pnpm</executable>
-+                                    <arguments>
-+                                        <argument>build-lib</argument>
-+                                    </arguments>
-                                 </configuration>
-                             </execution>
-                             <execution>
-                                 <id>pnpm-pack</id>
-                                 <phase>package</phase>
-                                 <goals>
--                                    <goal>pnpm</goal>
-+                                    <goal>exec</goal>
-                                 </goals>
-                                 <configuration>
--                                    <arguments>pack --pack-destination=target</arguments>
-+                                    <executable>pnpm</executable>
-+                                    <arguments>
-+                                        <argument>pack</argument>
-+                                        <argument>--pack-destination=target</argument>
-+                                    </arguments>
-                                 </configuration>
-                             </execution>
-                         </executions>
-@@ -81,4 +88,4 @@
-             </plugin>
-         </plugins>
-     </build>
--</project>
-\ No newline at end of file
-+</project>
-diff --git a/js/apps/create-keycloak-theme/templates/pom.xml.mu b/js/apps/create-keycloak-theme/templates/pom.xml.mu
-index 0892fbaa95..bc8fc82a4d 100644
---- a/js/apps/create-keycloak-theme/templates/pom.xml.mu
-+++ b/js/apps/create-keycloak-theme/templates/pom.xml.mu
-@@ -26,39 +26,37 @@
- 
-         <plugins>
-             <plugin>
--                <groupId>com.github.eirslett</groupId>
--                <artifactId>frontend-maven-plugin</artifactId>
--                <version>1.15.0</version>
-+                <groupId>org.codehaus.mojo</groupId>
-+                <artifactId>exec-maven-plugin</artifactId>
-+                <version>3.5.0</version>
-                 <executions>
--                    <execution>
--                        <goals>
--                            <goal>install-node-and-npm</goal>
--                        </goals>
--                    </execution>
-                     <execution>
-                         <id>npm-install</id>
-                         <goals>
--                            <goal>npm</goal>
-+                            <goal>exec</goal>
-                         </goals>
-                         <configuration>
--                            <arguments>install</arguments>
-+                            <executable>npm</executable>
-+                            <arguments>
-+                                <argument>install</argument>
-+                            </arguments>
-                             <workingDirectory>${maven.multiModuleProjectDirectory}</workingDirectory>
-                         </configuration>
-                     </execution>
-                     <execution>
-                         <id>npm-build</id>
-                         <goals>
--                            <goal>npm</goal>
-+                            <goal>exec</goal>
-                         </goals>
-                         <configuration>
--                            <arguments>run build</arguments>
-+                            <executable>npm</executable>
-+                            <arguments>
-+                                <argument>run</argument>
-+                                <argument>build</argument>
-+                            </arguments>
-                         </configuration>
-                     </execution>
-                 </executions>
--                <configuration>
--                    <nodeVersion>${node.version}</nodeVersion>
--                    <installDirectory>${maven.multiModuleProjectDirectory}</installDirectory>
--                </configuration>
-             </plugin>
-         </plugins>
-     </build>
-diff --git a/js/libs/keycloak-admin-client/pom.xml b/js/libs/keycloak-admin-client/pom.xml
-index b796d0a104..107a91370f 100644
---- a/js/libs/keycloak-admin-client/pom.xml
-+++ b/js/libs/keycloak-admin-client/pom.xml
-@@ -39,17 +39,21 @@
-                         </executions>
-                     </plugin>
-                     <plugin>
--                        <groupId>com.github.eirslett</groupId>
--                        <artifactId>frontend-maven-plugin</artifactId>
-+                        <groupId>org.codehaus.mojo</groupId>
-+                        <artifactId>exec-maven-plugin</artifactId>
-                         <executions>
-                             <execution>
-                                 <id>pnpm-pack</id>
-                                 <phase>package</phase>
-                                 <goals>
--                                    <goal>pnpm</goal>
-+                                    <goal>exec</goal>
-                                 </goals>
-                                 <configuration>
--                                    <arguments>pack --pack-destination=target</arguments>
-+                                    <executable>pnpm</executable>
-+                                    <arguments>
-+                                        <argument>pack</argument>
-+                                        <argument>--pack-destination=target</argument>
-+                                    </arguments>
-                                 </configuration>
-                             </execution>
-                         </executions>
-diff --git a/js/libs/keycloak-js/pom.xml b/js/libs/keycloak-js/pom.xml
-index 8c2261230d..6296e503cf 100644
---- a/js/libs/keycloak-js/pom.xml
-+++ b/js/libs/keycloak-js/pom.xml
-@@ -39,17 +39,21 @@
-                         </executions>
-                     </plugin>
-                     <plugin>
--                        <groupId>com.github.eirslett</groupId>
--                        <artifactId>frontend-maven-plugin</artifactId>
-+                        <groupId>org.codehaus.mojo</groupId>
-+                        <artifactId>exec-maven-plugin</artifactId>
-                         <executions>
-                             <execution>
-                                 <id>pnpm-pack</id>
-                                 <phase>package</phase>
-                                 <goals>
--                                    <goal>pnpm</goal>
-+                                    <goal>exec</goal>
-                                 </goals>
-                                 <configuration>
--                                    <arguments>pack --pack-destination=target</arguments>
-+                                    <executable>pnpm</executable>
-+                                    <arguments>
-+                                        <argument>pack</argument>
-+                                        <argument>--pack-destination=target</argument>
-+                                    </arguments>
-                                 </configuration>
-                             </execution>
-                         </executions>
-diff --git a/js/libs/ui-shared/pom.xml b/js/libs/ui-shared/pom.xml
-index ecd11567ff..5eff501cf6 100644
---- a/js/libs/ui-shared/pom.xml
-+++ b/js/libs/ui-shared/pom.xml
-@@ -39,17 +39,21 @@
-                         </executions>
-                     </plugin>
-                     <plugin>
--                        <groupId>com.github.eirslett</groupId>
--                        <artifactId>frontend-maven-plugin</artifactId>
-+                        <groupId>org.codehaus.mojo</groupId>
-+                        <artifactId>exec-maven-plugin</artifactId>
-                         <executions>
-                             <execution>
-                                 <id>pnpm-pack</id>
-                                 <phase>package</phase>
-                                 <goals>
--                                    <goal>pnpm</goal>
-+                                    <goal>exec</goal>
-                                 </goals>
-                                 <configuration>
--                                    <arguments>pack --pack-destination=target</arguments>
-+                                    <executable>pnpm</executable>
-+                                    <arguments>
-+                                        <argument>pack</argument>
-+                                        <argument>--pack-destination=target</argument>
-+                                    </arguments>
-                                 </configuration>
-                             </execution>
-                         </executions>
-diff --git a/js/pom.xml b/js/pom.xml
-index 194718c076..4c49dca04b 100644
 --- a/js/pom.xml
 +++ b/js/pom.xml
-@@ -34,22 +34,6 @@
-     </properties>
- 
-     <build>
--        <pluginManagement>
--            <plugins>
--                <plugin>
--                    <groupId>com.github.eirslett</groupId>
--                    <artifactId>frontend-maven-plugin</artifactId>
--                    <version>${frontend.plugin.version}</version>
--                    <configuration>
--                        <nodeVersion>${node.version}</nodeVersion>
--                        <pnpmVersion>${pnpm.version}</pnpmVersion>
--                        <installDirectory>${maven.multiModuleProjectDirectory}/js</installDirectory>
--                        <pnpmInheritsProxyConfigFromMaven>false</pnpmInheritsProxyConfigFromMaven>
--                    </configuration>
--                </plugin>
--            </plugins>
--        </pluginManagement>
--
-         <plugins>
-             <plugin>
-                 <!-- Clean child modules from parent, as we trigger the build here for parallelization. -->
-@@ -69,32 +53,35 @@
+@@ -96,50 +96,39 @@
                  </configuration>
              </plugin>
              <plugin>
 -                <groupId>com.github.eirslett</groupId>
 -                <artifactId>frontend-maven-plugin</artifactId>
--                <version>${frontend.plugin.version}</version>
 +                <groupId>org.codehaus.mojo</groupId>
 +                <artifactId>exec-maven-plugin</artifactId>
-+                <version>${exec.plugin.version}</version>
                  <inherited>false</inherited>
                  <executions>
--                    <execution>
+                     <execution>
 -                        <goals>
 -                            <goal>install-node-and-pnpm</goal>
 -                        </goals>
+-                        <phase>initialize</phase>
 -                    </execution>
-                     <execution>
+-                    <execution>
                          <id>pnpm-install</id>
++                        <phase>generate-resources</phase>
                          <goals>
 -                            <goal>pnpm</goal>
 +                            <goal>exec</goal>
                          </goals>
                          <configuration>
--                            <arguments>install --prefer-offline --frozen-lockfile --ignore-scripts</arguments>
+-                            <arguments>install --prefer-offline --frozen-lockfile --ignore-scripts --config.confirmModulesPurge=false</arguments>
 +                            <executable>pnpm</executable>
 +                            <arguments>
 +                                <argument>install</argument>
-+                                <argument>--frozen-lockfile</argument>
++                                <argument>--prefer-offline</argument>
++                                <argument>--no-frozen-lockfile</argument>
 +                                <argument>--ignore-scripts</argument>
++                                <argument>--config.confirmModulesPurge=false</argument>
 +                            </arguments>
                          </configuration>
                      </execution>
                      <execution>
                          <id>pnpm-build</id>
++                        <phase>generate-resources</phase>
                          <goals>
 -                            <goal>pnpm</goal>
 +                            <goal>exec</goal>
                          </goals>
                          <configuration>
 -                            <arguments>build</arguments>
+-                        </configuration>
+-                    </execution>
+-                </executions>
+-            </plugin>
+-            <!-- newer versions of pnpm do not have an executable cjs file, see https://github.com/eirslett/frontend-maven-plugin/issues/1224 -->
+-            <plugin>
+-                <artifactId>maven-antrun-plugin</artifactId>
+-                <executions>
+-                    <execution>
+-                        <phase>initialize</phase>
+-                        <configuration>
+-                            <target>
+-                                <chmod file="${maven.multiModuleProjectDirectory}/js/node/node_modules/pnpm/bin/pnpm.cjs" perm="755"/>
+-                            </target>
 +                            <executable>pnpm</executable>
 +                            <arguments>
 +                                <argument>build</argument>
 +                            </arguments>
                          </configuration>
+-                        <goals>
+-                            <goal>run</goal>
+-                        </goals>
                      </execution>
                  </executions>
-diff --git a/pom.xml b/pom.xml
-index cbb44ed569..33a50d9f2b 100644
---- a/pom.xml
-+++ b/pom.xml
-@@ -196,6 +196,7 @@
-         <nexus.staging.plugin.version>1.6.13</nexus.staging.plugin.version>
-         <nexus3.staging.plugin.version>1.0.7</nexus3.staging.plugin.version>
-         <frontend.plugin.version>1.15.0</frontend.plugin.version>
-+        <exec.plugin.version>3.5.0</exec.plugin.version>
-         <docker.maven.plugin.version>0.40.3</docker.maven.plugin.version>
-         <verifier.plugin.version>1.1</verifier.plugin.version>
-         <shade.plugin.version>3.4.1</shade.plugin.version>
+             </plugin>
+--- a/js/pnpm-workspace.yaml
++++ b/js/pnpm-workspace.yaml
+@@ -27,6 +27,9 @@
+   - patternfly-bootstrap-combobox
+   - patternfly-bootstrap-treeview
+ overrides:
++  # These packages do not provide native riscv64 bindings.
++  '@swc/core': npm:@swc/wasm@1.15.8
++  lightningcss: npm:lightningcss-wasm@1.30.2
+   serialize-javascript: ^7.0.5
+   'brace-expansion@^1': ^1.1.13
+   'brace-expansion@^2': ^2.0.3
+@@ -35,6 +38,8 @@
+   jquery@^3: ^3.7.1
+   lodash: ^4.17.23
+   mdast-util-to-hast: ^13.2.1
++patchedDependencies:
++  vite-plugin-lib-inject-css@2.2.2: use-rollup-parser.patch
+ allowBuilds:
+   '@swc/core': true
+   esbuild: true
+--- a/js/libs/keycloak-admin-client/package.json
++++ b/js/libs/keycloak-admin-client/package.json
+@@ -49,10 +49,7 @@
+       ]
+     },
+     "generate:openapi": {
+-      "command": "kiota generate -l typescript -d openapi.json -c AdminClient -n ApiSdk -o ./src/generated --clean-output",
+-      "env": {
+-        "KIOTA_VERSION": "v1.32.4"
+-      },
++      "command": "dotnet tool run kiota -- generate -l typescript -d openapi.json -c AdminClient -n ApiSdk -o ./src/generated --clean-output",
+       "files": [
+         "openapi.json"
+       ],

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -63,6 +63,7 @@ hyperfine
 iaito
 ihaskell
 keepassxc
+keycloak
 knot
 libaio
 libcuckoo

--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -7,6 +7,7 @@ gitea
 grafana
 grafana-agent
 jupyter-nbclassic
+keycloak
 navidrome
 openbao
 oxyromon

--- a/sv57-blacklist.txt
+++ b/sv57-blacklist.txt
@@ -1,0 +1,1 @@
+keycloak


### PR DESCRIPTION
Refresh the system-Node patch for the removed keycloak-js module and changed POMs. Limit it to the active JavaScript build path and remove the downloaded-pnpm chmod step. Bind install and build explicitly to generate-resources: exec-maven-plugin has no default lifecycle phase.

Use matching-version WASM packages for SWC and Lightning CSS, which lack native riscv64 bindings. Allow pnpm to update the lockfile for these overrides and the dependency patch. Add keycloak to the Sv39 blacklist because the UI build executes WebAssembly.

Use the Rollup parser in vite-plugin-lib-inject-css instead of ast-grep, whose native bindings also lack riscv64 support. Preserve CSS injection and the insertion point after imports and expression statements.

Install Kiota 1.32.4 as a local .NET tool and invoke it directly with dotnet tool run. The npm wrapper aborts with "Unsupported architecture: riscv64" during admin-client generation. The managed NuGet tool supports the packaged .NET runtime, preserving generation of the required client code without downloading an unsupported native executable.

Add keycloak to the qemu-user blacklist. On monferno, .NET first-run NuGet migration fails to create the NuGet-Migrations named mutex with pthread_mutex_init(...) == ENOTSUP/EOPNOTSUPP. It requires a process-shared robust mutex, but QEMU-user does not implement the robust-list syscalls, so glibc rejects its initialization.

Initialize the Sv57 blacklist with keycloak. On fennekin, Kiota installs successfully but OpenJDK 21.0.12.1+1 aborts before Maven starts with "Unsupported satp mode: SV57. Only satp modes up to sv48 are supported for now." Combined with the existing exclusions, this requires a non-qemu-user Sv48 builder.

https://github.com/openjdk/jdk21u/blob/jdk-21.0.12.1%2B1/src/hotspot/cpu/riscv/vm_version_riscv.cpp#L57