### PR TITLE
addpatch: mise 2026.9.1-1

### DIFF
--- a/mise/riscv64.patch
+++ b/mise/riscv64.patch
@@ -1,0 +1,21 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -48,6 +48,9 @@
+ prepare() {
+   cd "${pkgname}-${pkgver}"
+
++  # Select a foreign test target even when the host is riscv64.
++  patch -Np1 -i ../swift-foreign-target-test.patch
++
+   cargo fetch --locked --target "$(rustc --print host-tuple)"
+ }
+
+@@ -93,4 +96,8 @@
+   install --verbose -D --mode=0644 completions/_mise "${pkgdir}/usr/share/zsh/site-functions/_mise"
+ }
+
++source+=(swift-foreign-target-test.patch)
++sha512sums+=('4aa160ba79549849840658fc5e0de75b5f364dcc66635dc80c6b2d2ee61205925b2f1055e2a8f4f5a39d51de9c00c37745b3c7a5e84c054aa4d61526b0622545')
++b2sums+=('f278718cf145213e9f9020a5a06777ba5d189967663030e04494b45e2dde23c741677c8b38220d347bfbcb44b7ac7c632a4fb97d9113dab76aad4f7cacc33140')
++
+ # vim: tabstop=2 shiftwidth=2 expandtab:

--- a/mise/swift-foreign-target-test.patch
+++ b/mise/swift-foreign-target-test.patch
@@ -1,0 +1,28 @@
+--- a/src/plugins/core/swift.rs
++++ b/src/plugins/core/swift.rs
+@@ -572,17 +572,21 @@
+         let _guard = pin_platform(None);
+         let backend = SwiftPlugin::new();
+         let tv = tool_version(&backend, "6.3.1");
+-        // riscv64 is never the platform the test suite runs on
+-        let foreign = target("linux-riscv64");
++        let (foreign_platform, archive_suffix) = if target("linux-x64").is_current() {
++            ("linux-arm64", "-ubuntu24.04-aarch64.tar.gz")
++        } else {
++            ("linux-x64", "-ubuntu24.04.tar.gz")
++        };
++        let foreign = target(foreign_platform);
+         assert!(!foreign.is_current());
+
+         assert_eq!(
+-            options(&backend, &tv, "linux-riscv64"),
++            options(&backend, &tv, foreign_platform),
+             BTreeMap::from([(
+                 "swift_platform".to_string(),
+                 format!("ubuntu{DEFAULT_UBUNTU_VERSION}")
+             )])
+         );
+-        assert!(url(&tv, &foreign).ends_with("-ubuntu24.04-riscv64.tar.gz"));
++        assert!(url(&tv, &foreign).ends_with(archive_suffix));
+     }
+ }


### PR DESCRIPTION
Select a Linux target different from the host in the Swift lockfile test. Hardcoding linux-riscv64 makes !foreign.is_current() fail on riscv64. Keep the Ubuntu fallback and archive URL assertions.

https://github.com/jdx/mise/blob/v2026.9.1/src/plugins/core/swift.rs#L575