### PR TITLE
addpatch: borg 1.4.5-1

### DIFF
--- a/borg/riscv64.patch
+++ b/borg/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -26,7 +26,8 @@
+ 
+ build() {
+   cd "$_pkgname-$pkgver"
+-  python -m build --wheel --no-isolation
++  # Supply the release version when setuptools-scm cannot read the sdist metadata.
++  SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver python -m build --wheel --no-isolation
+ }
+ 
+ check() {


### PR DESCRIPTION
Set SETUPTOOLS_SCM_PRETEND_VERSION=$pkgver for the wheel build. The builder pairs setuptools-scm 10.0.5 with vcs-versioning 2.3.1, which lacks a registered PKG-INFO discovery hook in this combination. Version inference therefore fails despite the metadata in the release archive. Supply the known release version as documented by Borg.

https://github.com/borgbackup/borg/blob/1.4.5/docs/installation.rst#L388