### PR TITLE
addpatch: cl-trivial-features 1.0.r5.g18a5cfa-1

### DIFF
--- a/cl-trivial-features/riscv64-features.patch
+++ b/cl-trivial-features/riscv64-features.patch
@@ -1,0 +1,38 @@
+--- a/SPEC.md
++++ b/SPEC.md
+@@ -67,6 +67,7 @@
+   - `:HPPA64`
+   - `:ARM`
+   - `:ARM64`
++  - `:RISCV64`
+ 
+ [add more ...]
+ 
+--- a/src/tf-sbcl.lisp
++++ b/src/tf-sbcl.lisp
+@@ -49,4 +49,5 @@
+ ;;;; CPU
+ 
+ ;;; SBCL already pushes: :X86, :X86-64, :PPC, and :64-BIT
++#+(and riscv 64-bit) (pushnew :riscv64 *features*)
+ #-64-bit (pushnew :32-bit *features*)
+--- a/tests/tests.lisp
++++ b/tests/tests.lisp
+@@ -98,7 +98,7 @@
+   t)
+ 
+ (deftest cpu.1
+-    (mutually-exclusive-p '(:ppc :ppc64 :x86 :x86-64 :alpha :mips :arm :arm64))
++    (mutually-exclusive-p '(:ppc :ppc64 :x86 :x86-64 :alpha :mips :arm :arm64 :riscv64))
+   t)
+ 
+ #+windows
+@@ -117,6 +117,8 @@
+              (ecase (foreign-type-size :pointer)
+                (4 (featurep :x86))
+                (8 (featurep :x86-64))))
++            ((string= machine "riscv64")
++             (featurep :riscv64))
+             (t
+              (format *debug-io*
+                      "~&; NOTE: unhandled machine type, ~a, in CPU.2 test.~%"

--- a/cl-trivial-features/riscv64.patch
+++ b/cl-trivial-features/riscv64.patch
@@ -1,0 +1,22 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -27,6 +27,11 @@
+   git describe --tags | sed -e 's/^v//' -e 's/-/.r/' -e 's/-/./g'
+ }
+ 
++prepare() {
++  cd "$pkgname"
++  patch -Np1 -i "$srcdir/riscv64-features.patch"
++}
++
+ check() {
+   cd "$pkgname"
+ 
+@@ -49,3 +54,7 @@
+   # license
+   install -vDm644 -t "$pkgdir/usr/share/licenses/$pkgname" COPYRIGHT
+ }
++
++source+=(riscv64-features.patch)
++sha512sums+=('6224d5f54a28cd7d21b096d203fc4abfc29fbc58112763cfdc7da6f2613f4c335ab593ab9c49fae5acbd481bb297b22707f3f29065104b428f2605f697b0d2a8')
++b2sums+=('5fa2660a65ee23e2ba354d08e35fc2273ecadd93aaa4eacf8bdcd740157f13011acaaa078da311637f291e40425a357db7f62b053c572b08728c819c7d450110')


### PR DESCRIPTION
Normalize SBCL's riscv and 64-bit features to riscv64. Document the CPU feature and extend the existing CPU checks to recognize it, fixing the CPU.1 failure and the unhandled riscv64 machine type in CPU.2.