### PR TITLE
addpatch: ansible-lint 26.8.0-2

### DIFF
--- a/ansible-lint/riscv64.patch
+++ b/ansible-lint/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -54,6 +54,8 @@
+     --deselect 'test/test_main.py::test_call_from_outside_venv[isolated]'
+     --deselect 'test/test_main.py::test_call_from_outside_venv[in]'
+     --deselect 'test/test_main.py::test_call_from_outside_venv[missing]'
++    # Downloads cryptography from PyPI, which has no riscv64 wheels.
++    --deselect 'test/test_main.py::test_ro_venv'
+     --deselect 'test/test_rules_collection.py::test_rules_id_format'
+     --deselect 'test/test_main.py::test_get_version_warning[v1.2.2-True-pre-release-1]'
+     --deselect 'test/test_main.py::test_get_version_warning[v1.2.3-False--1]'


### PR DESCRIPTION
Skip test_ro_venv, which installs PyPI dependencies into an isolated venv. Cryptography has no riscv64 wheels, so it attempts a source build and fails bootstrapping Rust with an unsupported target triple. Follow the existing exclusions for virtual-environment tests.