### PR TITLE
updpatch: openucx 1.20.1-2

### DIFF
--- a/openucx/riscv64.patch
+++ b/openucx/riscv64.patch
@@ -1,5 +1,5 @@
---- PKGBUILD	2026-03-06 00:54:10.632632013 +0800
-+++ PKGBUILD.riscv64	2026-03-06 00:58:36.395091922 +0800
+--- PKGBUILD
++++ PKGBUILD
 @@ -19,12 +19,10 @@
  )
  makedepends=(
@@ -13,16 +13,7 @@
    'rocm-language-runtime: for ROCm support'
  )
  provides=(
-@@ -35,7 +33,7 @@
-   libuct.so
- )
- source=(
--  $pkgname-$pkgver.tar.gz::https://github.com/openucx/$_name/archive/refs/tags/$pkgver.tar.gz
-+  $pkgname-$pkgver.tar.gz::https://github.com/openucx/$_name/archive/refs/tags/v$pkgver.tar.gz
-   ucx-conf.patch
-   c-gnu23.patch
- )
-@@ -57,7 +55,6 @@
+@@ -52,7 +50,6 @@
    local configure_options=(
      --prefix=/usr
      --sysconfdir=/etc


### PR DESCRIPTION
Drop the source URL hunk: stable 1.20.1-2 already uses v$pkgver, so the old hunk fails during overlay application. Refresh the remaining CUDA-exclusion patch context.

https://gitlab.archlinux.org/archlinux/packaging/packages/openucx/-/blob/1.20.1-2/PKGBUILD