### PR TITLE
addpatch: python-faust-cchardet 3.2.0-1

### DIFF
--- a/python-faust-cchardet/restore-latin1-fallback.patch
+++ b/python-faust-cchardet/restore-latin1-fallback.patch
@@ -1,0 +1,87 @@
+--- a/src/ext/uchardet/src/nsUniversalDetector.cpp
++++ b/src/ext/uchardet/src/nsUniversalDetector.cpp
+@@ -213,19 +213,12 @@
+           if (nsnull == mCharSetProbers[1])
+             return NS_ERROR_OUT_OF_MEMORY;
+         }
+-        /* Disabling the generic WINDOWS-1252 (Latin 1) prober for now.
+-         * We now have specific per-language models which are much more
+-         * efficients and useful. This is where we should direct our
+-         * efforts. Probably the whole nsLatin1Prober should disappear
+-         * at some point, but let's keep it for now, in case this was an
+-         * error.
+-         */
+-       /* if (nsnull == mCharSetProbers[2])
++        if (nsnull == mCharSetProbers[2])
+         {
+           mCharSetProbers[2] = new nsLatin1Prober;
+           if (nsnull == mCharSetProbers[2])
+             return NS_ERROR_OUT_OF_MEMORY;
+-        }*/
++        }
+       }
+     }
+     else
+@@ -338,9 +331,14 @@
+   case eHighbyte:
+     {
+       float proberConfidence;
++      bool hasCandidate = false;
+ 
+       for (PRInt32 i = 0; i < NUM_OF_CHARSET_PROBERS; i++)
+       {
++        // Use generic Latin-1 only when the other probers have no candidate.
++        if (i == 2 && hasCandidate)
++          break;
++
+         if (mCharSetProbers[i])
+         {
+           int n_candidates = mCharSetProbers[i]->GetCandidates();
+@@ -355,6 +353,7 @@
+                 Report(mCharSetProbers[i]->GetCharSetName(c),
+                        mCharSetProbers[i]->GetLanguage(c),
+                        proberConfidence);
++                hasCandidate = true;
+             }
+           }
+         }
+--- a/src/cchardet/uchardet-overlay/nsMBCSGroupProber.cpp
++++ b/src/cchardet/uchardet-overlay/nsMBCSGroupProber.cpp
+@@ -134,17 +134,6 @@
+  */
+ #define MBCS_CANDIDATE_THRESHOLD 0.5f
+ 
+-/*
+- * When the stream is not valid UTF-8 the UTF-8 prober is kept only as a
+- * last-resort candidate with this fixed confidence. The value sits above
+- * nsUniversalDetector's MINIMUM_THRESHOLD (0.20), so the guess survives for
+- * near-ASCII data no other prober claims (mirroring upstream, whose
+- * language pass also leaves a weak UTF-8 guess there), and below
+- * CANDIDATE_THRESHOLD (0.30), so it can never outrank any other reported
+- * candidate.
+- */
+-#define UTF8_INVALID_CONFIDENCE 0.25f
+-
+ static nsProbingState
+ HandleCharsetData(nsCharSetProber* prober,
+                   const char* data,
+@@ -360,8 +349,8 @@
+       continue;
+ 
+     if (i == 0)
+-      /* Invalid UTF-8 stays listed as a penalized last-resort fallback. */
+-      candidates[0][0] = Utf8IsInvalid(langDetectors[0][0]) ||
++      /* UTF-8 must be valid and end at a complete code point. */
++      candidates[0][0] = langDetectors[0][0] == nsnull &&
+         (mProbers[0]->GetConfidence(0) > CANDIDATE_THRESHOLD);
+     else
+       candidates[i][0] =
+@@ -428,8 +417,6 @@
+       continue;
+     if (candidate == candidateIt)
+     {
+-      if (i == 0 && Utf8IsInvalid(langDetectors[0][0]))
+-        return UTF8_INVALID_CONFIDENCE;
+       return mProbers[i]->GetConfidence(0);
+     }
+     candidateIt++;

--- a/python-faust-cchardet/riscv64.patch
+++ b/python-faust-cchardet/riscv64.patch
@@ -1,0 +1,19 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -36,6 +36,9 @@
+   git submodule init
+   git submodule set-url src/ext/uchardet "$srcdir/uchardet"
+   git -c protocol.file.allow=always -c protocol.allow=never submodule update
++
++  # Short Latin-1 input must not fall back to invalid UTF-8.
++  patch -Np1 -i ../restore-latin1-fallback.patch
+ }
+ 
+ build() {
+@@ -47,3 +50,6 @@
+ }
+ 
+ # vim:set sw=2 sts=-1 et:
++
++source+=(restore-latin1-fallback.patch)
++b2sums+=('b41751c54dfa54a4b4417f7b408f8bd042c691815357a17d8c2a78aa80fe00d468ae353e871b046e712ef4ee29c7e3383333aa16a58d9f01e3715f6847caa04b')


### PR DESCRIPTION
Restore the bundled generic Windows-1252 prober as a last resort when other probers report no candidate. Short Latin-1 CSV samples lack enough language-model evidence, but the existing generic prober can recognize them. Preserve the priority of all existing reported candidates.

Remove the penalized UTF-8 fallback for invalid input and require a complete UTF-8 sequence at finalization. Otherwise the known-invalid UTF-8 candidate prevents a usable single-byte fallback.

CleverCSV 0.8.5 exposes this in four failures on glalie: test_code_3, test_code_4, test_encoding_cchardet and test_read_dataframe. Latin-1 data is reported as UTF-8, causing UnicodeDecodeError or an unexpected encoding instead of WINDOWS-1252. Fix the shared detector rather than skip these tests or change CleverCSV decoding.