### PR TITLE
updpatch: coin-or-mp 1.8.4-7

### DIFF
--- a/coin-or-mp/riscv64.patch
+++ b/coin-or-mp/riscv64.patch
@@ -1,15 +1,15 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -15,6 +15,12 @@ depends=(coin-or-cbc)
- source=(https://www.coin-or.org/download/source/CoinMP/CoinMP-$pkgver.tgz)
- sha256sums=('3459fb0ccbdd39342744684338984ac4cc153fb0434f4cae8cf74bd67490a38d')
+@@ -19,6 +19,12 @@
+ source=(git+https://github.com/coin-or/CoinMP#tag=releases/$pkgver)
+ sha256sums=('ca675f20c3008618ba8d6827191a0d64f9f08995b613adfd8aa2a40f47d3d2e2')
  
 +prepare() {
-+  cd CoinMP-$pkgver
++  cd CoinMP
 +  autoconf_file="/usr/share/autoconf/build-aux/config"
 +  echo ". CoinMP" | xargs -r -n1 cp ${autoconf_file}.{guess,sub}
 +}
 +
  build() {
-   cd CoinMP-$pkgver
-   COIN_SKIP_PROJECTS="Sample" \
+   cd CoinMP
+   export CXXFLAGS+=" -Wp,-U_GLIBCXX_ASSERTIONS"


### PR DESCRIPTION
Refresh patch and enter CoinMP in prepare() to match the Git source layout, fixing the missing CoinMP-1.8.4 directory failure.