### PR TITLE
updpatch: bun 1.4.0-1

### DIFF
--- a/bun/bun-riscv64.patch
+++ b/bun/bun-riscv64.patch
@@ -1,132 +1,125 @@
-diff --git a/build.zig b/build.zig
-index 39fb92d1e2..e965646985 100644
---- a/build.zig
-+++ b/build.zig
-@@ -120,10 +120,14 @@ pub fn getOSVersionMin(os: OperatingSystem) ?Target.Query.OsVersion {
-     };
+--- /dev/null
++++ b/patches/mimalloc/atomic-pause.patch
+@@ -0,0 +1,9 @@
++--- a/include/mimalloc/atomic.h
+++++ b/include/mimalloc/atomic.h
++@@ -412,5 +412,5 @@
++ #else
++ static inline void mi_atomic_pause(void) {
++-  mi_atomic_thread_fence(mi_memory_order_seq_cst);
+++  mi_atomic(thread_fence)(mi_memory_order(seq_cst));
++ }
++ #endif
+--- a/scripts/build/codegen.ts
++++ b/scripts/build/codegen.ts
+@@ -92,7 +92,7 @@
+           : cfg.os === "freebsd"
+             ? "freebsd"
+             : "linux";
+-  const arch = cfg.x64 ? "x64" : "arm64";
++  const arch = cfg.arm64 ? "arm64" : cfg.arch;
+   return { platform, arch };
  }
- 
--pub fn getOSGlibCVersion(os: OperatingSystem) ?Version {
-+pub fn getOSGlibCVersion(os: OperatingSystem, arch: Arch) ?Version {
-     return switch (os) {
-         // Compiling with a newer glibc than this will break certain cloud environments. See symbols.test.ts.
--        .linux => .{ .major = 2, .minor = 17, .patch = 0 },
-+        .linux => switch (arch) {
-+            // riscv64 support was added in glibc 2.27.
-+            .riscv64 => .{ .major = 2, .minor = 27, .patch = 0 },
-+            else => .{ .major = 2, .minor = 17, .patch = 0 },
-+        },
- 
-         else => null,
-     };
-@@ -180,7 +184,7 @@ pub fn build(b: *Build) !void {
-     }
- 
-     target_query.os_version_min = getOSVersionMin(os);
--    target_query.glibc_version = if (abi.isGnu()) getOSGlibCVersion(os) else null;
-+    target_query.glibc_version = if (abi.isGnu()) getOSGlibCVersion(os, arch) else null;
- 
-     const target = b.resolveTargetQuery(target_query);
- 
-@@ -612,7 +616,7 @@ const TargetDescription = struct {
-             .cpu_arch = desc.arch,
-             .cpu_model = getCpuModel(desc.os, desc.arch) orelse .determined_by_arch_os,
-             .os_version_min = getOSVersionMin(desc.os),
--            .glibc_version = if (desc.musl) null else getOSGlibCVersion(desc.os),
-+            .glibc_version = if (desc.musl) null else getOSGlibCVersion(desc.os, desc.arch),
-         });
-     }
- };
-diff --git a/scripts/build/config.ts b/scripts/build/config.ts
-index f5a672b070..da79542bed 100644
+
 --- a/scripts/build/config.ts
 +++ b/scripts/build/config.ts
-@@ -18,7 +18,7 @@ import { cyan, dim, green } from "./tty.ts";
- import { defaultZigCommit } from "./zig.ts";
- 
- export type OS = "linux" | "darwin" | "windows";
+@@ -18,7 +18,7 @@
+ import { cyan, dim, green } from "./tty.ts";
+
+ export type OS = "linux" | "darwin" | "windows" | "freebsd";
 -export type Arch = "x64" | "aarch64";
 +export type Arch = "x64" | "aarch64" | "riscv64";
- export type Abi = "gnu" | "musl";
+ export type Abi = "gnu" | "musl" | "android";
  export type BuildType = "Debug" | "Release" | "RelWithDebInfo" | "MinSizeRel";
- export type BuildMode = "full" | "cpp-only" | "zig-only" | "link-only";
-@@ -75,6 +75,7 @@ export interface Config {
+ export type BuildMode = "full" | "cpp-only" | "rust-only" | "link-only" | "rust-and-link" | "archive-link";
+@@ -86,6 +86,7 @@
    unix: boolean;
    x64: boolean;
    arm64: boolean;
 +  riscv64: boolean;
- 
+
    /**
     * What's running the build. Differs from os/arch/windows (target) in
-@@ -313,8 +314,10 @@ export function detectHost(): Host {
+@@ -514,9 +515,11 @@
        ? "x64"
        : a === "arm64"
          ? "aarch64"
+-        : (() => {
+-            throw new BuildError(`Unsupported host architecture: ${a}`, { hint: "Bun builds on x64 or arm64" });
+-          })();
 +        : a === "riscv64"
 +          ? "riscv64"
-         : (() => {
--            throw new BuildError(`Unsupported host architecture: ${a}`, { hint: "Bun builds on x64 or arm64" });
-+            throw new BuildError(`Unsupported host architecture: ${a}`, { hint: "Bun builds on x64, arm64, or riscv64" });
-           })();
- 
-   return { os, arch, exeSuffix: os === "windows" ? ".exe" : "" };
-@@ -352,6 +355,7 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
-   const unix = linux || darwin;
++          : (() => {
++              throw new BuildError(`Unsupported host architecture: ${a}`, { hint: "Bun builds on x64, arm64, or riscv64" });
++            })();
+
+   // rustTriple is stamped later from Toolchain.rustHostTriple in resolveConfig
+   // (the rustc probe is authoritative — distinguishes glibc/musl host etc.).
+@@ -740,6 +743,7 @@
+   const unix = linux || darwin || freebsd;
    const x64 = arch === "x64";
    const arm64 = arch === "aarch64";
 +  const riscv64 = arch === "riscv64";
- 
-   // Platform file conventions — MSVC style on Windows, Unix everywhere else.
-   const exeSuffix = windows ? ".exe" : "";
-@@ -421,8 +425,8 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
-   // failure is loud ("cannot find -l:libatomic.a") and the fix is obvious.
+   // Darwin target on a non-darwin host (Linux CI box building macOS
+   // binaries). Same host-clang + --target/-isysroot model as Android/FreeBSD,
+   // with ld64.lld doing the Mach-O link. See the cross block further down.
+@@ -896,8 +900,8 @@
    const staticLibatomic = partial.staticLibatomic ?? true;
- 
--  // TinyCC: off on Windows ARM64 (not supported), on elsewhere
--  const tinycc = partial.tinycc ?? !(windows && arm64);
-+  // TinyCC: off where the embedded JIT backend is not wired up.
-+  const tinycc = partial.tinycc ?? (!(windows && arm64) && !riscv64);
- 
+
+   // TinyCC: off on Android (no upstream bionic support; FFI cc() falls back
+-  // to dlopen-only) and FreeBSD (oven-sh/tinycc has no FreeBSD target).
+-  const tinycc = partial.tinycc ?? !(abi === "android" || freebsd);
++  // to dlopen-only), FreeBSD, and riscv64 (no embedded FFI backend).
++  const tinycc = partial.tinycc ?? !(abi === "android" || freebsd || riscv64);
+
    const valgrind = partial.valgrind ?? false;
    const fuzzilli = partial.fuzzilli ?? false;
-@@ -493,6 +497,7 @@ export function resolveConfig(partial: PartialConfig, toolchain: Toolchain): Con
+@@ -1020,7 +1024,7 @@
+   // and the libstdc++ ABI matches the WebKit prebuilt. musl uses an
+   // alpine-derived sysroot. Local dev without a sysroot builds native.
+   if (linux && abi !== "android" && crossTarget === undefined) {
+-    const llvmArch = x64 ? "x86_64" : "aarch64";
++    const llvmArch = x64 ? "x86_64" : arch;
+     const hostAbi = host.os === "linux" ? detectLinuxAbi() : undefined;
+     const isCross = arch !== host.arch || abi !== hostAbi;
+     if (abi === "musl") {
+@@ -1182,6 +1186,7 @@
      unix,
      x64,
      arm64,
 +    riscv64,
      host,
+     canRunOnHost: os === host.os && arch === host.arch && (!linux || abi === (detectLinuxAbi() ?? abi)),
      exeSuffix,
-     objSuffix,
-diff --git a/scripts/build/deps/boringssl.ts b/scripts/build/deps/boringssl.ts
-index e1e12d494d..2f2cb660a9 100644
---- a/scripts/build/deps/boringssl.ts
-+++ b/scripts/build/deps/boringssl.ts
-@@ -17,11 +17,15 @@ export const boringssl: Dependency = {
-     commit: BORINGSSL_COMMIT,
+--- a/scripts/build/deps/libjpeg-turbo.ts
++++ b/scripts/build/deps/libjpeg-turbo.ts
+@@ -98,7 +98,10 @@
+   patches: ["patches/libjpeg-turbo/8bit-only.patch", "patches/libjpeg-turbo/jbun_stubs.c"],
+
+   build: cfg => {
+-    const withSimd: [string, string] = ["#cmakedefine WITH_SIMD 1", "#define WITH_SIMD 1"];
++    const withSimd: [string, string] = [
++      "#cmakedefine WITH_SIMD 1",
++      cfg.x64 || cfg.arm64 ? "#define WITH_SIMD 1" : "/* #undef WITH_SIMD */",
++    ];
+     const srcDir = depSourceDir(cfg, "libjpeg-turbo");
+     const hostWin = cfg.host.os === "windows";
+     return {
+--- a/scripts/build/deps/mimalloc.ts
++++ b/scripts/build/deps/mimalloc.ts
+@@ -25,4 +25,6 @@
    }),
