### PR TITLE
addpatch: opencode 1.18.29-1

### DIFF
--- a/opencode/fix-oxide-worker-exit.patch
+++ b/opencode/fix-oxide-worker-exit.patch
@@ -1,0 +1,12 @@
+--- a/tailwindcss-oxide.wasi.cjs
++++ b/tailwindcss-oxide.wasi.cjs
+@@ -62,6 +62,9 @@
+     const worker = new Worker(__nodePath.join(__dirname, 'wasi-worker.mjs'), {
+       env: process.env,
+     })
++    // Scanner calls are synchronous; idle Rayon workers must not keep Node alive.
++    // Defer until online because the WASI runtime refs the worker after creation.
++    worker.once('online', () => worker.unref())
+     worker.onmessage = ({ data }) => {
+       __wasmCreateOnMessageForFsProxy(__nodeFs)(data)
+     }

--- a/opencode/riscv64-target.patch
+++ b/opencode/riscv64-target.patch
@@ -1,0 +1,34 @@
+--- a/packages/opencode/script/build.ts
++++ b/packages/opencode/script/build.ts
+@@ -52,12 +52,16 @@
+ 
+ const allTargets: {
+   os: string
+-  arch: "arm64" | "x64"
++  arch: "arm64" | "x64" | "riscv64"
+   abi?: "musl"
+   avx2?: false
+ }[] = [
+   {
+     os: "linux",
++    arch: "riscv64",
++  },
++  {
++    os: "linux",
+     arch: "arm64",
+   },
+   {
+--- a/packages/core/package.json
++++ b/packages/core/package.json
+@@ -34,9 +34,9 @@
+       "default": "./src/pty/pty.bun.ts"
+     },
+     "#fff": {
+-      "bun": "./src/filesystem/fff.bun.ts",
++      "bun": "./src/filesystem/fff.node.ts",
+       "node": "./src/filesystem/fff.node.ts",
+-      "default": "./src/filesystem/fff.bun.ts"
++      "default": "./src/filesystem/fff.node.ts"
+     }
+   },
+   "devDependencies": {

--- a/opencode/riscv64.patch
+++ b/opencode/riscv64.patch
@@ -1,0 +1,43 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -21,6 +21,7 @@
+ makedepends=(
+   'bun'
+   'git'
++  'nodejs'
+ )
+ optdepends=(
+   'wl-clipboard: clipboard support on Wayland'
+@@ -35,7 +36,14 @@
+ 
+ prepare() {
+   cd $pkgname
+-  bun install --frozen-lockfile --ignore-scripts
++  patch -Np1 -i ../wasm-css.patch
++  patch -Np1 -i ../riscv64-target.patch
++  cp ../fix-oxide-worker-exit.patch patches/
++  # The lockfile records RISC-V optional dependencies with an unsupported CPU.
++  sed -i '/linux-riscv64/s/"cpu": "none"/"cpu": "riscv64"/' bun.lock
++  # Install Oxide's threaded WASM fallback on the host architecture.
++  sed -i '/"@tailwindcss\/oxide-wasm32-wasi":/s/"cpu": "none"/"cpu": "riscv64"/' bun.lock
++  bun install --ignore-scripts
+ }
+ 
+ build() {
+@@ -60,6 +68,7 @@
+   cd $pkgname
+   case $CARCH in
+   aarch64) dir=opencode-linux-arm64 ;;
++  riscv64) dir=opencode-linux-riscv64 ;;
+   x86_64) dir=opencode-linux-x64-baseline ;;
+   esac
+   install -vDm755 -t "$pkgdir/usr/bin" "packages/opencode/dist/$dir/bin/opencode"
+@@ -71,3 +80,8 @@
+   SHELL=/bin/zsh "$pkgdir/usr/bin/opencode" completion \
+     | install -vDm644 /dev/stdin "$pkgdir/usr/share/zsh/site-functions/_opencode"
+ }
++
++source+=(wasm-css.patch fix-oxide-worker-exit.patch riscv64-target.patch)
++b2sums+=('b4fab5bac8f8f6c57c5ddbc404df67687abe8210773fac182cce0d5ee0b7e97a589701c32a150e61406f3c46a3690bbf133ac3fd5dbe645bbdc9b247f853b7a6'
++         '8ccefc948e86b53c43f77cc3f3ef3de557cd4c104a444fb0eb8b2626cfc607ae20825370ffa29eab66604514c5c76eeaa0c86d45a3b65776ac15edae374278b1'
++         '9f627012736692b0cebe7238e0abf1f43d41875de8e78b1b82f18873acae0645a608705dbaac5aecf65bd9a23334d3adb109a3ffb56824394c0a85cad8900c17')

