### PR TITLE
addpatch: haskell-clash-lib 1.8.2-169

### DIFF
--- a/haskell-clash-lib/ghc-9.6.7.patch
+++ b/haskell-clash-lib/ghc-9.6.7.patch
@@ -1,0 +1,158 @@
+--- a/src/Clash/Core/FreeVars.hs
++++ b/src/Clash/Core/FreeVars.hs
+@@ -29,11 +29,15 @@
+   )
+ where
+ 
++#if MIN_VERSION_ghc(9,8,4) || (MIN_VERSION_ghc(9,6,7) && !MIN_VERSION_ghc(9,8,0))
++#define UNIQUE_IS_WORD64
++#endif
++
+ import qualified Control.Lens           as Lens
+ import Control.Lens.Fold                (Fold)
+ import Control.Lens.Getter              (Contravariant)
+ import Data.Coerce
+-#if MIN_VERSION_ghc(9,8,4)
++#ifdef UNIQUE_IS_WORD64
+ import qualified GHC.Data.Word64Set     as IntSet
+ #else
+ import qualified Data.IntSet            as IntSet
+@@ -86,7 +90,7 @@
+   :: (Contravariant f, Applicative f)
+   => (forall b . Var b -> Bool)
+   -- ^ Predicate telling whether a variable is interesting
+-#if MIN_VERSION_ghc(9,8,4)
++#ifdef UNIQUE_IS_WORD64
+   -> IntSet.Word64Set
+ #else
+   -> IntSet.IntSet
+--- a/src/Clash/Core/VarEnv.hs
++++ b/src/Clash/Core/VarEnv.hs
+@@ -97,13 +97,17 @@
+   )
+ where
+ 
++#if MIN_VERSION_ghc(9,8,4) || (MIN_VERSION_ghc(9,6,7) && !MIN_VERSION_ghc(9,8,0))
++#define UNIQUE_IS_WORD64
++#endif
++
+ import           Control.DeepSeq           (NFData)
+ import           Data.Binary               (Binary)
+ import           Data.Coerce               (coerce)
+ import qualified Data.List                 as List
+ import qualified Data.List.Extra           as List
+ import           Data.Maybe                (fromMaybe)
+-#if MIN_VERSION_ghc(9,8,4)
++#ifdef UNIQUE_IS_WORD64
+ import           Data.Word                 (Word64)
+ #endif
+ 
+@@ -389,7 +393,7 @@
+ -- * InScopeSet
+ 
+ type Seed
+-#if MIN_VERSION_ghc(9,8,4)
++#ifdef UNIQUE_IS_WORD64
+   = Word64
+ #else
+   = Int
+--- a/src/Clash/Data/UniqMap.hs
++++ b/src/Clash/Data/UniqMap.hs
+@@ -39,13 +39,17 @@
+   , elems
+   ) where
+ 
++#if MIN_VERSION_ghc(9,8,4) || (MIN_VERSION_ghc(9,6,7) && !MIN_VERSION_ghc(9,8,0))
++#define UNIQUE_IS_WORD64
++#endif
++
+ import           Prelude hiding (elem, filter, lookup, notElem, null)
+ 
+ import           Control.DeepSeq (NFData)
+ import           Data.Binary (Binary (..))
+ import           Data.Bifunctor (first)
+ import           Data.Function (on)
+-#if MIN_VERSION_ghc(9,8,4)
++#ifdef UNIQUE_IS_WORD64
+ import           GHC.Data.Word64Map.Strict (Word64Map)
+ import qualified GHC.Data.Word64Map.Strict as IntMap
+ #else
+@@ -71,7 +75,7 @@
+ -- uniqueable and provide their own key, however a unique can be associated
+ -- with any value.
+ newtype UniqMap a
+-#if MIN_VERSION_ghc(9,8,4)
++#ifdef UNIQUE_IS_WORD64
+   = UniqMap { uniqMapToIntMap :: Word64Map a }
+ #else
+   = UniqMap { uniqMapToIntMap :: IntMap a }
+@@ -85,7 +89,7 @@
+     , Semigroup
+     , Show
+     )
+-#if MIN_VERSION_ghc(9,8,4)
++#ifdef UNIQUE_IS_WORD64
+ instance Binary a => Binary (UniqMap a) where
+   put (UniqMap m) = put (IntMap.size m) <> mapM_ put (IntMap.toAscList m)
+   get             = fmap (UniqMap . IntMap.fromDistinctAscList) get
+--- a/src/Clash/Unique.hs
++++ b/src/Clash/Unique.hs
+@@ -17,8 +17,13 @@
+   , fromGhcUnique
+   ) where
+ 
++#if MIN_VERSION_ghc(9,8,4) || (MIN_VERSION_ghc(9,6,7) && !MIN_VERSION_ghc(9,8,0))
++#define UNIQUE_IS_WORD64
++#endif
++
+ import Data.Word (Word64)
+-#if MIN_VERSION_ghc(9,8,4)
++
++#ifdef UNIQUE_IS_WORD64
+ import GHC.Word (Word64(W64#))
+ import GHC.Exts (Word64#)
+ #else
+@@ -31,7 +36,7 @@
+ import qualified Unique as GHC
+ #endif
+ 
+-#if MIN_VERSION_ghc(9,8,4)
++#ifdef UNIQUE_IS_WORD64
+ type Unique = Word64
+ type Unique# = Word64#
+ 
+@@ -63,7 +68,7 @@
+   getUnique = id
+   setUnique = flip const
+ 
+-#if !MIN_VERSION_ghc(9,8,4)
++#ifndef UNIQUE_IS_WORD64
+ instance Uniquable Word64 where
+   getUnique = fromIntegral
+   setUnique _ = fromIntegral
+--- a/src/Clash/Util/Graph.hs
++++ b/src/Clash/Util/Graph.hs
+@@ -14,9 +14,13 @@
+   , callGraphBindings
+   ) where
+ 
++#if MIN_VERSION_ghc(9,8,4) || (MIN_VERSION_ghc(9,6,7) && !MIN_VERSION_ghc(9,8,0))
++#define UNIQUE_IS_WORD64
++#endif
++
+ import           Data.Tuple            (swap)
+ import           Data.Foldable         (foldlM)
+-#if MIN_VERSION_ghc(9,8,4)
++#ifdef UNIQUE_IS_WORD64
+ import qualified GHC.Data.Word64Map.Strict as IntMap
+ import qualified GHC.Data.Word64Set        as IntSet
+ #else
+@@ -33,7 +37,7 @@
+ import           Clash.Normalize.Util (callGraph)
+ import           Clash.Unique (Unique)
+ 
+-#if MIN_VERSION_ghc(9,8,4)
++#ifdef UNIQUE_IS_WORD64
+ type IntMap = IntMap.Word64Map
+ type IntSet = IntSet.Word64Set
+ #endif

--- a/haskell-clash-lib/riscv64.patch
+++ b/haskell-clash-lib/riscv64.patch
@@ -1,0 +1,22 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -24,6 +24,12 @@
+ source=("https://hackage.haskell.org/packages/archive/$_hkgname/$pkgver/$_hkgname-$pkgver.tar.gz")
+ sha512sums=('78af3f3058c2bb178dd9da2264aa37dbc59eb9c906823995a3fd5e33a6c4a475a3102c46c14b24088bb2deda16a8af2547c1cb06798aaa304498a14ae1335f0e')
+ 
++prepare() {
++  cd $_hkgname-$pkgver
++  # https://github.com/clash-lang/clash-compiler/commit/66e474300488ce53f7bbeeef78de10ed203f6643
++  patch -Np1 -i "$srcdir/ghc-9.6.7.patch"
++}
++
+ build() {
+   cd $_hkgname-$pkgver
+ 
+@@ -63,3 +69,6 @@
+   install -D -m644 LICENSE -t "$pkgdir"/usr/share/licenses/$pkgname/
+   rm -f "$pkgdir"/usr/share/doc/$pkgname/LICENSE
+ }
++
++source+=(ghc-9.6.7.patch)
++sha512sums+=('df4a7e080f91574b73067e0ef962ad9761ec8cffd5fd836552e32109b67b7424239213aebb11022ba5dc43ea05f62fcab2a05f8c525369b3be99c31a3e3549f8')


### PR DESCRIPTION
Backport GHC 9.6.7 support for Word64 uniques. The existing version checks only cover GHC 9.8.4 and newer, so fromGhcUnique expects Int while GHC.getKey returns Word64. Update the matching unique maps and sets along with the Unique type.

https://github.com/clash-lang/clash-compiler/commit/66e474300488ce53f7bbeeef78de10ed203f6643