### PR TITLE
addpatch: python-logbook 1.10.1-1

### DIFF
--- a/python-logbook/riscv64.patch
+++ b/python-logbook/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,6 +17,8 @@
+ 
+ prepare() {
+   cd logbook
++  # A nonzero backlog is needed on kernels without SYN cookies.
++  sed -i 's/listen(0)/listen(1)/' tests/test_syslog_handler.py
+   python -m build --wheel --no-isolation
+ }
+ 


### PR DESCRIPTION
The TCP syslog tests use listen(0), causing connect() to time out on kernels without SYN cookies. Use a backlog of one so the test's connection can complete before accept() is called.