### PR TITLE
addpatch: opentofu 1.12.3-1

### DIFF
--- a/opentofu/go1.27-tests.patch
+++ b/opentofu/go1.27-tests.patch
@@ -1,0 +1,124 @@
+--- a/internal/command/init_test.go
++++ b/internal/command/init_test.go
+@@ -1852,7 +1852,7 @@
+ 			getproviders.MustParseVersionConstraints("= 1.2.4"),
+ 			[]getproviders.Hash{
+ 				getproviders.HashScheme1.New("vEthLkqAecdQimaW6JHZ0SBRNtHibLnOb31tX9ZXlcI="),
+-				getproviders.HashSchemeZip.New("ec7c3fd6eb575c06f0e6957e1ee8531a588805c4eeb8abb5e4156911e080eb31"),
++				getproviders.HashSchemeZip.New("4115ba79e1745c9236f24ce18e643cfc1893140cbc963066348d2dde9c7c55c5"),
+ 			},
+ 		),
+ 		addrs.NewDefaultProvider("test"): depsfile.NewProviderLock(
+@@ -1861,7 +1861,7 @@
+ 			getproviders.MustParseVersionConstraints("= 1.2.3"),
+ 			[]getproviders.Hash{
+ 				getproviders.HashScheme1.New("8CjxaUBuegKZSFnRos39Fs+CS78ax0Dyb7aIA5XBiNI="),
+-				getproviders.HashSchemeZip.New("6f85a1f747dd09455cd77683c0e06da647d8240461b8b36b304b9056814d91f2"),
++				getproviders.HashSchemeZip.New("ac90a1419dd4648431af93b6695b6d6efcad87950ee608de4198df8e6debff23"),
+ 			},
+ 		),
+ 		addrs.NewDefaultProvider("source"): depsfile.NewProviderLock(
+@@ -1870,7 +1870,7 @@
+ 			getproviders.MustParseVersionConstraints("= 1.2.3"),
+ 			[]getproviders.Hash{
+ 				getproviders.HashScheme1.New("ACYytVQ2Q6JfoEs7xxCqa1yGFf9HwF3SEHzJKBoJfo0="),
+-				getproviders.HashSchemeZip.New("69f700dbf9eda586abef22ab08e3a3896760e01885f6cbda4460ceeca4e3c0ba"),
++				getproviders.HashSchemeZip.New("4932d637b6c33444920bf945d6ee17de83ab4b193c1707b35c84d828de880158"),
+ 			},
+ 		),
+ 	}
+@@ -2119,7 +2119,7 @@
+ 			getproviders.MustParseVersionConstraints("> 1.0.0, < 3.0.0"),
+ 			[]getproviders.Hash{
+ 				getproviders.HashScheme1.New("ntfa04OlRqIfGL/Gkd+nGMJSHGWyAgMQplFWk7WEsOk="),
+-				getproviders.HashSchemeZip.New("29e1045215056680ac59fe95554f0eb1323534a3d411aae2a7a04495ac884258"),
++				getproviders.HashSchemeZip.New("cf1650d77dfe5681ebd7917a813c0c982d0d2e951ded422a83fbf22a1e0e6bc3"),
+ 			},
+ 		),
+ 		addrs.NewDefaultProvider("exact"): depsfile.NewProviderLock(
+@@ -2128,7 +2128,7 @@
+ 			getproviders.MustParseVersionConstraints("= 1.2.3"),
+ 			[]getproviders.Hash{
+ 				getproviders.HashScheme1.New("Xgk+LFrzi9Mop6+d01TCTaD3kgSrUASCAUU1aDsEsJU="),
+-				getproviders.HashSchemeZip.New("9cb7a3006b9c1344b2d838a5bb03c1e0f04b8c046beb38901eaf3cc99fceb870"),
++				getproviders.HashSchemeZip.New("604a3ebf14e83ef19aab2e8e4063c4cd7d53c9c4c30ad22db0d9ce4f8f6edc83"),
+ 			},
+ 		),
+ 		addrs.NewDefaultProvider("greater-than"): depsfile.NewProviderLock(
+@@ -2137,7 +2137,7 @@
+ 			getproviders.MustParseVersionConstraints(">= 2.3.3"),
+ 			[]getproviders.Hash{
+ 				getproviders.HashScheme1.New("8M5DXICmUiVjbkxNNO0zXNsV6duCVNWzq3/Kf0mNIo4="),
+-				getproviders.HashSchemeZip.New("bfb683ee94027efb191986484352ada8219cd45e856d25c2ddcb489e100a9a02"),
++				getproviders.HashSchemeZip.New("4c638927fcf2d35eb1c3a91c6745c0bef1a5365294641d4a8fca9c529cb8521f"),
+ 			},
+ 		),
+ 	}
+@@ -2321,7 +2321,7 @@
+   constraints = "1.2.3"
+   hashes = [
+     "h1:8CjxaUBuegKZSFnRos39Fs+CS78ax0Dyb7aIA5XBiNI=",
+-    "zh:6f85a1f747dd09455cd77683c0e06da647d8240461b8b36b304b9056814d91f2",
++    "zh:ac90a1419dd4648431af93b6695b6d6efcad87950ee608de4198df8e6debff23",
+   ]
+ }
+ `)
+@@ -2354,7 +2354,7 @@
+   version     = "1.2.3"
+   constraints = "1.2.3"
+   hashes = [
+-    "zh:6f85a1f747dd09455cd77683c0e06da647d8240461b8b36b304b9056814d91f2",
++    "zh:ac90a1419dd4648431af93b6695b6d6efcad87950ee608de4198df8e6debff23",
+   ]
+ }
+ `)
+@@ -2381,7 +2381,7 @@
+   constraints = "1.2.3"
+   hashes = [
+     "h1:8CjxaUBuegKZSFnRos39Fs+CS78ax0Dyb7aIA5XBiNI=",
+-    "zh:6f85a1f747dd09455cd77683c0e06da647d8240461b8b36b304b9056814d91f2",
++    "zh:ac90a1419dd4648431af93b6695b6d6efcad87950ee608de4198df8e6debff23",
+   ]
+ }
+ `)
+--- a/internal/lang/funcs/encoding_test.go
++++ b/internal/lang/funcs/encoding_test.go
+@@ -137,7 +137,7 @@
+ 	}{
+ 		{
+ 			cty.StringVal("test"),
+-			cty.StringVal("H4sIAAAAAAAA/ypJLS4BAAAA//8BAAD//wx+f9gEAAAA"),
++			cty.StringVal("H4sIAAAAAAAA/wAEAPv/dGVzdAAAAP//AwAMfn/YBAAAAA=="),
+ 			false,
+ 		},
+ 	}
+@@ -169,6 +169,11 @@
+ 		Err    string
+ 	}{
+ 		{
++			cty.StringVal("H4sIAAAAAAAA/wAEAPv/dGVzdAAAAP//AwAMfn/YBAAAAA=="),
++			cty.StringVal("test"),
++			"",
++		},
++		{
+ 			cty.StringVal("H4sIAAAAAAAA/ypJLS4BAAAA//8BAAD//wx+f9gEAAAA"),
+ 			cty.StringVal("test"),
+ 			"",
+--- a/internal/lang/functions_test.go
++++ b/internal/lang/functions_test.go
+@@ -108,13 +108,13 @@
+ 		"base64gzip": {
+ 			{
+ 				`base64gzip("test")`,
+-				cty.StringVal("H4sIAAAAAAAA/ypJLS4BAAAA//8BAAD//wx+f9gEAAAA"),
++				cty.StringVal("H4sIAAAAAAAA/wAEAPv/dGVzdAAAAP//AwAMfn/YBAAAAA=="),
+ 			},
+ 		},
+ 
+ 		"base64gunzip": {
+ 			{
+-				`base64gunzip("H4sIAAAAAAAA/ypJLS4BAAAA//8BAAD//wx+f9gEAAAA")`,
++				`base64gunzip("H4sIAAAAAAAA/wAEAPv/dGVzdAAAAP//AwAMfn/YBAAAAA==")`,
+ 				cty.StringVal("test"),
+ 			},
+ 		},

--- a/opentofu/riscv64.patch
+++ b/opentofu/riscv64.patch
@@ -1,0 +1,33 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -18,6 +18,11 @@
+ prepare() {
+   cd $pkgname-$pkgver
+   GOFLAGS="-mod=readonly" go mod vendor -v
++  # Restore HTTP/2 symbols needed by gRPC with Go 1.27.
++  patch -Np1 -d vendor/golang.org/x/net -i "$srcdir/x-net-go1.27.patch"
++  # Update compression expectations for Go 1.27.
++  # https://github.com/opentofu/opentofu/commit/69a5d5b8d2e96336c868f169d9cde9b90e009465
++  patch -Np1 -i "$srcdir/go1.27-tests.patch"
+ }
+ 
+ build() {
+@@ -40,7 +45,7 @@
+ check() {
+   cd $pkgname-$pkgver
+   # Skipped test asserts a hard-coded terraform_version that lags the release
+-  go test ./... -skip '^TestStateViews$'
++  go test -timeout 20m ./... -skip '^TestStateViews$'
+ }
+ 
+ package() {
+@@ -58,3 +63,9 @@
+   install -vDm644 -t "$pkgdir/usr/share/doc/$pkgname" ./*.md
+   cp -a -t "$pkgdir/usr/share/doc/$pkgname" docs
+ }
++
++source+=("x-net-go1.27.patch::https://github.com/golang/net/commit/23ee2efe81a3ff183b4eca46c42f749af7efca45.patch")
++b2sums+=('b2715449ffe87f5a653e2b9d69f7355329f82f19413b0b16ec98a3101c6f01c2a53cace11052300e374b3f755cff33223398322e3793816a6fa0d4d29a7b251b')
++
++source+=(go1.27-tests.patch)
++b2sums+=('f750be83e651322b1de06d6c9f261156ac65f1c17311e2e305844061ca5dcc9b48a2d7db205dc3c1bef8818b064e4d1c5a0d8ae944acf4b8e2c152e855a7fd2f')


### PR DESCRIPTION
Backport x/net's Go 1.27 API compatibility fix to restore http2.TrailerPrefix and fix the bundled gRPC build.

Backport upstream's test updates for Go 1.27's changed DEFLATE output, including gzip results and generated provider ZIP checksums.

Allow 20 minutes for each test package because internal/command exceeds Go's default ten-minute timeout on slower builders.

https://github.com/golang/net/commit/23ee2efe81a3ff183b4eca46c42f749af7efca45 https://github.com/opentofu/opentofu/commit/69a5d5b8d2e96336c868f169d9cde9b90e009465