### PR TITLE
addpatch: evolution-data-server 3.60.2-5

### DIFF
--- a/evolution-data-server/increase-stress-test-timeout.patch
+++ b/evolution-data-server/increase-stress-test-timeout.patch
@@ -1,0 +1,11 @@
+--- a/src/camel/tests/misc/test-store-search.c
++++ b/src/camel/tests/misc/test-store-search.c
+@@ -11,7 +11,7 @@
+ 
+ #include "lib-camel-test-utils.c"
+ 
+-#define SIMULTANEOUS_TIMEOUT_SECS 10
++#define SIMULTANEOUS_TIMEOUT_SECS 60
+ #define SIMULTANEOUS_N_REPEATS 100
+ 
+ static void

--- a/evolution-data-server/riscv64.patch
+++ b/evolution-data-server/riscv64.patch
@@ -1,0 +1,19 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -67,6 +67,9 @@
+ 
+ prepare() {
+   cd $pkgbase
++
++  # Allow more time for the four-thread summary save/reload stress test.
++  patch -Np1 -i ../increase-stress-test-timeout.patch
+ }
+ 
+ build() {
+@@ -157,3 +160,6 @@
+ }
+ 
+ # vim:set sw=2 sts=-1 et:
++
++source+=(increase-stress-test-timeout.patch)
++b2sums+=('6941ae2d24d1353aac30435a177a113c65e98e45569c579399284e227afc4f42b059ba1bd27915d2591b4bb18415df0706122c0282522ea2ef00e1dd72ca46d1')


### PR DESCRIPTION
The SimultaneousReadWriteStress test aborts in
 test_simultaneous_timeout_cb when its 10-second watchdog expires on
riscv64. Raise the timeout to 60 seconds to allow more time for the concurrent folder-summary save/reload workload, while retaining bounded hang detection and all four threads, 100 iterations and assertions.