### PR TITLE
updpatch: luajit 2.1.1788856981+c6ffc14-1

### DIFF
--- a/luajit/riscv64.patch
+++ b/luajit/riscv64.patch
@@ -1,31 +1,24 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -7,9 +7,11 @@
- 
- pkgname=luajit
- # LuaJIT has a "rolling release" where you should follow git HEAD
--_commit=ff204d0350575cf710f6f4af982db146cb454e1a
-+# note to riscv: choose commit close to (but newer than) Arch upstream from `riscv` branch of infiWang/LuaJIT
-+# make sure the selected commit contains necessary changes to RISC-V and update $_ct below
-+_commit=5938da937b13790dc3705ee5823405f0ff8c31ed
- # The patch version is the timestamp of the above git commit, obtain via `git show -s --format=%ct`
--_ct=1702233742
-+_ct=1702376626
- pkgver="2.1.${_ct}"
- pkgrel=1
- pkgdesc='Just-in-time compiler and drop-in replacement for Lua 5.1'
-@@ -17,10 +19,10 @@ arch=('x86_64')
- url='https://luajit.org/'
- license=('MIT')
- depends=('gcc-libs')
--source=("LuaJIT-${_commit}.tar.gz::https://github.com/LuaJIT/LuaJIT/archive/${_commit}.tar.gz")
--md5sums=('97486356d223510a6e3c31a20bcd32ed')
--sha256sums=('3ec37f78ab3b1afd4c3af0fde743c332da3da32eadc8500489c1cc2e4f0ec7eb')
--b2sums=('6ba03fa107baadf0ac980d515debd638b1a166014ee46c6fa95865a12678a831fbae04d14ccb737723a69874af2b0637bbaa516973830ca4c7e5311aa3f91b76')
-+source=("LuaJIT-${_commit}.tar.gz::https://github.com/infiWang/LuaJIT/archive/${_commit}.tar.gz")
-+md5sums=('aec4671279cacf32c09dab2fe9ff9aa1')
-+sha256sums=('0de7c45601a9052c4a37963f343c6963c84871be48be8893c9bace2c959b699e')
-+b2sums=('9f210fe44b7966051a3317dedf15f54252978eb953c297558dba265aa7852f6d715f26f46693271b726211da4ab49ad60b2b7c55315a9ac3372fac00fb34bf44')
- 
+@@ -19,6 +19,13 @@
+ sha256sums=('6e5fec07750add912e7c3eae0c194d24cd6d023714e1f04a0298a5b4819e4457')
+ b2sums=('1dd16b18f2310fd61ee6c3b8352c7a79d09b02da5ac13a8e00f6b67fdac9adcd40c7333428a2f6b3cf22b20797061bdfdba9fa211b9b10ee63a99546831e7da1')
+
++prepare() {
++  cd "LuaJIT-${_commit}"*/
++
++  # Add the RISC-V port to the packaged upstream revision.
++  patch -Np1 -i ../riscv64-port.patch
++}
++
  build() {
-   cd "LuaJIT-${_commit}"
+   cd "LuaJIT-${_commit}"*/
+
+@@ -40,3 +47,7 @@
+   make install DESTDIR="$pkgdir" PREFIX=/usr
+   install -Dm644 COPYRIGHT "$pkgdir/usr/share/licenses/$pkgname/COPYRIGHT"
+ }
++
++source+=("riscv64-port.patch::https://github.com/IgnotaYun/LuaJIT/compare/c6ffc141a8762b41703f9287d63d93622a13dd8f...fb8569e1e11b598c34ca16988682d8286219dfd5.diff")
++sha256sums+=('b49737da996b165698bb81e5883a575999de4b03c760aa0746ddd208d68fecc4')
++b2sums+=('7920441985c53aa7d3fd9c61763a826197e234fc699a44bccf63e32012c8ebb09497411b2772267da365735536206b5e477fba8f66d9aa463f096a787d5dd253')


### PR DESCRIPTION
Replace the obsolete fork source/version override with a source patch in prepare(), fixing both failed PKGBUILD hunks. Apply the RISC-V delta between Arch's c6ffc14 and fork merge fb8569e while preserving Arch's version, source archive and .relver check.

https://github.com/IgnotaYun/LuaJIT/commit/fb8569e1e11b598c34ca16988682d8286219dfd5