### PR TITLE
addpatch: pifpaf 3.4.0-2

### DIFF
--- a/pifpaf/fix-rabbitmq-cli-nodename.patch
+++ b/pifpaf/fix-rabbitmq-cli-nodename.patch
@@ -1,0 +1,14 @@
+--- a/pifpaf/drivers/rabbitmq.py
++++ b/pifpaf/drivers/rabbitmq.py
+@@ -116,8 +116,10 @@
+         self.start_node(nodename)
+ 
+     def rabbitmqctl(self, nodename, command):
++        # The CLI derives its own node name separately from the -n target.
++        env = dict(self.env, RABBITMQ_NODENAME=nodename)
+         self._exec(["rabbitmqctl", "-n", nodename] + command,
+-                   path=self._path, env=self.env)
++                   path=self._path, env=env)
+ 
+     def _setUp(self):
+         super(RabbitMQDriver, self)._setUp()

--- a/pifpaf/riscv64.patch
+++ b/pifpaf/riscv64.patch
@@ -1,0 +1,20 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -53,6 +53,8 @@
+ 
+ prepare() {
+   cd $pkgname
++  patch -Np1 -i "$srcdir/fix-testtools-try-import.patch"
++  patch -Np1 -i "$srcdir/fix-rabbitmq-cli-nodename.patch"
+   patch -Np1 -i ../$pkgname-skip-failing-tests.patch
+   # Move tests out of package to avoid installing.
+   mv pifpaf/tests tests
+@@ -75,3 +77,8 @@
+   cd $pkgname
+   python -m installer --destdir="$pkgdir" dist/*.whl
+ }
++
++source+=("fix-testtools-try-import.patch::https://github.com/jd/pifpaf/commit/0dc95746e00fff298a421767fe27c058d1787128.patch"
++         'fix-rabbitmq-cli-nodename.patch')
++sha512sums+=('085cc63a421778dacba5f82cfb7125c9fd948212ddae2cd9562f860449be4604529325874404f72d2ddbd28a9c4682183de519891db724e6d420bcd5a4fa1581'
++             '0812d1062312cb8783a5e7c5bbac772e64d9d48d43cef41ea7fa735fc20c931582b836867382977e7f9c4f7f0cb915e79e8349df42203c3748b55e02de2b57ae')


### PR DESCRIPTION
Backport the upstream replacement for testtools.try_import, removed in testtools 2.8.1. With testtools 2.9.1, tests.test_drivers fails to import with AttributeError before any driver tests can run.

Use a guarded httpbin import to preserve the existing availability check without adding skips or changing runtime behavior.

Upstream: https://github.com/jd/pifpaf/commit/0dc95746e00fff298a421767fe27c058d1787128

Pass RABBITMQ_NODENAME to rabbitmqctl as well as rabbitmq-server. After the RabbitMQ 4.3.1-1.1 rebuild, brokers start successfully, but both driver tests fail with "invalid node name ... reason: short" when invoking add_user or stop_app.

The -n argument selects the target broker, while the CLI derives its own node identity separately from the environment. Keep that identity on localhost by passing the corresponding server's explicit node name, avoiding dependence on the surrounding node-name configuration.