### PR TITLE
addpatch: python-numba 0.67.0-1

### DIFF
--- a/python-numba/fix-aot-linking.patch
+++ b/python-numba/fix-aot-linking.patch
@@ -1,0 +1,60 @@
+--- a/numba/core/codegen.py
++++ b/numba/core/codegen.py
+@@ -649,6 +649,7 @@
+             str(self._codegen._create_empty_module(self.name)))
+         self._final_module.name = cgutils.normalize_ir_text(self.name)
+         self._shared_module = None
++        self._linking_bitcode = None
+ 
+     def _optimize_functions(self, ll_module):
+         """
+@@ -702,7 +703,8 @@
+         self._ensure_finalized()
+         if self._shared_module is not None:
+             return self._shared_module
+-        mod = self._final_module
++        mod = (ll.parse_bitcode(self._linking_bitcode)
++               if self._linking_bitcode is not None else self._final_module)
+         to_fix = []
+         nfuncs = 0
+         for fn in mod.functions:
+@@ -723,6 +725,7 @@
+                 # to an ELF file
+                 mod.get_function(name).linkage = 'linkonce_odr'
+         self._shared_module = mod
++        self._linking_bitcode = None
+         return mod
+ 
+     def add_linking_library(self, library):
+@@ -768,6 +771,10 @@
+                     library._get_module_for_linking(), preserve=True,
+                 )
+ 
++        # Callers can target a different CPU (e.g. generic AOT versus host JIT).
++        # Keep linking IR before vectorization introduces target-specific types.
++        self._linking_bitcode = self._final_module.as_bitcode()
++
+         # Optimize the module after all dependences are linked in above,
+         # to allow for inlining.
+         self._optimize_final_module()
+@@ -920,7 +927,9 @@
+         Serialize this library using its bitcode as the cached representation.
+         """
+         self._ensure_finalized()
+-        return (self.name, 'bitcode', self._final_module.as_bitcode())
++        data = (self._final_module.as_bitcode(),
++                self._get_module_for_linking().as_bitcode())
++        return (self.name, 'bitcode', data)
+ 
+     def serialize_using_object_code(self):
+         """
+@@ -940,6 +949,9 @@
+         assert isinstance(self, cls)
+         if kind == 'bitcode':
+             # No need to re-run optimizations, just make the module ready
++            if isinstance(data, tuple):
++                data, shared_bitcode = data
++                self._shared_module = ll.parse_bitcode(shared_bitcode)
+             self._final_module = ll.parse_bitcode(data)
+             self._finalize_final_module()
+             return self

--- a/python-numba/fix-cmath-nan-sign.patch
+++ b/python-numba/fix-cmath-nan-sign.patch
@@ -1,0 +1,43 @@
+--- a/numba/cpython/cmathimpl.py
++++ b/numba/cpython/cmathimpl.py
+@@ -478,11 +478,7 @@
+     def atan_impl(z):
+         """cmath.atan(z) = -j * cmath.atanh(z j)"""
+         r = cmath.atanh(complex(-z.imag, z.real))
+-        if math.isinf(z.real) and math.isnan(z.imag):
+-            # XXX this is odd but necessary
+-            return complex(r.imag, r.real)
+-        else:
+-            return complex(r.imag, -r.real)
++        return complex(r.imag, -r.real)
+ 
+     res = context.compile_internal(builder, atan_impl, sig, args)
+     return impl_ret_untracked(context, builder, sig, res)
+@@ -507,7 +503,8 @@
+         ay = abs(z.imag)
+         if math.isnan(z.real) or z.real > THRES_LARGE or ay > THRES_LARGE:
+             if math.isinf(z.imag):
+-                real = math.copysign(0., z.real)
++                # CPython returns +0 for a NaN real part, regardless of its sign.
++                real = 0. if math.isnan(z.real) else math.copysign(0., z.real)
+             elif math.isinf(z.real):
+                 real = 0.
+             else:
+--- a/numba/tests/test_complex.py
++++ b/numba/tests/test_complex.py
+@@ -249,6 +249,15 @@
+     def test_atan_npm(self):
+         self.check_unary_func(atan_usecase, no_pyobj_flags, ulps=2,)
+ 
++    def test_atan_atanh_nonfinite(self):
++        nan = float('nan')
++        inf = float('inf')
++        values = [complex(x, y) for x, y in
++                  itertools.product([nan, -nan, inf, -inf], repeat=2)]
++        for pyfunc in (atan_usecase, atanh_usecase):
++            self.run_unary(pyfunc, [types.complex64, types.complex128],
++                           values, flags=no_pyobj_flags, ulps=2)
++
+     def test_cos(self):
+         self.check_unary_func(cos_usecase, enable_pyobj_flags, ulps=2)
+ 

--- a/python-numba/riscv-target-features.patch
+++ b/python-numba/riscv-target-features.patch
@@ -1,0 +1,13 @@
+--- a/numba/core/codegen.py
++++ b/numba/core/codegen.py
+@@ -1188,6 +1188,10 @@
+         tm_options = dict(opt=config.OPT)
+         self._tm_features = self._customize_tm_features()
+         self._customize_tm_options(tm_options)
++        if target.triple.startswith('riscv64'):
++            # LLVM's generic CPU is RV64I. Start with the distro's RV64GC
++            # baseline for atomics and the LP64D ABI, then apply user features.
++            tm_options['features'] = '+m,+a,+f,+d,+c,' + tm_options['features']
+         tm = target.create_target_machine(**tm_options)
+         use_lmm = config.USE_LLVMLITE_MEMORY_MANAGER
+         engine = ll.create_mcjit_compiler(llvm_module, tm, use_lmm=use_lmm)

--- a/python-numba/riscv64.patch
+++ b/python-numba/riscv64.patch
@@ -1,0 +1,30 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -56,6 +56,13 @@
+ sha512sums=('f64aba5d04245bee0ddc74fc8abc6eb0ad74558ce5eac77c3a5e852695d525d095b47664abfbece985b60f3b863b96e8614d3e3e72083d9313cdd498f36e646d')
+ b2sums=('48b76ff0b1f7374a3f059a26dc3dbf67671ae0f6f5bfed164bcdf946bb5ea5a9bc8b364c9f2a8440100f4c550e6481c9f2ede4b8674674b713134c85a68e8bc9')
+ 
++prepare() {
++  cd numba
++  patch -Np1 -i ../riscv-target-features.patch
++  patch -Np1 -i ../fix-cmath-nan-sign.patch
++  patch -Np1 -i ../fix-aot-linking.patch
++}
++
+ build() {
+   cd numba
+   python -m build --wheel --no-isolation
+@@ -75,3 +82,13 @@
+   python -m installer --destdir="$pkgdir" dist/*.whl
+   install -Dm644 LICENSE -t "$pkgdir"/usr/share/licenses/$pkgname/
+ }
++
++source+=(riscv-target-features.patch
++         fix-cmath-nan-sign.patch
++         fix-aot-linking.patch)
++sha512sums+=('c226b6fa23e39b388db88fe38770d6bc1dd80321221613c906e53e655930a976f79f859b5f1e93fdd8a3bad56fdfa68a869083bb9d8f5e6cfa1a5223a531a8d9'
++             '8af78ba79e5e558f53d910b46da6f59b9db76383f7938a3e4e35279fb38340ffd16a17f963ce6049bdb267a90901016736cc4f23d5d996f53f94a9a10eacc365'
++             'd817e6a7fa6d232426c5eb98044cf812699653a19ddda7ce30ba0c5b5144bb663362684b3fdc33a16535dc595a34286c189965f554aa79fe9848f14b7f968ca4')
++b2sums+=('75770fd99c605512bd30c8634924fa669397e9dac9e556fc3925babccf276f14051635dbc387dd3ae71bf9851965279a56314db265f4e81e4a24c2f810d9f6ce'
++         '81468e4af79e4fb48dc6d9ed9726456399e121f3b10480b5b811c6d7f6c6ed0dab0ce21b8f793ccb570ba61dcfc268ce7b2bdd63fdbba9dd10fba0b177e2e744'
++         '742cc82ea746f6d39a81834e056c641ca9c347b65a638df8a7d4604cbf4a658a3503b7d2dcf324917cfab3d5b879ed04a7d30422e7e4aa4ad7d2ad0faf3d7b6a')

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -118,6 +118,7 @@ pyqt6-webengine
 python
 python-filelock
 python-libtmux
+python-numba
 python-prctl
 python-setproctitle
 python-tpm2-pytss


### PR DESCRIPTION
Use the RV64GC baseline for JIT and AOT target machines. LLVM defaults to RV64I without explicit features, producing soft-float AOT objects and unresolved __atomic_compare_exchange_8 calls with CPU feature overrides. Enable atomics and the LP64D ABI while preserving user feature precedence.

Match CPython's atanh signed-zero handling for NaN real parts and infinite imaginary parts, and remove atan's compensating sign special case. RISC-V NaN canonicalization exposes the incorrect result. Add regression coverage for signed NaNs and infinities in both precisions.

Preserve helper bitcode before module-level vectorization and carry it through serialization. Generic RV64GC AOT links RVV-optimized host JIT helpers, aborting object emission with "Don't know how to legalize this scalable vector type". Optimize the linking IR for each caller's target while retaining host-specific JIT optimization.

Blacklist QEMU-user builders. On electivire,
test_cannot_find_gdb_from_path fails because posix_spawn returns a failing child for a missing executable instead of raising FileNotFoundError. Numba therefore reports a failed GDB launch without the expected "No such file or directory" diagnostic. Python documents this behavior under QEMU user emulation.

The same run exceeds test_unsafe_import_in_registry's 30-second subprocess timeout. Both tests passed in the earlier native glalie run; retain their assertions and timeout for the native retry.

https://docs.python.org/3.14/library/subprocess.html#subprocess.Popen