### PR TITLE
addpatch: python-langsmith 0.11.2-1

### DIFF
--- a/python-langsmith/relax-async-evaluation-timing.patch
+++ b/python-langsmith/relax-async-evaluation-timing.patch
@@ -1,0 +1,11 @@
+--- a/tests/unit_tests/evaluation/test_runner.py
++++ b/tests/unit_tests/evaluation/test_runner.py
+@@ -706,7 +706,7 @@
+             deltas.append((now - last))
+             last = now
+         total = now - start  # type: ignore
+-        assert 3.3 > total > 1.5
++        assert 4 > total > 1.5
+ 
+         # Essentially we want to check that most calls were very fast.
+         assert len(deltas) == SPLIT_SIZE * NUM_REPETITIONS

--- a/python-langsmith/riscv64.patch
+++ b/python-langsmith/riscv64.patch
@@ -1,0 +1,17 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -65,6 +65,7 @@
+ 
+ prepare() {
+   cd langsmith-sdk/python
++  patch -Np1 -i "$srcdir/relax-async-evaluation-timing.patch"
+ 
+   # Python 3.14 deprecates asyncio.iscoroutinefunction; tests import with -W error.
+   sed -i 's/import asyncio/import inspect/' langsmith/_internal/_beta_decorator.py
+@@ -109,3 +110,6 @@
+   python -m installer --destdir="$pkgdir" dist/*.whl
+   install -Dm644 ../LICENSE -t "$pkgdir"/usr/share/licenses/$pkgname/
+ }
++
++source+=(relax-async-evaluation-timing.patch)
++sha512sums+=('d29afc54a0c84a6b93979a49cc2eb7a1e8a38728c8f233bdcc28d2bc1a829e2e338b4c5a4755214040219e3290296c9439e15f1a64a1403dc303d49d18c6ab33')


### PR DESCRIPTION
Allow four seconds instead of 3.3 for the nonblocking async evaluation test. Its intentional three-second delay takes 3.45 seconds overall on the RISC-V builder, failing test_aevaluate_results[False-False-False].

Keep the 1.5-second lower bound, streaming-order checks and result assertions unchanged.