### PR TITLE
addpatch: lua-cliargs 3.0.2-2

### DIFF
--- a/lua-cliargs/riscv64.patch
+++ b/lua-cliargs/riscv64.patch
@@ -1,0 +1,21 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -25,6 +25,11 @@
+ source=("$url/archive/v$pkgver/$_archive.tar.gz")
+ sha256sums=('a7a57ab9c73f6c44040a78305b6dc7780ca1565cc4c9057d74a6608cb0443af4')
+ 
++prepare() {
++	cd "$_archive"
++	patch -Np1 -i "$srcdir/preserve-parse-errors.patch"
++}
++
+ check() {
+ 	cd "$_archive"
+ 	busted
+@@ -58,3 +63,6 @@
+ package_lua54-cliargs() {
+ 	_package 5.4
+ }
++
++source+=("preserve-parse-errors.patch::https://github.com/lunarmodules/lua_cliargs/commit/1680d489335ae814b6a41e7f2f081d4ae58589ef.patch")
++sha256sums+=('706bbef87ee9f6446052bb28c0c1bbab74a4059039c873efcbb0d9917e32eb51')


### PR DESCRIPTION
Backport the parse return-count fix to preserve nil and the error message on Lua 5.5. Packing and unpacking with an explicit count avoids relying on the length of a table containing a nil hole.

https://github.com/lunarmodules/lua_cliargs/commit/1680d489335ae814b6a41e7f2f081d4ae58589ef