### PR TITLE
addpatch: libphonenumber 1:9.0.38-2

### DIFF
--- a/libphonenumber/fix-protobuf-generation-race.patch
+++ b/libphonenumber/fix-protobuf-generation-race.patch
@@ -1,0 +1,50 @@
+--- a/cpp/CMakeLists.txt
++++ b/cpp/CMakeLists.txt
+@@ -237,6 +237,9 @@
+   DEPENDS ${PROTOBUF_SOURCES}
+ )
+ 
++# Generate shared protobuf sources once before any library compiles them.
++add_custom_target (generate-protobuf DEPENDS ${PROTOBUF_OUTPUT})
++
+ if (BUILD_GEOCODER)
+   # Geocoding data cpp file generation
+   add_subdirectory("${TOOLS_DIR}" "${TOOLS_BINARY_DIR}")
+@@ -455,11 +458,13 @@
+ if (BUILD_STATIC_LIB)
+   # Build a static library (without -fPIC).
+   add_library (phonenumber STATIC ${SOURCES})
++  add_dependencies (phonenumber generate-protobuf)
+   target_link_libraries (phonenumber ${LIBRARY_DEPS})
+   target_include_directories(phonenumber PUBLIC $<INSTALL_INTERFACE:include>)
+ 
+   if (BUILD_GEOCODER)
+     add_library (geocoding STATIC ${GEOCODING_SOURCES})
++    add_dependencies (geocoding generate-protobuf)
+     target_link_libraries (geocoding ${LIBRARY_DEPS})
+     target_include_directories(geocoding PUBLIC $<INSTALL_INTERFACE:include>)
+     add_dependencies (geocoding generate_geocoding_data)
+@@ -475,6 +480,7 @@
+ if (BUILD_SHARED_LIBS)
+   # Build a shared library (with -fPIC).
+   add_library (phonenumber-shared SHARED ${SOURCES})
++  add_dependencies (phonenumber-shared generate-protobuf)
+   target_link_libraries (phonenumber-shared ${LIBRARY_DEPS})
+   target_include_directories(phonenumber-shared PUBLIC $<INSTALL_INTERFACE:include>)
+ 
+@@ -491,6 +497,7 @@
+ 
+   if (BUILD_GEOCODER)
+     add_library (geocoding-shared SHARED ${GEOCODING_SOURCES})
++    add_dependencies (geocoding-shared generate-protobuf)
+     target_link_libraries (geocoding-shared ${LIBRARY_DEPS})
+     target_include_directories(geocoding-shared PUBLIC $<INSTALL_INTERFACE:include>)
+     add_dependencies (geocoding-shared generate_geocoding_data)
+@@ -511,6 +518,7 @@
+ 
+ if(BUILD_TESTING)
+   add_library (phonenumber_testing STATIC ${TESTING_LIBRARY_SOURCES})
++  add_dependencies (phonenumber_testing generate-protobuf)
+   if (BUILD_GEOCODER)
+     add_dependencies (phonenumber_testing generate_geocoding_data)
+   endif ()

--- a/libphonenumber/riscv64.patch
+++ b/libphonenumber/riscv64.patch
@@ -1,0 +1,19 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -45,6 +45,9 @@
+ 
+   # Fix building test with BUILD_STATIC_LIB=OFF
+   git apply -3 ../0003-Fix-BUILD_STATIC_LIB-OFF.patch
++
++  # Prevent concurrent protoc invocations from overwriting sources during compilation.
++  patch -Np1 -i ../fix-protobuf-generation-race.patch
+ }
+ 
+ build() {
+@@ -81,3 +84,6 @@
+ }
+ 
+ # vim:set sw=2 sts=-1 et:
++
++source+=(fix-protobuf-generation-race.patch)
++b2sums+=(2bdd3a2888fd570c53a858635ed4c5c6b3577653fdc1269986b936ed7010fb961b3f6507f0dcb59dcdd2be292fb062db20173db41cfd99b2bb395d0b097644ad)


### PR DESCRIPTION
The parallel build invokes protoc three times on the same output files, allowing generated sources to be overwritten during compilation. Linking geocoding_test_program then fails with undefined PhoneMetadata and NumberFormat symbols from libphonenumber.so.

Generate the protobuf sources through one shared CMake target and make all consuming libraries depend on it, preventing the race while retaining parallel compilation.