### PR TITLE
blacklist: exclude unavailable CUDA and Intel components

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -1,6 +1,8 @@
 # Binary package that don't have RISC-V support
 cuda
 cudnn
+cudss
+cutensor
 discord
 discord-canary
 hsa-amd-aqlprofile-bin
@@ -16,8 +18,11 @@ intel-oneapi-mkl
 intel-oneapi-openmp
 intel-oneapi-tbb
 intel-oneapi-tcm
+intel-oneapi-toolkit
 intel-oneapi-umf
 nsight-compute
+nsight-systems
+nvhpc
 nvidia
 nvidia-cg-toolkit
 nvidia-dkms
@@ -31,6 +36,28 @@ teamspeak3
 teamspeak3-server
 vivaldi
 
+# Requires CUDA or the proprietary NVIDIA driver
+cudnn-frontend
+cutlass-headers
+libnvidia-container
+nccl
+nvidia-container-toolkit
+nvidia-open
+nvidia-open-lts
+nvidia-prime
+nvshmem
+popsift
+python-cccl
+python-cuda
+python-cuda-core
+python-cuda-pathfinder
+python-cuda-tile
+python-nsight
+python-numba-cuda
+python-numba-cuda-mlir
+python-nvidia-ml-py
+python-pycuda
+
 # Entirely x86-centric software
 fasm
 
@@ -38,10 +65,12 @@ fasm
 amd-ucode
 dosemu
 i7z
+intel-lpmd
 intel-metee
 intel-metee-doc
 intel-mkl
 intel-mkl-static
+intel-npu-driver
 intel-ucode
 intel-undervolt
 libva-intel-driver
@@ -53,6 +82,7 @@ tp_smapi-lts
 tpacpi-bat
 turbostat
 x86_energy_perf_policy
+xf86-video-intel
 
 # Cross toolchain for RISC-V
 riscv32-elf-binutils


### PR DESCRIPTION
Exclude binary SDKs without RISC-V distributions and packages whose functionality requires CUDA or the proprietary NVIDIA driver, including CUDA Python bindings and NVIDIA container integration.

Also exclude tools and drivers tied to Intel CPU power management, integrated NPUs and legacy integrated graphics. Leave packages with usable CPU, ROCm or other backends eligible.