### PR TITLE
updpatch: hipblaslt 7.2.4-1

### DIFF
--- a/hipblaslt/riscv64.patch
+++ b/hipblaslt/riscv64.patch
@@ -1,14 +1,26 @@
-diff --git PKGBUILD PKGBUILD
-index 95936fb..4230625 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -8,7 +8,8 @@
- license=('MIT')
- depends=('rocm-core' 'glibc' 'gcc-libs' 'hip-runtime-amd' 'hipblas' 'rocblas')
- makedepends=('rocm-cmake' 'python' 'cmake' 'git'
--             'msgpack-cxx' 'python-msgpack' 'python-joblib' 'python-pyaml' 'hipblas-common')
-+             'msgpack-cxx' 'python-msgpack' 'python-joblib' 'python-pyaml' 'hipblas-common'
-+             'python-simplejson' 'python-ujson' 'python-orjson')
- _git='https://github.com/ROCm/hipBLASLt'
- source=("$pkgname-$pkgver.tar.gz::$_git/archive/rocm-$pkgver.tar.gz"
-         "$pkgname-find-msgpack5.patch"
+@@ -48,11 +48,13 @@
+ source=("rocm-libraries::git+$_git.git#tag=rocm-$pkgver"
+         "hipblaslt-Don-t-fetch-deps-for-rocroller.patch"
+         "rocroller-Always-fetch-libdivide-if-it-s-not-install.patch"
+-        "hipblaslt-7.2.3-cstdint-include.patch")
++        "hipblaslt-7.2.3-cstdint-include.patch"
++        "rocroller-fix-hip-noinline.patch")
+ sha256sums=('b476acbcd0f4017c800e4b05533e6dfb875bde32242729c8df557d4624379623'
+             '81c0f9ac1872e34555c2f9d64eecec75c42fd8813c4acf54cd665b03e59cb752'
+             'b845a96fee02651f2cad2417fc9e8522ab143849b2049b0010d17401e6000e52'
+-            '337feb845674f8ec6015c902b27bd01bc51f530035cda769b7dea5ad12d41920')
++            '337feb845674f8ec6015c902b27bd01bc51f530035cda769b7dea5ad12d41920'
++            '867bce65900e560b7c6e03ff7aae84caebff26ac1b45019bd3b31f1b51203566')
+ _dirname="rocm-libraries/projects/$pkgname"
+
+ options=(!strip)
+@@ -62,6 +64,7 @@
+   patch -Np1 -i "$srcdir/hipblaslt-Don-t-fetch-deps-for-rocroller.patch"
+   patch -Np1 -i "$srcdir/rocroller-Always-fetch-libdivide-if-it-s-not-install.patch"
+   patch -Np1 -i "$srcdir/hipblaslt-7.2.3-cstdint-include.patch"
++  patch -Np1 -i "$srcdir/rocroller-fix-hip-noinline.patch"
+ }
+
+ build() {

--- a/hipblaslt/rocroller-fix-hip-noinline.patch
+++ b/hipblaslt/rocroller-fix-hip-noinline.patch
@@ -1,0 +1,30 @@
+--- a/shared/rocroller/lib/include/rocRoller/Utilities/Timer.hpp
++++ b/shared/rocroller/lib/include/rocRoller/Utilities/Timer.hpp
+@@ -31,7 +31,12 @@
+ #pragma once
+
+ #include <atomic>
++// HIP's host-mode macro conflicts with libstdc++ attributes in <chrono>.
++// https://github.com/ROCm/rocm-systems/issues/9897
++#pragma push_macro("__noinline__")
++#undef __noinline__
+ #include <chrono>
++#pragma pop_macro("__noinline__")
+ #include <map>
+ #include <memory>
+ #include <string>
+--- a/shared/rocroller/lib/include/rocRoller/Utilities/HIPTimer.hpp
++++ b/shared/rocroller/lib/include/rocRoller/Utilities/HIPTimer.hpp
+@@ -32,7 +32,12 @@
+
+ #ifdef ROCROLLER_USE_HIP
+
++// HIP's host-mode macro conflicts with libstdc++ attributes in <chrono>.
++// https://github.com/ROCm/rocm-systems/issues/9897
++#pragma push_macro("__noinline__")
++#undef __noinline__
+ #include <chrono>
++#pragma pop_macro("__noinline__")
+ #include <map>
+ #include <memory>
+ #include <string>


### PR DESCRIPTION
Temporarily undefine the HIP __noinline__ macro around the <chrono> includes in rocRoller Timer.hpp and HIPTimer.hpp, then restore it. The macro otherwise corrupts a GCC 16 libstdc++ attribute and stops compilation with expected identifier in <format>.

Drop the obsolete Python dependency additions, which are already present in Arch packaging for 7.2.4-1.

Upstream report: https://github.com/ROCm/rocm-systems/issues/9897

Packaged reference: https://gitlab.archlinux.org/archlinux/packaging/packages/hipblaslt/-/blob/7.2.4-1/PKGBUILD