### PR TITLE
addpatch: python-poetry-plugin-export 1.10.0-1

### DIFF
--- a/python-poetry-plugin-export/riscv64.patch
+++ b/python-poetry-plugin-export/riscv64.patch
@@ -1,0 +1,17 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,6 +17,7 @@
+ 
+ prepare() {
+   cd poetry-plugin-export
++  patch -Np1 -i ../fix-marker-unions.patch
+ }
+ 
+ build() {
+@@ -36,3 +37,6 @@
+   python -m installer -d "$pkgdir" dist/*.whl
+   install -Dm644 -t "$pkgdir/usr/share/licenses/$pkgname/" LICENSE
+ }
++
++source+=("fix-marker-unions.patch::https://github.com/python-poetry/poetry-plugin-export/commit/b5cd46a5ff206522275c218064225a257b8bae33.patch")
++sha512sums+=('9369c9ae34db88d53a30d4acbc76099eeba61979589512156f4993fe4a5ffa344b412bff5a283414294814d8300a509fac9cdb775fd78d398b47428a286e87e5')


### PR DESCRIPTION
Backport the upstream fix for marker unions containing extras. Evaluate extras with Marker.apply() instead of validating and then removing them, which can discard a remaining Python-version condition.

This addresses the two test_export_markers failures with poetry-core 2.4.1. Without extra1, python_version >= "3.6" or extra == "extra1" must retain the Python condition; with extra1 it is unconditional.

Requires rebuilding python-poetry-core with the paired Marker.apply() backport first. Otherwise the compatibility path retains the old logic.

https://github.com/python-poetry/poetry-plugin-export/commit/b5cd46a5ff206522275c218064225a257b8bae33