### PR TITLE
addpatch: python-roman-numerals-py 4.1.0-1

### DIFF
--- a/python-roman-numerals-py/riscv64.patch
+++ b/python-roman-numerals-py/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -22,6 +22,8 @@
+ prepare() {
+   cd $_name
+   ln -ft python LICENCE.rst
++  # pytest 9.1 deprecates iterators in parametrize.
++  sed -i 's/enumerate(TEST_NUMERALS_[A-Z]*, start=1)/list(&)/' python/tests/test_{from,to}_string.py
+ }
+ 
+ build() {


### PR DESCRIPTION
Convert enumerate iterators to lists in test parametrization. Pytest 9.1 deprecates iterator inputs, and warnings treated as errors prevent test collection.