### PR TITLE
updpatch: kresus 0.25.2-1

### DIFF
--- a/kresus/riscv64.patch
+++ b/kresus/riscv64.patch
@@ -1,20 +1,24 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -22,7 +22,18 @@
+@@ -22,7 +22,21 @@
  
  prepare() {
-     cd ${pkgname}-${pkgver}
+     cd ${pkgname}
+-    yarn install --no-fund
 +    # Replace @napi-rs/magic-string with pure JS magic-string for riscv64
 +    # https://github.com/zheeeng/vite-plugin-plain-text/issues/6
-+    sed -i 's/"@types\/react": "~18.2.0"/"@types\/react": "~18.2.0",\n    "@napi-rs\/magic-string": "npm:magic-string@^0.30.0"/' package.json
++    sed -i '/"resolutions": {/a\        "@napi-rs/magic-string": "npm:magic-string@^0.30.0",' package.json
++    # Use Lightning CSS's WASM build where native riscv64 bindings are unavailable.
++    sed -i '/"resolutions": {/a\        "lightningcss": "npm:lightningcss-wasm@1.32.0",' package.json
 +
-     yarn install --no-fund
-+    # Fix API differences between @napi-rs/magic-string and magic-string:
-+    # 1. @napi-rs/magic-string exports { MagicString }, magic-string exports default
-+    # 2. @napi-rs/magic-string's generateMap().toMap() vs magic-string's generateMap() returns SourceMap directly
-+    find node_modules/vite-plugin-plain-text -name "*.js" -exec sed -i \
-+        -e 's/new magic_string_1.MagicString/new magic_string_1/g' \
-+        -e 's/\.generateMap(\([^)]*\))\.toMap()/.generateMap(\1)/g' {} \;
++    # Yarn 1 otherwise skips Rolldown's wasm32 fallback binding.
++    yarn install --no-fund --ignore-platform
++    # Adapt both plugin entry points to magic-string's default export and SourceMap API.
++    sed -i \
++        -e 's/import_magic_string\.MagicString/import_magic_string/g' \
++        -e 's/import { MagicString }/import MagicString/' \
++        -e 's/\.generateMap(\([^)]*\))\.toMap()/.generateMap(\1)/g' \
++        node_modules/vite-plugin-plain-text/dist/index.{js,mjs}
 +
      sed -e 's|^datadir=$|&/var/lib/kresus|' -e 's|^python_exec=$|&python|' -i support/docker/config.example.ini
  }

--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -12,6 +12,7 @@ jupyter-nbclassic
 jupyter-notebook
 jupyterlab
 keycloak
+kresus
 llama-cpp
 navidrome
 openbao


### PR DESCRIPTION
Refresh patch for the git source layout and update the magic-string resolution and API substitutions for both plugin entry points.

Use Lightning CSS's WASM build and allow Yarn 1 to install Rolldown's wasm32 fallback because Vite 8's dependencies lack native riscv64 bindings.

Add kresus to the Sv39 blacklist because Rolldown executes WASM in parallel worker threads.