### PR TITLE
addpatch: python-unicodedata2 17.0.1-1

### DIFF
--- a/python-unicodedata2/riscv64.patch
+++ b/python-unicodedata2/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -19,7 +19,7 @@
+               python-pytest-randomly)
+ _archive="$_pyname-$pkgver"
+ source=("$url/archive/$pkgver/$_archive.tar.gz")
+-sha256sums=('3d2cc9a7360672fbb591aa56f49b21faeed999c241317aff677be6152150fd9e')
++sha256sums=('bbd3e238c163d6a1d7f0d919fb5abd28030660f3d53cad757c8eca4b6239a128')
+ 
+ build() {
+ 	cd "$_archive"


### PR DESCRIPTION
Update the SHA-256 for the current GitHub archive to fix source verification. The current 17.0.1 tag was created on February 12, after Arch's February 11 package build.

Keep the original GitHub source URL and archive filename.