### PR TITLE
updpatch: consul 2.0.2-1

### DIFF
--- a/consul/riscv64.patch
+++ b/consul/riscv64.patch
@@ -1,6 +1,6 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -37,8 +37,8 @@ export CGO_CXXFLAGS="${CXXFLAGS}"
+@@ -34,8 +34,8 @@ export CGO_CXXFLAGS="${CXXFLAGS}"
  export GOFLAGS="-trimpath -mod=readonly -modcacherw"
  
  export GOOS='linux'
@@ -11,13 +11,13 @@
  
  prepare() {
    cd "${srcdir}/${pkgname}"
-@@ -51,6 +51,10 @@ prepare() {
+@@ -48,6 +48,10 @@ prepare() {
    done
  
    mkdir -p build
 +
++  # Replace only legacy Bolt, which lacks riscv64 support.
 +  go mod edit -replace=github.com/boltdb/bolt=go.etcd.io/bbolt@v1.3.6
-+  go mod edit -replace=go.etcd.io/bbolt=github.com/coreos/bbolt@v1.3.6
 +  go mod tidy
  }
  

--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -1,4 +1,5 @@
 argocd
+consul
 corepack
 criterion
 eslint


### PR DESCRIPTION
Remove the replacement that downgrades Consul's bbolt dependency from 1.4.3 to coreos/bbolt 1.3.6. Keep the separate legacy boltdb/bolt replacement, which is still needed for RISC-V support in raft-boltdb's database migration code.

https://github.com/hashicorp/consul/blob/v2.0.2/go.mod

Add consul to the Sv39 blacklist because its UI build uses Webpack's WebAssembly hashing.