### PR TITLE
updpatch: protobuf 36.1-1

### DIFF
--- a/protobuf/riscv64.patch
+++ b/protobuf/riscv64.patch
@@ -15,10 +15,10 @@
 +  # Keep it here instead of bottom of the file because this file updates along with the package
 +  "$pkgbase-$pkgver-python.tar.gz::https://files.pythonhosted.org/packages/source/${pkgbase::1}/${pkgbase//-/_}/${pkgbase//-/_}-7.$pkgver.tar.gz"
  )
- sha512sums=('e1ebed47daa921e304a038e0b90412cda2d4614d3add0f70ce5e17553623b2aabd739b0aa7c134f78e0fe901b7afb037c1a7656046de79e3f6ff5b284ab5dedf'
+ sha512sums=('d319a7b67b4755976a972b98fc5b82cfa0c4fc9e71013a4cc7820f421d1e092efb6480aadf30ed078a19a876281c438217375dd0321cd9c5916b003921fd78d4'
 -            '18bc71031bbcbc3810a9985fa670465040f06a6c104ab8079b56bdfc499bb6cec40805a0cefd455031142490a576dc60aa8000523877ac0353b93558e9beabbd')
 +            '18bc71031bbcbc3810a9985fa670465040f06a6c104ab8079b56bdfc499bb6cec40805a0cefd455031142490a576dc60aa8000523877ac0353b93558e9beabbd'
-+            'e6ac5262d0ed06a1b646e21618b83641101b2e16b2c431a9ae165af62e2c8a062e93589784e46dab8255fc925f42eac9e2246f281ae628f0b95f8fb2bf9dfe13')
++            '4971ab513ac375d378bb66ca8b5676a77b57a39a6e0f3c3ea0aa05feee96e8d04f62a793bcfd8aa05b2dd0ce5784088aa98763f34f7f13c802aaf1d9418191d4')
  
  options=(!lto)
  


### PR DESCRIPTION
Refresh patch and update the Python 7.36.1 sdist checksum.