### PR TITLE
updpatch: primecount 8.7-1

### DIFF
--- a/primecount/riscv64.patch
+++ b/primecount/riscv64.patch
@@ -1,8 +1,14 @@
-diff --git PKGBUILD PKGBUILD
-index bde2f61..adfb673 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -21,7 +21,7 @@ build() {
+@@ -10,7 +10,6 @@
+ depends=(glibc
+          libgcc
+          libgomp
+-         libquadmath
+          libstdc++
+          primesieve)
+ makedepends=(cmake
+@@ -24,7 +23,7 @@
      -DBUILD_LIBPRIMESIEVE=OFF \
      -DBUILD_STATIC_LIBS=OFF \
      -DBUILD_SHARED_LIBS=ON \


### PR DESCRIPTION
Drop the libquadmath dependency ahead of its removal from the riscv64 repository. This build already uses WITH_FLOAT128=OFF.