### PR TITLE
addpatch: jupyter-notebook 7.6.2-1

### DIFF
--- a/jupyter-notebook/riscv64.patch
+++ b/jupyter-notebook/riscv64.patch
@@ -1,0 +1,15 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -31,6 +31,12 @@
+ source=(git+https://github.com/jupyter/notebook#tag=v$pkgver)
+ sha256sums=('1bf5806b1581354ca86e717f4682532ec201cb0577bf9ea4de8c2d44bf6d01cf')
+ 
++prepare() {
++  cd notebook
++  # Install Rspack's WASM fallback; 2.0.4 has no riscv64 native binding.
++  jlpm config set supportedArchitectures.cpu --json '["current", "wasm32"]'
++}
++
+ build() {
+   cd notebook
+   python -m build --wheel --no-isolation --skip-dependency-check

--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -7,6 +7,7 @@ gitea
 grafana
 grafana-agent
 jupyter-nbclassic
+jupyter-notebook
 keycloak
 navidrome
 openbao


### PR DESCRIPTION
Enable Yarn's wasm32 optional dependencies so Rspack 2.0.4 can use its WASM fallback on riscv64, which has no native binding.

Add jupyter-notebook to the Sv39 blacklist because the frontend build executes WebAssembly. Yarn's WASM archive workers hit ERR_WORKER_OUT_OF_MEMORY during installation on glalie.