### PR TITLE
addpatch: jupyterlab 4.6.3-1

### DIFF
--- a/jupyterlab/riscv64.patch
+++ b/jupyterlab/riscv64.patch
@@ -1,0 +1,18 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -35,6 +35,15 @@
+ source=(git+https://github.com/jupyterlab/jupyterlab#tag=v$pkgver)
+ sha256sums=('67e1ad62331e3db61d2afa56d1e8163dc81002ff22ba520179cd5b629af8c923')
+ 
++prepare() {
++  # Allow WASM frontend builds to finish before build-API requests time out.
++  sed -i 's/request_timeout=250/request_timeout=1200/' $pkgname/jupyterlab/pytest_plugin.py
++
++  cd $pkgname/jupyterlab/staging
++  # Install Rspack's WASM fallback; 2.0.2 has no riscv64 native binding.
++  jlpm config set supportedArchitectures.cpu --json '["current", "wasm32"]'
++}
++
+ build() {
+   cd $pkgname
+ # https://github.com/nodejs/node/issues/48444

--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -9,6 +9,7 @@ grafana
 grafana-agent
 jupyter-nbclassic
 jupyter-notebook
+jupyterlab
 keycloak
 navidrome
 openbao


### PR DESCRIPTION
Rspack 2.0.2 has no native riscv64 binding, so the frontend build fails with Cannot find module '@rspack/binding-linux-riscv64-gnu'. Its WASM fallback is already locked, but Yarn excludes it due to cpu=wasm32.

Enable current and wasm32 in Yarn's supportedArchitectures.cpu using jlpm config set. Keep the pinned dependencies unchanged and update the bundled staging configuration so extension rebuilds inherit the fix.

Add jupyterlab to the Sv39 blacklist because the build now executes WASM.

Raise fetch_long's request timeout from 250 to 1200 seconds. The build API's test_build and test_clear fail with HTTPTimeoutError: dependency installation alone takes 224 seconds, leaving little time for the WASM frontend build. Cancellation also waits for the build to finish. Keep both tests enabled and give their requests enough time to complete.