### PR TITLE
addpatch: python-scikit-learn 1.9.0-2

### DIFF
--- a/python-scikit-learn/riscv64.patch
+++ b/python-scikit-learn/riscv64.patch
@@ -1,0 +1,13 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -29,8 +29,8 @@
+ 	cd $_archive
+ 	sed -i -E \
+ 		-e '/meson-python/s/,<0.20.0//' \
+-		-e '/numpy/s/,<2.3.0//' \
+-		-e '/scipy/s/,<1.16.0//' \
++		-e '/numpy/s/,<2.5.0//' \
++		-e '/scipy/s/,<1.18.0//' \
+ 		-e '/Cython/s/,<3.2.0//' \
+ 		pyproject.toml
+ }


### PR DESCRIPTION
Refresh the NumPy and SciPy upper-bound substitutions to match 1.9.0. The stale patterns leave numpy<2.5.0 and scipy<1.18.0 in place, rejecting the builder's NumPy 2.5.3 and SciPy 1.18.1 before compilation.