### PR TITLE
blacklist: add fasm

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -31,6 +31,9 @@ teamspeak3
 teamspeak3-server
 vivaldi
 
+# Entirely x86-centric software
+fasm
+
 # No hardware support
 amd-ucode
 dosemu


### PR DESCRIPTION
The 1.73.35-1 build leaves SRCDIR unset on riscv64 and fails to move source//fasm. The assembler and its tools are written in x86 assembly, and the supplied bootstrap executables only support i386 and x86_64. Exclude fasm until a RISC-V host implementation is available.

https://flatassembler.net/download.php