### PR TITLE
addpatch: dot-language-server 3.2.0-1

### DIFF
--- a/dot-language-server/riscv64.patch
+++ b/dot-language-server/riscv64.patch
@@ -1,0 +1,24 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -9,7 +9,6 @@
+ license=(MIT)
+ depends=(nodejs)
+ makedepends=(
+-  bun
+   npm
+   typescript
+ )
+@@ -19,11 +18,12 @@
+ 
+ build() {
+   cd $pkgname-$pkgver
++  # Use system TypeScript and install only the Node types needed below.
++  npm pkg delete devDependencies
+   npm install --omit=dev --cache "$srcdir"/npm-cache
+   # required for typescript when not installing dev dependencies
+   npm install --save-dev @types/node --cache "$srcdir"/npm-cache
+   tsc
+-  bun build --compile --minify src/cli.ts --target=bun-linux-x64-modern --outfile=dist/linux-x64/dot-language-server
+ }
+ 
+ check() {


### PR DESCRIPTION
Installing @types/node with --save-dev also installs all declared dev dependencies, failing with EBADPLATFORM for bun@1.3.14 on riscv64. Clear the dev dependencies first and use system TypeScript with the Node types.

Drop the Bun build dependency and x86-only standalone executable build. The package ships the Node entry point and compiled JavaScript, so the Bun executable is unused. Keep the existing type check.