--- a/opencode/wasm-css.patch
+++ b/opencode/wasm-css.patch
@@ -1,0 +1,29 @@
+--- a/package.json
++++ b/package.json
+@@ -137,6 +137,7 @@
+     "electron"
+   ],
+   "overrides": {
++    "lightningcss": "npm:lightningcss-wasm@1.30.1",
+     "@ai-sdk/anthropic": "3.0.111",
+     "@opentui/core": "catalog:",
+     "@opentui/keymap": "catalog:",
+@@ -145,6 +146,7 @@
+     "@types/node": "catalog:"
+   },
+   "patchedDependencies": {
++    "@tailwindcss/oxide-wasm32-wasi@4.1.11": "patches/fix-oxide-worker-exit.patch",
+     "@dnd-kit/dom@0.5.0": "patches/@dnd-kit%2Fdom@0.5.0.patch",
+     "@npmcli/agent@4.0.2": "patches/@npmcli%2Fagent@4.0.2.patch",
+     "@silvia-odwyer/photon-node@0.3.4": "patches/@silvia-odwyer%2Fphoton-node@0.3.4.patch",
+--- a/packages/opencode/script/build.ts
++++ b/packages/opencode/script/build.ts
+@@ -27,7 +27,7 @@
+   console.log(`Building Web UI to embed in the binary`)
+   const appDir = path.join(import.meta.dirname, "../../app")
+   const dist = path.join(appDir, "dist")
+-  await $`OPENCODE_CHANNEL=${Script.channel} bun run --cwd ${appDir} build`
++  await $`OPENCODE_CHANNEL=${Script.channel} node ${appDir}/node_modules/vite/bin/vite.js build`.cwd(appDir)
+   const files = (await Array.fromAsync(new Bun.Glob("**/*").scan({ cwd: dist })))
+     .map((file) => file.replaceAll("\\", "/"))
+     .filter((file) => !file.endsWith(".map"))

--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -17,6 +17,7 @@ kresus
 llama-cpp
 navidrome
 openbao
+opencode
 oxyromon
 phpldapadmin
 prettier


### PR DESCRIPTION
Correct RISC-V optional dependency CPU metadata from "none" to "riscv64" before installing dependencies. The incorrect lockfile entries cause Bun to skip native packages, failing the web UI build with "Cannot find module @rollup/rollup-linux-riscv64-gnu".

Apply the correction to all RISC-V entries, including esbuild, while preserving their versions and integrity hashes.

Use the matching Oxide 4.1.11 and Lightning CSS 1.30.1 WASM packages because native RISC-V bindings are not published. Allow installation of Oxide despite its wasm32 CPU metadata, and relax the frozen install to accommodate the Lightning CSS override and worker patch.

Run Vite under Node for the WASI worker runtime. Reuse the llama-cpp fix that unreferences idle Oxide workers after startup so they do not keep the build process alive. Blacklist sv39 builders because Oxide executes threaded WebAssembly during the web UI build.

Add linux-riscv64 to the binary targets and select its output directory in package(). Without these mappings, --single selects no target and packaging fails with "cannot stat packages/opencode/dist//bin/opencode" after successfully building the web UI. Keep the binary smoke test enabled.

Select the existing non-FFF adapter for filesystem search. The @ff-labs/fff-bun 0.9.4 package only supports x64 and arm64, so Bun skips it and bundling fails with "Could not resolve: @ff-labs/fff-bun". The adapter reports FFF unavailable, selecting the existing ripgrep and fuzzysort implementation for file search, globbing and grep instead of requiring an unusable native binding. Other native runtime support gaps remain.