### PR TITLE
addpatch: papilo 3.0.1-5

### DIFF
--- a/papilo/riscv64.patch
+++ b/papilo/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -13,7 +13,6 @@
+          gmp
+          libgcc
+          libgfortran
+-         libquadmath
+          libstdc++
+          tbb)
+ makedepends=(boost


### PR DESCRIPTION
Drop the libquadmath dependency ahead of its removal from the riscv64 repository. PaPILO already detects its absence and builds without it.