### PR TITLE
addpatch: python-geoip2 5.3.0-1

### DIFF
--- a/python-geoip2/riscv64.patch
+++ b/python-geoip2/riscv64.patch
@@ -1,0 +1,14 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -35,6 +35,11 @@
+ 
+ prepare() {
+   cd GeoIP2-python
++
++  # Allow the system uv-build 0.12, matching upstream.
++  # https://github.com/maxmind/GeoIP2-python/commit/05b5c4343f4a90c3c5465e8b8de7fd8a58cbd2ba
++  sed -i 's/uv_build>=0.11.26,<0.12.0/uv_build>=0.11.26,<0.13.0/' pyproject.toml
++
+   git submodule init
+   git config submodule.tests/data.url "$srcdir/MaxMind-DB"
+   git -c protocol.file.allow=always submodule update


### PR DESCRIPTION
Raise the uv-build upper bound from <0.12.0 to <0.13.0, matching upstream while preserving the packaged minimum of 0.11.26. The build rejects the installed python-uv-build 0.12.7 with "Missing dependencies: uv_build<0.12.0,>=0.11.26" before wheel generation.

Upstream: https://github.com/maxmind/GeoIP2-python/commit/05b5c4343f4a90c3c5465e8b8de7fd8a58cbd2ba