### PR TITLE
addpatch: tlottie 0.1.0.git1.758c7cb-1

### DIFF
--- a/tlottie/riscv64.patch
+++ b/tlottie/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -27,7 +27,8 @@
+ check() {
+   cd "$pkgname"
+ 
+-  cargo test --frozen --features c-api
++  # The DoS tests enforce a 1.5-second per-frame wall-clock budget.
++  cargo test --release --frozen --features c-api -- --test-threads=1
+ }
+ 
+ package() {


### PR DESCRIPTION
Run tests in release mode and serially. The unoptimized parallel run on cubchoo exceeds the DoS tests' 1.5-second frame budget in 15 cases. Use the shipped optimization profile and avoid contention while retaining all tests and their time and memory limits.