### PR TITLE
updpatch: mumble 1.5.915-4

### DIFF
--- a/mumble/riscv64.patch
+++ b/mumble/riscv64.patch
@@ -1,6 +1,6 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -34,7 +34,6 @@ makedepends+=(
+@@ -36,7 +36,6 @@
    alsa-lib
    hicolor-icon-theme
    jack
@@ -8,13 +8,20 @@
    libpulse
    libsndfile
    libspeechd
-@@ -89,6 +88,9 @@ prepare() {
- }
- 
- build() {
-+  # fix signedness of char, see https://github.com/mumble-voip/mumble/issues/3845
-+  CFLAGS+=" -fsigned-char "
-+  CXXFLAGS+=" -fsigned-char "
-   local default_options=(
-     -D CMAKE_INSTALL_PREFIX=/usr
-     -D CMAKE_BUILD_TYPE=None
+@@ -103,6 +102,8 @@
+   local cmake_options_client=(
+     -D update=OFF
+     -D server=OFF
++    # No multilib on riscv64; keep the native overlay.
++    -D overlay-xcompile=OFF
+     -B build-client
+     -D bundled-json=OFF
+     -D bundled-rnnoise=OFF
+@@ -153,7 +154,6 @@
+   )
+   optdepends=(
+     'bash: for mumble-overlay'
+-    'lib32-glibc: for mumble-overlay'
+     'espeak-ng: Text-to-speech support'
+     'speech-dispatcher: Text-to-speech support'
+   )


### PR DESCRIPTION
Disable the 32-bit overlay cross-build on riscv64, where multilib is unavailable. This fixes client configuration failing with "Can't find the 32bit version of sys/cdefs.h" while preserving the native overlay. Remove the inapplicable lib32-glibc optional dependency.

Drop the redundant -fsigned-char additions: upstream already requests ENSURE_DEFAULT_CHAR_IS_SIGNED and applies those flags to its sources.

https://github.com/mumble-voip/mumble/blob/v1.5.915/cmake/compiler.cmake#L24