### PR TITLE
updpatch: openmpi 5.0.10-3

### DIFF
--- a/openmpi/riscv64.patch
+++ b/openmpi/riscv64.patch
@@ -1,29 +1,17 @@
-diff --git PKGBUILD PKGBUILD
-index 73f1276..11cda03 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -16,8 +16,6 @@ arch=(x86_64)
+@@ -16,8 +16,6 @@
  url='https://www.open-mpi.org'
  license=('BSD-3-Clause AND LicenseRef-MPICH')
  makedepends=(
 -  cuda
 -  nvidia-utils  # for libcuda.so
    gcc-fortran
-   gcc-libs
    glibc
-@@ -27,7 +25,6 @@ makedepends=(
-   libfabric
-   libnl
-   openpmix
--  openucc
-   openucx
-   prrte
-   valgrind
-@@ -70,12 +67,7 @@ build() {
-     --with-pmix=external
-     --with-prrte=external
+   hip-runtime-amd
+@@ -77,10 +75,6 @@
      --with-valgrind
--    --with-ucc=/usr
+     --with-ucc=/usr
      --with-ucx=/usr
 -    --with-cuda=/opt/cuda
 -    # this tricks the configure script to look for /usr/lib/pkgconfig/cuda.pc
@@ -32,15 +20,11 @@ index 73f1276..11cda03 100644
      --with-rocm=/opt/rocm
      # all components that link to libraries provided by optdepends must be run-time loadable
      --enable-mca-dso=accelerator_cuda,accelerator_rocm,btl_smcuda,rcache_gpusm,rcache_rgpusm,coll_ucc,scoll_ucc
-@@ -115,11 +107,9 @@ package_openmpi() {
-     zlib
+@@ -117,7 +111,6 @@
+     prrte
    )
    optdepends=(
 -    'cuda: cuda support'
      'hip-runtime-amd: ROCm support'
      'gcc-fortran: fortran support'
      'openssh: for execution on remote hosts via plm_ssh_agent'
--    'openucc: for UCC accelerated collectives'
-   )
-   provides=(
-     libmpi.so


### PR DESCRIPTION
Re-enable the OpenUCC build dependency, configure option and optional runtime dependency now that its CUDA and NCCL dependency blockers have an overlay. Refresh the patch while retaining the CUDA exclusions.