### PR TITLE
qemu-user-blacklist: add tpm2-pkcs11

### DIFF
--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -147,6 +147,7 @@ tiled
 tinyssh
 tmuxp
 tpm2-openssl
+tpm2-pkcs11
 tpm2-tools
 tpm2-tss
 tracexec


### PR DESCRIPTION
All 31 tests in 1.10.1-1 fail on electivire with "Failed to start simulator after 10 tries. Giving up." QEMU user mode does not support the seccomp filter used by swtpm. Select a non-qemu-user builder to preserve the full test suite.

https://github.com/qemu/qemu/blob/v11.0.3/linux-user/syscall.c#L6805