### PR TITLE
updpatch: sbcl 2.6.8-1

### DIFF
--- a/sbcl/remove-qemu-workarounds.patch
+++ b/sbcl/remove-qemu-workarounds.patch
@@ -1,21 +1,6 @@
-Index: sbcl-2.4.4/make-config.sh
-===================================================================
---- sbcl-2.4.4.orig/make-config.sh
-+++ sbcl-2.4.4/make-config.sh
-@@ -565,7 +565,7 @@ case "$sbcl_os" in
-     linux)
-         printf ' :unix :linux :elf' >> $ltf
-         case "$sbcl_arch" in
--          arm64 | ppc64 | x86 | x86-64)
-+          arm64 | ppc64 | x86 | x86-64 | riscv)
- 	        printf ' :gcc-tls' >> $ltf
-         esac
-         case "$sbcl_arch" in
-Index: sbcl-2.4.4/src/runtime/gc-common.c
-===================================================================
---- sbcl-2.4.4.orig/src/runtime/gc-common.c
-+++ sbcl-2.4.4/src/runtime/gc-common.c
-@@ -3187,9 +3187,6 @@ static inline void memset_page_range(int
+--- a/src/runtime/gc-common.c
++++ b/src/runtime/gc-common.c
+@@ -2978,9 +2978,6 @@
   *   Otherwise, pages which are already zero-filled are skipped.
   *   For each newly zeroed page, clear the need_to_zero flag.
   */
@@ -25,11 +10,9 @@ Index: sbcl-2.4.4/src/runtime/gc-common.c
  void prepare_pages(__attribute__((unused)) bool commit,
                     page_index_t start, page_index_t end,
                     int page_type, generation_index_t generation) {
-Index: sbcl-2.4.4/src/runtime/gencgc-impl.h
-===================================================================
---- sbcl-2.4.4.orig/src/runtime/gencgc-impl.h
-+++ sbcl-2.4.4/src/runtime/gencgc-impl.h
-@@ -575,11 +575,7 @@ extern os_vm_size_t auto_gc_trigger;
+--- a/src/runtime/gencgc-impl.h
++++ b/src/runtime/gencgc-impl.h
+@@ -600,11 +600,7 @@
  typedef unsigned int page_bytes_t;
  #define page_words_used(index) page_table[index].words_used_
  #define page_bytes_used(index) ((page_bytes_t)page_table[index].words_used_<<WORD_SHIFT)
@@ -41,22 +24,37 @@ Index: sbcl-2.4.4/src/runtime/gencgc-impl.h
  #define set_page_bytes_used(index,val) page_table[index].words_used_ = ((val)>>WORD_SHIFT)
  #define set_page_need_to_zero(index,val) page_table[index].need_zerofill = val
  
-Index: sbcl-2.4.4/src/runtime/linux-os.c
-===================================================================
---- sbcl-2.4.4.orig/src/runtime/linux-os.c
-+++ sbcl-2.4.4/src/runtime/linux-os.c
-@@ -275,23 +275,16 @@ extern char **environ;
+--- a/src/runtime/interrupt.c
++++ b/src/runtime/interrupt.c
+@@ -486,14 +486,8 @@
+         lose("deferrables unblocked");
+ }
+ 
+-#ifdef LISP_FEATURE_RISCV
+-int sigaction_does_not_mask;
+-#endif
+ static void assert_blockables_blocked()
+ {
+-#ifdef LISP_FEATURE_RISCV
+-    if (sigaction_does_not_mask) return; // assert nothing
+-#endif
+ #if !defined(LISP_FEATURE_WIN32)
+     /* On Windows, there are no actual signals, but since the win32 port
+      * tracks the sigmask and checks it explicitly, some functions are
+--- a/src/runtime/linux-os.c
++++ b/src/runtime/linux-os.c
+@@ -183,29 +183,6 @@
+ extern char **environ;
  int os_preinit(char *argv[], char *envp[])
  {
- #ifdef LISP_FEATURE_RISCV
+-#ifdef LISP_FEATURE_RISCV
 -    extern int riscv_user_emulation, mmap_does_not_zero, sigaction_does_not_mask;
 -    /* Accomodate buggy mmap() emulation, but detect up front whether it may be.
 -     * Full system emulation running a RISCV kernel is generally fine. User mode is not.
 -     * There's no way to know what it _will_ do, so we have to guess based on
 -     * whether the emulation looks bad. */
-+    extern int sigaction_does_not_mask;
-     char buf[100];
-     FILE *f = fopen("/proc/cpuinfo", "r");
+-    char buf[100];
+-    FILE *f = fopen("/proc/cpuinfo", "r");
 -    ignore_value(fgets(buf, sizeof buf, f));
 -    ignore_value(fgets(buf, sizeof buf, f));
 -    if (!strstr(buf, "hart")) { // look for "hardware thread" string
@@ -67,21 +65,17 @@ Index: sbcl-2.4.4/src/runtime/linux-os.c
 -        fprintf(stderr, "----\n");
 -        riscv_user_emulation = 1;
 -        mmap_does_not_zero = 1;
-+    buf[0] = 0;
-+    if (f != NULL) {
-+        while (fgets(buf, sizeof buf, f) && buf[0] != '\n')
-+            if (strncmp(buf, "uarch", strlen("uarch")) == 0)
-+                break;
-+    }
-+    if (strstr(buf, "qemu")) { // look for "uarch : qemu"
-         sigaction_does_not_mask = 1;
-     }
-     fclose(f);
-Index: sbcl-2.4.4/src/runtime/pmrgc-impl.h
-===================================================================
---- sbcl-2.4.4.orig/src/runtime/pmrgc-impl.h
-+++ sbcl-2.4.4/src/runtime/pmrgc-impl.h
-@@ -568,11 +568,7 @@ extern os_vm_size_t auto_gc_trigger;
+-        sigaction_does_not_mask = 1;
+-    }
+-    fclose(f);
+-#endif
+-
+ #if ALLOW_PERSONALITY_CHANGE
+     if (getenv("SBCL_IS_RESTARTING")) {
+         /* We restarted due to previously enabled ASLR.  Now,
+--- a/src/runtime/pmrgc-impl.h
++++ b/src/runtime/pmrgc-impl.h
+@@ -584,11 +584,7 @@
  typedef unsigned int page_bytes_t;
  #define page_words_used(index) page_table[index].words_used_
  #define page_bytes_used(index) ((page_bytes_t)page_table[index].words_used_<<WORD_SHIFT)
@@ -93,11 +87,9 @@ Index: sbcl-2.4.4/src/runtime/pmrgc-impl.h
  #define set_page_bytes_used(index,val) page_table[index].words_used_ = ((val)>>WORD_SHIFT)
  #define set_page_need_to_zero(index,val) page_table[index].need_zerofill = val
  
-Index: sbcl-2.4.4/src/runtime/riscv-arch.c
-===================================================================
---- sbcl-2.4.4.orig/src/runtime/riscv-arch.c
-+++ sbcl-2.4.4/src/runtime/riscv-arch.c
-@@ -94,27 +94,11 @@ arch_handle_single_step_trap(os_context_
+--- a/src/runtime/riscv-arch.c
++++ b/src/runtime/riscv-arch.c
+@@ -84,27 +84,11 @@
      arch_skip_instruction(context);
  }
  
@@ -125,4 +117,3 @@ Index: sbcl-2.4.4/src/runtime/riscv-arch.c
      if (trap_instruction != 0x100073) {
          lose("Unrecognized trap instruction %08x in sigtrap_handler()",
               trap_instruction);
-

--- a/sbcl/riscv64-callbacks.patch
+++ b/sbcl/riscv64-callbacks.patch
@@ -1,0 +1,122 @@
+--- a/make-config.sh
++++ b/make-config.sh
+@@ -783,7 +783,7 @@
+    ;;
+   riscv)
+     if [ "$xlen" = "64" ]; then
+-        printf ' :64-bit' >> $ltf
++        printf ' :64-bit :alien-callbacks' >> $ltf
+     elif [ "$xlen" = "32" ]; then
+         :
+     else
+--- a/src/compiler/riscv/c-call.lisp
++++ b/src/compiler/riscv/c-call.lisp
+@@ -243,7 +243,95 @@
+ 
+ ;;; Returns a vector in static space containing machine code for the
+ ;;; callback wrapper.
+-#-sb-xc-host
++#-(or sb-xc-host 64-bit)
+ (defun alien-callback-assembler-wrapper (index result-type argument-types)
+   (declare (ignore index result-type argument-types))
+   (error "please implement"))
++
++#+(and (not sb-xc-host) 64-bit)
++(defun alien-callback-assembler-wrapper (index result-type argument-types)
++  (flet ((scalar-type-p (type)
++           (or (and (alien-integer-type-p type)
++                    (<= (alien-type-bits type) n-word-bits))
++               (alien-pointer-type-p type)
++               (alien-type-= #.(parse-alien-type 'system-area-pointer nil) type)
++               (alien-single-float-type-p type)
++               (alien-double-float-type-p type))))
++    (dolist (type argument-types)
++      (unless (scalar-type-p type)
++        (error "Unsupported callback argument type: ~A" type)))
++    (unless (or (alien-void-type-p result-type) (scalar-type-p result-type))
++      (error "Unsupported callback result type: ~A" result-type)))
++  (let* ((segment (make-segment))
++         ;; Result slot followed by the word-aligned argument buffer.
++         (frame-size (align-up (* (1+ (length argument-types)) n-word-bytes)
++                              (1+ +number-stack-alignment-mask+)))
++         ;; Only use C caller-saved registers outside a0-a7 while saving arguments.
++         (stack-tn (make-reg-tn 5))
++         (args-tn (make-reg-tn 6))
++         (temp-tn (make-reg-tn 7))
++         (ca0 (make-reg-tn ca0-offset))
++         (ca1 (make-reg-tn ca1-offset))
++         (ca2 (make-reg-tn ca2-offset))
++         (integer-registers 0)
++         (float-registers 0))
++    (assemble (segment nil)
++      (move stack-tn nsp-tn)
++      ;; LI uses TMP (s9) for wide immediates; preserve it for the C caller.
++      (inst addi nsp-tn nsp-tn -16)
++      (storew ra-tn nsp-tn)
++      (storew tmp-tn nsp-tn 1)
++      (inst li temp-tn frame-size)
++      (inst sub nsp-tn nsp-tn temp-tn)
++      (inst addi args-tn nsp-tn n-word-bytes)
++      (dolist (type argument-types)
++        (cond ((and (alien-float-type-p type)
++                    (< float-registers n-foreign-register-args))
++               (inst fstore
++                     (if (alien-single-float-type-p type) :single :double)
++                     (make-reg-tn (+ fa0-offset float-registers) 'double-reg)
++                     args-tn 0)
++               (incf float-registers))
++              ;; Once fa0-fa7 are exhausted, floats follow the integer ABI.
++              ((< integer-registers n-foreign-register-args)
++               (storew (make-reg-tn (register-args-offset integer-registers))
++                       args-tn)
++               (incf integer-registers))
++              (t
++               (loadw temp-tn stack-tn)
++               (storew temp-tn args-tn)
++               (inst addi stack-tn stack-tn n-word-bytes)))
++        (inst addi args-tn args-tn n-word-bytes))
++      (inst li ca0 (fixnumize index))
++      (inst addi ca1 nsp-tn n-word-bytes)
++      (move ca2 nsp-tn)
++      (inst li temp-tn (callback_wrapper_trampoline))
++      (inst jalr ra-tn temp-tn 0)
++      (cond ((alien-void-type-p result-type))
++            ((alien-float-type-p result-type)
++             ;; FLW also NaN-boxes a single-float result in fa0.
++             (inst fload
++                   (if (alien-single-float-type-p result-type) :single :double)
++                   (make-reg-tn fa0-offset 'double-reg) nsp-tn 0))
++            ((and (alien-integer-type-p result-type)
++                  (= (alien-type-bits result-type) 32))
++             ;; The RV64 ABI sign-extends even unsigned 32-bit results.
++             (inst lw ca0 nsp-tn 0))
++            (t
++             (loadw ca0 nsp-tn)))
++      (inst li temp-tn frame-size)
++      (inst add nsp-tn nsp-tn temp-tn)
++      (loadw ra-tn nsp-tn)
++      (loadw tmp-tn nsp-tn 1)
++      (inst addi nsp-tn nsp-tn 16)
++      (inst jalr zero-tn ra-tn 0))
++    (finalize-segment segment)
++    (let* ((buffer (sb-assem:segment-buffer segment))
++           (vector (make-static-vector (length buffer)
++                                       :element-type '(unsigned-byte 8)
++                                       :initial-contents buffer)))
++      (alien-funcall
++       (extern-alien "os_flush_icache"
++                     (function void system-area-pointer unsigned-long))
++       (vector-sap vector) (length buffer))
++      vector)))
+--- a/tests/fcb-threads.impure.lisp
++++ b/tests/fcb-threads.impure.lisp
+@@ -15,7 +15,8 @@
+ ;;;  - garbage_collect: no SP known for thread 0x802bea000 (OS 34367133952)
+ ;;;  - failed AVER: (NOT (SB-THREAD::AVL-FIND ADDR SB-THREAD::OLD))
+ 
+-#+(or riscv (not sb-thread) freebsd) (invoke-restart 'run-tests::skip-file)
++#+(or (and riscv (not 64-bit)) (not sb-thread) freebsd)
++(invoke-restart 'run-tests::skip-file)
+ 
+ (setf (generation-number-of-gcs-before-promotion 0) 5)
+ (setf (generation-number-of-gcs-before-promotion 1) 3)

--- a/sbcl/riscv64.patch
+++ b/sbcl/riscv64.patch
@@ -1,21 +1,25 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -19,6 +19,11 @@ sha256sums=('68544d2503635acd015d534ccc9b2ae9f68996d429b5a9063fd22ff0925011d2'
+@@ -21,6 +21,14 @@
              'b5a6468dcbc1012cae2c3cda155762a37b6d96ef89bba4f723315063b0b5e7ce')
  
  
 +prepare() {
-+  patch -Np1 -d "$pkgname-$pkgver" < riscv-qemu-user.patch
++  # Remove obsolete QEMU workarounds and restore signal-mask assertions.
++  patch -Np1 -d "$pkgname-$pkgver" < remove-qemu-workarounds.patch
++  # Implement RV64 foreign callbacks, which currently raise "please implement".
++  patch -Np1 -d "$pkgname-$pkgver" < riscv64-callbacks.patch
 +}
 +
 +
  build() {
    cd "$srcdir/$pkgname-$pkgver"
    export CFLAGS+=" -D_GNU_SOURCE -fno-omit-frame-pointer -DSBCL_HOME=/usr/lib/sbcl"
-@@ -57,3 +62,6 @@ package() {
+@@ -72,3 +80,7 @@
    rm "$pkgdir/usr/share/sbcl-source/src/runtime/sbcl"
  
  }
 +
-+source+=(riscv-qemu-user.patch)
-+sha256sums+=(f0facef287c9203adf0eef0a6bff4655257171e8730854b7af68641f276f05cd)
++source+=(remove-qemu-workarounds.patch riscv64-callbacks.patch)
++sha256sums+=(3339ef8fa8736c5e5f40cff5934814cdad74e5e37226498b3434aa9fe0cd641e
++             1a7422b90cfff41ed5deaaf9de28a06001846c9637bc1cfafa629d7224942fd2)


### PR DESCRIPTION
Implement RV64 scalar foreign callbacks. cl-cffi aborts while loading its first callback because ALIEN-CALLBACK-ASSEMBLER-WRAPPER raises "please implement".

Marshal LP64D integer, floating-point and stack arguments through the existing callback dispatcher. Preserve 16-byte stack alignment and s9, which LI uses for wide immediates, sign-extend 32-bit results, and flush the instruction cache. Leave RV32 unchanged and reject unsupported aggregate types.

Enable the RV64 callback feature and foreign-thread callback tests. Refresh the packaging overlay against stable 2.6.8-1.

Replace the old QEMU patch with the cleanup carried by openSUSE for 2.6.8 [1]. Remove obsolete /proc/cpuinfo detection and restore signal-mask assertions. Drop the bundled GCC TLS enablement, also removed by openSUSE, restoring upstream pthread-based thread lookup.

[1] https://api.opensuse.org/public/source/openSUSE:Factory:RISCV/sbcl/remove-qemu-workarounds.patch