### PR TITLE
addpatch: thunderbird 155.0-1

### DIFF
--- a/thunderbird/llama-rvv-feature-detection.patch
+++ b/thunderbird/llama-rvv-feature-detection.patch
@@ -1,0 +1,191 @@
+--- a/third_party/llama.cpp/ggml/src/ggml-cpu/ggml-cpu-c.c
++++ b/third_party/llama.cpp/ggml/src/ggml-cpu/ggml-cpu-c.c
+@@ -730,7 +730,7 @@
+ #endif
+ #endif // __ARM_ARCH
+ 
+-#if defined(__riscv) && defined(__riscv_v_intrinsic)
++#if defined(__riscv_vector) && defined(__riscv_v_intrinsic)
+ #include <riscv_vector.h>
+ static void ggml_init_riscv_arch_features(void) {
+     ggml_riscv_arch_features.rvv_vlen = __riscv_vlenb();
+@@ -3651,7 +3651,7 @@
+ }
+ 
+ int ggml_cpu_has_riscv_v(void) {
+-#if defined(__riscv_v_intrinsic)
++#if defined(__riscv_vector) && defined(__riscv_v_intrinsic)
+     return 1;
+ #else
+     return 0;
+@@ -3659,7 +3659,7 @@
+ }
+ 
+ int ggml_cpu_get_rvv_vlen(void) {
+-#if defined(__riscv) && defined(__riscv_v_intrinsic)
++#if defined(__riscv_vector) && defined(__riscv_v_intrinsic)
+     return ggml_riscv_arch_features.rvv_vlen;
+ #else
+     return 0;
+--- a/third_party/llama.cpp/ggml/src/ggml-cpu/ggml-cpu-impl.h
++++ b/third_party/llama.cpp/ggml/src/ggml-cpu/ggml-cpu-impl.h
+@@ -345,7 +345,8 @@
+ #include <immintrin.h>
+ #endif
+ 
+-#ifdef __riscv_v_intrinsic
++// The intrinsic API can be available even when vector instructions are disabled.
++#if defined(__riscv_vector) && defined(__riscv_v_intrinsic)
+ #include <riscv_vector.h>
+ #endif
+ 
+--- a/third_party/llama.cpp/ggml/src/ggml-cpu/simd-mappings.h
++++ b/third_party/llama.cpp/ggml/src/ggml-cpu/simd-mappings.h
+@@ -14,7 +14,7 @@
+ #include <arm_neon.h>
+ #endif
+ 
+-#if defined(__riscv_v_intrinsic)
++#if defined(__riscv_vector) && defined(__riscv_v_intrinsic)
+ #include <riscv_vector.h>
+ #endif
+ 
+@@ -1262,7 +1262,7 @@
+ #define GGML_BF16_FMA_HI(acc, x, y) \
+     (acc) = GGML_F32x4_FMA((acc), GGML_BF16_TO_F32_HI(x), GGML_BF16_TO_F32_HI(y))
+ 
+-#elif defined(__riscv_v_intrinsic)
++#elif defined(__riscv_vector) && defined(__riscv_v_intrinsic)
+ 
+ // compatible with vlen >= 128
+ 
+--- a/third_party/llama.cpp/ggml/src/ggml-cpu/vec.cpp
++++ b/third_party/llama.cpp/ggml/src/ggml-cpu/vec.cpp
+@@ -84,7 +84,7 @@
+         }
+         // reduce sum1,sum2 to sum1
+         GGML_F32_VEC_REDUCE(sumf, sum1, sum2, sum3, sum4, sum5, sum6, sum7, sum8);
+-    #elif defined(__riscv_v_intrinsic)
++    #elif defined(__riscv_vector) && defined(__riscv_v_intrinsic)
+         int vl = __riscv_vsetvlmax_e32m8();
+         vfloat32m1_t vs = __riscv_vfmv_v_f_f32m1(0.0f, 1);
+         vfloat32m8_t vsum;
+@@ -318,7 +318,7 @@
+         sum1_hi = svadd_f32_m(DEFAULT_PG32, sum1_hi, sum3_hi);
+ 
+         sumf = ggml_sve_sum_f32x2(sum1_lo, sum1_hi);
+-    #elif defined(__riscv_v_intrinsic)
++    #elif defined(__riscv_vector) && defined(__riscv_v_intrinsic)
+         #if defined(__riscv_zvfh)
+             int vl = __riscv_vsetvlmax_e32m2();
+             vfloat32m1_t vs = __riscv_vfmv_v_f_f32m1(0.0f, 1);
+@@ -401,7 +401,7 @@
+     for (; i + 3 < n; i += 4) {
+         vst1q_f32(y + i, ggml_v_silu(vld1q_f32(x + i)));
+     }
+-#elif defined(__riscv_v_intrinsic)
++#elif defined(__riscv_vector) && defined(__riscv_v_intrinsic)
+     for (int vl; i < n; i += vl) {
+         vl = __riscv_vsetvl_e32m2(n - i);
+         vfloat32m2_t vx = __riscv_vle32_v_f32m2(&x[i], vl);
+@@ -438,7 +438,7 @@
+     for (; i + 3 < n; i += 4) {
+         vst1q_f32(y + i, vmulq_f32(ggml_v_silu(vld1q_f32(x + i)), vld1q_f32(g + i)));
+     }
+-#elif defined(__riscv_v_intrinsic)
++#elif defined(__riscv_vector) && defined(__riscv_v_intrinsic)
+     for (int vl; i < n; i += vl) {
+         vl = __riscv_vsetvl_e32m2(n - i);
+         vfloat32m2_t vx = __riscv_vle32_v_f32m2(&x[i], vl);
+@@ -508,7 +508,7 @@
+         val = vec_mul(val, val);
+         sum += (ggml_float)vec_hsum_f32x4(val);
+     }
+-#elif defined(__riscv_v_intrinsic)
++#elif defined(__riscv_vector) && defined(__riscv_v_intrinsic)
+     vfloat64m1_t vsum = __riscv_vfmv_v_f_f64m1(0, 1);
+     for (int vl; i < n; i += vl) {
+         vl = __riscv_vsetvl_e32m2(n - i);
+@@ -581,7 +581,7 @@
+         vst1q_f32(y + i, val);
+         sum += (ggml_float)vaddvq_f32(val);
+     }
+-#elif defined(__riscv_v_intrinsic)
++#elif defined(__riscv_vector) && defined(__riscv_v_intrinsic)
+     vfloat64m1_t vsum = __riscv_vfmv_v_f_f64m1(0, 1);
+     for (int avl; i < n; i += avl) {
+         avl = __riscv_vsetvl_e32m2(n - i);
+--- a/third_party/llama.cpp/ggml/src/ggml-cpu/vec.h
++++ b/third_party/llama.cpp/ggml/src/ggml-cpu/vec.h
+@@ -207,7 +207,7 @@
+         sumf[0] = ggml_sve_sum_f32x2(sum_0_lo, sum_0_hi);
+         sumf[1] = ggml_sve_sum_f32x2(sum_1_lo, sum_1_hi);
+         np = n;
+-    #elif defined(__riscv_v_intrinsic)
++    #elif defined(__riscv_vector) && defined(__riscv_v_intrinsic)
+         #if defined(__riscv_zvfh)
+             size_t vl = __riscv_vsetvlmax_e32m4();
+ 
+@@ -397,7 +397,7 @@
+ 
+             svst1_f32(pg, y + np2, ay1);
+         }
+-    #elif defined(__riscv_v_intrinsic)
++    #elif defined(__riscv_vector) && defined(__riscv_v_intrinsic)
+         for (int i = 0, avl; i < n; i += avl) {
+             avl = __riscv_vsetvl_e32m8(n - i);
+             vfloat32m8_t ax = __riscv_vle32_v_f32m8(&x[i], avl);
+@@ -514,7 +514,7 @@
+         svst1_f16(pg, (__fp16 *)(y + np2), hy);
+     }
+     np = n;
+-#elif defined(__riscv_v_intrinsic) // implies __riscv_v_intrinsic
++#elif defined(__riscv_vector) && defined(__riscv_v_intrinsic)
+     #if defined (__riscv_zvfh)
+         const ggml_fp16_t s = GGML_CPU_FP32_TO_FP16(v);
+         const _Float16 scale = *(const _Float16*)(&s);
+@@ -600,7 +600,7 @@
+                 y[i] += x[k][i]*v[k][0];
+             }
+         }
+-    #elif defined(__riscv_v_intrinsic)
++    #elif defined(__riscv_vector) && defined(__riscv_v_intrinsic)
+         for (int i = 0, avl; i < n; i += avl) {
+             avl = __riscv_vsetvl_e32m8(n - i);
+             vfloat32m8_t ay = __riscv_vle32_v_f32m8(&y[i], avl);
+@@ -661,7 +661,7 @@
+         for (int i = 0; i < n; ++i) {
+             y[i] = x[i]*s + b;
+         }
+-    #elif defined(__riscv_v_intrinsic)
++    #elif defined(__riscv_vector) && defined(__riscv_v_intrinsic)
+         for (int i = 0, avl; i < n; i += avl) {
+             avl = __riscv_vsetvl_e32m8(n - i);
+             vfloat32m8_t ax = __riscv_vle32_v_f32m8(&x[i], avl);
+@@ -730,7 +730,7 @@
+             ay1 = svmul_f32_m(pg, ay1, vx);
+             svst1_f32(pg, y + i, ay1);
+         }
+-    #elif defined(__riscv_v_intrinsic)
++    #elif defined(__riscv_vector) && defined(__riscv_v_intrinsic)
+         for (int i = 0, avl; i < n; i += avl) {
+             avl = __riscv_vsetvl_e32m8(n - i);
+             vfloat32m8_t ay = __riscv_vle32_v_f32m8(&y[i], avl);
+@@ -794,7 +794,7 @@
+         svst1_f16(pg, (__fp16 *)(y + np), out);
+     }
+     np = n;
+-#elif defined(__riscv_v_intrinsic)
++#elif defined(__riscv_vector) && defined(__riscv_v_intrinsic)
+     #if defined(__riscv_zvfh)
+         const ggml_fp16_t s = GGML_CPU_FP32_TO_FP16(v);
+         const _Float16 scale = *(const _Float16*)(&s);
+@@ -1315,7 +1315,7 @@
+     return _mm_div_ps(x, one_plus_exp_neg_x);
+ }
+ 
+-#elif defined(__riscv_v_intrinsic)
++#elif defined(__riscv_vector) && defined(__riscv_v_intrinsic)
+ 
+ // adapted from arm limited optimized routine
+ // the maximum error is 1.45358 plus 0.5 ulps

--- a/thunderbird/riscv64.patch
+++ b/thunderbird/riscv64.patch
@@ -1,0 +1,9 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -357 +357,6 @@
+ # vim:set sw=2 et:
++
++# Clang 20+ exposes RVV intrinsics even when the target has no vector extension.
++# https://github.com/ggml-org/llama.cpp/issues/22159
++source+=(llama-rvv-feature-detection.patch)
++sha512sums+=('0cf88c26b4e550f1c317aae769a23ca2a414c2f09dda8010b4e35b56e9a5f44859c3ffaa3bc98022fad98e97b827a0096d2e3bc1afd26b83bc0038f77ef2a699')


### PR DESCRIPTION
Clang 20+ defines __riscv_v_intrinsic even when vector instructions are not enabled. Bundled llama.cpp mistakes intrinsic API availability for target support, failing with "RISC-V type 'vfloat32m8_t' requires the 'zve32f' extension".

Also require __riscv_vector for the RVV paths and feature reporting, keeping the scalar backend on baseline riscv64 without requiring RVV.

Upstream: https://github.com/ggml-org/llama.cpp/issues/22159