### PR TITLE
addpatch: python-setuptools 1:84.0.0-1

### DIFF
--- a/python-setuptools/riscv64.patch
+++ b/python-setuptools/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -74,7 +74,7 @@
+     python-setuptools::git+https://github.com/pypa/setuptools.git
+   )
+ fi
+-b2sums=('f02e3374cf7c180da3be60e33c1b441291a73cf65f2383ea399d5bcf5dcfeb716002cbd912b78fb9c99ca58b3d8f4303ae42bafea7df5f118d6fd2ec8c5636b4'
++b2sums=('2826e1bceb5373b0b96bbf64ccf4183982e8eddb53d06cd346f81f4c5e0177f80a4ebfa281f7eec6af26f26d479b6e2a7d71d60813959086c8959e5f20cedf8f'
+         'ff0caf384def8ba8aa1c7fbb29077f2bc14c42935f7f81b6c4993ebe835053207b6773865158ad3143147234b311b95033b266f9b4c34a78a67f0b7e83bb5537')
+ #validpgpkeys=('CE380CF3044959B8F377DA03708E6CB181B4C47E') # Jason R. Coombs <jaraco@jaraco.com>
+ 


### PR DESCRIPTION
Update the BLAKE2 checksum after upstream moved v84.0.0 from bb1b381 to 72e919a on August 8, after Arch built the package on August 7. The old checksum exactly matches bb1b381; the only source change is the integration-test fix for selecting the top-level pyproject.toml.

Keep the original Git source URL and tag.

https://github.com/pypa/setuptools/pull/5293