### PR TITLE
addpatch: python-poetry-core 2.4.1-1

### DIFF
--- a/python-poetry-core/riscv64.patch
+++ b/python-poetry-core/riscv64.patch
@@ -1,0 +1,17 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -35,6 +35,7 @@
+             '8ab581197e30a457b1388cc77437c6d202b59dd1d5a7444d9c2e5a1958cca3cf')
+ 
+ prepare() {
++	patch -Np1 -d "$_archive" -i "$srcdir/marker-apply.patch"
+ 	if (( _devendored == 1 )); then
+ 		sed -e "s/2.3.2/$pkgver/" "../$pkgname-1.9.0-devendor.patch" |
+ 			patch -Np1 -d "$_archive"
+@@ -60,3 +61,6 @@
+ 	python -m installer -d "$pkgdir" dist/*.whl
+ 	install -Dm0644 -t "$pkgdir/usr/share/licenses/$pkgname/" LICENSE
+ }
++
++source+=("marker-apply.patch::https://github.com/python-poetry/poetry-core/commit/60516b6ce7b7e19c5e5af3a4e9c5bdf30fef92a2.patch")
++sha256sums+=('6057c307db163292603838ace30451422549e09944ec3f84e7f118300668c56e')


### PR DESCRIPTION
Backport Marker.apply() to partially evaluate dependency markers while preserving conditions for environment variables that are not supplied.

This provides the API required by the paired poetry-plugin-export fix. Its validate()/without_extras() combination can lose Python-version conditions in marker unions with extras. Rebuild poetry-core before python-poetry-plugin-export so the exporter uses the corrected path.

https://github.com/python-poetry/poetry-core/commit/60516b6ce7b7e19c5e5af3a4e9c5bdf30fef92a2