### PR TITLE
addpatch: scx-scheds 1.1.3-2

### DIFF
--- a/scx-scheds/fix-lavd-memcmp.patch
+++ b/scx-scheds/fix-lavd-memcmp.patch
@@ -1,0 +1,11 @@
+--- a/scheds/rust/scx_lavd/src/bpf/util.bpf.c
++++ b/scheds/rust/scx_lavd/src/bpf/util.bpf.c
+@@ -157,7 +157,7 @@
+ __hidden
+ bool is_ksoftirqd(struct task_struct *p)
+ {
+-	return is_kernel_task(p) && !__builtin_memcmp(p->comm, "ksoftirqd/", 10);
++	return is_kernel_task(p) && !bpf_strncmp(p->comm, 10, "ksoftirqd/");
+ }
+ 
+ __hidden

--- a/scx-scheds/riscv64.patch
+++ b/scx-scheds/riscv64.patch
@@ -1,0 +1,38 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -41,10 +41,24 @@
+   # Fix migration-disabled task stalls in LAVD (upstream PR #3748).
+   git cherry-pick --no-commit 6d31ddd8973333e95ae7e3584e84029533064d69
+ 
++  # BPF targets lack the RISC-V ABI macros required by glibc's errno.h.
++  sed -i 's|<errno.h>|<asm-generic/errno.h>|' \
++    scheds/rust/*/src/bpf/*.bpf.c scheds/include/scx/task_local_data.bpf.h
++
++  # Freestanding BPF must not emit a libc memcmp call.
++  patch -Np1 -i "$srcdir/fix-lavd-memcmp.patch"
++
++  # Use system protoc; perfetto_protos has no bundled riscv64 binary.
++  patch -Np1 -d ../perfetto_protos-0.51.1 -i "$srcdir/perfetto-protos-system-protoc.patch"
++  echo -e "\n[patch.crates-io]\nperfetto_protos = { path = '../perfetto_protos-0.51.1' }" >> Cargo.toml
++  cargo update -p perfetto_protos
+   cargo fetch --locked --target "$(rustc --print host-tuple)"
+ }
+ build() {
+   cd $_gitname
++  export PERFETTO_PROTOS_PROTOC=/usr/bin/protoc
++  # Keep Clang's limits.h from including glibc headers for the BPF target.
++  export BPF_EXTRA_CFLAGS_PRE_INCL=-ffreestanding
+   cargo build \
+      --release \
+      --frozen \
+@@ -65,3 +79,10 @@
+     -maxdepth 1 -type f -executable ! -name '*.so' \
+     -exec install -Dm755 -t "$pkgdir/usr/bin/" {} +
+ }
++
++source+=("perfetto_protos-0.51.1.tar.gz::https://static.crates.io/crates/perfetto_protos/perfetto_protos-0.51.1.crate"
++        "perfetto-protos-system-protoc.patch::https://github.com/a6f/perfetto_protos/commit/faf8cd21e19313ea72f63f6fa9d8d5dde9edaa9e.patch"
++        fix-lavd-memcmp.patch)
++sha256sums+=('634f88ebef917643d9e470dbf99637fbfa8295f54525954d156641f06823f9ac'
++             '60299d1118169a69ab87d1e09fd6e123996288611163c2932c0a1eb0ef79f58b'
++             '94af5cc1a0b2a0236231559eef8c6d843d4b774c3a965f5111acceb8527d621f')


### PR DESCRIPTION
perfetto_protos 0.51.1 unconditionally selects a vendored protoc and panics with Error { os: "linux", arch: "riscv64" } because no bundled binary supports this architecture.

Apply the upstream protoc override fix to the existing crate through a local Cargo override. Set PERFETTO_PROTOS_PROTOC=/usr/bin/protoc to use the existing protobuf dependency, keeping scxtop enabled.

Upstream: https://github.com/a6f/perfetto_protos/pull/8

Use asm-generic/errno.h in BPF sources and the task-local-data header. scx_p2dq fails with "bits/wordsize.h:22:3: error: unsupported ABI" because glibc's errno.h requires __riscv_xlen, which Clang does not define for the BPF target. Cover the same includes in the other schedulers while leaving userspace headers unchanged.

Follow common.bpf.h and the upstream portability change: https://github.com/sched-ext/scx/pull/62

Set BPF_EXTRA_CFLAGS_PRE_INCL=-ffreestanding for BPF compilation and interface bindgen. scx_beerland and scx_cosmos still hit "unsupported ABI" through limits.h, which includes glibc headers in hosted mode. Freestanding mode keeps Clang's integer limits, including ULLONG_MAX, without pulling in the host libc. Userspace compilation is unchanged; the errno.h substitution remains needed because that header does not honor freestanding mode.

Replace LAVD's __builtin_memcmp with bpf_strncmp. Freestanding mode disables libc-call simplification, leaving an external memcmp that fails BPF linking with "failed to find BTF info for global/extern symbol 'memcmp'". The BPF helper preserves the ten-byte ksoftirqd/ prefix comparison and is already used elsewhere in LAVD.