### PR TITLE
addpatch: python-joblib 1.6.0-2

### DIFF
--- a/python-joblib/fix-dask-event-counting.patch
+++ b/python-joblib/fix-dask-event-counting.patch
@@ -1,0 +1,16 @@
+--- a/joblib/test/test_dask.py
++++ b/joblib/test/test_dask.py
+@@ -64,11 +64,8 @@
+ 
+ def count_events(event_name, client):
+     def work(dask_worker):
+-        count = 0
+-        for task_state in dask_worker.state.tasks.values():
+-            task_story = dask_worker.state.story(task_state)
+-            count += len([event for event in task_story if event[1] == event_name])
+-        return count
++        # Completed tasks may be forgotten while their events remain in the log.
++        return sum(event[1] == event_name for event in dask_worker.state.log)
+ 
+     return client.run(work)
+ 

--- a/python-joblib/fix-test-timing.patch
+++ b/python-joblib/fix-test-timing.patch
@@ -1,0 +1,43 @@
+--- a/joblib/test/test_dask.py
++++ b/joblib/test/test_dask.py
+@@ -86,7 +86,7 @@
+                 assert seq == [inc(i) for i in range(10)]
+ 
+ 
+-def test_dask_backend_uses_autobatching(loop):
++def test_dask_backend_uses_autobatching(loop, monkeypatch):
+     assert (
+         DaskDistributedBackend.compute_batch_size
+         is AutoBatchingMixin.compute_batch_size
+@@ -103,6 +103,15 @@
+                     assert backend.parallel is parallel
+                     assert backend._effective_batch_size == 1
+ 
++                    # Exercise batch growth independently of machine speed.
++                    monkeypatch.setattr(
++                        backend,
++                        "batch_completed",
++                        lambda batch_size, duration: AutoBatchingMixin.batch_completed(
++                            backend, batch_size, 0.01
++                        ),
++                    )
++
+                     # Launch many short tasks that should trigger
+                     # auto-batching:
+                     parallel(delayed(lambda: None)() for _ in range(int(1e4)))
+--- a/joblib/test/test_memmapping.py
++++ b/joblib/test/test_memmapping.py
+@@ -35,11 +35,11 @@
+ from joblib.testing import parametrize, raises, skipif
+ 
+ 
+-def setup_module():
++def setup_function():
+     faulthandler.dump_traceback_later(timeout=300, exit=True)
+ 
+ 
+-def teardown_module():
++def teardown_function():
+     faulthandler.cancel_dump_traceback_later()
+ 
+ 

--- a/python-joblib/riscv64.patch
+++ b/python-joblib/riscv64.patch
@@ -1,0 +1,24 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -35,6 +35,12 @@
+ source=("https://github.com/joblib/joblib/archive/${pkgver}/${pkgname}-${pkgver}.tar.gz")
+ b2sums=('38ad1d8b871a8cb3ebc834c48f563a1eb872cf0bc7390c0822c7f865abba480d2f66e5ae4e769f35a4d6b005efb90afa8532ebf067a64641e4536926cfdbd978')
+ 
++prepare() {
++  cd ${pkgname#python-}-${pkgver}
++  patch -Np1 -i "$srcdir/fix-dask-event-counting.patch"
++  patch -Np1 -i "$srcdir/fix-test-timing.patch"
++}
++
+ build() {
+   cd ${pkgname#python-}-${pkgver}
+   python -m build --wheel --no-isolation
+@@ -53,3 +59,8 @@
+   python -m installer --destdir="$pkgdir" dist/*.whl
+   install -vDm644 -t "$pkgdir/usr/share/licenses/$pkgname" LICENSE.txt
+ }
++
++source+=(fix-dask-event-counting.patch
++         fix-test-timing.patch)
++b2sums+=('99ecce0ef206c370019a525c21c73dd86436ec60019c539ec81077a30c3beadda6e3bad4b100252939d40b41c69cb0af6b15a5639ea422604c0f61dd2cb65316'
++         '386389ad4c158bb10906b6db26d53d9cbb0ab95e4b6d7a235b09a3d9f19696a4a72253d81af070bc49676c4b221291e41962c168282f88383e41904e2f4269d4')


### PR DESCRIPTION
Count scatter events from the retained worker state log instead of stories for tasks still in its task table. Joblib releases scatter futures when Parallel() finishes, so Dask can forget the tasks before the assertions run.

This fixes the zero event counts in test_auto_scatter and test_no_undesired_distributed_cache_hit without skipping either test. The task-table filtering was introduced by:
https://github.com/joblib/joblib/pull/1803

Make the Dask autobatching test independent of host speed by feeding fixed short durations through the real batch-completion logic. Its batch-growth check fails on smoochum under qemu-user.

Apply the memmapping watchdog's 300-second limit per test rather than per module. The run exits midway through that module without a pytest summary, consistent with the watchdog terminating a slow suite.