### PR TITLE
addpatch: crun 1.29.1-1

### DIFF
--- a/crun/riscv64.patch
+++ b/crun/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -31,7 +31,7 @@
+ validpgpkeys=('AC404C1C0BF735C63FF4D562263D6DF2E163E1EA')
+ sha256sums=('d5f2f27ea25554ad28c4163749cd3060f39ba48461b5dc6e80cf676b53ba5515'
+             '8d487cb316b802961d53620eac4b2c8742e14b68cee04511d36a070227635510'
+-            'd90a2cf783c1d498d3bd345fc25794d3489625ca302c9829da9b8317e7c1fd4c')
++            '15a9bc24b4015f793876fa3b644c063de60f0e28752de1447e08f15d3f3e2ef7')
+ 
+ prepare() {
+     cd "$pkgname"


### PR DESCRIPTION
Update the SHA-256 checksum of PR 2188 after it was force-pushed
following Arch's package build. Keep the original PR URL.

https://github.com/containers/crun/pull/2188