### PR TITLE
addpatch: python-clevercsv 0.8.5-1

### DIFF
--- a/python-clevercsv/riscv64.patch
+++ b/python-clevercsv/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -24,7 +24,7 @@
+   cd CleverCSV
+   local python_version=$(python -c 'import sys; print("".join(map(str, sys.version_info[:2])))')
+   # chardet 6 can still return None for tiny Latin-1 samples after upstream's relaxed expectations.
+-  PYTHONPATH="build/lib.linux-x86_64-cpython-${python_version}" pytest \
++  PYTHONPATH="build/lib.linux-${CARCH}-cpython-${python_version}" pytest \
+     --deselect tests/test_unit/test_console.py::ConsoleTestCase::test_standardize_target_encoding2 \
+     --deselect tests/test_unit/test_encoding.py::EncodingTestCase::test_encoding_chardet
+ }


### PR DESCRIPTION
Restore the CARCH-based PYTHONPATH in check(). The build produces build/lib.linux-riscv64-cpython-314, but the hard-coded x86_64 path causes all 17 test modules to fail collection with "ModuleNotFoundError: No module named 'clevercsv'".

Arch packaging main already contains this fix, but the stable 0.8.5-1 tag still uses x86_64, so the overlay is still needed.

https://gitlab.archlinux.org/archlinux/packaging/packages/python-clevercsv/-/commit/2f06cd78dd570f111bdf7a589c4d3998cc0e953d