### PR TITLE
addpatch: python-nbdime 4.0.4-1

### DIFF
--- a/python-nbdime/riscv64.patch
+++ b/python-nbdime/riscv64.patch
@@ -1,0 +1,16 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -40,6 +40,13 @@
+ prepare() {
+   cd nbdime-$pkgver
+
++  # Lerna's Nx dependency has no riscv64 native binding.
++  npm pkg delete devDependencies.lerna
++  npm pkg set 'scripts.build=npm run build -w nbdime && npm run build -w nbdime-jupyterlab && npm run build -w nbdime-webapp'
++
++  # Allow time for Mercurial repository setup on slower builders.
++  sed -i 's/timeout=WEB_TEST_TIMEOUT)/timeout=3*WEB_TEST_TIMEOUT)/' nbdime/tests/test_cli_apps.py
++
+   # Many tests need a valid git config
+   cat > gitconfig <<EOF
+ [user]

--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -17,6 +17,7 @@ prettier
 prometheus
 python-anywidget
 python-esphome-dashboard
+python-nbdime
 syslog-ng
 typescript-language-server
 vue-language-tools


### PR DESCRIPTION
Lerna 7.3.1 pulls in Nx 16.10.0, whose native loader fails with "Unsupported architecture on Linux: riscv64". Remove Lerna and run the three existing workspace builds through npm, building the core library before the JupyterLab extension and webapp.

Add python-nbdime to the Sv39 blacklist because Webpack executes WebAssembly for hashing.

Raise test_hg_mergetool's timeout from 15 to 45 seconds, matching the Mercurial diffweb and Git mergetool tests. On shinx, its 15-second budget expires during hg_repo setup, before the test body runs.