- 
--  build: () => ({
-+  build: cfg => ({
-     kind: "nested-cmake",
-     // No explicit targets — defaults to lib names (crypto, ssl, decrepit).
-     // BoringSSL's cmake targets match its output library names.
--    args: {},
-+    //
-+    // BoringSSL's generated source list includes assembly for every supported
-+    // ISA. On riscv64 that can leave x86/arm objects in libcrypto.a unless ASM
-+    // is disabled explicitly.
-+    args: cfg.riscv64 ? { OPENSSL_NO_ASM: "1" } : {},
-   }),
- 
-   provides: () => ({
-diff --git a/scripts/build/deps/webkit.ts b/scripts/build/deps/webkit.ts
-index 2dcc0ab836..160fa78bfd 100644
+
++  patches: ["patches/mimalloc/atomic-pause.patch"],
++
+   build: cfg => {
+     // ─── Override behavior (global malloc replacement) ───
 --- a/scripts/build/deps/webkit.ts
 +++ b/scripts/build/deps/webkit.ts
-@@ -251,6 +251,19 @@ export const webkit: Dependency = {
+@@ -340,6 +340,19 @@
        ...(cfg.asan ? { ENABLE_SANITIZERS: "address" } : {}),
      };
- 
+
 +    if (cfg.riscv64) {
 +      Object.assign(args, {
 +        ENABLE_JIT: "OFF",
@@ -143,198 +136,336 @@ index 2dcc0ab836..160fa78bfd 100644
      const spec: NestedCmakeBuild = {
        kind: "nested-cmake",
        targets: ["jsc"],
-diff --git a/scripts/build/flags.ts b/scripts/build/flags.ts
-index 1ac5b4d4f0..2484c8469c 100644
+--- a/scripts/build/deps/zlib.ts
++++ b/scripts/build/deps/zlib.ts
+@@ -203,6 +203,11 @@
+       }
+       sources.push(...GENERIC.map(s => `arch/generic/${s}.c`));
+       sources.push("arch/arm/arm_features.c");
++    } else if (cfg.riscv64) {
++      kernels = [];
++      archDir = "generic";
++      defines.WITH_ALL_FALLBACKS = true;
++      sources.push(...GENERIC.map(s => `arch/generic/${s}.c`));
+     } else {
+       throw new Error(`zlib: no SIMD kernel table for arch ${cfg.arch}`);
+     }
 --- a/scripts/build/flags.ts
 +++ b/scripts/build/flags.ts
-@@ -36,6 +36,11 @@ export interface Flag {
- // ═══════════════════════════════════════════════════════════════════════════
- 
+@@ -48,6 +48,11 @@
+
  export const cpuTargetFlags: Flag[] = [
-+  {
+   {
 +    flag: ["-march=rv64gc", "-mabi=lp64d", "-mno-relax"],
 +    when: c => c.linux && c.riscv64,
 +    desc: "RISC-V Linux: RV64GC with double-float ABI and fixed instruction layout",
 +  },
-   {
++  {
      flag: "-mcpu=apple-m1",
      when: c => c.darwin && c.arm64,
-@@ -706,19 +711,27 @@ export const linkerFlags: Flag[] = [
-       "-Wl,--wrap=exp",
-       "-Wl,--wrap=exp2",
-       "-Wl,--wrap=expf",
--      "-Wl,--wrap=fcntl64",
--      "-Wl,--wrap=getrandom",
--      "-Wl,--wrap=gettid",
-       "-Wl,--wrap=log",
-       "-Wl,--wrap=log2",
-       "-Wl,--wrap=log2f",
-       "-Wl,--wrap=logf",
-       "-Wl,--wrap=pow",
-       "-Wl,--wrap=powf",
-+    ],
-+    when: c => c.linux && c.abi !== "musl" && !c.riscv64,
-+    desc: "Wrap old glibc libm symbols (portable down to glibc 2.17)",
-+  },
-+  {
-+    // RISC-V glibc starts at 2.27, so the libm version wrappers above are not
-+    // needed there and recurse without an architecture-specific .symver alias.
-+    flag: [
-+      "-Wl,--wrap=fcntl64",
-+      "-Wl,--wrap=getrandom",
-+      "-Wl,--wrap=gettid",
-       "-Wl,--wrap=quick_exit",
-     ],
-     when: c => c.linux && c.abi !== "musl",
--    desc: "Wrap glibc 2.18+ symbols (portable down to glibc 2.17)",
-+    desc: "Wrap newer glibc runtime symbols",
-   },
-   {
-     flag: ["-static-libstdc++", "-static-libgcc"],
-@@ -747,6 +760,11 @@ export const linkerFlags: Flag[] = [
-     when: c => c.linux,
-     desc: "Use lld instead of system ld",
-   },
+     desc: "Target Apple M1 (works on all Apple Silicon)",
+@@ -826,6 +831,11 @@
+ // ═══════════════════════════════════════════════════════════════════════════
+
+ export const linkerFlags: Flag[] = [
 +  {
 +    flag: "-Wl,--no-relax",
 +    when: c => c.linux && c.riscv64,
-+    desc: "Disable RISC-V linker relaxation so JSC IPInt opcode labels keep fixed spacing",
++    desc: "Keep JSC IPInt opcode labels at fixed spacing",
 +  },
+   // ─── Sanitizers ───
    {
-     flag: ["-fno-pic", "-Wl,-no-pie"],
-     when: c => c.linux,
-diff --git a/scripts/build/source.ts b/scripts/build/source.ts
-index bee06834a8..4cdc14c587 100644
+     flag: "-fsanitize=address",
+@@ -1225,7 +1235,7 @@
+       "_dl_find_object",
+       "posix_spawn_file_actions_addchdir_np",
+     ].map(s => `-Wl,--wrap=${s}`),
+-    when: c => c.linux && c.abi === "gnu",
++    when: c => c.linux && c.abi === "gnu" && !c.riscv64,
+     desc: "Wrap glibc 2.18+ symbols (portable down to glibc 2.17)",
+   },
+   {
+--- a/scripts/build/rust.ts
++++ b/scripts/build/rust.ts
+@@ -52,7 +52,7 @@
+
+ /** `rustTarget()` on the bare target platform; `abi` is linux-only. */
+ export function rustTriple(os: OS, arch: Arch, abi: Abi | undefined): string {
+-  const rustArch = arch === "x64" ? "x86_64" : "aarch64";
++  const rustArch = arch === "x64" ? "x86_64" : arch === "riscv64" ? "riscv64gc" : "aarch64";
+   if (os === "darwin") return `${rustArch}-apple-darwin`;
+   if (os === "windows") return `${rustArch}-pc-windows-msvc`;
+   if (os === "freebsd") return `${rustArch}-unknown-freebsd`;
+@@ -143,6 +143,7 @@
+  * clang-cl (windows) spells the same flags `/clang:-march=...`.
+  */
+ function rustCpuTargetFlags(cfg: Config): string[] {
++  if (cfg.riscv64) return ["-Ctarget-cpu=generic-rv64", "-Ctarget-feature=+m,+a,+f,+d,+c,-relax"];
+   const rustflags: string[] = [];
+   for (const clangFlag of computeCpuTargetFlags(cfg)) {
+     const parsed = /^(?:\/clang:)?-m(cpu|tune|arch)=(.+)$/.exec(clangFlag);
 --- a/scripts/build/source.ts
 +++ b/scripts/build/source.ts
-@@ -1023,8 +1023,12 @@ function emitNestedCmake(
+@@ -1211,8 +1211,10 @@
      // Most deps are static-lib-only so this usually doesn't matter, but when
      // it does (dep builds a tool to generate a header), using lld keeps the
      // toolchain consistent.
 -    args.push(`-DCMAKE_EXE_LINKER_FLAGS=--ld-path=${cfg.ld}`);
 -    args.push(`-DCMAKE_SHARED_LINKER_FLAGS=--ld-path=${cfg.ld}`);
 +    const linkerFlags = [`--ld-path=${cfg.ld}`];
-+    if (cfg.riscv64) {
-+      linkerFlags.push("-Wl,--no-relax");
-+    }
++    if (cfg.riscv64) linkerFlags.push("-Wl,--no-relax");
 +    args.push(`-DCMAKE_EXE_LINKER_FLAGS=${linkerFlags.join(" ")}`);
 +    args.push(`-DCMAKE_SHARED_LINKER_FLAGS=${linkerFlags.join(" ")}`);
    }
    if (cfg.windows) {
      // Windows-specific toolchain forwarding. When CMAKE_C_COMPILER is
-diff --git a/scripts/build/tools.ts b/scripts/build/tools.ts
-index 4af051385b..af9fcf30eb 100644
---- a/scripts/build/tools.ts
-+++ b/scripts/build/tools.ts
-@@ -425,9 +425,10 @@ export function resolveLlvmToolchain(
-     ld = ""; // darwin: unused
-   }
- 
--  // strip: GNU strip on Linux (more features), llvm-strip elsewhere
-+  // strip: GNU strip on native Linux (more features), llvm-strip for cross
-+  // targets because the host binutils may not recognize the target ELF.
-   let strip: string;
--  if (os === "linux") {
-+  if (os === "linux" && arch !== "riscv64") {
-     strip = findTool({ names: ["strip"], required: true, hint: "Install binutils for your distro" })?.path ?? "";
-   } else {
-     strip = findLlvmTool("llvm-strip", paths, os, { checkVersion: false, required: true })?.path ?? "";
-diff --git a/scripts/build/zig.ts b/scripts/build/zig.ts
-index cc3867919c..db083d960a 100644
---- a/scripts/build/zig.ts
-+++ b/scripts/build/zig.ts
-@@ -74,11 +74,10 @@ function usingParallelCompiler(cfg: Config): boolean {
- // ───────────────────────────────────────────────────────────────────────────
- 
- /**
-- * Zig target triple. Arch is always `x86_64`/`aarch64` (zig's naming),
-- * not `x64`/`arm64`.
-+ * Zig target triple. Arch is always zig's naming, not Node's `x64`/`arm64`.
-  */
- export function zigTarget(cfg: Config): string {
--  const arch = cfg.x64 ? "x86_64" : "aarch64";
-+  const arch = cfg.x64 ? "x86_64" : cfg.arm64 ? "aarch64" : "riscv64";
-   if (cfg.darwin) return `${arch}-macos-none`;
-   if (cfg.windows) return `${arch}-windows-msvc`;
-   // linux: abi is always set (resolveConfig asserts)
-@@ -129,6 +128,9 @@ export function zigCpu(cfg: Config): string {
-     if (cfg.windows) return "cortex_a76";
-     return "native";
-   }
-+  if (cfg.riscv64) {
-+    return "baseline_rv64";
-+  }
-   // x64
-   return cfg.baseline ? "nehalem" : "haswell";
+--- a/scripts/build/stream.ts
++++ b/scripts/build/stream.ts
+@@ -259,11 +259,13 @@
+   });
+
+   child.on("close", (code, signal) => {
++    // Let queued output drain before exiting, including compiler errors.
+     if (signal) {
+       writeFinal(`killed by ${signal}\n`);
+-      process.exit(1);
++      process.exitCode = 1;
++      return;
+     }
+     if (code === 0) writeStamp();
+-    process.exit(code ?? 1);
++    process.exitCode = code ?? 1;
+   });
  }
-diff --git a/src/Global.zig b/src/Global.zig
-index 1c6c1bf22a..9231367932 100644
---- a/src/Global.zig
-+++ b/src/Global.zig
-@@ -53,6 +53,8 @@ else if (Environment.isX86)
+--- a/src/bun_core/Global.rs
++++ b/src/bun_core/Global.rs
+@@ -577,6 +577,8 @@
      "x86"
- else if (Environment.isAarch64)
+ } else if cfg!(target_arch = "aarch64") {
      "arm64"
-+else if (Environment.isRiscV64)
++} else if cfg!(target_arch = "riscv64") {
 +    "riscv64"
- else
-     "unknown";
- 
-diff --git a/src/analytics.zig b/src/analytics.zig
-index f62f8f4408..9571db90cc 100644
---- a/src/analytics.zig
-+++ b/src/analytics.zig
-@@ -240,7 +240,7 @@ pub const EventName = enum(u8) {
- 
- var random: std.rand.DefaultPrng = undefined;
- 
--const platform_arch = if (Environment.isAarch64) analytics.Architecture.arm else analytics.Architecture.x64;
-+const platform_arch = if (Environment.isAarch64) analytics.Architecture.arm else if (Environment.isRiscV64) analytics.Architecture.riscv64 else analytics.Architecture.x64;
- 
- // TODO: move this code somewhere more appropriate, and remove it from "analytics"
- // The following code is not currently even used for analytics, just feature-detection
-diff --git a/src/analytics/schema.zig b/src/analytics/schema.zig
-index 33d3fcadbb..02c860dd1e 100644
---- a/src/analytics/schema.zig
-+++ b/src/analytics/schema.zig
-@@ -350,6 +350,9 @@ pub const analytics = struct {
-         /// arm
-         arm,
- 
-+        /// riscv64
-+        riscv64,
-+
-         _,
- 
-         pub fn jsonStringify(self: @This(), writer: anytype) !void {
-diff --git a/src/bun.js/api/ffi.zig b/src/bun.js/api/ffi.zig
-index 6f4ec41433..79017a581e 100644
---- a/src/bun.js/api/ffi.zig
-+++ b/src/bun.js/api/ffi.zig
-@@ -301,6 +301,18 @@ pub const FFI = struct {
-                     } else if (bun.FD.cwd().directoryExistsAt("/usr/lib64").isTrue()) {
-                         cached_default_system_library_dir = "/usr/lib64";
-                     }
-+                } else if (Environment.isRiscV64) {
-+                    if (bun.FD.cwd().directoryExistsAt("/usr/include/riscv64-linux-gnu").isTrue()) {
-+                        cached_default_system_include_dir = "/usr/include/riscv64-linux-gnu";
-+                    } else if (bun.FD.cwd().directoryExistsAt("/usr/include").isTrue()) {
-+                        cached_default_system_include_dir = "/usr/include";
-+                    }
-+
-+                    if (bun.FD.cwd().directoryExistsAt("/usr/lib/riscv64-linux-gnu").isTrue()) {
-+                        cached_default_system_library_dir = "/usr/lib/riscv64-linux-gnu";
-+                    } else if (bun.FD.cwd().directoryExistsAt("/usr/lib64").isTrue()) {
-+                        cached_default_system_library_dir = "/usr/lib64";
-+                    }
-                 }
-             }
+ } else {
+     "unknown"
+ };
+--- a/src/bun_core/debug.rs
++++ b/src/bun_core/debug.rs
+@@ -48,7 +48,16 @@
+         };
+         fp
+     }
+-    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
++    #[cfg(target_arch = "riscv64")]
++    {
++        let fp: usize;
++        // SAFETY: reading s0 (fp) is side-effect-free.
++        unsafe {
++            core::arch::asm!("mv {}, s0", out(reg) fp, options(nomem, nostack))
++        };
++        fp
++    }
++    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64")))]
+     {
+         // Approximate with a stack local's addr on arches
+         // without an asm! mapping yet. fp-walk will fail its alignment sanity
+--- a/src/bun_core/env.rs
++++ b/src/bun_core/env.rs
+@@ -175,6 +175,7 @@
+ pub enum Architecture {
+     X64,
+     Arm64,
++    Riscv64,
+     Wasm,
+ }
+
+@@ -184,6 +185,7 @@
+         match self {
+             Self::X64 => "x64",
+             Self::Arm64 => "aarch64",
++            Self::Riscv64 => "riscv64",
+             Self::Wasm => "wasm",
          }
-diff --git a/src/bun.js/bindings/BunProcess.cpp b/src/bun.js/bindings/BunProcess.cpp
-index a5c074c385..a3cdbbce41 100644
---- a/src/bun.js/bindings/BunProcess.cpp
-+++ b/src/bun.js/bindings/BunProcess.cpp
-@@ -172,6 +172,8 @@ static JSValue constructArch(VM& vm, JSObject* processObject)
+     }
+@@ -196,6 +198,7 @@
+         b"amd64" => Architecture::X64,
+         b"aarch64" => Architecture::Arm64,
+         b"arm64" => Architecture::Arm64,
++        b"riscv64" => Architecture::Riscv64,
+         b"wasm" => Architecture::Wasm,
+     };
+ }
+@@ -206,6 +209,8 @@
+     Architecture::X64
+ } else if IS_AARCH64 {
+     Architecture::Arm64
++} else if cfg!(target_arch = "riscv64") {
++    Architecture::Riscv64
+ } else {
+     panic!("Please add your architecture to the Architecture enum")
+ };
+--- a/src/bun_core/lib.rs
++++ b/src/bun_core/lib.rs
+@@ -2946,7 +2946,13 @@
+         // return-address slot at `[fp + PC_OFFSET]` is always mapped.
+         unsafe { *((fp + debug::PC_OFFSET) as *const usize) }
+     }
+-    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
++    #[cfg(target_arch = "riscv64")]
++    {
++        let fp = debug::frame_address();
++        // SAFETY: the RISC-V ABI stores this frame's return address at fp - 8.
++        unsafe { *((fp - debug::PC_OFFSET) as *const usize) }
++    }
++    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64")))]
+     {
+         // No frame-pointer asm! mapping for this arch; capture_current treats 0
+         // as "no trim".
+--- a/src/crash_handler/CPUFeatures.rs
++++ b/src/crash_handler/CPUFeatures.rs
+@@ -44,7 +44,22 @@
+     }
+ }
+
+-#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
++#[cfg(target_arch = "riscv64")]
++bitflags::bitflags! {
++    #[repr(transparent)]
++    #[derive(Copy, Clone)]
++    pub struct Flags: u8 {
++        const NONE = 1 << 0;
++        const M    = 1 << 1;
++        const A    = 1 << 2;
++        const F    = 1 << 3;
++        const D    = 1 << 4;
++        const C    = 1 << 5;
++        const V    = 1 << 6;
++    }
++}
++
++#[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64")))]
+ compile_error!("CPUFeatures: unsupported target architecture");
+
+ // Per-arch const table of flag names, skipping "none" and padding bits.
+@@ -67,6 +82,16 @@
+     ("sve", Flags::SVE),
+ ];
+
++#[cfg(target_arch = "riscv64")]
++const NAMED_FLAGS: &[(&str, Flags)] = &[
++    ("m", Flags::M),
++    ("a", Flags::A),
++    ("f", Flags::F),
++    ("d", Flags::D),
++    ("c", Flags::C),
++    ("v", Flags::V),
++];
++
+ impl fmt::Display for CPUFeatures {
+     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+         let mut is_first = true;
+--- a/src/crash_handler/lib.rs
++++ b/src/crash_handler/lib.rs
+@@ -1498,6 +1498,8 @@
+         } else {
+             "arm64"
+         }
++    } else if cfg!(target_arch = "riscv64") {
++        "riscv64"
+     } else {
+         "x64"
+     };
+@@ -1538,6 +1540,12 @@
+             let mc = &(*uc).uc_mcontext;
+             Some((mc.pc as usize, mc.regs[29] as usize))
+         }
++        #[cfg(all(target_os = "linux", target_arch = "riscv64"))]
++        // SAFETY: the kernel passes a valid ucontext_t as the handler's 3rd arg.
++        unsafe {
++            let mc = &(*uc).uc_mcontext;
++            Some((mc.__gregs[libc::REG_PC] as usize, mc.__gregs[libc::REG_S0] as usize))
++        }
+         #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+         // SAFETY: the kernel passes a valid ucontext_t as the handler's 3rd arg.
+         unsafe {
+@@ -1559,6 +1567,7 @@
+         #[cfg(not(any(
+             all(target_os = "linux", target_arch = "x86_64"),
+             all(target_os = "linux", target_arch = "aarch64"),
++            all(target_os = "linux", target_arch = "riscv64"),
+             all(target_os = "macos", target_arch = "x86_64"),
+             all(target_os = "macos", target_arch = "aarch64"),
+         )))]
+@@ -2370,6 +2379,10 @@
+             {
+                 b'm'
+             }
++            #[cfg(all(target_os = "linux", target_arch = "riscv64"))]
++            {
++                b'r'
++            }
+             #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+             {
+                 b'M'
+--- a/src/install_types/resolver_hooks.rs
++++ b/src/install_types/resolver_hooks.rs
+@@ -913,6 +913,7 @@
+     pub(crate) const S390X: u16 = 1 << 9;
+     pub(crate) const X32: u16 = 1 << 10;
+     pub(crate) const X64: u16 = 1 << 11;
++    pub(crate) const RISCV64: u16 = 1 << 12;
+
+     pub const ALL_VALUE: u16 = Self::ARM
+         | Self::ARM64
+@@ -924,12 +925,15 @@
+         | Self::S390
+         | Self::S390X
+         | Self::X32
+-        | Self::X64;
++        | Self::X64
++        | Self::RISCV64;
+
+     #[cfg(target_arch = "aarch64")]
+     pub const CURRENT: Self = Self(Self::ARM64);
+     #[cfg(target_arch = "x86_64")]
+     pub const CURRENT: Self = Self(Self::X64);
++    #[cfg(target_arch = "riscv64")]
++    pub const CURRENT: Self = Self(Self::RISCV64);
+
+     #[inline]
+     pub const fn none() -> Self {
+@@ -957,6 +961,7 @@
+     b"arm" => ARM, b"ppc" => PPC, b"x32" => X32, b"x64" => X64,
+     b"ia32" => IA32, b"mips" => MIPS, b"s390" => S390,
+     b"arm64" => ARM64, b"ppc64" => PPC64, b"s390x" => S390X, b"mipsel" => MIPSEL,
++    b"riscv64" => RISCV64,
+ ] }
+
+ // ─── Repository (data) ────────────────────────────────────────────────────
+--- a/src/js/node/os.ts
++++ b/src/js/node/os.ts
+@@ -97,7 +97,7 @@
+     },
+     cpus: lazyCpus(binding),
+     endianness: function () {
+-      return process.arch === "arm64" || process.arch === "x64" //
++      return process.arch === "arm64" || process.arch === "x64" || process.arch === "riscv64" //
+         ? "LE"
+         : $bundleError("TODO: endianness");
+     },
+@@ -142,7 +142,9 @@
+           ? process.platform === "freebsd"
+             ? "amd64"
+             : "x86_64"
+-          : $bundleError("TODO: machine");
++          : process.arch === "riscv64"
++            ? "riscv64"
++            : $bundleError("TODO: machine");
+     },
+     devNull: process.platform === "win32" ? "\\\\.\\nul" : "/dev/null",
+     get EOL() {
+--- a/src/jsc/bindings/BunProcess.cpp
++++ b/src/jsc/bindings/BunProcess.cpp
+@@ -195,6 +195,8 @@
      return JSC::jsString(vm, makeAtomString("x64"_s));
  #elif CPU(ARM64)
      return JSC::jsString(vm, makeAtomString("arm64"_s));
@@ -343,7 +474,7 @@ index a5c074c385..a3cdbbce41 100644
  #else
  #error "Unknown architecture"
  #endif
-@@ -2293,6 +2295,9 @@ static JSValue constructProcessConfigObject(VM& vm, JSObject* processObject)
+@@ -2836,6 +2838,9 @@
  #elif CPU(ARM64)
      variables->putDirect(vm, JSC::Identifier::fromString(vm, "host_arch"_s), JSC::jsString(vm, String("arm64"_s)), 0);
      variables->putDirect(vm, JSC::Identifier::fromString(vm, "target_arch"_s), JSC::jsString(vm, String("arm64"_s)), 0);
@@ -353,14 +484,12 @@ index a5c074c385..a3cdbbce41 100644
  #else
  #error "Unsupported architecture"
  #endif
-diff --git a/src/bun.js/bindings/CPUFeatures.cpp b/src/bun.js/bindings/CPUFeatures.cpp
-index d1b1560565..f7feb1db0a 100644
---- a/src/bun.js/bindings/CPUFeatures.cpp
-+++ b/src/bun.js/bindings/CPUFeatures.cpp
-@@ -17,6 +17,15 @@ enum class AArch64CPUFeature : uint8_t {
+--- a/src/jsc/bindings/CPUFeatures.cpp
++++ b/src/jsc/bindings/CPUFeatures.cpp
+@@ -17,6 +17,15 @@
      sve = 6,
  };
- 
+
 +enum class RISCV64CPUFeature : uint8_t {
 +    m = 1,
 +    a = 2,
@@ -371,12 +500,12 @@ index d1b1560565..f7feb1db0a 100644
 +};
 +
  #if CPU(X86_64)
- 
+
  #if OS(WINDOWS)
-@@ -130,12 +139,46 @@ static uint8_t aarch64_cpu_features()
- 
+@@ -130,12 +139,46 @@
+
  #endif
- 
+
 +#if CPU(RISCV64)
 +
 +#if OS(LINUX)
@@ -420,82 +549,17 @@ index d1b1560565..f7feb1db0a 100644
  #else
  #error "Unknown architecture"
  #endif
-diff --git a/src/bun.js/bindings/CPUFeatures.zig b/src/bun.js/bindings/CPUFeatures.zig
-index 29e4a6e040..ec4cfde413 100644
---- a/src/bun.js/bindings/CPUFeatures.zig
-+++ b/src/bun.js/bindings/CPUFeatures.zig
-@@ -28,6 +28,18 @@ pub const Flags = switch (@import("builtin").cpu.arch) {
- 
-         padding: u1 = 0,
-     },
-+    .riscv64 => packed struct(u8) {
-+        none: bool,
-+
-+        m: bool,
-+        a: bool,
-+        f: bool,
-+        d: bool,
-+        c: bool,
-+        v: bool,
-+
-+        padding: u1 = 0,
-+    },
-     else => unreachable,
- };
- 
-@@ -52,6 +64,7 @@ pub fn isEmpty(features: CPUFeatures) bool {
- }
- 
- pub fn hasAnyAVX(features: CPUFeatures) bool {
-+    if (comptime !bun.Environment.isX64) return false;
-     return features.flags.avx or features.flags.avx2 or features.flags.avx512;
- }
- 
-diff --git a/src/bun.js/bindings/JSBuffer.cpp b/src/bun.js/bindings/JSBuffer.cpp
-index 5b1ccd84da..56e7a21b66 100644
---- a/src/bun.js/bindings/JSBuffer.cpp
-+++ b/src/bun.js/bindings/JSBuffer.cpp
-@@ -2060,16 +2060,18 @@ static JSC::EncodedJSValue jsBufferPrototypeFunction_toStringBody(JSC::JSGlobalO
-         RETURN_IF_EXCEPTION(scope, {});
-     }
- 
--    auto fstart = arg2.toNumber(lexicalGlobalObject);
--    RETURN_IF_EXCEPTION(scope, {});
--    if (fstart < 0) {
--        fstart = 0;
--        goto lstart;
--    }
--    if (fstart > byteLength) {
--        return JSC::JSValue::encode(JSC::jsEmptyString(vm));
-+    if (!arg2.isUndefined()) {
-+        auto fstart = arg2.toNumber(lexicalGlobalObject);
-+        RETURN_IF_EXCEPTION(scope, {});
-+        if (fstart < 0) {
-+            fstart = 0;
-+            goto lstart;
-+        }
-+        if (fstart > byteLength) {
-+            return JSC::JSValue::encode(JSC::jsEmptyString(vm));
-+        }
-+        start = static_cast<uint32_t>(fstart);
-     }
--    start = static_cast<uint32_t>(fstart);
- lstart:
- 
-     if (!arg3.isUndefined()) {
-diff --git a/src/bun.js/bindings/NodeVMScript.cpp b/src/bun.js/bindings/NodeVMScript.cpp
-index b6ae742d67..c6ce606bbd 100644
---- a/src/bun.js/bindings/NodeVMScript.cpp
-+++ b/src/bun.js/bindings/NodeVMScript.cpp
-@@ -8,6 +8,7 @@
+--- a/src/jsc/bindings/NodeVMScript.cpp
++++ b/src/jsc/bindings/NodeVMScript.cpp
+@@ -10,6 +10,7 @@
  #include "JavaScriptCore/JSWeakMapInlines.h"
  #include "JavaScriptCore/ProgramCodeBlock.h"
  #include "JavaScriptCore/SourceCodeKey.h"
 +#include "JavaScriptCore/Watchdog.h"
- 
+
  #include "NodeVMScriptFetcher.h"
- #include "../vm/SigintWatcher.h"
-@@ -163,6 +164,7 @@ constructScript(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newT
+ #include "../vm/NodeVMRunTermination.h"
+@@ -191,6 +192,7 @@
                  codeBlock = JSC::ProgramCodeBlock::create(vm, executable, unlinkedBlock, jsScope);
                  RETURN_IF_EXCEPTION(scope, {});
              }
@@ -503,7 +567,7 @@ index b6ae742d67..c6ce606bbd 100644
              JSC::CompilationResult compilationResult = JIT::compileSync(vm, codeBlock, JITCompilationEffort::JITCompilationCanFail);
              if (compilationResult != JSC::CompilationResult::CompilationFailed) {
                  executable->installCode(codeBlock);
-@@ -170,6 +172,9 @@ constructScript(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newT
+@@ -198,6 +200,9 @@
              } else {
                  script->cachedDataRejected(TriState::True);
              }
@@ -511,13 +575,11 @@ index b6ae742d67..c6ce606bbd 100644
 +            script->cachedDataRejected(TriState::True);
 +#endif
          }
-     } else if (produceCachedData) {
+     } else if (script->options().produceCachedData) {
          script->cacheBytecode();
-diff --git a/src/bun.js/bindings/NodeVMSourceTextModule.cpp b/src/bun.js/bindings/NodeVMSourceTextModule.cpp
-index 5c3ad694ec..e4ac037db7 100644
---- a/src/bun.js/bindings/NodeVMSourceTextModule.cpp
-+++ b/src/bun.js/bindings/NodeVMSourceTextModule.cpp
-@@ -140,12 +140,16 @@ NodeVMSourceTextModule* NodeVMSourceTextModule::create(VM& vm, JSGlobalObject* g
+--- a/src/jsc/bindings/NodeVMSourceTextModule.cpp
++++ b/src/jsc/bindings/NodeVMSourceTextModule.cpp
+@@ -143,12 +143,16 @@
              RETURN_IF_EXCEPTION(scope, nullptr);
          }
          if (codeBlock) {
@@ -533,12 +595,10 @@ index 5c3ad694ec..e4ac037db7 100644
 +#endif
          }
      }
- 
-diff --git a/src/bun.js/bindings/webcore/SerializedScriptValue.cpp b/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
-index 3125ee8411..e8400b7cb0 100644
---- a/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
-+++ b/src/bun.js/bindings/webcore/SerializedScriptValue.cpp
-@@ -3424,12 +3424,13 @@ private:
+
+--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
++++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+@@ -2580,12 +2580,13 @@
          ptr += length * sizeof(char16_t);
  #else
          std::span<char16_t> characters;
@@ -553,11 +613,21 @@ index 3125ee8411..e8400b7cb0 100644
  #endif
          return true;
      }
-diff --git a/src/bun.js/modules/BunJSCModule.h b/src/bun.js/modules/BunJSCModule.h
-index 038fbe1c14..f3d3ae2eaa 100644
---- a/src/bun.js/modules/BunJSCModule.h
-+++ b/src/bun.js/modules/BunJSCModule.h
-@@ -582,7 +582,11 @@ JSC_DECLARE_HOST_FUNCTION(functionTotalCompileTime);
+--- a/src/jsc/bindings/workaround-missing-symbols.cpp
++++ b/src/jsc/bindings/workaround-missing-symbols.cpp
+@@ -62,7 +62,8 @@
+ // if linux
+ #if defined(__linux__)
+ #include <features.h>
+-#ifdef __GNU_LIBRARY__
++// The glibc 2.17 compatibility ABI predates the RISC-V port.
++#if defined(__GNU_LIBRARY__) && !defined(__riscv)
+
+ #ifndef _GNU_SOURCE
+ #define _GNU_SOURCE
+--- a/src/jsc/modules/BunJSCModule.h
++++ b/src/jsc/modules/BunJSCModule.h
+@@ -596,7 +596,11 @@
  JSC_DEFINE_HOST_FUNCTION(functionTotalCompileTime,
      (JSGlobalObject*, CallFrame*))
  {
@@ -567,199 +637,278 @@ index 038fbe1c14..f3d3ae2eaa 100644
 +    return JSValue::encode(jsNumber(0));
 +#endif
  }
- 
+
  JSC_DECLARE_HOST_FUNCTION(functionGetProtectedObjects);
-diff --git a/src/cli/upgrade_command.zig b/src/cli/upgrade_command.zig
-index 036d9d9e75..20125d2487 100644
---- a/src/cli/upgrade_command.zig
-+++ b/src/cli/upgrade_command.zig
-@@ -42,7 +42,7 @@ pub const Version = struct {
-         .wasm => @compileError("Unsupported OS for Bun Upgrade"),
-     };
- 
--    pub const arch_label = if (Environment.isAarch64) "aarch64" else "x64";
-+    pub const arch_label = if (Environment.isAarch64) "aarch64" else if (Environment.isRiscV64) "riscv64" else "x64";
-     pub const triplet = platform_label ++ "-" ++ arch_label;
-     const suffix_abi = if (Environment.isMusl) "-musl" else "";
-     const suffix_cpu = if (Environment.baseline) "-baseline" else "";
-diff --git a/src/compile_target.zig b/src/compile_target.zig
-index a1400d0151..629fe568dc 100644
---- a/src/compile_target.zig
-+++ b/src/compile_target.zig
-@@ -462,13 +462,14 @@ pub fn defineValues(this: *const CompileTarget) []const []const u8 {
-     // Use inline else to avoid extra allocations.
-     switch (this.os) {
-         inline else => |os| switch (this.arch) {
--            inline .arm64, .x64 => |arch| return struct {
-+            inline .arm64, .x64, .riscv64 => |arch| return struct {
-                 pub const values = &.{
-                     "\"" ++ os.nameString() ++ "\"",
- 
-                     switch (arch) {
-                         .x64 => "\"x64\"",
-                         .arm64 => "\"arm64\"",
-+                        .riscv64 => "\"riscv64\"",
-                         .wasm => @compileError("TODO"),
-                     },
- 
-diff --git a/src/crash_handler.zig b/src/crash_handler.zig
-index 58a6a191bd..8f6e8e22e3 100644
---- a/src/crash_handler.zig
-+++ b/src/crash_handler.zig
-@@ -813,6 +813,8 @@ pub fn reportBaseUrl() []const u8 {
- 
- const arch_display_string = if (bun.Environment.isAarch64)
-     if (bun.Environment.isMac) "Silicon" else "arm64"
-+else if (bun.Environment.isRiscV64)
-+    "riscv64"
- else
-     "x64";
- 
-@@ -1096,6 +1098,7 @@ const Platform = enum(u8) {
-     linux_x86_64 = 'l',
-     linux_x86_64_baseline = 'B',
-     linux_aarch64 = 'L',
-+    linux_riscv64 = 'r',
- 
-     mac_x86_64_baseline = 'b',
-     mac_x86_64 = 'm',
-diff --git a/src/env.zig b/src/env.zig
-index 4d4fa2bbda..ddd972a5de 100644
---- a/src/env.zig
-+++ b/src/env.zig
-@@ -20,6 +20,7 @@ pub const isLinux = builtin.target.os.tag == .linux;
- pub const isAarch64 = builtin.target.cpu.arch.isAARCH64();
- pub const isX86 = builtin.target.cpu.arch.isX86();
- pub const isX64 = builtin.target.cpu.arch == .x86_64;
-+pub const isRiscV64 = builtin.target.cpu.arch == .riscv64;
- pub const isMusl = builtin.target.abi.isMusl();
- pub const allow_assert = isDebug or isTest or std.builtin.OptimizeMode.ReleaseSafe == builtin.mode;
- pub const ci_assert = isDebug or isTest or enable_asan or (std.builtin.OptimizeMode.ReleaseSafe == builtin.mode and is_canary);
-@@ -144,6 +145,7 @@ else
- pub const Architecture = enum {
-     x64,
-     arm64,
-+    riscv64,
-     wasm,
- 
-     /// npm package name, `@oven-sh/bun-{os}-{arch}`
-@@ -151,6 +153,7 @@ pub const Architecture = enum {
-         return switch (this) {
-             .x64 => "x64",
-             .arm64 => "aarch64",
-+            .riscv64 => "riscv64",
-             .wasm => "wasm",
+--- a/src/options_types/compile_target.rs
++++ b/src/options_types/compile_target.rs
+@@ -428,6 +428,7 @@
+         let arch: &'static [u8] = match self.arch {
+             Architecture::X64 => b"\"x64\"",
+             Architecture::Arm64 => b"\"arm64\"",
++            Architecture::Riscv64 => b"\"riscv64\"",
+             Architecture::Wasm => b"\"wasm\"",
          };
+         const VERSION: &[u8] =
+--- a/src/platform/linux.rs
++++ b/src/platform/linux.rs
+@@ -71,7 +71,27 @@
+         }
+         return ret;
      }
-@@ -161,6 +164,7 @@ pub const Architecture = enum {
-         .{ "amd64", .x64 },
-         .{ "aarch64", .arm64 },
-         .{ "arm64", .arm64 },
-+        .{ "riscv64", .riscv64 },
-         .{ "wasm", .wasm },
-     });
- };
-@@ -171,6 +175,8 @@ else if (isX64)
-     .x64
- else if (isAarch64)
-     .arm64
-+else if (isRiscV64)
-+    .riscv64
- else
-     @compileError("Please add your architecture to the Architecture enum");
- 
-diff --git a/src/install/npm.zig b/src/install/npm.zig
-index 255a4f7f30..81d64f091d 100644
---- a/src/install/npm.zig
-+++ b/src/install/npm.zig
-@@ -759,18 +759,21 @@ pub const Architecture = enum(u16) {
-     pub const s390x: u16 = 1 << 9;
-     pub const x32: u16 = 1 << 10;
-     pub const x64: u16 = 1 << 11;
-+    pub const riscv64: u16 = 1 << 12;
- 
--    pub const all_value: u16 = arm | arm64 | ia32 | mips | mipsel | ppc | ppc64 | s390 | s390x | x32 | x64;
-+    pub const all_value: u16 = arm | arm64 | ia32 | mips | mipsel | ppc | ppc64 | s390 | s390x | x32 | x64 | riscv64;
- 
-     pub const current: Architecture = switch (Environment.arch) {
-         .arm64 => @enumFromInt(arm64),
-         .x64 => @enumFromInt(x64),
-+        .riscv64 => @enumFromInt(riscv64),
-         .wasm => @compileError("Specify architecture: " ++ Environment.arch),
+-    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
++    #[cfg(target_arch = "riscv64")]
++    {
++        let ret: isize;
++        // SAFETY: Linux RISC-V syscall ABI: a7 holds the number, a0..a5
++        // hold the arguments, and a0 receives the raw result.
++        unsafe {
++            core::arch::asm!(
++                "ecall",
++                in("a7") nr,
++                inlateout("a0") a1 as isize => ret,
++                in("a1") a2,
++                in("a2") a3,
++                in("a3") a4,
++                in("a4") a5,
++                in("a5") a6,
++                options(nostack),
++            );
++        }
++        return ret;
++    }
++    #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64", target_arch = "riscv64")))]
+     compile_error!("raw_syscall6: unsupported architecture");
+ }
+
+--- a/src/runtime/cli/upgrade_command.rs
++++ b/src/runtime/cli/upgrade_command.rs
+@@ -100,6 +100,8 @@
+
+     pub(crate) const ARCH_LABEL: &'static str = if cfg!(target_arch = "aarch64") {
+         "aarch64"
++    } else if cfg!(target_arch = "riscv64") {
++        "riscv64"
+     } else {
+         "x64"
      };
- 
-     pub const current_name = switch (Environment.arch) {
-         .arm64 => "arm64",
-         .x64 => "x64",
-+        .riscv64 => "riscv64",
-         .wasm => @compileError("Unsupported architecture: " ++ @tagName(current)),
-     };
- 
-@@ -786,6 +789,7 @@ pub const Architecture = enum(u16) {
-         .{ "s390x", s390x },
-         .{ "x32", x32 },
-         .{ "x64", x64 },
-+        .{ "riscv64", riscv64 },
-     });
- 
-     pub inline fn has(this: Architecture, other: u16) bool {
-diff --git a/src/js/node/os.ts b/src/js/node/os.ts
-index 64b1a1c0ac..c81a16f037 100644
---- a/src/js/node/os.ts
-+++ b/src/js/node/os.ts
-@@ -96,7 +96,7 @@ function bound(binding) {
-     },
-     cpus: lazyCpus(binding),
-     endianness: function () {
--      return process.arch === "arm64" || process.arch === "x64" //
-+      return process.arch === "arm64" || process.arch === "x64" || process.arch === "riscv64" //
-         ? "LE"
-         : $bundleError("TODO: endianness");
-     },
-@@ -132,7 +132,9 @@ function bound(binding) {
-         ? "arm64"
-         : process.arch === "x64"
-           ? "x86_64"
--          : $bundleError("TODO: machine");
-+          : process.arch === "riscv64"
-+            ? "riscv64"
-+            : $bundleError("TODO: machine");
-     },
-     devNull: process.platform === "win32" ? "\\\\.\\nul" : "/dev/null",
-     get EOL() {
-diff --git a/src/sys.zig b/src/sys.zig
-index 9f48b78540..bad867e41a 100644
---- a/src/sys.zig
-+++ b/src/sys.zig
-@@ -93,7 +93,7 @@ pub const O = switch (Environment.os) {
- 
-         pub const toPacked = toPackedO;
-     },
--    .linux, .wasm => switch (Environment.isX86) {
-+    .linux, .wasm => switch (Environment.isX86 or Environment.isRiscV64) {
-         true => struct {
-             pub const RDONLY = 0x0000;
-             pub const WRONLY = 0x0001;
-diff --git a/src/workaround_missing_symbols.zig b/src/workaround_missing_symbols.zig
-index fda57737a6..0e888e99cd 100644
---- a/src/workaround_missing_symbols.zig
-+++ b/src/workaround_missing_symbols.zig
-@@ -66,15 +66,15 @@ pub const darwin = struct {
- 
-     pub const lstat = blk: {
-         const T = *const fn (?[*:0]const u8, ?*bun.Stat) callconv(.c) c_int;
--        break :blk @extern(T, .{ .name = if (bun.Environment.isAarch64) "lstat" else "lstat64" });
-+        break :blk @extern(T, .{ .name = if (bun.Environment.isAarch64 or bun.Environment.isRiscV64) "lstat" else "lstat64" });
-     };
-     pub const fstat = blk: {
-         const T = *const fn (i32, ?*bun.Stat) callconv(.c) c_int;
--        break :blk @extern(T, .{ .name = if (bun.Environment.isAarch64) "fstat" else "fstat64" });
-+        break :blk @extern(T, .{ .name = if (bun.Environment.isAarch64 or bun.Environment.isRiscV64) "fstat" else "fstat64" });
-     };
-     pub const stat = blk: {
-         const T = *const fn (?[*:0]const u8, ?*bun.Stat) callconv(.c) c_int;
--        break :blk @extern(T, .{ .name = if (bun.Environment.isAarch64) "stat" else "stat64" });
-+        break :blk @extern(T, .{ .name = if (bun.Environment.isAarch64 or bun.Environment.isRiscV64) "stat" else "stat64" });
-     };
- };
- pub const windows = struct {
+--- a/src/runtime/ffi/ffi_body.rs
++++ b/src/runtime/ffi/ffi_body.rs
+@@ -591,6 +591,27 @@
+                         .set(bun_core::ZBox::from_vec_with_nul(b"/usr/lib64".to_vec()));
+                 }
+             }
++            #[cfg(target_arch = "riscv64")]
++            {
++                if dir_exists(b"/usr/include/riscv64-linux-gnu") {
++                    let _ =
++                        CACHED_DEFAULT_SYSTEM_INCLUDE_DIR.set(bun_core::ZBox::from_vec_with_nul(
++                            b"/usr/include/riscv64-linux-gnu".to_vec(),
++                        ));
++                } else if dir_exists(b"/usr/include") {
++                    let _ = CACHED_DEFAULT_SYSTEM_INCLUDE_DIR
++                        .set(bun_core::ZBox::from_vec_with_nul(b"/usr/include".to_vec()));
++                }
++
++                if dir_exists(b"/usr/lib/riscv64-linux-gnu") {
++                    let _ = CACHED_DEFAULT_SYSTEM_LIBRARY_DIR.set(
++                        bun_core::ZBox::from_vec_with_nul(b"/usr/lib/riscv64-linux-gnu".to_vec()),
++                    );
++                } else if dir_exists(b"/usr/lib64") {
++                    let _ = CACHED_DEFAULT_SYSTEM_LIBRARY_DIR
++                        .set(bun_core::ZBox::from_vec_with_nul(b"/usr/lib64".to_vec()));
++                }
++            }
+         }
+     }
+
+--- a/src/runtime/server/server_body.rs
++++ b/src/runtime/server/server_body.rs
+@@ -465,6 +465,7 @@
+         match arch {
+             Architecture::X64 => b"x64",
+             Architecture::Arm64 => b"arm",
++            Architecture::Riscv64 => b"riscv64",
+             Architecture::Wasm => b"wasm",
+         }
+     }
+--- a/src/windows_sys/externs.rs
++++ b/src/windows_sys/externs.rs
+@@ -1665,6 +1665,7 @@
+ /// reservation is the OS thread-block pointer — is guaranteed by the Windows
+ /// ABI for every thread, so there is no caller-side obligation. The deref
+ /// obligation lives with the caller of the returned `*mut TEB`.
++#[cfg(windows)]
+ #[inline(always)]
+ pub fn teb() -> *mut TEB {
+     #[cfg(target_arch = "x86_64")]
+@@ -1691,6 +1692,7 @@
+ /// by the OS/CRT behind Rust's back (`SetStdHandle`, debugger toggling
+ /// `BeingDebugged`, …). Materializing a `&'static` to it would be UB under
+ /// Rust's aliasing rules. Callers must read fields through raw-pointer deref.
++#[cfg(windows)]
+ #[inline(always)]
+ pub fn peb() -> *const PEB {
+     #[cfg(target_arch = "x86_64")]
+--- a/src/jsc/bindings/highway_xml.cpp
++++ b/src/jsc/bindings/highway_xml.cpp
+@@ -22,6 +22,19 @@
+
+ using D8 = hn::CappedTag<uint8_t, 64>;
+
++template<class M>
++static HWY_INLINE uint64_t ToBits(D8 d, M mask)
++{
++#if HWY_MAX_BYTES > 64
++    // The capped mask fits in 64 bits even on scalable-vector targets.
++    uint64_t bits = 0;
++    hn::StoreMaskBits(d, mask, reinterpret_cast<uint8_t*>(&bits));
++    return bits;
++#else
++    return hn::BitsFromMask(d, mask);
++#endif
++}
++
+ // The classes of one 64-position block, as bit masks.
+ struct BlockMasks {
+     uint64_t lt = 0, gt = 0, always = 0, tag = 0, nonchar = 0;
+@@ -37,10 +50,10 @@
+     const auto v_zero = hn::Zero(d);
+     const auto cls = hn::And(hn::TableLookupBytes(lut_lo, hn::And(lo, v_0f)),
+         hn::TableLookupBytes(lut_hi, hn::ShiftRight<4>(lo)));
+-    m.lt |= hn::BitsFromMask(d, hn::Ne(hn::And(cls, hn::Set(d, (uint8_t)BUN_XML_CLASS_LT)), v_zero)) << sh;
+-    m.gt |= hn::BitsFromMask(d, hn::Ne(hn::And(cls, hn::Set(d, (uint8_t)BUN_XML_CLASS_GT)), v_zero)) << sh;
+-    m.always |= hn::BitsFromMask(d, hn::Ne(hn::And(cls, hn::Set(d, (uint8_t)BUN_XML_CLASS_ALWAYS)), v_zero)) << sh;
+-    m.tag |= hn::BitsFromMask(d, hn::Ne(hn::And(cls, hn::Set(d, (uint8_t)BUN_XML_CLASS_TAG)), v_zero)) << sh;
++    m.lt |= ToBits(d, hn::Ne(hn::And(cls, hn::Set(d, (uint8_t)BUN_XML_CLASS_LT)), v_zero)) << sh;
++    m.gt |= ToBits(d, hn::Ne(hn::And(cls, hn::Set(d, (uint8_t)BUN_XML_CLASS_GT)), v_zero)) << sh;
++    m.always |= ToBits(d, hn::Ne(hn::And(cls, hn::Set(d, (uint8_t)BUN_XML_CLASS_ALWAYS)), v_zero)) << sh;
++    m.tag |= ToBits(d, hn::Ne(hn::And(cls, hn::Set(d, (uint8_t)BUN_XML_CLASS_TAG)), v_zero)) << sh;
+ }
+
+ // The part both kernels share: `in_tag` = MatchStar(lt, ~gt) — every position reachable from a
+@@ -106,9 +119,9 @@
+             const auto chunk = hn::LoadU(d, p + v * N);
+             const unsigned sh = (unsigned)(v * N);
+             Classify(d, chunk, sh, m);
+-            m_ef |= hn::BitsFromMask(d, hn::Eq(chunk, v_ef)) << sh;
+-            m_bf |= hn::BitsFromMask(d, hn::Eq(chunk, v_bf)) << sh;
+-            m_bebf |= hn::BitsFromMask(d, hn::Eq(hn::Or(chunk, v_01), v_bf)) << sh;
++            m_ef |= ToBits(d, hn::Eq(chunk, v_ef)) << sh;
++            m_bf |= ToBits(d, hn::Eq(chunk, v_bf)) << sh;
++            m_bebf |= ToBits(d, hn::Eq(hn::Or(chunk, v_01), v_bf)) << sh;
+         }
+         m.nonchar = m_bebf & ((m_bf << 1) | (prev_bf >> 63)) & ((m_ef << 2) | (prev_ef >> 62));
+         prev_ef = m_ef;
+@@ -169,16 +182,16 @@
+             const unsigned sh = (unsigned)(v * N);
+             BlockMasks unit;
+             Classify(d, lo, 0, unit);
+-            const uint64_t ascii = hn::BitsFromMask(d, hn::Eq(hi, v_zero));
++            const uint64_t ascii = ToBits(d, hn::Eq(hi, v_zero));
+             m.lt |= (unit.lt & ascii) << sh;
+             m.gt |= (unit.gt & ascii) << sh;
+             m.always |= (unit.always & ascii) << sh;
+             m.tag |= (unit.tag & ascii) << sh;
+-            const uint64_t nonchar = hn::BitsFromMask(d, hn::And(hn::Eq(hi, v_ff), hn::Eq(hn::Or(lo, v_01), v_ff)));
++            const uint64_t nonchar = ToBits(d, hn::And(hn::Eq(hi, v_ff), hn::Eq(hn::Or(lo, v_01), v_ff)));
+             m.nonchar |= nonchar << sh;
+             const auto plane = hn::And(hi, v_fc);
+-            lead |= hn::BitsFromMask(d, hn::Eq(plane, v_d8)) << sh;
+-            trail |= hn::BitsFromMask(d, hn::Eq(plane, v_dc)) << sh;
++            lead |= ToBits(d, hn::Eq(plane, v_d8)) << sh;
++            trail |= ToBits(d, hn::Eq(plane, v_dc)) << sh;
+         }
+         lead &= valid;
+         trail &= valid;
+--- a/src/jsc/bindings/highway_json.cpp
++++ b/src/jsc/bindings/highway_json.cpp
+@@ -23,6 +23,19 @@
+
+ using D8 = hn::CappedTag<uint8_t, 64>;
+
++template<class M>
++static HWY_INLINE uint64_t ToBits(D8 d, M mask)
++{
++#if HWY_MAX_BYTES > 64
++    // The capped mask fits in 64 bits even on scalable-vector targets.
++    uint64_t bits = 0;
++    hn::StoreMaskBits(d, mask, reinterpret_cast<uint8_t*>(&bits));
++    return bits;
++#else
++    return hn::BitsFromMask(d, mask);
++#endif
++}
++
+ static HWY_INLINE uint64_t PrefixXor(uint64_t x)
+ {
+     x ^= x << 1;
+@@ -81,14 +94,14 @@
+         for (size_t v = 0; v < 64 / N; ++v) {
+             const auto chunk = hn::LoadU(d, p + v * N);
+             const unsigned sh = (unsigned)(v * N);
+-            m_bs |= hn::BitsFromMask(d, hn::Eq(chunk, v_bs)) << sh;
+-            m_quote |= hn::BitsFromMask(d, hn::Eq(chunk, v_quote)) << sh;
++            m_bs |= ToBits(d, hn::Eq(chunk, v_bs)) << sh;
++            m_quote |= ToBits(d, hn::Eq(chunk, v_quote)) << sh;
+             const auto cls = hn::And(hn::TableLookupBytes(lut_lo, hn::And(chunk, v_0f)),
+                 hn::TableLookupBytes(lut_hi, hn::ShiftRight<4>(chunk)));
+-            m_op |= hn::BitsFromMask(d, hn::Ne(hn::And(cls, v_op_bits), v_zero)) << sh;
+-            m_opws |= hn::BitsFromMask(d, hn::Ne(hn::And(cls, v_opws_bits), v_zero)) << sh;
+-            m_odd |= hn::BitsFromMask(d, hn::Ne(hn::And(cls, v_odd_bits), v_zero)) << sh;
+-            m_ctrl |= hn::BitsFromMask(d, hn::Ne(hn::And(cls, v_ctrl_bits), v_zero)) << sh;
++            m_op |= ToBits(d, hn::Ne(hn::And(cls, v_op_bits), v_zero)) << sh;
++            m_opws |= ToBits(d, hn::Ne(hn::And(cls, v_opws_bits), v_zero)) << sh;
++            m_odd |= ToBits(d, hn::Ne(hn::And(cls, v_odd_bits), v_zero)) << sh;
++            m_ctrl |= ToBits(d, hn::Ne(hn::And(cls, v_ctrl_bits), v_zero)) << sh;
+         }
+
+         uint64_t escaped;
+--- a/src/jsc/bindings/highway_sourcemap.cpp
++++ b/src/jsc/bindings/highway_sourcemap.cpp
+@@ -313,6 +313,10 @@
+     // MFromD<D>::raw is __mmask{8,16,32,64}; the 64-byte CappedTag this
+     // file uses makes it __mmask64.
+     return static_cast<uint64_t>(m.raw);
++#elif HWY_MAX_BYTES > 64
++    uint64_t bits = 0;
++    hn::StoreMaskBits(d, m, reinterpret_cast<uint8_t*>(&bits));
++    return bits;
+ #else
+     return hn::BitsFromMask(d, m);
+ #endif
+--- a/scripts/build/buildOptionsRs.ts
++++ b/scripts/build/buildOptionsRs.ts
+@@ -69,6 +69,7 @@
+     "pub const ENABLE_TINYCC: bool = !cfg!(any(",
+     `    target_os = "android",`,
+     `    target_os = "freebsd",`,
++    `    target_arch = "riscv64",`,
+     "));",
+     "",
+   ];
+--- a/src/tcc_sys/tcc.rs
++++ b/src/tcc_sys/tcc.rs
+@@ -12,7 +12,7 @@
+ pub type ErrorFunc<Ctx> = unsafe extern "C" fn(ctx: *mut Ctx, msg: *const c_char);
+
+ // `libtcc.a` is only built where `cfg.tinycc` is true (`scripts/build/config.ts`):
+-// not Android, not FreeBSD (the vendored fork doesn't support those targets).
++// not Android, FreeBSD, or RISC-V.
+ // On those platforms these `extern "C"` decls would be undefined at link:
+ // `bun_runtime::ffi::ffi_body::{Source::add,
+ // CompileC::compile}` are reachable from `extern "C"` JS bindings and the
+@@ -27,12 +27,12 @@
+ // and `ENABLE_TINYCC` in `scripts/build/buildOptionsRs.ts`.
+ macro_rules! tcc_externs {
+     ($($(#[$attr:meta])* fn $name:ident($($arg:ident: $ty:ty),* $(,)?) $(-> $ret:ty)?;)*) => {
+-        #[cfg(not(any(target_os = "android", target_os = "freebsd")))]
++        #[cfg(not(any(target_os = "android", target_os = "freebsd", target_arch = "riscv64")))]
+         unsafe extern "C" {
+             $($(#[$attr])* fn $name($($arg: $ty),*) $(-> $ret)?;)*
+         }
+         $(
+-            #[cfg(any(target_os = "android", target_os = "freebsd"))]
++            #[cfg(any(target_os = "android", target_os = "freebsd", target_arch = "riscv64"))]
+             #[allow(unused_variables, clippy::missing_safety_doc)]
+             unsafe extern "C" fn $name($($arg: $ty),*) $(-> $ret)? {
+                 unreachable!(concat!(

--- a/bun/bun-webkit-riscv64.patch
+++ b/bun/bun-webkit-riscv64.patch
@@ -1,11 +1,9 @@
-diff --git a/Source/JavaScriptCore/CMakeLists.txt b/Source/JavaScriptCore/CMakeLists.txt
-index d7e3e82010e8..5d9926ce3018 100644
 --- a/Source/JavaScriptCore/CMakeLists.txt
 +++ b/Source/JavaScriptCore/CMakeLists.txt
-@@ -56,6 +56,10 @@ if(USE_CAPSTONE)
+@@ -61,6 +61,10 @@
      list(APPEND JavaScriptCore_PRIVATE_INCLUDE_DIRECTORIES "${THIRDPARTY_DIR}/capstone/Source/include")
  endif()
- 
+
 +if(USE_MIMALLOC)
 +    list(APPEND JavaScriptCore_PRIVATE_INCLUDE_DIRECTORIES "${BMALLOC_DIR}/mimalloc/mimalloc/include")
 +endif()
@@ -13,39 +11,9 @@ index d7e3e82010e8..5d9926ce3018 100644
  set(JavaScriptCore_OBJECT_LUT_SOURCES
      runtime/ArrayConstructor.cpp
      runtime/AsyncFromSyncIteratorPrototype.cpp
-diff --git a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
-index 2f58ddbe6d91..77b6910ef4fa 100644
---- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
-+++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
-@@ -4365,20 +4365,20 @@ private:
-         using IType = RISCV64Assembler::IImmediate;
-         template<int32_t value>
-         static IType I() { return IType::v<IType, value>(); }
--        template<typename T, typename = EnableIfInteger<T>>
-+        template<std::integral T>
-         static IType I(T value) { return IType::v<IType>(value); }
-         static IType I(uint32_t value) { return IType(value); }
- 
-         using SType = RISCV64Assembler::SImmediate;
-         template<int32_t value>
-         static SType S() { return SType::v<SType, value>(); }
--        template<typename T, typename = EnableIfInteger<T>>
-+        template<std::integral T>
-         static SType S(T value) { return SType::v<SType>(value); }
- 
-         using BType = RISCV64Assembler::BImmediate;
-         template<int32_t value>
-         static BType B() { return BType::v<BType, value>(); }
--        template<typename T, typename = EnableIfInteger<T>>
-+        template<std::integral T>
-         static BType B(T value) { return BType::v<BType>(value); }
-         static BType B(uint32_t value) { return BType(value); }
- 
-diff --git a/Source/JavaScriptCore/b3/B3Validate.cpp b/Source/JavaScriptCore/b3/B3Validate.cpp
-index a3f5f6cb8f9a..1879239b565e 100644
 --- a/Source/JavaScriptCore/b3/B3Validate.cpp
 +++ b/Source/JavaScriptCore/b3/B3Validate.cpp
-@@ -493,7 +493,7 @@ public:
+@@ -479,7 +479,7 @@
              case VectorExtractLane:
                  VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
                  VALIDATE(value->numChildren() == 1, ("At ", *value));
@@ -54,7 +22,7 @@ index a3f5f6cb8f9a..1879239b565e 100644
                  VALIDATE(value->child(0)->type() == V128, ("At ", *value));
                  break;
              case VectorReplaceLane:
-@@ -501,7 +501,7 @@ public:
+@@ -487,7 +487,7 @@
                  VALIDATE(value->numChildren() == 2, ("At ", *value));
                  VALIDATE(value->type() == V128, ("At ", *value));
                  VALIDATE(value->child(0)->type() == V128, ("At ", *value));
@@ -63,46 +31,21 @@ index a3f5f6cb8f9a..1879239b565e 100644
                  break;
              case VectorDupElement:
                  VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
-@@ -523,7 +523,7 @@ public:
+@@ -509,7 +509,7 @@
                  VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
                  VALIDATE(value->numChildren() == 1, ("At ", *value));
                  VALIDATE(value->type() == V128, ("At ", *value));
 -                VALIDATE(value->child(0)->type() == Wasm::toB3Type(Wasm::simdScalarType(value->asSIMDValue()->simdLane())), ("At ", *value));
 +                VALIDATE(value->child(0)->type() == simdB3ScalarType(value->asSIMDValue()->simdLane()), ("At ", *value));
                  break;
- 
+
              case VectorPopcnt:
-diff --git a/Source/JavaScriptCore/b3/air/AirArg.h b/Source/JavaScriptCore/b3/air/AirArg.h
-index 5012f3318a5c..de62de31be18 100644
---- a/Source/JavaScriptCore/b3/air/AirArg.h
-+++ b/Source/JavaScriptCore/b3/air/AirArg.h
-@@ -1475,17 +1475,15 @@ public:
-         if (!isARM64() && !isX86_64())
-             return false;
- 
-+        uint64_t u64 = static_cast<uint64_t>(value);
- #if CPU(ARM64)
-         if (ARM64Assembler::canEncodeFPImm<64>(value))
-             return true;
- 
--        uint64_t u64 = static_cast<uint64_t>(value);
-         if (ARM64FPImmediate::create64(u64).isValid())
-             return true;
- 
- #elif CPU(X86_64)
--        uint64_t u64 = static_cast<uint64_t>(value);
--
-         if (u64 == 0xFFFFFFFFFFFFFFFFULL)
-             return true;
- 
-diff --git a/Source/JavaScriptCore/domjit/DOMJITEffect.h b/Source/JavaScriptCore/domjit/DOMJITEffect.h
-index 6ba85116d1be..943754f793a4 100644
 --- a/Source/JavaScriptCore/domjit/DOMJITEffect.h
 +++ b/Source/JavaScriptCore/domjit/DOMJITEffect.h
 @@ -28,6 +28,16 @@
  #include "DFGAbstractHeap.h"
  #include "DOMJITHeapRange.h"
- 
+
 +#if !ENABLE(DFG_JIT)
 +namespace JSC { namespace DFG {
 +enum AbstractHeapKind : unsigned {
@@ -114,48 +57,14 @@ index 6ba85116d1be..943754f793a4 100644
 +#endif
 +
  WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
- 
+
  namespace JSC {
-diff --git a/Source/JavaScriptCore/jit/GdbJIT.cpp b/Source/JavaScriptCore/jit/GdbJIT.cpp
-index a812a7622291..d9599230a09f 100644
---- a/Source/JavaScriptCore/jit/GdbJIT.cpp
-+++ b/Source/JavaScriptCore/jit/GdbJIT.cpp
-@@ -873,7 +873,7 @@ private:
-             0x7F, 'E', 'L', 'F', 1, 1, 1, 0,
-             0, 0, 0, 0, 0, 0, 0, 0
-         };
--#elif CPU(X86_64) || CPU(ARM64)
-+#elif CPU(X86_64) || CPU(ARM64) || CPU(RISCV64)
-         const uint8_t ident[16] = {
-             0x7F, 'E', 'L', 'F', 2, 1, 1, 0,
-             0, 0, 0, 0, 0, 0, 0, 0
-@@ -895,6 +895,9 @@ private:
- #elif CPU(ARM64)
-         // AARCH64
-         header->machine = 0xB7;
-+#elif CPU(RISCV64)
-+        // RISC-V
-+        header->machine = 0xF3;
- #else
- #error Unsupported target architecture.
- #endif
-@@ -996,7 +999,7 @@ public:
-         uint8_t m_other;
-         uint16_t m_section;
-     } __attribute__((packed,aligned(1)));
--#elif CPU(X86_64) || CPU(ARM64)
-+#elif CPU(X86_64) || CPU(ARM64) || CPU(RISCV64)
-     struct SerializedLayout {
-         SerializedLayout(uint32_t name, uintptr_t value, uintptr_t size, Binding binding, Type type, uint16_t section)
-             : m_name(name)
-diff --git a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
-index 74697f1525a1..9cc5fafef17f 100644
 --- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
 +++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
-@@ -332,14 +332,19 @@ end
+@@ -383,14 +383,19 @@
  macro ipintAtomicOp(name, impl)
      atomicInstructionLabel(name)
- 
+
 -    if TRACING
 -        move cfr, a1
 -        move PC, a2
@@ -172,98 +81,106 @@ index 74697f1525a1..9cc5fafef17f 100644
 +            move MC, a3
 +            operationCall(macro() cCall4(_ipint_extern_trace) end)
 +        end
- 
+
 -    impl()
 +        impl()
 +    end
  end
- 
+
  macro reservedAtomicOpcode(opcode)
-@@ -1275,7 +1280,7 @@ op(wasm_throw_from_fault_handler_trampoline_reg_instance, macro ()
+@@ -1225,7 +1230,7 @@
  end)
- 
+
  op(ipint_entry, macro()
--if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
-+if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7 or RISCV64)
+-if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
++if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or RISCV64)
      preserveCallerPCAndCFR()
      saveIPIntRegisters()
      storep wasmInstance, CodeBlock[cfr]
-@@ -1289,10 +1294,15 @@ else
+@@ -1239,7 +1244,7 @@
  end
  end)
- 
--if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
-+if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7 or RISCV64)
+
+-if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
++if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or RISCV64)
  .ipint_entry_end_local:
-     argumINTInitializeDefaultLocals()
-+if RISCV64
-+    pcrtoaddr .ipint_entry_end_local, csr4
-+    jmp csr4
-+else
-     jmp .ipint_entry_end_local
-+end
- 
- .ipint_entry_finish_zero:
-     argumINTFinish()
-@@ -1421,7 +1431,7 @@ end
+     loadp UnboxedWasmCalleeStackSlot[cfr], MC
+     loadp Wasm::IPIntCallee::m_localInitBytecode + VectorBufferOffset[MC], MC
+@@ -1319,7 +1324,7 @@
+ end
+
+ op(ipint_catch_entry, macro()
+-if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
++if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or RISCV64)
+     ipintCatchCommon()
+
+     move cfr, a1
+@@ -1335,7 +1340,7 @@
  end)
- 
+
+ op(ipint_catch_all_entry, macro()
+-if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
++if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or RISCV64)
+     ipintCatchCommon()
+
+     move cfr, a1
+@@ -1351,7 +1356,7 @@
+ end)
+
  op(ipint_table_catch_entry, macro()
--if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
-+if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7 or RISCV64)
+-if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
++if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or RISCV64)
      ipintCatchCommon()
- 
+
      # push arguments but no ref: sp in a2, call normal operation
-@@ -1440,7 +1450,7 @@ end
+@@ -1369,7 +1374,7 @@
  end)
- 
+
  op(ipint_table_catch_ref_entry, macro()
--if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
-+if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7 or RISCV64)
+-if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
++if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or RISCV64)
      ipintCatchCommon()
- 
+
      # push both arguments and ref
-@@ -1459,7 +1469,7 @@ end
+@@ -1387,7 +1392,7 @@
  end)
- 
+
  op(ipint_table_catch_all_entry, macro()
--if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
-+if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7 or RISCV64)
+-if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
++if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or RISCV64)
      ipintCatchCommon()
- 
+
      # do nothing: 0 in sp for no arguments, call normal operation
-@@ -1478,7 +1488,7 @@ end
+@@ -1405,7 +1410,7 @@
  end)
- 
+
  op(ipint_table_catch_allref_entry, macro()
--if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7)
-+if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or ARMv7 or RISCV64)
+-if WEBASSEMBLY and (ARM64 or ARM64E or X86_64)
++if WEBASSEMBLY and (ARM64 or ARM64E or X86_64 or RISCV64)
      ipintCatchCommon()
- 
+
      # push only the ref
-@@ -1985,7 +1995,7 @@ _pinballHandlerRejectFunction:
+@@ -1954,7 +1959,7 @@
  # 5. Instruction implementation #
  #################################
- 
--if JSVALUE64 and (ARM64 or ARM64E or X86_64)
-+if JSVALUE64 and (ARM64 or ARM64E or X86_64 or RISCV64)
+
+-if ARM64 or ARM64E or X86_64
++if ARM64 or ARM64E or X86_64 or RISCV64
      include InPlaceInterpreter64
  else
  # For unimplemented architectures: make sure that the assertions can still find the labels
-diff --git a/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp b/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
-index a14c01138994..0c97a67b71fb 100644
 --- a/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
 +++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.cpp
-@@ -78,7 +78,7 @@ do { \
- 
+@@ -77,7 +77,7 @@
+
  void initialize()
  {
 -#if !ENABLE(C_LOOP) && (CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64)))
 +#if !ENABLE(C_LOOP) && (CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64) || CPU(RISCV64)))
- 
+
  #define INIT_IPINT_BASE_POINTER(basePointerName, targetAddress) \
      g_opcodeConfig.basePointerName = removeCodePtrTag(reinterpret_cast<void*>(targetAddress));
-@@ -97,13 +97,13 @@ void initialize()
+@@ -95,13 +95,13 @@
      FOR_EACH_IPINT_MINT_RETURN_OPCODE(VALIDATE_IPINT_MINT_RETURN_OPCODE);
      FOR_EACH_IPINT_UINT_OPCODE(VALIDATE_IPINT_UINT_OPCODE);
  #else
@@ -271,41 +188,37 @@ index a14c01138994..0c97a67b71fb 100644
 +    RELEASE_ASSERT_NOT_REACHED("IPInt only supports ARM64, X86_64, and RISCV64 (for now).");
  #endif
  }
- 
+
  void verifyInitialization()
  {
 -#if !ENABLE(C_LOOP) && (CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64)))
 +#if !ENABLE(C_LOOP) && (CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64) || CPU(RISCV64)))
- 
+
  #define VERIFY_IPINT_BASE_POINTER(basePointerName, targetAddress) \
      RELEASE_ASSERT(g_opcodeConfig.basePointerName == removeCodePtrTag(reinterpret_cast<void*>(targetAddress)));
-diff --git a/Source/JavaScriptCore/llint/InPlaceInterpreter.h b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
-index 6d6d95024df9..c16754a5ce94 100644
 --- a/Source/JavaScriptCore/llint/InPlaceInterpreter.h
 +++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.h
-@@ -788,7 +788,7 @@ extern "C" void SYSV_ABI ipint_entry();
+@@ -783,7 +783,7 @@
      m(0x11, uint_stack_vector) \
      m(0x12, uint_ret) \
- 
+
 -#if !ENABLE(C_LOOP) && (CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64)))
 +#if !ENABLE(C_LOOP) && (CPU(ADDRESS64) && (CPU(ARM64) || CPU(X86_64) || CPU(RISCV64)))
  FOR_EACH_IPINT_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
  FOR_EACH_IPINT_GC_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
  FOR_EACH_IPINT_CONVERSION_OPCODE(IPINT_VALIDATE_DEFINE_FUNCTION);
-diff --git a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
-index 653b6a343537..8805ace80a5f 100644
 --- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
 +++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
-@@ -51,7 +51,7 @@ end
- 
+@@ -51,7 +51,7 @@
+
  # Dispatch target bases
- 
+
 -if ARM64 or ARM64E or X86_64
 +if ARM64 or ARM64E or X86_64 or RISCV64
  const ipint_dispatch_base = _ipint_unreachable
  end
- 
-@@ -71,7 +71,7 @@ if ARM64 or ARM64E
+
+@@ -71,7 +71,7 @@
      pcrtoaddr ipint_dispatch_base, t7
      addlshiftp t7, t0, (constexpr (WTF::fastLog2(JSC::IPInt::alignIPInt))), t0
      jmp t0
@@ -314,7 +227,7 @@ index 653b6a343537..8805ace80a5f 100644
      pcrtoaddr ipint_dispatch_base, t1
      lshiftq (constexpr (WTF::fastLog2(JSC::IPInt::alignIPInt))), t0
      addq t1, t0
-@@ -87,7 +87,7 @@ end
+@@ -87,7 +87,7 @@
  macro pushQuad(reg)
      if ARM64 or ARM64E
          push reg, reg
@@ -323,7 +236,7 @@ index 653b6a343537..8805ace80a5f 100644
          push reg, reg
      else
          break
-@@ -102,7 +102,7 @@ macro popQuad(reg)
+@@ -102,7 +102,7 @@
      # FIXME: emit post-increment in offlineasm
      if ARM64 or ARM64E
          loadqinc [sp], reg, V128ISize
@@ -332,7 +245,7 @@ index 653b6a343537..8805ace80a5f 100644
          loadq [sp], reg
          addq V128ISize, sp
      else
-@@ -200,7 +200,7 @@ macro argumINTDispatch()
+@@ -208,7 +208,7 @@
      addp 1, MC
      bbgteq argumINTTmp, (constexpr IPInt::ArgumINTBytecode::NumOpcodes), _ipint_argument_dispatch_err
      lshiftp (constexpr (WTF::fastLog2(JSC::IPInt::alignArgumInt))), argumINTTmp
@@ -341,7 +254,7 @@ index 653b6a343537..8805ace80a5f 100644
      pcrtoaddr _argumINT_begin, argumINTDsp
      addp argumINTTmp, argumINTDsp
      jmp argumINTDsp
-@@ -219,7 +219,7 @@ macro argumINTInitializeDefaultLocals()
+@@ -227,7 +227,7 @@
  if ARM64 or ARM64E
      # offlineasm doesn't have xzr so emit it
      emit "stp x19, xzr, [x9]"
@@ -350,7 +263,7 @@ index 653b6a343537..8805ace80a5f 100644
      storep argumINTTmp, [argumINTDst]
      storep 0, 8[argumINTDst]
  end
-@@ -502,7 +502,7 @@ end)
+@@ -511,7 +511,7 @@
  if ARM64 or ARM64E
      const IPIntCallCallee = sc1
      const IPIntCallFunctionSlot = sc0
@@ -359,16 +272,33 @@ index 653b6a343537..8805ace80a5f 100644
      const IPIntCallCallee = t7
      const IPIntCallFunctionSlot = t6
  end
-@@ -3201,7 +3201,7 @@ ipintOp(_atomic_prefix, macro()
+@@ -3143,7 +3143,7 @@
      if ARM64 or ARM64E
-         addlshiftp t1, t0, constexpr (WTF::fastLog2(JSC::IPInt::alignAtomicIPInt)), t0
+         addlshiftp t1, t0, (constexpr (WTF::fastLog2(JSC::IPInt::alignAtomicIPInt))), t0
          jmp t0
 -    elsif X86_64
 +    elsif X86_64 or RISCV64
-         lshiftq constexpr (WTF::fastLog2(JSC::IPInt::alignAtomicIPInt)), t0
+         lshiftq (constexpr (WTF::fastLog2(JSC::IPInt::alignAtomicIPInt))), t0
          addq t1, t0
          jmp t0
-@@ -10953,7 +10953,7 @@ macro mintArgDispatch()
+@@ -11333,6 +11333,8 @@
+ # t7 = new value for CAS (must be push/popped around loadStoreMakePointerSlow).
+ # After loadStoreMakePointerSlow, t4 points past the memarg.
+
++# Atomic opcode handlers trap on RISC-V and never reach these slow paths.
++if not RISCV64
+ .ipint_i32_atomic_load_slow_path:
+     loadStoreMakePointerSlow(t4, t0, 4, t1, t2, t5, t6)
+     doI32AtomicLoad(t0, t2)
+@@ -11766,6 +11768,7 @@
+     pushInt64(t0)
+     move t4, PC
+     nextIPIntInstruction()
++end
+
+ ##################################
+ ## "Out of line" logic for call ##
+@@ -11788,7 +11791,7 @@
      addq 1, MC
      bigteq sc0, (constexpr IPInt::CallArgumentBytecode::NumOpcodes), _ipint_mint_arg_dispatch_err
      lshiftq (constexpr (WTF::fastLog2(JSC::IPInt::alignMInt))), sc0
@@ -377,7 +307,7 @@ index 653b6a343537..8805ace80a5f 100644
      pcrtoaddr _mint_begin, csr4
      addq sc0, csr4
      jmp csr4
-@@ -10969,7 +10969,7 @@ macro mintRetDispatch()
+@@ -11804,7 +11807,7 @@
      addq 1, MC
      bigteq sc0, (constexpr IPInt::CallResultBytecode::NumOpcodes), _ipint_mint_ret_dispatch_err
      lshiftq (constexpr (WTF::fastLog2(JSC::IPInt::alignMInt))), sc0
@@ -386,171 +316,171 @@ index 653b6a343537..8805ace80a5f 100644
      pcrtoaddr _mint_begin_return, csr4
      addq sc0, csr4
      jmp csr4
-@@ -11205,7 +11205,7 @@ mintAlign(_a1)
+@@ -12132,7 +12135,7 @@
      mintArgDispatch()
- 
+
  mintAlign(_a2)
 -if ARM64 or ARM64E or X86_64
 +if ARM64 or ARM64E or X86_64 or RISCV64
      mintPop(a2)
      mintArgDispatch()
  else
-@@ -11213,7 +11213,7 @@ else
+@@ -12140,7 +12143,7 @@
  end
- 
+
  mintAlign(_a3)
 -if ARM64 or ARM64E or X86_64
 +if ARM64 or ARM64E or X86_64 or RISCV64
      mintPop(a3)
      mintArgDispatch()
  else
-@@ -11221,7 +11221,7 @@ else
+@@ -12148,7 +12151,7 @@
  end
- 
+
  mintAlign(_a4)
 -if ARM64 or ARM64E or X86_64
 +if ARM64 or ARM64E or X86_64 or RISCV64
      mintPop(a4)
      mintArgDispatch()
  else
-@@ -11229,7 +11229,7 @@ else
+@@ -12156,7 +12159,7 @@
  end
- 
+
  mintAlign(_a5)
 -if ARM64 or ARM64E or X86_64
 +if ARM64 or ARM64E or X86_64 or RISCV64
      mintPop(a5)
      mintArgDispatch()
  else
-@@ -11237,7 +11237,7 @@ else
+@@ -12164,7 +12167,7 @@
  end
- 
+
  mintAlign(_a6)
 -if ARM64 or ARM64E
 +if ARM64 or ARM64E or RISCV64
      mintPop(a6)
      mintArgDispatch()
  else
-@@ -11245,7 +11245,7 @@ else
+@@ -12172,7 +12175,7 @@
  end
- 
+
  mintAlign(_a7)
 -if ARM64 or ARM64E
 +if ARM64 or ARM64E or RISCV64
      mintPop(a7)
      mintArgDispatch()
  else
-@@ -11447,7 +11447,7 @@ mintAlign(_r1)
+@@ -12366,7 +12369,7 @@
      mintRetDispatch()
- 
+
  mintAlign(_r2)
 -if ARM64 or ARM64E or X86_64
 +if ARM64 or ARM64E or X86_64 or RISCV64
      subp StackValueSize, mintRetDst
      storeq wa2, [mintRetDst]
      mintRetDispatch()
-@@ -11456,7 +11456,7 @@ else
+@@ -12375,7 +12378,7 @@
  end
- 
+
  mintAlign(_r3)
 -if ARM64 or ARM64E or X86_64
 +if ARM64 or ARM64E or X86_64 or RISCV64
      subp StackValueSize, mintRetDst
      storeq wa3, [mintRetDst]
      mintRetDispatch()
-@@ -11465,7 +11465,7 @@ else
+@@ -12384,7 +12387,7 @@
  end
- 
+
  mintAlign(_r4)
 -if ARM64 or ARM64E or X86_64
 +if ARM64 or ARM64E or X86_64 or RISCV64
      subp StackValueSize, mintRetDst
      storeq wa4, [mintRetDst]
      mintRetDispatch()
-@@ -11474,7 +11474,7 @@ else
+@@ -12393,7 +12396,7 @@
  end
- 
+
  mintAlign(_r5)
 -if ARM64 or ARM64E or X86_64
 +if ARM64 or ARM64E or X86_64 or RISCV64
      subp StackValueSize, mintRetDst
      storeq wa5, [mintRetDst]
      mintRetDispatch()
-@@ -11483,7 +11483,7 @@ else
+@@ -12402,7 +12405,7 @@
  end
- 
+
  mintAlign(_r6)
 -if ARM64 or ARM64E
 +if ARM64 or ARM64E or RISCV64
      subp StackValueSize, mintRetDst
      storeq wa6, [mintRetDst]
      mintRetDispatch()
-@@ -11492,7 +11492,7 @@ else
+@@ -12411,7 +12414,7 @@
  end
- 
+
  mintAlign(_r7)
 -if ARM64 or ARM64E
 +if ARM64 or ARM64E or RISCV64
      subp StackValueSize, mintRetDst
      storeq wa7, [mintRetDst]
      mintRetDispatch()
-@@ -11854,7 +11854,7 @@ argumINTAlign(_a1)
+@@ -12799,7 +12802,7 @@
      argumINTDispatch()
- 
+
  argumINTAlign(_a2)
 -if ARM64 or ARM64E or X86_64
 +if ARM64 or ARM64E or X86_64 or RISCV64
      storeq wa2, [argumINTDst]
-     addp LocalSize, argumINTDst
+     subp LocalSize, argumINTDst
      argumINTDispatch()
-@@ -11864,7 +11864,7 @@ end
- 
- 
+@@ -12809,7 +12812,7 @@
+
+
  argumINTAlign(_a3)
 -if ARM64 or ARM64E or X86_64
 +if ARM64 or ARM64E or X86_64 or RISCV64
      storeq wa3, [argumINTDst]
-     addp LocalSize, argumINTDst
+     subp LocalSize, argumINTDst
      argumINTDispatch()
-@@ -11873,7 +11873,7 @@ else
+@@ -12818,7 +12821,7 @@
  end
- 
+
  argumINTAlign(_a4)
 -if ARM64 or ARM64E or X86_64
 +if ARM64 or ARM64E or X86_64 or RISCV64
      storeq wa4, [argumINTDst]
-     addp LocalSize, argumINTDst
+     subp LocalSize, argumINTDst
      argumINTDispatch()
-@@ -11882,7 +11882,7 @@ else
+@@ -12827,7 +12830,7 @@
  end
- 
+
  argumINTAlign(_a5)
 -if ARM64 or ARM64E or X86_64
 +if ARM64 or ARM64E or X86_64 or RISCV64
      storeq wa5, [argumINTDst]
-     addp LocalSize, argumINTDst
+     subp LocalSize, argumINTDst
      argumINTDispatch()
-@@ -11891,7 +11891,7 @@ else
+@@ -12836,7 +12839,7 @@
  end
- 
+
  argumINTAlign(_a6)
 -if ARM64 or ARM64E
 +if ARM64 or ARM64E or RISCV64
      storeq wa6, [argumINTDst]
-     addp LocalSize, argumINTDst
+     subp LocalSize, argumINTDst
      argumINTDispatch()
-@@ -11900,7 +11900,7 @@ else
+@@ -12845,7 +12848,7 @@
  end
- 
+
  argumINTAlign(_a7)
 -if ARM64 or ARM64E
 +if ARM64 or ARM64E or RISCV64
      storeq wa7, [argumINTDst]
-     addp LocalSize, argumINTDst
+     subp LocalSize, argumINTDst
      argumINTDispatch()
-@@ -11965,7 +11965,12 @@ argumINTAlign(_stack_vector)
+@@ -12910,7 +12913,12 @@
      argumINTDispatch()
- 
+
  argumINTAlign(_end)
 +if RISCV64
 +    pcrtoaddr .ipint_entry_end_local, argumINTDsp
@@ -558,201 +488,74 @@ index 653b6a343537..8805ace80a5f 100644
 +else
      jmp .ipint_entry_end_local
 +end
- 
+
  if ARM64E
      global _wasmTailCallTrampoline
-diff --git a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
-index 71cf86f85df2..219faf9d36f1 100644
 --- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
 +++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
-@@ -364,6 +364,43 @@ elsif X86_64
-     const wfa6 = ft6
-     const wfa7 = ft7
- 
-+    const fr = fa0
-+elsif RISCV64
-+    const a0 = t0
-+    const a1 = t1
-+    const a2 = t2
-+    const a3 = t3
-+    const a4 = t4
-+    const a5 = t5
-+    const a6 = t6
-+    const a7 = t7
-+
-+    const wa0 = a0
-+    const wa1 = a1
-+    const wa2 = a2
-+    const wa3 = a3
-+    const wa4 = a4
-+    const wa5 = a5
-+    const wa6 = a6
-+    const wa7 = a7
-+
-+    const ws0 = t9
-+    const ws1 = t10
-+    const ws2 = t11
-+    const ws3 = t12
-+
-+    const r0 = a0
-+    const r1 = a1
-+
-+    const wfa0 = fa0
-+    const wfa1 = fa1
-+    const wfa2 = fa2
-+    const wfa3 = fa3
-+    const wfa4 = fa4
-+    const wfa5 = fa5
-+    const wfa6 = fa6
-+    const wfa7 = fa7
-+
-     const fr = fa0
- else
-     const a0 = t0
-@@ -906,8 +943,12 @@ macro checkStackPointerAlignment(tempReg, location)
+@@ -813,8 +813,11 @@
      end
  end
- 
+
 -if C_LOOP or ARM64 or ARM64E or X86_64 or RISCV64
 +if C_LOOP or ARM64 or ARM64E or X86_64
      const CalleeSaveRegisterCount = 0
 +elsif RISCV64
-+    # Save s1-s11 and fs0-fs11. s0/fp is already saved as cfr by functionPrologue().
-+    # The extra slot keeps the stack 16-byte aligned after pushCalleeSaves().
++    # s1-s11 and fs0-fs11, rounded up to preserve 16-byte stack alignment.
 +    const CalleeSaveRegisterCount = 24
- elsif ARMv7
-     const CalleeSaveRegisterCount = 5 + 2 * 2 // 5 32-bit GPRs + 2 64-bit FPRs
  end
-@@ -923,7 +964,32 @@ macro pushCalleeSaves()
-     # but are not in RegisterSet::vmCalleeSaveRegisters() need to be saved here,
-     # i.e.: only those registers that are callee save in the C ABI, but are not
-     # callee save in the JIT ABI.
--    if C_LOOP or ARM64 or ARM64E or X86_64 or RISCV64
-+    if C_LOOP or ARM64 or ARM64E or X86_64
-+    elsif RISCV64
+
+ const CalleeRegisterSaveSize = CalleeSaveRegisterCount * MachineRegisterSize
+--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
++++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+@@ -177,6 +177,11 @@
+ macro doVMEntry(makeCall)
+     functionPrologue()
+
++    if RISCV64
 +        subp CalleeRegisterSaveSize, sp
-+        storeq csr0, [sp]
-+        storeq csr1, 8[sp]
-+        storeq csr2, 16[sp]
-+        storeq csr3, 24[sp]
-+        storeq csr4, 32[sp]
-+        storeq csr5, 40[sp]
-+        storeq csr6, 48[sp]
-+        storeq csr7, 56[sp]
-+        storeq csr8, 64[sp]
-+        storeq csr9, 72[sp]
-+        storeq csr10, 80[sp]
-+        stored csfr0, 88[sp]
-+        stored csfr1, 96[sp]
-+        stored csfr2, 104[sp]
-+        stored csfr3, 112[sp]
-+        stored csfr4, 120[sp]
-+        stored csfr5, 128[sp]
-+        stored csfr6, 136[sp]
-+        stored csfr7, 144[sp]
-+        stored csfr8, 152[sp]
-+        stored csfr9, 160[sp]
-+        stored csfr10, 168[sp]
-+        stored csfr11, 176[sp]
-     elsif ARMv7
-         emit "vpush.64 {d14, d15}"
-         emit "push {r4-r6, r8-r9}"
-@@ -931,7 +997,32 @@ macro pushCalleeSaves()
- end
- 
- macro popCalleeSaves()
--    if C_LOOP or ARM64 or ARM64E or X86_64 or RISCV64
-+    if C_LOOP or ARM64 or ARM64E or X86_64
-+    elsif RISCV64
-+        loadq [sp], csr0
-+        loadq 8[sp], csr1
-+        loadq 16[sp], csr2
-+        loadq 24[sp], csr3
-+        loadq 32[sp], csr4
-+        loadq 40[sp], csr5
-+        loadq 48[sp], csr6
-+        loadq 56[sp], csr7
-+        loadq 64[sp], csr8
-+        loadq 72[sp], csr9
-+        loadq 80[sp], csr10
-+        loadd 88[sp], csfr0
-+        loadd 96[sp], csfr1
-+        loadd 104[sp], csfr2
-+        loadd 112[sp], csfr3
-+        loadd 120[sp], csfr4
-+        loadd 128[sp], csfr5
-+        loadd 136[sp], csfr6
-+        loadd 144[sp], csfr7
-+        loadd 152[sp], csfr8
-+        loadd 160[sp], csfr9
-+        loadd 168[sp], csfr10
-+        loadd 176[sp], csfr11
++        copyCalleeSavesToBuffer(sp)
++    end
++
+     const entry = a0
+     const vm = a1
+     const protoCallFrame = a2
+@@ -306,6 +311,10 @@
+     end
+
+     subp cfr, CalleeRegisterSaveSize, sp
++    if RISCV64
++        restoreCalleeSavesFromBuffer(sp)
 +        addp CalleeRegisterSaveSize, sp
-     elsif ARMv7
-         emit "pop {r4-r6, r8-r9}"
-         emit "vpop.64 {d14, d15}"
-diff --git a/Source/JavaScriptCore/offlineasm/registers.rb b/Source/JavaScriptCore/offlineasm/registers.rb
-index 9c605e6f52d4..38715831151a 100644
---- a/Source/JavaScriptCore/offlineasm/registers.rb
-+++ b/Source/JavaScriptCore/offlineasm/registers.rb
-@@ -67,6 +67,22 @@ FPRS =
-      "ft5",
-      "ft6",
-      "ft7",
-+     "fa0",
-+     "fa1",
-+     "fa2",
-+     "fa3",
-+     "fa4",
-+     "fa5",
-+     "fa6",
-+     "fa7",
-+     "wfa0",
-+     "wfa1",
-+     "wfa2",
-+     "wfa3",
-+     "wfa4",
-+     "wfa5",
-+     "wfa6",
-+     "wfa7",
-      "csfr0",
-      "csfr1",
-      "csfr2",
-diff --git a/Source/JavaScriptCore/offlineasm/riscv64.rb b/Source/JavaScriptCore/offlineasm/riscv64.rb
-index d9ed36aa5350..1953bf837f20 100644
++    end
+
+     functionEpilogue()
+     ret
+@@ -331,6 +340,10 @@
+     move ValueUndefined, r0
+
+     subp cfr, CalleeRegisterSaveSize, sp
++    if RISCV64
++        restoreCalleeSavesFromBuffer(sp)
++        addp CalleeRegisterSaveSize, sp
++    end
+     functionEpilogue()
+     ret
+
+@@ -388,6 +401,10 @@
+     move ValueUndefined, r0
+
+     subp cfr, CalleeRegisterSaveSize, sp
++    if RISCV64
++        restoreCalleeSavesFromBuffer(sp)
++        addp CalleeRegisterSaveSize, sp
++    end
+     functionEpilogue()
+     ret
+ end)
 --- a/Source/JavaScriptCore/offlineasm/riscv64.rb
 +++ b/Source/JavaScriptCore/offlineasm/riscv64.rb
-@@ -170,10 +170,16 @@ class RegisterID
-             'x16'
-         when 't7', 'a7', 'wa7'
-             'x17'
--        when 'ws0'
-+        when 't8'
-+            'x5'
-+        when 't9', 'ws0'
-             'x6'
--        when 'ws1'
-+        when 't10', 'ws1'
-             'x7'
-+        when 't11'
-+            'x28'
-+        when 't12'
-+            'x29'
-         when 'csr0'
-             'x9'
-         when 'csr1'
-@@ -223,6 +229,10 @@ class FPRegisterID
-             'f4'
-         when 'ft5'
-             'f5'
-+        when 'ft6'
-+            'f6'
-+        when 'ft7'
-+            'f7'
-         when 'csfr0'
-             'f8'
-         when 'csfr1'
-@@ -467,7 +477,7 @@ def riscv64LowerAddressLoads(list)
+@@ -460,7 +460,7 @@
                  riscv64ValidateOperands(node.operands, [LabelReference, RegisterID])
                  newList << Instruction.new(node.codeOrigin, "rv_la", node.operands)
              when "pcrtoaddr"
@@ -761,45 +564,10 @@ index d9ed36aa5350..1953bf837f20 100644
                  newList << Instruction.new(node.codeOrigin, "rv_lla", node.operands)
              else
                  newList << node
-@@ -570,6 +580,25 @@ def riscv64LowerOperation(list)
-         newList << Instruction.new(node.codeOrigin, "rv_s#{suffix}", node.operands)
-     end
- 
-+    def emitTransferOperation(newList, node, size)
-+        riscv64ValidateOperands(node.operands, [Address, Address])
-+
-+        case size
-+        when :i
-+            loadSuffix = "wu"
-+            storeSuffix = "w"
-+        when :p, :q
-+            loadSuffix = "d"
-+            storeSuffix = "d"
-+        else
-+            raise "Invalid size #{size}"
-+        end
-+
-+        tmp = Tmp.new(node.codeOrigin, :gpr)
-+        newList << Instruction.new(node.codeOrigin, "rv_l#{loadSuffix}", [node.operands[0], tmp])
-+        newList << Instruction.new(node.codeOrigin, "rv_s#{storeSuffix}", [tmp, node.operands[1]])
-+    end
-+
-     def emitMove(newList, node)
-         case riscv64OperandTypes(node.operands)
-         when [RegisterID, RegisterID]
-@@ -600,7 +629,7 @@ def riscv64LowerOperation(list)
-         case riscv64OperandTypes(node.operands)
-         when [RegisterID]
-             callOpcode = "jalr"
--        when [LabelReference]
-+        when [LabelReference], [LocalLabelReference]
-             callOpcode = "call"
-         else
-             riscv64RaiseMismatchedOperands(node.operands)
-@@ -784,13 +813,24 @@ def riscv64LowerOperation(list)
+@@ -796,13 +796,24 @@
              return
          end
- 
+
 +        case [extension, fromSize, toSize]
 +        when [:z, :b, :i], [:z, :b, :p], [:z, :b, :q]
 +            newList << Instruction.new(node.codeOrigin, "rv_slli", [source, Immediate.new(node.codeOrigin, 56), dest])
@@ -822,19 +590,10 @@ index d9ed36aa5350..1953bf837f20 100644
              newList << Instruction.new(node.codeOrigin, "rv_slli", [source, Immediate.new(node.codeOrigin, 56), dest])
              newList << Instruction.new(node.codeOrigin, "rv_srai", [dest, Immediate.new(node.codeOrigin, 56), dest])
          when [:h, :i]
-@@ -852,6 +892,8 @@ def riscv64LowerOperation(list)
-                 emitLoadOperation(newList, node, $1.to_sym)
-             when /^store(b|h|i|p|q)$/
-                 emitStoreOperation(newList, node, $1.to_sym)
-+            when /^transfer(i|p|q)$/
-+                emitTransferOperation(newList, node, $1.to_sym)
-             when "move"
-                 emitMove(newList, node)
-             when "jmp"
-@@ -1197,6 +1239,60 @@ def riscv64LowerFPOperation(list)
+@@ -1211,6 +1222,60 @@
          newList << Instruction.new(node.codeOrigin, "rv_fs#{suffix}", node.operands)
      end
- 
+
 +    def emitLoadVectorOperation(newList, node)
 +        case riscv64OperandTypes(node.operands)
 +        when [Address, FPRegisterID]
@@ -892,7 +651,7 @@ index d9ed36aa5350..1953bf837f20 100644
      def emitMoveOperation(newList, node, precision)
          riscv64ValidateOperands(node.operands, [FPRegisterID, FPRegisterID])
          raise "Invalid precision" unless [:f, :d].include? precision
-@@ -1366,6 +1462,14 @@ def riscv64LowerFPOperation(list)
+@@ -1380,6 +1445,14 @@
                  emitLoadOperation(newList, node, $1.to_sym)
              when /^store(f|d)$/
                  emitStoreOperation(newList, node, $1.to_sym)
@@ -907,7 +666,16 @@ index d9ed36aa5350..1953bf837f20 100644
              when /^move(d)$/
                  emitMoveOperation(newList, node, $1.to_sym)
              when /^f(i|p|q|f|d)2(i|p|q|f|d)$/
-@@ -1589,7 +1693,7 @@ class Instruction
+@@ -1488,7 +1561,7 @@
+     end
+
+     def emit(newList, node, precision, condition)
+-        riscv64ValidateOperands(node.operands, [FPRegisterID, FPRegisterID, LocalLabelReference])
++        riscv64ValidateOperands(node.operands, [FPRegisterID, FPRegisterID, LocalLabelReference], [FPRegisterID, FPRegisterID, LabelReference])
+         operands = node.operands
+
+         if [:equn, :nequn, :gtun, :gtequn, :ltun, :ltequn].include? condition
+@@ -1603,7 +1676,7 @@
              riscv64ValidateOperands(operands, [LabelReference], [LocalLabelReference])
              $asm.puts "#{rvop(opcode)} #{operands[0].asmLabel}"
          when /^rv_(la|lla)$/
@@ -916,11 +684,18 @@ index d9ed36aa5350..1953bf837f20 100644
              $asm.puts "#{rvop(opcode)} #{operands[1].riscv64Operand}, #{operands[0].asmLabel}"
          when "rv_mv"
              riscv64ValidateOperands(operands, [RegisterID, RegisterID])
-diff --git a/Source/JavaScriptCore/runtime/Options.cpp b/Source/JavaScriptCore/runtime/Options.cpp
-index a4cf996708be..a9dffffce1f5 100644
+@@ -1641,7 +1714,7 @@
+             riscv64ValidateOperands(operands, [RegisterID, RegisterID, LocalLabelReference], [RegisterID, RegisterID, LabelReference])
+             $asm.puts "#{rvop(opcode)} #{operands[0].riscv64Operand}, #{operands[1].riscv64Operand}, #{operands[2].asmLabel}"
+         when /^rv_b(eqz|nez|lez|ltz|gez|gtz)$/
+-            riscv64ValidateOperands(operands, [RegisterID, LocalLabelReference])
++            riscv64ValidateOperands(operands, [RegisterID, LocalLabelReference], [RegisterID, LabelReference])
+             $asm.puts "#{rvop(opcode)} #{operands[0].riscv64Operand}, #{operands[1].asmLabel}"
+         when "rv_nop", "rv_ret", "rv_ebreak"
+             $asm.puts "#{rvop(opcode)}"
 --- a/Source/JavaScriptCore/runtime/Options.cpp
 +++ b/Source/JavaScriptCore/runtime/Options.cpp
-@@ -801,7 +801,11 @@ void Options::notifyOptionsChanged()
+@@ -828,7 +828,11 @@
      Options::useConcurrentGC() = false;
      Options::forceUnlinkedDFG() = false;
      Options::useWasmSIMD() = false;
@@ -929,14 +704,12 @@ index a4cf996708be..a9dffffce1f5 100644
 +#else
      Options::useWasmIPInt() = false;
 +#endif
- #if !CPU(ARM_THUMB2)
      Options::useBBQJIT() = false;
  #endif
-diff --git a/Source/JavaScriptCore/runtime/Options.h b/Source/JavaScriptCore/runtime/Options.h
-index 6c707f34ef73..47c73896f51b 100644
+
 --- a/Source/JavaScriptCore/runtime/Options.h
 +++ b/Source/JavaScriptCore/runtime/Options.h
-@@ -175,7 +175,7 @@ private:
+@@ -174,7 +174,7 @@
      static unsigned computeNumberOfWorkerThreads(int maxNumberOfWorkerThreads, int minimum = 1);
      static int32_t computePriorityDeltaOfWorkerThreads(int32_t twoCorePriorityDelta, int32_t multiCorePriorityDelta);
      static constexpr bool jitEnabledByDefault() { return isAddress64Bit(); }
@@ -945,3 +718,23 @@ index 6c707f34ef73..47c73896f51b 100644
      static double defaultQuickDFGTierUpThresholdFactor()
      {
  #if PLATFORM(MAC)
+--- a/Source/JavaScriptCore/wasm/WasmAddressType.cpp
++++ b/Source/JavaScriptCore/wasm/WasmAddressType.cpp
+@@ -48,7 +48,7 @@
+     }
+ }
+
+-#if !PLATFORM(PLAYSTATION)
++#if !PLATFORM(PLAYSTATION) && ENABLE(JIT)
+ AddressType::AddressType(B3::Type type)
+ {
+     switch (type.kind()) {
+@@ -88,7 +88,7 @@
+     RELEASE_ASSERT_NOT_REACHED(invalidAddressTypeConversion);
+ }
+
+-#if !PLATFORM(PLAYSTATION)
++#if !PLATFORM(PLAYSTATION) && ENABLE(JIT)
+ B3::TypeKind AddressType::asB3TypeKind() const
+ {
+     switch (m_type) {

--- a/bun/riscv64.patch
+++ b/bun/riscv64.patch
@@ -1,83 +1,45 @@
-diff --git PKGBUILD PKGBUILD
-index 0c96862..f3902de 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -29,6 +29,12 @@
-   ruby-getoptlong # webkit
-   unzip
+@@ -32,6 +32,7 @@
+   ruby-erb
+   ruby-getoptlong
  )
-+makedepends_riscv64=(
-+  bun
-+  clang20
-+  lld20
-+  llvm20
-+)
++makedepends_riscv64=(bun nodejs)
  options=('!lto')
  source=(
    "git+$url.git#tag=bun-v$pkgver"
-@@ -71,15 +77,45 @@
-   case "$CARCH" in
-     x86_64)  _zigzip="$srcdir/$pkgname-zig-$_zigver-x86_64.zip" ;;
-     aarch64) _zigzip="$srcdir/$pkgname-zig-$_zigver-aarch64.zip" ;;
-+    riscv64)
-+      patch -Np1 -d vendor/WebKit < "$srcdir/$pkgname-webkit-riscv64.patch"
-+      patch -Np1 < "$srcdir/$pkgname-riscv64.patch"
-+      ;;
-   esac
--  # unzip can't strip dirs but we want to get rid of the first contained dir so we have to do a little dance
--  mkdir -p vendor/zig.extract
--  unzip -q "$_zigzip" -d vendor/zig.extract
--  mv vendor/zig.extract/* vendor/zig
--  printf '%s\n' "$_zigver" > vendor/zig/.zig-commit
-+  if [[ -n "${_zigzip:-}" ]]; then
-+    # unzip can't strip dirs but we want to get rid of the first contained dir so we have to do a little dance
-+    mkdir -p vendor/zig.extract
-+    unzip -q "$_zigzip" -d vendor/zig.extract
-+    mv vendor/zig.extract/* vendor/zig
-+    printf '%s\n' "$_zigver" > vendor/zig/.zig-commit
+@@ -68,6 +69,11 @@
+   # See also https://bun.sh/docs/project/contributing#building-webkit-locally-+-debug-mode-of-jsc
+   mkdir -p vendor
+   cp -r "$srcdir/$pkgname-WebKit" vendor/WebKit
++
++  if [[ "$CARCH" == riscv64 ]]; then
++    patch -Np1 -d vendor/WebKit < "$srcdir/$pkgname-webkit-riscv64.patch"
++    patch -Np1 < "$srcdir/$pkgname-riscv64.patch"
 +  fi
  }
- 
+
  build() {
-+  if [[ "$CARCH" == riscv64 ]]; then
-+    local cmake_vars=(
-+      CMAKE_INSTALL_PREFIX=/usr
-+      CMAKE_BUILD_TYPE=None
-+      ZIG_PIE=ON
-+      ZIG_SHARED_LLVM=ON
-+      ZIG_USE_LLVM_CONFIG=ON
-+      ZIG_TARGET_TRIPLE=native-linux.6.6-gnu.2.40
-+      ZIG_TARGET_MCPU=baseline
-+    )
-+
-+    (
-+      export PATH="/usr/lib/llvm20/bin:$PATH"
-+      cmake -B "$srcdir/$pkgname-zig-build" "${cmake_vars[@]/#/-D}" "$srcdir/$pkgname-zig"
-+      cmake --build "$srcdir/$pkgname-zig-build"
-+      DESTDIR="$srcdir/$pkgname-zig-install" cmake --install "$srcdir/$pkgname-zig-build"
-+    )
-+
-+    mkdir -p "$srcdir/$pkgname/vendor/zig"
-+    install -Dm755 "$srcdir/$pkgname-zig-install/usr/bin/zig" "$srcdir/$pkgname/vendor/zig/zig"
-+    cp -a "$srcdir/$pkgname-zig-install/usr/lib/zig" "$srcdir/$pkgname/vendor/zig/lib"
-+    printf '%s\n' "$_zigver" > "$srcdir/$pkgname/vendor/zig/.zig-commit"
-+  fi
-+
-   export PATH="/usr/lib/llvm21/bin:$PATH"
- 
-   case "$CARCH" in
-@@ -87,7 +123,9 @@
+@@ -78,12 +84,15 @@
+     x86_64)  _bundir="bun-linux-x64" ;;
      aarch64) _bundir="bun-linux-aarch64" ;;
    esac
- 
 -  export PATH="$srcdir/$_bundir:$PATH"
 +  if [[ -n "${_bundir:-}" ]]; then
 +    export PATH="$srcdir/$_bundir:$PATH"
 +  fi
- 
-   cd $pkgname
-   bun scripts/build.ts \
-@@ -112,3 +150,12 @@
+
+-  bun scripts/build.ts \
++  # Bootstrap Bun makes Ninja's inherited log pipe nonblocking, losing output.
++  node --experimental-strip-types scripts/build.ts \
+     --profile=release-local \
+     --canary=0 \
+-    --baseline=on \
++    --baseline=off \
+     --build-dir=build/release \
+     --cache-dir="$srcdir/build-cache"
+ }
+@@ -106,3 +115,10 @@
    install -vDm644 completions/bun.fish "$pkgdir/usr/share/fish/vendor_completions.d/bun.fish"
    install -vDm644 completions/bun.zsh "$pkgdir/usr/share/zsh/site-functions/_bun"
  }
@@ -85,8 +47,6 @@ index 0c96862..f3902de 100644
 +source_riscv64=(
 +  "$pkgname-riscv64.patch"
 +  "$pkgname-webkit-riscv64.patch"
-+  "$pkgname-zig::git+https://github.com/oven-sh/zig.git#tag=autobuild-$_zigver"
 +)
-+b2sums_riscv64=('d815fa6f73e37b3c2d20183fc3418a313592752b8e381fc7d3217952a5ba7b65c278bcca63173eb083a7a3f04d00ea25ccc67ec75418b7d6d75de4183ca05fb7'
-+                'b64777e7bf3fb030235f3a53ad035c835a9c4335e3508ab9d94c93804041e5d3380a0c63803c6dd5612ecbef765a998cf9496ca8d612c9c361cff4cf8c187292'
-+                '45421c507deaf962313ab0e7fb94768bf8aad6313597e372f965149409f0a5432f1f6b75e7dc57e66c5ad8180aa59f4292db508dbb6ed52d2c0cb72989462ba8')
++b2sums_riscv64=('e5f4a9b33fc70bfd608cb4c10d0284b042b5909dfb88357c1396f8c287fe10feef33d64c43b62d9f13169dca6ba1f25cc9ee9458383502c528e0d176c4fa84e6'
++                'a7d50d7416e2b043167109745d551ba975864641413ca4905a5c186e58ca14af49010fb338a203970e246cf27590b1b3585ea4189042acf6affe1d1c4eb496ab')


### PR DESCRIPTION
Refresh for Bun's Zig-to-Rust migration, which breaks the old PKGBUILD patch. Remove the Zig bootstrap and port the RISC-V architecture, syscall and crash-reporting support to Rust.

Select portable zlib/JPEG implementations and skip the glibc compatibility ABI that predates RISC-V. Guard Windows-only teb()/peb() bodies and reuse debug::PC_OFFSET to avoid the unused-constant build failure.

Fix mimalloc's generic pause fallback using its existing C/C++ atomic macros, and apply the patch through Bun's dependency fetcher.

Rebase the interpreter-only WebKit changes. Exclude unsupported atomic slow paths, allow global labels in IPInt floating-point branch lowering, and restore upstream's scratch-register pool to avoid exhausting it during LLIntAssembly.h generation.

Backport the WasmAddressType.cpp JIT guards so the interpreter-only build does not compile B3 conversions:
https://github.com/WebKit/WebKit/commit/f69625842f3157301031121ad3d8fcf48f52080d

Use StoreMaskBits for the capped XML, JSON and source-map masks on scalable-vector targets, where Highway does not provide BitsFromMask.

Add RISC-V to Rust's TinyCC availability and binding predicates, matching the existing build exclusion and avoiding undefined tcc_* symbols.

Use the upstream-supported Node build driver and let queued output drain via process.exitCode. Bootstrap Bun makes Ninja's inherited log pipe nonblocking, while process.exit() also truncates failure output. Keep Bun for code generation.

Drop fixes already present in the pinned upstream sources:

https://github.com/oven-sh/WebKit/blob/0f966e81b78c84bb23213e391bc679c4ef83e56b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h https://github.com/oven-sh/WebKit/blob/0f966e81b78c84bb23213e391bc679c4ef83e56b/Source/JavaScriptCore/b3/air/AirArg.h https://github.com/oven-sh/WebKit/blob/0f966e81b78c84bb23213e391bc679c4ef83e56b/Source/JavaScriptCore/jit/GdbJIT.cpp https://github.com/oven-sh/bun/blob/bun-v1.4.0/src/jsc/bindings/JSBuffer.cpp#L2294