### PR TITLE
addpatch: qsv 22.0.1-1

### DIFF
--- a/qsv/riscv64.patch
+++ b/qsv/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -39,6 +39,8 @@
+ 
+ prepare() {
+ 	_srcenv
++	# Fix cache-line detection on non-x86/ARM hosts (kiddo#537).
++	cargo update -p kiddo --precise 6.2.0
+ 	cargo fetch --locked --target host-tuple
+ 	sed -i -e '/^lto/s/true/false/' Cargo.toml
+ }


### PR DESCRIPTION
Update Kiddo to 6.2.0 to fix the missing get_cache_line_size function on riscv64. Its build script now limits cache-line detection to supported hosts and uses the existing 64-byte fallback elsewhere.

https://github.com/sdd-org/kiddo/pull/537