### PR TITLE
addpatch: llama-cpp 0.4.0-1

### DIFF
--- a/llama-cpp/fix-oxide-worker-exit.patch
+++ b/llama-cpp/fix-oxide-worker-exit.patch
@@ -1,0 +1,12 @@
+--- a/tailwindcss-oxide.wasi.cjs
++++ b/tailwindcss-oxide.wasi.cjs
+@@ -62,6 +62,9 @@
+     const worker = new Worker(__nodePath.join(__dirname, 'wasi-worker.mjs'), {
+       env: process.env,
+     })
++    // Scanner calls are synchronous; idle Rayon workers must not keep Node alive.
++    // Defer until online because the WASI runtime refs the worker after creation.
++    worker.once('online', () => worker.unref())
+     worker.onmessage = ({ data }) => {
+       __wasmCreateOnMessageForFsProxy(__nodeFs)(data)
+     }

--- a/llama-cpp/riscv64.patch
+++ b/llama-cpp/riscv64.patch
@@ -1,0 +1,22 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -35,7 +35,11 @@
+ 
+ build() {
+   pushd "./llama.cpp/tools/ui"
+-  npm ci --ignore-scripts
++  # Use matching WASM CSS tooling; Oxide's cpu=wasm32 tag requires --force.
++  npm install --ignore-scripts --force --save-exact \
++    lightningcss@npm:lightningcss-wasm@1.30.1 \
++    @tailwindcss/oxide-wasm32-wasi@4.1.11
++  patch -Np1 -d node_modules/@tailwindcss/oxide-wasm32-wasi -i "$srcdir/fix-oxide-worker-exit.patch"
+   npm run build
+   popd
+ 
+@@ -60,3 +64,6 @@
+   sed -i "s/%PKGVER%/$pkgver/g" "${pkgdir}"/usr/lib/systemd/*/llama-server.service
+   mkdir -p "${pkgdir}"/usr/share/llama/models
+ }
++
++source+=(fix-oxide-worker-exit.patch)
++b2sums+=('8ccefc948e86b53c43f77cc3f3ef3de557cd4c104a444fb0eb8b2626cfc607ae20825370ffa29eab66604514c5c76eeaa0c86d45a3b65776ac15edae374278b1')

--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -12,6 +12,7 @@ jupyter-nbclassic
 jupyter-notebook
 jupyterlab
 keycloak
+llama-cpp
 navidrome
 openbao
 oxyromon


### PR DESCRIPTION
Use version-matched Lightning CSS WASM and Tailwind Oxide WASI packages for the UI build. The locked native packages lack riscv64 binaries, causing the missing lightningcss.linux-riscv64-gnu.node failure. Install Lightning CSS through an explicit npm alias and use --force for the Oxide fallback tagged cpu=wasm32.

Add llama-cpp to the SV39 blacklist because the UI build now executes Node.js WASM bindings, which require a non-SV39 builder to avoid address-space allocation failures.

Fix Vite remaining alive for over 46 hours after writing dist on rapidash. Oxide's WASI runtime leaves a persistent Rayon worker referenced after the synchronous scan returns. The same WASM scanner hangs on native x86_64, so this is not a QEMU-specific failure.

Unref each Oxide worker once it comes online, after the WASI runtime's ref() during thread creation. Keep synchronous scans and worker reuse intact while allowing Node to exit normally.