### PR TITLE
qemu-user-blacklist: add python-tpm2-pytss

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -120,6 +120,7 @@ python-filelock
 python-libtmux
 python-prctl
 python-setproctitle
+python-tpm2-pytss
 python-virtualenv
 python-xmlsec
 qalculate-qt


### PR DESCRIPTION
The 3.0.0-1 checks on ninetales fail because swtpm cannot install its seccomp filter under QEMU user mode: "seccomp_load failed with errno 125: Operation canceled". The simulator exits, causing 286 test failures and 119 setup errors with "tcti:IO failure". Select a non-qemu-user builder to preserve the full test suite.

https://github.com/qemu/qemu/blob/v11.0.3/linux-user/syscall.c#L6805