### PR TITLE
addpatch: python-openstacksdk 4.20.0-1

### DIFF
--- a/python-openstacksdk/riscv64.patch
+++ b/python-openstacksdk/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -25,6 +25,7 @@
+ }
+ 
+ check() {
++  export OS_TEST_TIMEOUT=30
+   # From https://github.com/openstack/openstacksdk/blob/master/tox.ini
+   export OS_LOG_CAPTURE=true OS_STDOUT_CAPTURE=true OS_STDERR_CAPTURE=true
+ 


### PR DESCRIPTION
Raise OS_TEST_TIMEOUT from the default five seconds to 30 seconds. TestGenerateFakeProxy.test_get_returns_resource and test_find_returns_resource time out inside unittest.mock.create_autospec on the RISC-V builder while the other 4847 tests pass.

Use the existing timeout setting, keeping all tests and assertions unchanged.