### PR TITLE
addpatch: ruby-parallel 2.1.0-1

### DIFF
--- a/ruby-parallel/riscv64.patch
+++ b/ruby-parallel/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -37,6 +37,9 @@
+ prepare() {
+   cd "${_gemname}-${pkgver}"
+ 
++  # Use GEM_HOME in subprocess tests without Bundler startup overhead.
++  sed -i "/require 'bundler\/setup'/d" spec/cases/helper.rb
++
+   # update gemspec/Gemfile to allow newer version of the dependencies
+   sed --in-place --regexp-extended \
+     --expression 's|~>|>=|g' \


### PR DESCRIPTION
Remove bundler/setup from the subprocess test helper. Arch already supplies the installed gem through GEM_HOME, so subprocesses can load parallel directly without repeating Bundler setup.

Two subprocess timing tests exceed their 2.5-second limits, taking 3.11 and 2.72 seconds on the RISC-V builder. Two custom-interrupt tests also find no surviving processes after sending SIGINT at 1.5 seconds, consistent with startup not yet reaching the signal handler.

Avoid redundant startup work while preserving all timing limits and assertions. Bundler overhead is a suspected contributor, not a confirmed sole cause of the four failures.