### PR TITLE
updpatch: nodejs-lts-krypton 24.20.0-2

### DIFF
--- a/nodejs-lts-krypton/fix-wasm-i32-stack-loads.patch
+++ b/nodejs-lts-krypton/fix-wasm-i32-stack-loads.patch
@@ -1,0 +1,39 @@
+--- a/deps/v8/src/compiler/backend/riscv/code-generator-riscv.cc
++++ b/deps/v8/src/compiler/backend/riscv/code-generator-riscv.cc
+@@ -4740,6 +4740,23 @@
+   }
+ }
+ 
++namespace {
++bool Is32BitOperand(InstructionOperand* operand) {
++  DCHECK(operand->IsStackSlot() || operand->IsRegister());
++  MachineRepresentation mr = LocationOperand::cast(operand)->representation();
++  return mr == MachineRepresentation::kWord32 ||
++         mr == MachineRepresentation::kCompressed ||
++         mr == MachineRepresentation::kCompressedPointer;
++}
++
++// When we need only 32 bits, move only 32 bits, otherwise the destination
++// register' upper 32 bits may contain dirty data.
++bool Use32BitMove(InstructionOperand* source, InstructionOperand* destination) {
++  return Is32BitOperand(source) && Is32BitOperand(destination);
++}
++
++}  // namespace
++
+ void CodeGenerator::AssembleMove(InstructionOperand* source,
+                                  InstructionOperand* destination) {
+   RiscvOperandConverter g(this, nullptr);
+@@ -4757,7 +4774,11 @@
+     DCHECK(destination->IsRegister() || destination->IsStackSlot());
+     MemOperand src = g.ToMemOperand(source);
+     if (destination->IsRegister()) {
+-      __ LoadWord(g.ToRegister(destination), src);
++      if (Use32BitMove(source, destination)) {
++        __ Lw(g.ToRegister(destination), src);
++      } else {
++        __ LoadWord(g.ToRegister(destination), src);
++      }
+     } else {
+       Register temp = kScratchReg;
+       __ LoadWord(temp, src);

--- a/nodejs-lts-krypton/fix-wasm-lazy-jump.patch
+++ b/nodejs-lts-krypton/fix-wasm-lazy-jump.patch
@@ -1,0 +1,110 @@
+--- a/deps/v8/src/wasm/jump-table-assembler.cc
++++ b/deps/v8/src/wasm/jump-table-assembler.cc
+@@ -687,15 +687,20 @@
+ #elif V8_TARGET_ARCH_RISCV64
+ void JumpTableAssembler::EmitLazyCompileJumpSlot(uint32_t func_index,
+                                                  Address lazy_compile_target) {
+-  static_assert(kLazyCompileTableSlotSize == 3 * kInstrSize);
++  static_assert(kLazyCompileTableSlotSize == 4 * kInstrSize);
+   int64_t high_20 = (func_index + 0x800) >> 12;
+   int64_t low_12 = int64_t(func_index) << 52 >> 52;
+
++  // The lazy compile target (a slot in the far jump table) can be farther away
++  // than the range of a single JAL for large modules. Use a checked AUIPC/JALR
++  // pair instead, so an out-of-range displacement cannot be silently truncated
++  // in release builds.
+   int64_t target_offset = MacroAssembler::CalculateTargetOffset(
+       lazy_compile_target, RelocInfo::NO_INFO,
+       reinterpret_cast<uint8_t*>(pc_ + 2 * kInstrSize));
+-  DCHECK(is_int21(target_offset));
+-  DCHECK_EQ(target_offset & 0x1, 0);
++  CHECK(is_int32(target_offset));
++  int32_t hi20 = (static_cast<int32_t>(target_offset) + 0x800) >> 12;
++  int32_t lo12 = static_cast<int32_t>(target_offset) << 20 >> 20;
+
+   const uint32_t inst[kLazyCompileTableSlotSize / 4] = {
+       (RO_LUI | (kWasmCompileLazyFuncIndexRegister.code() << kRdShift) |
+@@ -703,16 +708,16 @@
+       (RO_ADDI | (kWasmCompileLazyFuncIndexRegister.code() << kRdShift) |
+        (kWasmCompileLazyFuncIndexRegister.code() << kRs1Shift) |
+        int32_t(low_12 << kImm12Shift)),  // addi t0, t0, low_12
+-      (RO_JAL | (zero_reg.code() << kRdShift) |
+-       uint32_t(target_offset & 0xff000) |           // bits 19-12
+-       uint32_t((target_offset & 0x800) << 9) |      // bit  11
+-       uint32_t((target_offset & 0x7fe) << 20) |     // bits 10-1
+-       uint32_t((target_offset & 0x100000) << 11)),  // bit  20 ),  // jal
++      (RO_AUIPC | (t6.code() << kRdShift) |
++       (uint32_t(hi20) << kImm20Shift)),  // auipc t6, hi20
++      (RO_JALR | (zero_reg.code() << kRdShift) | (t6.code() << kRs1Shift) |
++       (uint32_t(lo12) << kImm12Shift)),  // jalr x0, t6, lo12
+   };
+
+   emit<uint32_t>(inst[0]);
+   emit<uint32_t>(inst[1]);
+   emit<uint32_t>(inst[2]);
++  emit<uint32_t>(inst[3]);
+ }
+
+ bool JumpTableAssembler::EmitJumpSlot(Address target) {
+@@ -781,15 +786,19 @@
+ #elif V8_TARGET_ARCH_RISCV32
+ void JumpTableAssembler::EmitLazyCompileJumpSlot(uint32_t func_index,
+                                                  Address lazy_compile_target) {
+-  static_assert(kLazyCompileTableSlotSize == 3 * kInstrSize);
++  static_assert(kLazyCompileTableSlotSize == 4 * kInstrSize);
+   int64_t high_20 = (func_index + 0x800) >> 12;
+   int64_t low_12 = int64_t(func_index) << 52 >> 52;
+
++  // See the RISC-V64 implementation: use a checked AUIPC/JALR pair instead of
++  // a range-limited JAL so an out-of-range displacement cannot be silently
++  // truncated in release builds.
+   int64_t target_offset = MacroAssembler::CalculateTargetOffset(
+       lazy_compile_target, RelocInfo::NO_INFO,
+       reinterpret_cast<uint8_t*>(pc_ + 2 * kInstrSize));
+-  DCHECK(is_int21(target_offset));
+-  DCHECK_EQ(target_offset & 0x1, 0);
++  CHECK(is_int32(target_offset));
++  int32_t hi20 = (static_cast<int32_t>(target_offset) + 0x800) >> 12;
++  int32_t lo12 = static_cast<int32_t>(target_offset) << 20 >> 20;
+
+   const uint32_t inst[kLazyCompileTableSlotSize / 4] = {
+       (RO_LUI | (kWasmCompileLazyFuncIndexRegister.code() << kRdShift) |
+@@ -797,16 +806,16 @@
+       (RO_ADDI | (kWasmCompileLazyFuncIndexRegister.code() << kRdShift) |
+        (kWasmCompileLazyFuncIndexRegister.code() << kRs1Shift) |
+        int32_t(low_12 << kImm12Shift)),  // addi t0, t0, low_12
+-      (RO_JAL | (zero_reg.code() << kRdShift) |
+-       uint32_t(target_offset & 0xff000) |           // bits 19-12
+-       uint32_t((target_offset & 0x800) << 9) |      // bit  11
+-       uint32_t((target_offset & 0x7fe) << 20) |     // bits 10-1
+-       uint32_t((target_offset & 0x100000) << 11)),  // bit  20 ),  // jal
++      (RO_AUIPC | (t6.code() << kRdShift) |
++       (uint32_t(hi20) << kImm20Shift)),  // auipc t6, hi20
++      (RO_JALR | (zero_reg.code() << kRdShift) | (t6.code() << kRs1Shift) |
++       (uint32_t(lo12) << kImm12Shift)),  // jalr x0, t6, lo12
+   };
+
+   emit<uint32_t>(inst[0]);
+   emit<uint32_t>(inst[1]);
+   emit<uint32_t>(inst[2]);
++  emit<uint32_t>(inst[3]);
+ }
+ bool JumpTableAssembler::EmitJumpSlot(Address target) {
+   uint32_t high_20 = (int64_t(4 * kInstrSize + 0x800) >> 12);
+--- a/deps/v8/src/wasm/jump-table-assembler.h
++++ b/deps/v8/src/wasm/jump-table-assembler.h
+@@ -234,12 +234,12 @@
+   static constexpr int kJumpTableSlotSize = 2 * kInstrSize;
+   static constexpr int kJumpTableLineSize = kJumpTableSlotSize;
+   static constexpr int kFarJumpTableSlotSize = 6 * kInstrSize;
+-  static constexpr int kLazyCompileTableSlotSize = 3 * kInstrSize;
++  static constexpr int kLazyCompileTableSlotSize = 4 * kInstrSize;
+ #elif V8_TARGET_ARCH_RISCV32
+   static constexpr int kJumpTableSlotSize = 5 * kInstrSize;
+   static constexpr int kJumpTableLineSize = kJumpTableSlotSize;
+   static constexpr int kFarJumpTableSlotSize = kJumpTableSlotSize;
+-  static constexpr int kLazyCompileTableSlotSize = 3 * kInstrSize;
++  static constexpr int kLazyCompileTableSlotSize = 4 * kInstrSize;
+ #elif V8_TARGET_ARCH_LOONG64
+   static constexpr int kJumpTableLineSize = 1 * kInstrSize;
+   static constexpr int kJumpTableSlotSize = 1 * kInstrSize;

--- a/nodejs-lts-krypton/fix-wasm-vector-spills.patch
+++ b/nodejs-lts-krypton/fix-wasm-vector-spills.patch
@@ -1,0 +1,51 @@
+--- a/deps/v8/src/wasm/baseline/riscv/liftoff-assembler-riscv-inl.h
++++ b/deps/v8/src/wasm/baseline/riscv/liftoff-assembler-riscv-inl.h
+@@ -2325,10 +2325,37 @@
+     }
+     DCHECK_EQ(offset, num_fp_regs * sizeof(double));
+   }
++
++  // Liftoff uses the same register codes for FP and SIMD values, but RISC-V
++  // has separate register banks. Preserve both across runtime calls.
++  fp_regs = regs & kFpCacheRegList;
++  if (CpuFeatures::SupportsWasmSimd128() && !fp_regs.is_empty()) {
++    li(kScratchReg, kSimd128Size);
++    VU.clear();
++    VU.set(zero_reg, kScratchReg, E8, m1);
++    while (!fp_regs.is_empty()) {
++      LiftoffRegister reg = fp_regs.GetFirstRegSet();
++      AddWord(sp, sp, Operand(-kSimd128Size));
++      vs(reg.fp().toV(), sp, 0, E8);
++      fp_regs.clear(reg);
++    }
++  }
+ }
+ 
+ void LiftoffAssembler::PopRegisters(LiftoffRegList regs) {
+   LiftoffRegList fp_regs = regs & kFpCacheRegList;
++  if (CpuFeatures::SupportsWasmSimd128() && !fp_regs.is_empty()) {
++    li(kScratchReg, kSimd128Size);
++    VU.clear();
++    VU.set(zero_reg, kScratchReg, E8, m1);
++    while (!fp_regs.is_empty()) {
++      LiftoffRegister reg = fp_regs.GetLastRegSet();
++      vl(reg.fp().toV(), sp, 0, E8);
++      AddWord(sp, sp, Operand(kSimd128Size));
++      fp_regs.clear(reg);
++    }
++  }
++  fp_regs = regs & kFpCacheRegList;
+   int32_t fp_offset = 0;
+   while (!fp_regs.is_empty()) {
+     LiftoffRegister reg = fp_regs.GetFirstRegSet();
+@@ -2352,7 +2379,9 @@
+     SafepointTableBuilder::Safepoint& safepoint, LiftoffRegList all_spills,
+     LiftoffRegList ref_spills, int spill_offset) {
+   LiftoffRegList fp_spills = all_spills & kFpCacheRegList;
+-  int spill_space_size = fp_spills.GetNumRegsSet() * kSimd128Size;
++  int fp_slot_size =
++      kDoubleSize + (CpuFeatures::SupportsWasmSimd128() ? kSimd128Size : 0);
++  int spill_space_size = fp_spills.GetNumRegsSet() * fp_slot_size;
+   LiftoffRegList gp_spills = all_spills & kGpCacheRegList;
+   while (!gp_spills.is_empty()) {
+     LiftoffRegister reg = gp_spills.GetFirstRegSet();

--- a/nodejs-lts-krypton/fix-wasm-vector-state.patch
+++ b/nodejs-lts-krypton/fix-wasm-vector-state.patch
@@ -1,0 +1,10 @@
+--- a/deps/v8/src/codegen/riscv/assembler-riscv.cc
++++ b/deps/v8/src/codegen/riscv/assembler-riscv.cc
+@@ -753,6 +753,7 @@
+ void Assembler::bind(Label* L) {
+   DCHECK(!L->is_bound());  // Label can only be bound once.
+   bind_to(L, pc_offset());
++  VU.clear();
+ }
+ 
+ void Assembler::next(Label* L, bool is_internal) {

--- a/nodejs-lts-krypton/riscv64.patch
+++ b/nodejs-lts-krypton/riscv64.patch
@@ -1,6 +1,6 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -65,12 +65,24 @@
+@@ -65,12 +65,41 @@
    # /usr/lib/libnode.so uses malloc_usable_size, which is incompatible with fortification level 3
    CFLAGS="${CFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
    CXXFLAGS="${CXXFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
@@ -16,16 +16,33 @@
    patch --forward --strip=1 --input=../0001-test-account-for-varied-OpenSSL-CCM-final-behaviours.patch
 +  patch -Np1 -i ../hwy-broken-rvv.diff
 +
++  # Fix stale RISC-V vector configuration after Wasm branches.
++  # https://github.com/v8/v8/commit/c81ffb7a356dc408940d479fbbec1d048181be71
++  patch -Np1 -i ../fix-wasm-vector-state.patch
++
++  # Preserve live Wasm vectors across runtime calls, including tier-up.
++  # https://github.com/v8/v8/commit/9e974a766900c7bf90625f43daebb78c35c3a82e
++  # https://github.com/v8/v8/commit/2f53cbb0d31176a4219b34310db49f26be6ceb4c
++  patch -Np1 -i ../fix-wasm-vector-spills.patch
++
++  # Avoid reading stale upper bits from Wasm i32 stack arguments.
++  # https://github.com/v8/v8/commit/6c093feb492d2f68ea0b688281076ee43ff66b7a
++  patch -Np1 -i ../fix-wasm-i32-stack-loads.patch
++
 +  # Fix missed WASI worker notifications and the short startup timeout.
 +  # https://github.com/nodejs/node/commit/bb8f1148c4437eabf9ab568dc5b199cac0b2ae93
 +  patch -Np1 -i ../fix-wasi-thread-spawn.patch
++
++  # Large Wasm modules can overflow RISC-V lazy-compile jump offsets.
++  # https://github.com/v8/v8/commit/def38dd3f8726ed595932624ee5d681a3f02ed4a
++  patch -Np1 -i ../fix-wasm-lazy-jump.patch
 +
 +  # Ten WPT workers can exhaust the Wasm address space available on Sv39.
 +  sed -i 's/concurrency = Math.min(10, concurrency);/concurrency = Math.min(2, concurrency);/' test/common/wpt.js
  }
  
  build() {
-@@ -105,6 +117,8 @@
+@@ -105,6 +134,8 @@
  check() {
    _set_flags
    cd node
@@ -34,13 +51,21 @@
    rm test/parallel/test-http2-client-set-priority.js
    rm test/parallel/test-http2-client-unescaped-path.js
    rm test/parallel/test-http2-max-invalid-frames.js
-@@ -124,3 +138,9 @@
+@@ -124,3 +155,17 @@
    make DESTDIR="$pkgdir" install
    install -Dm644 LICENSE -t "$pkgdir"/usr/share/licenses/$pkgname
  }
 +
 +makedepends+=(clang)
 +source+=("hwy-broken-rvv.diff"
-+         "fix-wasi-thread-spawn.patch")
++         "fix-wasi-thread-spawn.patch"
++         "fix-wasm-lazy-jump.patch"
++         "fix-wasm-vector-state.patch"
++         "fix-wasm-vector-spills.patch"
++         "fix-wasm-i32-stack-loads.patch")
 +b2sums+=('4717b78b17b63195ee6c4f3b989e52aa6cabb2ed565945371774d643faa235f14fd315df5eac2800709b95b5e6ba889d60410f6242e11873a995e2a78e37d5cc'
-+         'f4392dd1649f9f3e041890ca74b434f5f560a46b54ef6994826c35e5852c11897c85563504434cc03e9163049e328a7cc93162a53cc9e96a4de18611fae38131')
++         'f4392dd1649f9f3e041890ca74b434f5f560a46b54ef6994826c35e5852c11897c85563504434cc03e9163049e328a7cc93162a53cc9e96a4de18611fae38131'
++         'fc115df5c010588b446bcded60d2debec9d67cb84acd201594c4f27b8542eaf55b2f20b8f7ac5b994518032c046e81e0be24bc39e23c9e156091569a617b580e'
++         '77aea04aa568cff2572a46709b83811f4bd5b7e93ecdcbe9e3213f4db4f496bdcbcc235a2bbf475a95fd0e561ef67efcb7fcaa0e1631a5d9d288faae5a8f8681'
++         '04ba2abd06b098db9ef9e7dbed272bb42581be8474afb353a87c107ea24fbf3b226e4341e5eddf67b7315ac12dbab06ead1353383ea6b8da1c6840440dde4051'
++         '0265cc552fd5d1b7c42451f4390124a65cd9ced822448a5be319f919a7d3dc382420c9e02d76285b52f55060d7b60b33e0778346e2c035a44ec538a586f45998')


### PR DESCRIPTION
Backport V8 fixes for RISC-V failures in Kresus's Rolldown Wasm binding.

Use checked AUIPC/JALR pairs in lazy-compile slots so large modules cannot overflow JAL's range and jump into unpopulated memory. Adapt the larger slots to Node 24's layout and RV32 emit signature.

Clear cached vector configuration at branch targets so skipped vector setup cannot leave later loads with an invalid register grouping.

Preserve live vectors across Liftoff runtime calls, including tier-up. Node 24 aliases FP and SIMD register codes, but saving FP registers alone does not preserve the separate vector bank. Save both banks, restore in reverse stack order and account for the extra spill space.

Load 32-bit stack operands with lw in TurboFan. Liftoff leaves the upper half of i32 stack slots uninitialized, so ld can turn a length of 2 into 0x1600000002. This breaks substring searches and causes false "Unterminated multiline comment" errors after tier-up.

Upstream: https://github.com/v8/v8/commit/def38dd3f8726ed595932624ee5d681a3f02ed4a
Upstream: https://github.com/v8/v8/commit/c81ffb7a356dc408940d479fbbec1d048181be71
Upstream: https://github.com/v8/v8/commit/9e974a766900c7bf90625f43daebb78c35c3a82e
Upstream: https://github.com/v8/v8/commit/2f53cbb0d31176a4219b34310db49f26be6ceb4c
Upstream: https://github.com/v8/v8/commit/6c093feb492d2f68ea0b688281076ee43ff66b7a