### PR TITLE
addpatch: python-filelock 3.31.2-1

### DIFF
--- a/python-filelock/riscv64.patch
+++ b/python-filelock/riscv64.patch
@@ -1,0 +1,21 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -28,6 +28,11 @@
+ source=("git+$url.git#tag=$pkgver")
+ b2sums=('8bea4a3aa4ec79562d933f5065e1481fd74cdb0728aa068e2235030c30503ea6f1a94bf70f748d1d95f2fd7a7d723b6899b3857ac1c2c2d3aae08588d8b05c28')
+ 
++prepare() {
++  cd ${pkgname#python-}
++  patch -Np1 -i "$srcdir/stress-test-timeouts.patch"
++}
++
+ build() {
+   cd ${pkgname#python-}
+   python -m build --wheel --no-isolation
+@@ -45,3 +50,6 @@
+   python -m installer --destdir="$pkgdir" dist/*.whl
+   install -vDm644 -t "$pkgdir/usr/share/licenses/$pkgname" LICENSE
+ }
++
++source+=(stress-test-timeouts.patch)
++b2sums+=('a14a3f07c6579609dfd65108b2eb265489feaa92adaad9efafc342c98d62e0b32e66214cfdd9080ccfed802faccabaf6734f00439940cd7217ba796e73f873ff')

--- a/python-filelock/stress-test-timeouts.patch
+++ b/python-filelock/stress-test-timeouts.patch
@@ -1,0 +1,46 @@
+--- a/tests/test_filelock.py
++++ b/tests/test_filelock.py
+@@ -284,8 +284,8 @@
+             raise RuntimeError from self.ex[1]  # pragma: no cover  # only a worker that raised gets re-raised here
+ 
+ 
+-# 100 threads x 100 acquisitions is thousands of lock cycles; the 20s default is tight on a loaded Windows runner.
+-@pytest.mark.timeout(60)
++# Threaded stress tests need more time on slower builders.
++@pytest.mark.timeout(300)
+ @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+ def test_threaded_shared_lock_obj(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+     if sys.platform == "win32" and lock_type.__name__ == "SoftFileLock":  # pragma: win32 cover
+@@ -311,7 +311,7 @@
+     assert not lock.is_locked
+ 
+ 
+-@pytest.mark.timeout(60)
++@pytest.mark.timeout(300)
+ @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+ def test_threaded_lock_different_lock_obj(lock_type: type[BaseFileLock], tmp_path: Path) -> None:
+     if sys.platform == "win32" and (hasattr(sys, "pypy_version_info") or lock_type.__name__ == "SoftFileLock"):
+@@ -688,6 +688,7 @@
+         assert txt_file.read_text(encoding="utf-8") == uuid
+ 
+ 
++@pytest.mark.timeout(300)
+ @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+ def test_thrashing_with_thread_pool_passing_lock_to_threads(tmp_path: Path, lock_type: type[BaseFileLock]) -> None:
+     def mess_with_file(lock_: BaseFileLock) -> None:
+@@ -701,6 +702,7 @@
+     assert all(r.result() is None for r in results)
+ 
+ 
++@pytest.mark.timeout(300)
+ @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+ def test_thrashing_with_thread_pool_global_lock(tmp_path: Path, lock_type: type[BaseFileLock]) -> None:
+     def mess_with_file() -> None:
+@@ -715,6 +717,7 @@
+     assert all(r.result() is None for r in results)
+ 
+ 
++@pytest.mark.timeout(300)
+ @pytest.mark.parametrize("lock_type", [FileLock, SoftFileLock])
+ def test_thrashing_with_thread_pool_lock_recreated_in_each_thread(
+     tmp_path: Path,


### PR DESCRIPTION
Allow 300 seconds for the five threaded stress tests. Their 20- and 60-second limits expire on the RISC-V builder, leaving worker threads running and contaminating later tests' captured logs and mocks.

Keep the stress workloads and assertions unchanged.