### PR TITLE
updpatch: galculator 2.1.4-12

### DIFF
--- a/galculator/riscv64.patch
+++ b/galculator/riscv64.patch
@@ -1,15 +1,10 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -16,6 +16,12 @@ makedepends=('intltool')
- source=("http://galculator.mnim.org/downloads/${pkgname}-${pkgver}.tar.bz2")
- sha256sums=('01cfafe6606e7ec45facb708ef85efd6c1e8bb41001a999d28212a825ef778ae')
-
-+prepare() {
-+  cd $pkgname-$pkgver
-+  autoupdate
-+  autoreconf -fiv
-+}
-+
- build() {
-   CFLAGS+=' -fcommon' # https://wiki.gentoo.org/wiki/Gcc_10_porting_notes/fno_common
-   cd "${srcdir}/${pkgname}-${pkgver}"
+@@ -17,7 +17,6 @@
+   glibc
+   gtk3
+   hicolor-icon-theme
+-  libquadmath
+   pango
+ )
+ makedepends=(


### PR DESCRIPTION
Drop the libquadmath dependency ahead of its removal from the riscv64 repository. Galculator already builds without it when detection fails.

Drop the old Autotools regeneration workaround: Arch now uses the Git source and runs autoreconf in prepare(), refreshing config.guess.

https://gitlab.archlinux.org/archlinux/packaging/packages/galculator/-/blob/2.1.4-12/PKGBUILD#L53