### PR TITLE
addpatch: python-moto 5.2.3-1

### DIFF
--- a/python-moto/fix-test-timing.patch
+++ b/python-moto/fix-test-timing.patch
@@ -1,0 +1,59 @@
+--- a/tests/test_scheduler/__init__.py
++++ b/tests/test_scheduler/__init__.py
+@@ -1,8 +1,12 @@
+ from datetime import datetime, timedelta
+ 
++from freezegun import freeze_time
++
+ from moto.core.utils import utcnow
+ 
+ 
++# Match the test clock so parameters cannot expire between collection and execution.
++@freeze_time("2024-01-01 00:00:00.123456")
+ def pytest_parametrize_test_create_get_schedule__with_start_date() -> list[
+     tuple[datetime, datetime]
+ ]:
+--- a/tests/test_scheduler/test_scheduler.py
++++ b/tests/test_scheduler/test_scheduler.py
+@@ -3,6 +3,7 @@
+ import boto3
+ import pytest
+ from botocore.client import ClientError
++from freezegun import freeze_time
+ 
+ from moto import mock_aws
+ from moto.core import DEFAULT_ACCOUNT_ID
+@@ -241,6 +242,7 @@
+     "start_date,expected_start_date",
+     pytest_parametrize_test_create_get_schedule__with_start_date(),
+ )
++@freeze_time("2024-01-01 00:00:00.123456")
+ def test_create_get_schedule__with_start_date(start_date, expected_start_date):
+     # Act
+     client = boto3.client("scheduler", region_name="eu-west-1")
+--- a/tests/test_stepfunctions/parser/test_stepfunctions_idempotency.py
++++ b/tests/test_stepfunctions/parser/test_stepfunctions_idempotency.py
+@@ -46,12 +46,18 @@
+ 
+         if execution["status"] == "RUNNING":
+             # We can start the execution just fine
+-            idempotent = client.start_execution(name=name, stateMachineArn=arn)
+-            assert idempotent["executionArn"] == execution_arn
++            try:
++                idempotent = client.start_execution(name=name, stateMachineArn=arn)
++            except client.exceptions.ExecutionAlreadyExists:
++                # The execution may finish after describe_execution returns RUNNING.
++                execution = client.describe_execution(executionArn=execution_arn)
++                assert execution["status"] == "SUCCEEDED"
++            else:
++                assert idempotent["executionArn"] == execution_arn
+ 
+-            # We're not done yet - we should check in on the progress later
+-            return False
+-        elif execution["status"] == "SUCCEEDED":
++                # We're not done yet - we should check in on the progress later
++                return False
++        if execution["status"] == "SUCCEEDED":
+             # Execution fails if we re-start it after it finishes
+             with pytest.raises(ClientError) as exc:
+                 client.start_execution(name=name, stateMachineArn=arn)

--- a/python-moto/riscv64.patch
+++ b/python-moto/riscv64.patch
@@ -1,0 +1,17 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -78,6 +78,7 @@
+ 
+ prepare() {
+   cd ${pkgname#python-}
++  patch -Np1 -i ../fix-test-timing.patch
+   python update_version_from_git.py $pkgver
+ }
+ 
+@@ -115,3 +116,6 @@
+   cd ${pkgname#python-}
+   python -m installer --destdir="$pkgdir" dist/*.whl
+ }
++
++source+=(fix-test-timing.patch)
++b2sums+=('09eec179e35e8ef2d2bb7abd54ed676e6bd6563e6d9dc1688687d146f691a8d240ea3cddb66515659239c04dab15ecef8130370cc734eef5d456daa37376b093')


### PR DESCRIPTION
Freeze the scheduler test clock during parameter generation and execution. The one-hour-ahead StartDate is computed at collection and expires before the test runs in the 99-minute suite on aurorus, triggering "The StartDate you specify cannot be earlier than 5 minutes ago." Retain fractional seconds to preserve the timestamp truncation check.

Handle completion between describe_execution and start_execution in the Step Functions idempotency test. A stale RUNNING result can be followed by a valid ExecutionAlreadyExists error. Confirm SUCCEEDED before taking the existing completed-execution path, retaining its error code and message checks. Keep both tests enabled and runtime behavior unchanged.