### PR TITLE
addpatch: csound-plugins 1.0.2-18

### DIFF
--- a/csound-plugins/riscv64.patch
+++ b/csound-plugins/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -48,7 +48,9 @@
+ }
+ 
+ build() {
++	# FLTK's public headers require Cairo include paths missing from FindFLTK.
+ 	CFLAGS+=" -Wno-incompatible-pointer-types" \
++	CXXFLAGS+=" $(pkg-config --cflags cairo)" \
+ 	cmake -B build -S "plugins-$pkgver" \
+ 		-DCMAKE_BUILD_TYPE='None' \
+ 		-DCMAKE_INSTALL_PREFIX='/usr' \


### PR DESCRIPTION
Add Cairo cflags to the C++ build, following the LimeSuite workaround. FLTK public headers include cairo.h, but FindFLTK does not supply its include paths, causing the widgets and virtual keyboard plugins to fail with "fatal error: cairo.h: No such file or directory".

Cairo is already installed through the build dependencies. Keep all plugins enabled and obtain the missing include flags from pkg-config.