### PR TITLE
addpatch: blueprint-compiler 0.22.2-1

### DIFF
--- a/blueprint-compiler/riscv64.patch
+++ b/blueprint-compiler/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -39,7 +39,7 @@
+ check() {
+   dbus-run-session xvfb-run \
+     -s '-screen 0 1920x1080x24 -nolisten local' \
+-    meson test -C build --print-errorlogs --no-rebuild
++    meson test -C build --print-errorlogs --no-rebuild --timeout-multiplier 10
+ }
+ 
+ package() {


### PR DESCRIPTION
Increase the test timeout from 30 to 300 seconds. Meson runs the whole Python suite as one test, which times out during the sample checks on houndour. Keep all tests enabled.