### PR TITLE
addpatch: biome 2.5.12-1

### DIFF
--- a/biome/increase-workspace-timeout.patch
+++ b/biome/increase-workspace-timeout.patch
@@ -1,0 +1,11 @@
+--- a/crates/biome_cli/src/service/mod.rs
++++ b/crates/biome_cli/src/service/mod.rs
+@@ -226,7 +226,7 @@
+                         Err(_) => Err(TransportError::ChannelClosed),
+                     }
+                 }
+-                _ = sleep(Duration::from_secs(15)) => {
++                _ = sleep(Duration::from_secs(60)) => {
+                     Err(TransportError::Timeout)
+                 }
+             }

--- a/biome/riscv64.patch
+++ b/biome/riscv64.patch
@@ -1,0 +1,17 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -30,6 +30,7 @@
+ 
+ prepare() {
+ 	_srcenv
++	patch -Np1 -i "$srcdir/increase-workspace-timeout.patch"
+ 	cargo fetch --locked --target host-tuple
+ }
+ 
+@@ -57,3 +58,6 @@
+ 	install -Dm0755 -t "$pkgdir/usr/bin/" "target/release/$pkgname"
+ 	install -Dm0644 -t "$pkgdir/usr/share/licenses/$pkgname/" LICENSE-*
+ }
++
++source+=(increase-workspace-timeout.patch)
++sha256sums+=('bd734ad62d9cfffee67564f2257a564db4fb48e40c8aeb545f48b6487e7fc8a6')


### PR DESCRIPTION
Increase the socket workspace request timeout from 15 to 60 seconds. On the native RISC-V builder, 140 CLI test failures report "the request to the remote workspace timed out" instead of their expected results. Keep test concurrency and assertions unchanged.

The separate include_files_in_symlinked_subdir failure reports no files processed and remains unresolved; this change only addresses timeouts.