### PR TITLE
addpatch: haskell-hadrian 0.1.0.0+9.6.6-92

### DIFF
--- a/haskell-hadrian/riscv64.patch
+++ b/haskell-hadrian/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,7 +15,7 @@
+ source=("https://downloads.haskell.org/~ghc/$_ghcver/ghc-${_ghcver}-src.tar.xz"
+         ghc-enable-ghci-for-riscv64.patch::https://gitlab.haskell.org/ghc/ghc/-/commit/dd38aca95ac25adc9888083669b32ff551151259.patch)
+ sha256sums=('008f7a04d89ad10baae6486c96645d7d726aaac7e1476199f6dd86c6bd9977ad'
+-            '705c79d713e7344b5300c1b87eeb7faad31fa6bf65d5c164eb588606d58e803e')
++            'd8a643af92ec0e867dda0000a8b002d5c016d0bed0a626afd86e8b134868a81d')
+ 
+ prepare() {
+   cd ghc-$_ghcver


### PR DESCRIPTION
Refresh the SHA-256 checksum of the patch enabling GHCi on riscv64 to match the current download from GitLab.