### PR TITLE
addpatch: wasmer 7.4.0-1

### DIFF
--- a/wasmer/riscv64.patch
+++ b/wasmer/riscv64.patch
@@ -1,0 +1,21 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -11,4 +11,5 @@
+ depends=('libgcc' 'libstdc++' 'zlib' 'ncurses' 'libffi' 'libxkbcommon' 'llvm' 'glibc')
+ makedepends=('clang' 'git' 'rustup' 'cmake')
++makedepends_riscv64=('lld')
+ source=("git+https://github.com/wasmerio/wasmer#tag=v${pkgver}"
+         "${pkgname}-napi::git+https://github.com/wasmerio/napi"
+@@ -32,4 +33,6 @@
+ build() {
+   cd "$pkgname"
++  # The pinned Rust toolchain defaults to BFD, which rejects --icf=safe.
++  export RUSTFLAGS+=" -C link-arg=-fuse-ld=lld"
+   make ENABLE_CRANELIFT=1 ENABLE_LLVM=1 WASMER_REPRODUCIBLE_BUILD=1 WASMER_INSTALL_PREFIX=/usr
+ }
+@@ -37,4 +40,5 @@
+ check() {
+   cd "$pkgname"
++  export RUSTFLAGS+=" -C link-arg=-fuse-ld=lld"
+   make test-examples
+ }


### PR DESCRIPTION
Use LLD in build() and check() and add its build dependency. The pinned Rust 1.95 toolchain selects GNU BFD on riscv64, which rejects the --icf=safe option inherited through RUSTFLAGS and fails linking.

https://github.com/wasmerio/wasmer/blob/v7.4.0/rust-toolchain.toml