### PR TITLE
addpatch: python-lsp-server 1.15.0-1

### DIFF
--- a/python-lsp-server/riscv64.patch
+++ b/python-lsp-server/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -62,6 +62,8 @@
+ prepare() {
+   cd $pkgname-$pkgver
+   sed 's|jedi>=[0-9.]\+,<[0-9.]\+|jedi|' -i pyproject.toml
++  # Allow Rope autoimport cache generation to finish on slower builders.
++  sed -i 's/CALL_TIMEOUT_IN_SECONDS = 30/CALL_TIMEOUT_IN_SECONDS = 120/' test/test_utils.py
+ }
+ 
+ build() {


### PR DESCRIPTION
Two autoimport integration tests time out waiting for initialization. Synchronous Rope cache generation and import preloading take about 68 and 54 seconds on the riscv64 builder, with successful responses arriving after the shared 30-second test deadline.

Raise the shared test timeout to 120 seconds, preserving all tests and assertions without changing runtime behavior.