### PR TITLE
addpatch: python-pysdl3 0.9.12b1-1

### DIFF
--- a/python-pysdl3/riscv64-system-libraries.patch
+++ b/python-pysdl3/riscv64-system-libraries.patch
@@ -1,0 +1,20 @@
+--- a/sdl3/__init__.py
++++ b/sdl3/__init__.py
+@@ -12,6 +12,7 @@
+     """Format the architecture string."""
+     if arch.lower() in ["x64", "x86_64", "amd64"]: return "AMD64"
+     if arch.lower() in ["aarch64", "arm64"]: return "ARM64"
++    if arch.lower() == "riscv64": return "RISCV64"
+     assert False, "Unknown architecture."
+ 
+ SDL_SYSTEM, SDL_ARCH = os.uname().sysname if hasattr(os, "uname") else platform.system(), SDL_FORMAT_ARCH(platform.machine())
+@@ -173,7 +174,8 @@
+         except OSError as exc:
+             SDL_LOGGER.Log(SDL_LOGGER.Error, f"Failed to create binary path: {exc}.")
+ 
+-    if int(os.environ.get("SDL_DISABLE_METADATA", "0")) > 0:
++    # RISC-V uses system libraries; upstream provides no prebuilt binaries.
++    if int(os.environ.get("SDL_DISABLE_METADATA", "1" if SDL_ARCH == "RISCV64" else "0")) > 0:
+         if os.path.exists(binaryPath) and os.path.isdir(binaryPath):
+             for root, _, files in os.walk(binaryPath):
+                 binaryData["files"] += [os.path.join(root, file) for file in files if SDL_CHECK_BINARY_NAME(file)]

--- a/python-pysdl3/riscv64.patch
+++ b/python-pysdl3/riscv64.patch
@@ -1,0 +1,21 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -30,6 +30,11 @@
+ sha256sums=('d9d02c5f267d200afb9155e1c27af8ea40ec8015644585f985e13c9cf681af4e')
+ 
+ 
++prepare() {
++	cd "${srcdir}/${pkgname}-${pkgver}"
++	patch -Np1 -i "$srcdir/riscv64-system-libraries.patch"
++}
++
+ build() {
+ 	cd "${srcdir}/${pkgname}-${pkgver}"
+ 	python -m build
+@@ -49,3 +54,6 @@
+ 	cp -r sdl3/__doc__.py "${pkgdir}/usr/lib/python${_PYTHON_VERSION}/site-packages/sdl3/"
+ 	install -Dm644 "${srcdir}/${pkgname}-${pkgver}/LICENSE" "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+ }
++
++source+=(riscv64-system-libraries.patch)
++sha256sums+=('c6d74cae376418c65a3336cfa861b6af49ecbf2e2ffa11cd57f218f52ecf6fbf')


### PR DESCRIPTION
Recognize riscv64 so importing sdl3 no longer aborts with "Unknown architecture" during documentation generation.

Default to system-library discovery on RISC-V instead of trying to download prebuilt binaries, which are only available for AMD64 and ARM64.