### PR TITLE
addpatch: python-pydantic-core 2.46.5-1

### DIFF
--- a/python-pydantic-core/riscv64.patch
+++ b/python-pydantic-core/riscv64.patch
@@ -1,0 +1,32 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -43,6 +43,12 @@
+ sha512sums=('77adaf98c0f22d7fd21b3f2dfe500293c8c12ae1c11a193daf912af8c3b25862387d9e36f1ca00109a008401afec216a437bfefe37dce1ffe2247d71f9c7cd4f')
+ b2sums=('dd04858c892929e0ed32738d7f44f3c382bceb2d51c4baa3b84aa06ea4cef9bac9a708ebbc63eeaf286e43879f14302ce298d97aed551ad9146679cc041b6cbd')
+ 
++prepare() {
++  cd pydantic
++  # pytest 9.1 deprecates class-scoped fixtures defined as instance methods.
++  git apply --include='pydantic-core/*' "$srcdir/pytest-9.1.patch"
++}
++
+ build() {
+   cd "pydantic/$_name"
+   python -m build --wheel --no-isolation
+@@ -51,6 +57,8 @@
+ check() {
+   local pytest_options=(
+     -vv
++    # The GC tests create 10,000 enum classes on slower builders.
++    --timeout=300
+     --ignore tests/test_docstrings.py  # we are not interested in linting/ formatting with ruff
+   )
+   local site_packages=$(python -c "import site; print(site.getsitepackages()[0])")
+@@ -68,3 +76,7 @@
+   install -vDm 644 LICENSE -t "$pkgdir/usr/share/licenses/$pkgname/"
+   install -vDm 644 README.md -t "$pkgdir/usr/share/doc/$pkgname/"
+ }
++
++source+=("pytest-9.1.patch::https://github.com/pydantic/pydantic/commit/f257d0155c6643fbda9516af6b2c4ca082ed7651.patch")
++sha512sums+=('11584017f955c65a9ea5b58b5045e3a8138c78fb52d9350d9a7480b44a7e66a372e5a92dd53c190259de1900e3b3082efd079999e6397d5b80e812d60caef3b2')
++b2sums+=('36d6593a9032de34acd645f650e8264d82177d79b2e1a7f9ba94628c890e2f9984cfdc747c10b6cfa0da792a4f94076f00b94ac7c37c3eafbde1153f935a9ffb')


### PR DESCRIPTION
Backport the upstream pytest 9.1 compatibility fix. Class-scoped instance fixtures trigger PytestRemovedIn10Warning, which the suite treats as an error, leading to 34 setup errors. Convert them to class methods while preserving fixture scope and test coverage.

Apply only the pydantic-core changes, excluding parent-project tests and the incompatible lockfile update.

https://github.com/pydantic/pydantic/commit/f257d0155c6643fbda9516af6b2c4ca082ed7651

Raise the pytest timeout from 30 to 300 seconds. The enum serializer and validator GC tests time out while creating 10,000 enum classes on the riscv64 builder, before reaching their GC assertions. Keep all iterations and assertions unchanged.