### PR TITLE
addpatch: openucc 1.8.0-2

### DIFF
--- a/openucc/riscv64.patch
+++ b/openucc/riscv64.patch
@@ -1,0 +1,49 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,10 +14,8 @@
+   openucx
+ )
+ makedepends=(
+-  cuda
+   hip-runtime-amd
+   rocm-llvm
+-  nccl
+   rccl
+   rdma-core
+ )
+@@ -25,9 +23,7 @@
+   gtest
+ )
+ optdepends=(
+-  'cuda: for CUDA execution engine and transport layer'
+   'hip-runtime-amd: for HIP execution engine'
+-  'nccl: for NCCL transport layer'
+   'rccl: for RCCL transport layer'
+   'rdma-core: for InfiniBand transport layer'
+ )
+@@ -43,20 +39,23 @@
+   cd $_name-$pkgver
+   # fix building with gcc 15 (yes ucx bundles its old version of gtest...)
+   sed -i '1i\#include <cstdint>' test/gtest/common/gtest-all.cc
++
++  # Let amdclang use its native host target for ROCm kernels.
++  sed -i 's/ -target x86_64-unknown-linux-gnu//g' cuda_lt.sh
+ }
+ 
+ build() {
+   local configure_options=(
+     --prefix=/usr
+     --with-ucx=/usr
+-    --with-cuda=/opt/cuda
++    --without-cuda
++    --without-nccl
+     --with-rocm=/opt/rocm
+     --with-rocm-arch=all-arch-no-native
+     --enable-gtest
+     CFLAGS="$CFLAGS"
+     CXXFLAGS="$CXXFLAGS"
+     LDFLAGS="$LDFLAGS"
+-    NVCC_CFLAGS="--threads 0"
+     HIPCC="/opt/rocm/lib/llvm/bin/amdclang"
+   )
+ 


### PR DESCRIPTION
Remove the unavailable CUDA and NCCL dependencies and disable their backends. Keep ROCm, RCCL and InfiniBand support.

Remove the hardcoded x86_64 host target from the ROCm build helper so amdclang uses the native target and finds the RISC-V C++ headers.