### PR TITLE
updpatch: fftw 3.3.11-1

### DIFF
--- a/fftw/riscv64.patch
+++ b/fftw/riscv64.patch
@@ -1,6 +1,12 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -24,7 +24,7 @@
+@@ -18,13 +18,12 @@
+   glibc
+   libgcc
+   libgomp
+-  libquadmath
+   openmpi
+ )
  source=(http://www.fftw.org/$pkgname-$pkgver.tar.gz)
  sha512sums=('ca1bf80490dc6955a0ab49b1af05d6658c2ecc0968b3bde5b4af22271e47d30cd38f6f8347e8e6124091b6a17717447942bee95f94ca29574ba71c4d167af351')
  b2sums=('4bd2ae0ada612243f0681b185230969da2bca6cfccb1e16d17f84459cbdd4ae84dc8a9ddb39ce5e4dfc7d0308709d1dc56688826299ee1017fc6115d16b2bd38')
@@ -9,7 +15,7 @@
  _soname=3.7.11
  
  _pick() {
-@@ -61,21 +61,13 @@
+@@ -61,21 +60,13 @@
      MPILIBS="$(mpicc --showme:link)"
    )
    local _configure_single=(
@@ -31,7 +37,7 @@
    local _cmake_options=(
      -B build
      -S $pkgname-$pkgver-$_build_types
-@@ -86,11 +78,6 @@
+@@ -86,11 +77,6 @@
      -D ENABLE_THREADS=ON
      -D ENABLE_FLOAT=ON
      -D ENABLE_LONG_DOUBLE=ON
@@ -43,7 +49,7 @@
    )
  
    # create missing FFTW3LibraryDepends.cmake
-@@ -101,7 +88,7 @@
+@@ -101,7 +87,7 @@
  
    export F77='gfortran'
    # use upstream default CFLAGS while keeping our -march/-mtune
@@ -52,7 +58,7 @@
  
    for _name in "${_build_types[@]}"; do
      (
-@@ -116,9 +103,6 @@
+@@ -116,9 +102,6 @@
          long-double)
          "${_configure[@]}" "${_configure_long_double[@]}"
          ;;
@@ -62,3 +68,11 @@
        esac
        # fix overlinking because of libtool
        sed -i -e 's/ -shared / -Wl,-O1,--as-needed\0/g' libtool
+@@ -144,7 +127,6 @@
+     glibc
+     libgcc
+     libgomp
+-    libquadmath
+   )
+   optdepends=('fftw-openmpi: for OpenMPI integration')
+   provides=(


### PR DESCRIPTION
Drop the libquadmath build and runtime dependencies ahead of its removal from the riscv64 repository. The overlay already disables the quad-precision build.