### PR TITLE
addpatch: ocicl 2.17.0-1

### DIFF
--- a/ocicl/fix-idna-list-access.patch
+++ b/ocicl/fix-idna-list-access.patch
@@ -1,0 +1,13 @@
+--- a/decode.lisp
++++ b/decode.lisp
+@@ -94,8 +94,8 @@
+       (loop with len = output-length
+             for i from 0 below len
+             do (when (elt case-flags i)
+-                 (setf (aref output i)
+-                       (char-code (char-upcase (code-char (aref output i))))))))
++                 (setf (elt output i)
++                       (char-code (char-upcase (code-char (elt output i))))))))
+     (map 'string #'code-char output)))
+ 
+ (defun to-unicode (string)

--- a/ocicl/riscv64.patch
+++ b/ocicl/riscv64.patch
@@ -1,0 +1,25 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,6 +14,14 @@
+ sha512sums=('577b895e044a91aa4c69f144734c94544a359a6f950c5431446f0a29c582cee9e960c6f9656d6f61d912cbb9045339c52b1b9aebe7d578e336db2844a9ea964f')
+ b2sums=('2b48ca5266237b96051313dafb0c82b4fe810afe8820fe8dd8211e054fed61b2d8894d568eabcfd7efc8158eb31fe5e8d837a477572d0ca1d43786bd81549e6a')
+ 
++prepare() {
++  cd "$pkgname"
++
++  # IDNA uses array access on a list, causing a fatal SBCL type warning.
++  # https://github.com/antifuchs/idna/issues/2
++  patch -Np1 -d systems/idna-20240503-bf789e6 -i "$srcdir/fix-idna-list-access.patch"
++}
++
+ build() {
+   cd "$pkgname"
+ 
+@@ -45,3 +53,7 @@
+     LICENSE \
+     VENDORED-LICENSES.txt
+ }
++
++source+=(fix-idna-list-access.patch)
++sha512sums+=('38913b76d81b19c6ddbc5dc695d4b8b308d9e52f70d3d0a6437a40cb4ed218396df17fb11cad21519c59056baf45da1467252abab6259f8918e6f5d57b3d8ae0')
++b2sums+=('08feeb19a27738d547fcabe3f71c440ed9bbe7e08fbd32e09a83cbfbb9b32eb8b1719e98118080135bad17533e90bf5166a2678f853d667e770813dcfd2757c9')


### PR DESCRIPTION
Use ELT instead of AREF for the list-valued output in bundled IDNA's punycode-decode. The riscv64 build stops at a COMPILE-FILE-ERROR for idna/decode; the same failure is reported upstream with a LIST versus VECTOR type warning at these accesses.

https://github.com/antifuchs/idna/issues/2