### PR TITLE
updpatch: ghc 9.6.7.20250817-1

### DIFF
--- a/ghc/fix-riscv-fcvt-rounding.patch
+++ b/ghc/fix-riscv-fcvt-rounding.patch
@@ -1,0 +1,168 @@
+--- a/compiler/GHC/CmmToAsm/RV64/CodeGen.hs
++++ b/compiler/GHC/CmmToAsm/RV64/CodeGen.hs
+@@ -728,7 +728,7 @@
+               ( \dst ->
+                   code
+                     `appOL` code_x
+-                    `snocOL` annExpr expr (FCVT IntToFloat (OpReg to dst) (OpReg from reg_x)) -- (Signed ConVerT Float)
++                    `snocOL` annExpr expr (FCVT IntToFloat (OpReg to dst) (OpReg from reg_x) Rne) -- (Signed ConVerT Float)
+               )
+         MO_SF_Conv from to ->
+           pure $
+@@ -736,7 +736,7 @@
+               (floatFormat to)
+               ( \dst ->
+                   code
+-                    `snocOL` annExpr expr (FCVT IntToFloat (OpReg to dst) (OpReg from reg)) -- (Signed ConVerT Float)
++                    `snocOL` annExpr expr (FCVT IntToFloat (OpReg to dst) (OpReg from reg) Rne) -- (Signed ConVerT Float)
+               )
+         -- TODO: Can this case happen?
+         MO_FS_Conv from to
+@@ -748,7 +748,7 @@
+                       code
+                         `snocOL`
+                         -- W32 is the smallest width to convert to. Decrease width afterwards.
+-                        annExpr expr (FCVT FloatToInt (OpReg W32 dst) (OpReg from reg))
++                        annExpr expr (FCVT FloatToInt (OpReg W32 dst) (OpReg from reg) Rtz)
+                         `appOL` signExtendAdjustPrecission W32 to dst dst -- (float convert (-> zero) signed)
+                   )
+         MO_FS_Conv from to ->
+@@ -757,7 +757,7 @@
+               (intFormat to)
+               ( \dst ->
+                   code
+-                    `snocOL` annExpr expr (FCVT FloatToInt (OpReg to dst) (OpReg from reg))
++                    `snocOL` annExpr expr (FCVT FloatToInt (OpReg to dst) (OpReg from reg) Rtz)
+                     `appOL` truncateReg from to dst -- (float convert (-> zero) signed)
+               )
+         MO_UU_Conv from to
+@@ -779,7 +779,7 @@
+                     `appOL` truncateReg from to dst
+               )
+         MO_SS_Conv from to -> ss_conv from to reg code
+-        MO_FF_Conv from to -> return $ Any (floatFormat to) (\dst -> code `snocOL` annExpr e (FCVT FloatToFloat (OpReg to dst) (OpReg from reg)))
++        MO_FF_Conv from to -> return $ Any (floatFormat to) (\dst -> code `snocOL` annExpr e (FCVT FloatToFloat (OpReg to dst) (OpReg from reg) Rne))
+         -- Conversions
+         -- TODO: Duplication with MO_UU_Conv
+         MO_XX_Conv from to
+--- a/compiler/GHC/CmmToAsm/RV64/Instr.hs
++++ b/compiler/GHC/CmmToAsm/RV64/Instr.hs
+@@ -105,7 +105,7 @@
+   LDR _ dst src -> usage (regOp src, regOp dst)
+   LDRU _ dst src -> usage (regOp src, regOp dst)
+   FENCE _ _ -> usage ([], [])
+-  FCVT _variant dst src -> usage (regOp src, regOp dst)
++  FCVT _variant dst src _rm -> usage (regOp src, regOp dst)
+   FABS dst src -> usage (regOp src, regOp dst)
+   _ -> panic $ "regUsageOfInstr: " ++ instrCon instr
+   where
+@@ -187,7 +187,7 @@
+   LDR f o1 o2 -> LDR f (patchOp o1) (patchOp o2)
+   LDRU f o1 o2 -> LDRU f (patchOp o1) (patchOp o2)
+   FENCE o1 o2 -> FENCE o1 o2
+-  FCVT variant o1 o2 -> FCVT variant (patchOp o1) (patchOp o2)
++  FCVT variant o1 o2 rm -> FCVT variant (patchOp o1) (patchOp o2) rm
+   FABS o1 o2 -> FABS (patchOp o1) (patchOp o2)
+   _ -> panic $ "patchRegsOfInstr: " ++ instrCon instr
+   where
+@@ -592,7 +592,7 @@
+     -- Memory barrier.
+     FENCE FenceType FenceType
+   | -- | Floating point conversion
+-    FCVT FcvtVariant Operand Operand
++    FCVT FcvtVariant Operand Operand RoundingMode
+   | -- | Floating point ABSolute value
+     FABS Operand Operand
+ 
+@@ -602,6 +602,21 @@
+ -- | Variant of a floating point conversion instruction
+ data FcvtVariant = FloatToFloat | IntToFloat | FloatToInt
+ 
++-- | The rounding mode associated with an instruction
++data RoundingMode
++  = -- | Round to nearest, ties to even
++    Rne
++  | -- | Round toward zero
++    Rtz
++  | -- | Round downward (toward negative infinity)
++    Rdn
++  | -- | Round upward (toward positive infinity)
++    Rup
++  | -- | Round to nearest, ties to max magnitude
++    Rmm
++  | -- | Dynamic rounding mode
++    Dyn
++
+ instrCon :: Instr -> String
+ instrCon i =
+   case i of
+--- a/compiler/GHC/CmmToAsm/RV64/Ppr.hs
++++ b/compiler/GHC/CmmToAsm/RV64/Ppr.hs
+@@ -410,6 +410,17 @@
+       -- no support for widths > W64.
+       | otherwise = pprPanic "Unsupported width in register (max is 64)" (ppr w <+> int i)
+ 
++-- | Pretty print a rounding mode
++--
++-- If the rounding mode is omitted, 'dyn' will be used.
++pprRm :: IsLine doc => RoundingMode -> doc
++pprRm Rne = text "rne"
++pprRm Rtz = text "rtz"
++pprRm Rdn = text "rdn"
++pprRm Rup = text "rup"
++pprRm Rmm = text "rmm"
++pprRm Dyn = text "dyn"
++
+ -- | Single precission `Operand` (floating-point)
+ isSingleOp :: Operand -> Bool
+ isSingleOp (OpReg W32 _) = True
+@@ -647,30 +658,33 @@
+   LDRU FF64 o1 o2@(OpAddr (AddrRegImm _ _)) -> op2 (text "\tfld") o1 o2
+   LDRU f o1 o2 -> pprPanic "Unsupported unsigned load" ((text . show) f <+> pprOp platform o1 <+> pprOp platform o2)
+   FENCE r w -> line $ text "\tfence" <+> pprFenceType r <> char ',' <+> pprFenceType w
+-  FCVT FloatToFloat o1@(OpReg W32 _) o2@(OpReg W64 _) -> op2 (text "\tfcvt.s.d") o1 o2
+-  FCVT FloatToFloat o1@(OpReg W64 _) o2@(OpReg W32 _) -> op2 (text "\tfcvt.d.s") o1 o2
+-  FCVT FloatToFloat o1 o2 ->
++  FCVT FloatToFloat o1@(OpReg W32 _) o2@(OpReg W64 _) rm -> op2rm (text "\tfcvt.s.d") o1 o2 rm
++  -- The assembler seems to be unhappy with explicit rounding mode on fcvt.d.s
++  FCVT FloatToFloat o1@(OpReg W64 _) o2@(OpReg W32 _) _rm -> op2 (text "\tfcvt.d.s") o1 o2
++  FCVT FloatToFloat o1 o2 rm ->
+     pprPanic "RV64.pprInstr - impossible float to float conversion"
+-      $ line (pprOp platform o1 <> text "->" <> pprOp platform o2)
+-  FCVT IntToFloat o1@(OpReg W32 _) o2@(OpReg W32 _) -> op2 (text "\tfcvt.s.w") o1 o2
+-  FCVT IntToFloat o1@(OpReg W32 _) o2@(OpReg W64 _) -> op2 (text "\tfcvt.s.l") o1 o2
+-  FCVT IntToFloat o1@(OpReg W64 _) o2@(OpReg W32 _) -> op2 (text "\tfcvt.d.w") o1 o2
+-  FCVT IntToFloat o1@(OpReg W64 _) o2@(OpReg W64 _) -> op2 (text "\tfcvt.d.l") o1 o2
+-  FCVT IntToFloat o1 o2 ->
++      $ line (pprOp platform o1 <> text "->" <> pprOp platform o2 <> text "," <> pprRm rm)
++  FCVT IntToFloat o1@(OpReg W32 _) o2@(OpReg W32 _) rm -> op2rm (text "\tfcvt.s.w") o1 o2 rm
++  FCVT IntToFloat o1@(OpReg W32 _) o2@(OpReg W64 _) rm -> op2rm (text "\tfcvt.s.l") o1 o2 rm
++  FCVT IntToFloat o1@(OpReg W64 _) o2@(OpReg W32 _) rm -> op2rm (text "\tfcvt.d.w") o1 o2 rm
++  FCVT IntToFloat o1@(OpReg W64 _) o2@(OpReg W64 _) rm -> op2rm (text "\tfcvt.d.l") o1 o2 rm
++  FCVT IntToFloat o1 o2 rm ->
+     pprPanic "RV64.pprInstr - impossible integer to float conversion"
+-      $ line (pprOp platform o1 <> text "->" <> pprOp platform o2)
+-  FCVT FloatToInt o1@(OpReg W32 _) o2@(OpReg W32 _) -> op2 (text "\tfcvt.w.s") o1 o2
+-  FCVT FloatToInt o1@(OpReg W32 _) o2@(OpReg W64 _) -> op2 (text "\tfcvt.w.d") o1 o2
+-  FCVT FloatToInt o1@(OpReg W64 _) o2@(OpReg W32 _) -> op2 (text "\tfcvt.l.s") o1 o2
+-  FCVT FloatToInt o1@(OpReg W64 _) o2@(OpReg W64 _) -> op2 (text "\tfcvt.l.d") o1 o2
+-  FCVT FloatToInt o1 o2 ->
++      $ line (pprOp platform o1 <> text "->" <> pprOp platform o2 <> text "," <> pprRm rm)
++  FCVT FloatToInt o1@(OpReg W32 _) o2@(OpReg W32 _) rm -> op2rm (text "\tfcvt.w.s") o1 o2 rm
++  FCVT FloatToInt o1@(OpReg W32 _) o2@(OpReg W64 _) rm -> op2rm (text "\tfcvt.w.d") o1 o2 rm
++  FCVT FloatToInt o1@(OpReg W64 _) o2@(OpReg W32 _) rm -> op2rm (text "\tfcvt.l.s") o1 o2 rm
++  FCVT FloatToInt o1@(OpReg W64 _) o2@(OpReg W64 _) rm -> op2rm (text "\tfcvt.l.d") o1 o2 rm
++  FCVT FloatToInt o1 o2 rm ->
+     pprPanic "RV64.pprInstr - impossible float to integer conversion"
+-      $ line (pprOp platform o1 <> text "->" <> pprOp platform o2)
++      $ line (pprOp platform o1 <> text "->" <> pprOp platform o2 <> text "," <> pprRm rm)
+   FABS o1 o2 | isSingleOp o2 -> op2 (text "\tfabs.s") o1 o2
+   FABS o1 o2 | isDoubleOp o2 -> op2 (text "\tfabs.d") o1 o2
+   instr -> panic $ "RV64.pprInstr - Unknown instruction: " ++ instrCon instr
+   where
+     op2 op o1 o2 = line $ op <+> pprOp platform o1 <> comma <+> pprOp platform o2
++    op2rm op o1 o2 Dyn = line $ op <+> pprOp platform o1 <> comma <+> pprOp platform o2
++    op2rm op o1 o2 rm = line $ op <+> pprOp platform o1 <> comma <+> pprOp platform o2 <> comma <+> pprRm rm
+     op3 op o1 o2 o3 = line $ op <+> pprOp platform o1 <> comma <+> pprOp platform o2 <> comma <+> pprOp platform o3
+     pprFenceType FenceRead = text "r"
+     pprFenceType FenceWrite = text "w"

--- a/ghc/riscv64-truncate-immediate.patch
+++ b/ghc/riscv64-truncate-immediate.patch
@@ -1,0 +1,22 @@
+--- a/compiler/GHC/CmmToAsm/RV64/CodeGen.hs
++++ b/compiler/GHC/CmmToAsm/RV64/CodeGen.hs
+@@ -849,13 +849,17 @@
+     -- 1. Compute Reg +/- n directly.
+     --    For Add/Sub we can directly encode 12bits, or 12bits lsl #12.
+     CmmMachOp (MO_Add w) [CmmReg reg, CmmLit (CmmInt n _)]
+-      | fitsIn12bitImm n -> return $ Any (intFormat w) (\d -> unitOL $ annExpr expr (ADD (OpReg w d) (OpReg w' r') (OpImm (ImmInteger n))))
++      | fitsIn12bitImm n -> return $ Any (intFormat w) $ \d ->
++          unitOL (annExpr expr (ADD (OpReg w d) (OpReg w' r') (OpImm (ImmInteger n))))
++            `appOL` truncateReg w w d
+       where
+         -- TODO: 12bits lsl #12; e.g. lower 12 bits of n are 0; shift n >> 12, and set lsl to #12.
+         w' = formatToWidth (cmmTypeFormat (cmmRegType plat reg))
+         r' = getRegisterReg plat reg
+     CmmMachOp (MO_Sub w) [CmmReg reg, CmmLit (CmmInt n _)]
+-      | fitsIn12bitImm n -> return $ Any (intFormat w) (\d -> unitOL $ annExpr expr (SUB (OpReg w d) (OpReg w' r') (OpImm (ImmInteger n))))
++      | fitsIn12bitImm n -> return $ Any (intFormat w) $ \d ->
++          unitOL (annExpr expr (SUB (OpReg w d) (OpReg w' r') (OpImm (ImmInteger n))))
++            `appOL` truncateReg w w d
+       where
+         -- TODO: 12bits lsl #12; e.g. lower 12 bits of n are 0; shift n >> 12, and set lsl to #12.
+         w' = formatToWidth (cmmTypeFormat (cmmRegType plat reg))

--- a/ghc/riscv64.patch
+++ b/ghc/riscv64.patch
@@ -1,8 +1,6 @@
-diff --git PKGBUILD PKGBUILD
-index 69700b6..5c25d7d 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -11,7 +11,7 @@ shopt -s extglob
+@@ -11,7 +11,7 @@
  
  pkgbase=ghc
  pkgname=(ghc-libs ghc ghc-static)
@@ -11,7 +9,7 @@ index 69700b6..5c25d7d 100644
  pkgrel=1
  pkgdesc='The Glasgow Haskell Compiler'
  arch=('x86_64')
-@@ -19,20 +19,27 @@ url='https://www.haskell.org/ghc/'
+@@ -19,20 +19,34 @@
  license=('custom')
  makedepends=('ghc-static' 'perl' 'libxslt' 'docbook-xsl' 'python-sphinx' 'haskell-hadrian'
               'haskell-hscolour' 'texlive-fontsrecommended' 'texlive-latexextra' 'texlive-xetex'
@@ -22,10 +20,11 @@ index 69700b6..5c25d7d 100644
          "$pkgname-gcc-15.patch::https://gitlab.haskell.org/ghc/ghc/-/commit/f983a00ffc97b779eb52b10e69e254ec107f8311.patch"
 -        ghc-rebuild-doc-index.hook ghc-register.hook ghc-unregister.hook)
 -sha512sums=('532bbf5ab44fd4a42abc7904d86ada4803ecbc3cbb499d907520610466b6c2a0c95e07167e8a10c12f3871f3d1d9e54221469ee7a75c3fae1c49b1b281b857ef'
+-            '577f8772652a371e51c185c2d1456584b5ca716df18bc99fa6a8db348c3e0ccd47510792bca5903750d0e40dbbc6cd9b75cffa1fac1434ab2f2d80784b86cb4a'
 +        ghc-rebuild-doc-index.hook ghc-register.hook ghc-unregister.hook
 +        0001-rts-posix-OSMem-Shrinking-allocation-size-when-it-s-.patch)
 +sha512sums=('SKIP'
-             '577f8772652a371e51c185c2d1456584b5ca716df18bc99fa6a8db348c3e0ccd47510792bca5903750d0e40dbbc6cd9b75cffa1fac1434ab2f2d80784b86cb4a'
++            '1c0d31bde8cf4f7e2deba38a59743b37d18382f8ca2bee37302b491a2e0c36877e0f09eb10ab4a191ad756f150f87114074f32f9e2f99efe100b2bf8bfa8d1b1'
              'd69e5222d1169c4224a2b69a13e57fdd574cb1b5932b15f4bc6c7d269a9658dd87acb1be81f52fbcf3cb64f96978b9943d10cee2c21bff0565aaa93a5d35fcae'
              '5f659651d8e562a4dcaae0f821d272d6e9c648b645b1d6ab1af61e4dd690dc5a4b9c6846753b7f935963f001bb1ae1f40cd77731b71ef5a8dbc079a360aa3f8f'
 -            '3bdbd05c4a2c4fce4adf6802ff99b1088bdfad63da9ebfc470af9e271c3dd796f86fba1cf319d8f4078054d85c6d9e6a01f79994559f24cc77ee1a25724af2e6')
@@ -42,10 +41,17 @@ index 69700b6..5c25d7d 100644
  
    patch -p1 -i ../$pkgname-gcc-15.patch
 +  patch -p1 -i ../0001-rts-posix-OSMem-Shrinking-allocation-size-when-it-s-.patch
++
++  # RISC-V float-to-integer conversions must truncate toward zero.
++  # https://github.com/ghc/ghc/commit/e8a547133031b7de8f6f9bbd70a7148eda0941ee
++  patch -p1 -i ../fix-riscv-fcvt-rounding.patch
++
++  # Keep narrow immediate arithmetic wrapped to its declared width.
++  patch -p1 -i ../riscv64-truncate-immediate.patch
  
    # devendor rtd-theme for sphinx compatibility
    rm -r docs/users_guide/rtd-theme
-@@ -43,8 +50,9 @@ prepare() {
+@@ -43,8 +57,9 @@
  }
  
  build() {
@@ -56,7 +62,7 @@ index 69700b6..5c25d7d 100644
    LDFLAGS="${LDFLAGS/-Wl,-z,pack-relative-relocs/}" ./configure \
      --prefix=/usr \
      --docdir=/usr/share/doc/ghc \
-@@ -53,7 +61,7 @@ build() {
+@@ -53,7 +68,7 @@
  }
  
  check() {
@@ -65,7 +71,7 @@ index 69700b6..5c25d7d 100644
    # hadrian test --flavour=perf
  }
  
-@@ -61,7 +69,7 @@ package_ghc-static() {
+@@ -61,7 +76,7 @@
    pkgdesc='The Glasgow Haskell Compiler - Static Libraries and Documentation'
    depends=('ghc')
  
@@ -74,7 +80,7 @@ index 69700b6..5c25d7d 100644
  
    DESTDIR="$pkgdir" LDFLAGS="${LDFLAGS/-Wl,-z,pack-relative-relocs/}" hadrian install --flavour=perf --prefix=/usr
  
-@@ -92,7 +100,7 @@ package_ghc() {
+@@ -92,7 +107,7 @@
    provides+=("haskell-ghc=$pkgver")
    replaces+=("haskell-ghc")
  
@@ -83,7 +89,7 @@ index 69700b6..5c25d7d 100644
    DESTDIR="$pkgdir" LDFLAGS="${LDFLAGS/-Wl,-z,pack-relative-relocs/}" hadrian install --flavour=perf --prefix=/usr
  
    # Remove static libs
-@@ -187,7 +195,7 @@ package_ghc-libs() {
+@@ -187,7 +202,7 @@
    provides+=("haskell-ghci=$pkgver")
    conflicts+=('haskell-ghci')
  
@@ -92,3 +98,12 @@ index 69700b6..5c25d7d 100644
  
    DESTDIR="$pkgdir" LDFLAGS="${LDFLAGS/-Wl,-z,pack-relative-relocs/}" hadrian install --flavour=perf --prefix=/usr
  
+@@ -211,3 +226,8 @@
+ 
+   install -Dm644 LICENSE "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
+ }
++
++source+=(fix-riscv-fcvt-rounding.patch
++         riscv64-truncate-immediate.patch)
++sha512sums+=('cc2e35531f92c8a314978f2e6d633bb0c3b32b3043b19e6ee3dd2ad4d1bbfedb9925e5a5d607537922cbfbae90e6b0c1f9c84ea2d8e6f042e31ebc833770cf6d'
++             '29ca0991ebf0908f37e56ec6604628899463b60e2950cee6a1f4422898e5d5199b68925c04512914c851eae5f9ea85cf954dd0964f36acc79edffb00794b2052')


### PR DESCRIPTION
Backport the upstream RISC-V NCG floating-point conversion rounding fix to ewe/ghc-9.6. Emit rtz for float-to-integer conversions and rne for other conversions where rounding applies, instead of using the dynamic rounding mode.

Without this, arithmoi's double2Int# (7 / log 7) produces 4 instead of 3, skipping prime 7 in its lookup table. This causes 16 prime-enumeration property failures in haskell-arithmoi 0.13.4.0-11 across Int, Word, Integer and Natural.

The nine quantile failures in haskell-statistics 0.16.5.0-9 have the same cause: properFraction (3.5 :: Double) :: (Int, Double) returns (4, -0.5) instead of (3, 0.5), giving a median of 6.75 instead of 5.0.

Its probability generator also uses properFraction. Nearest rounding limits its fractional part to [-0.5, 0.5], consistent with the normal and transformed-normal CDF inverse tests giving up after 1000 discards.

https://github.com/ghc/ghc/commit/e8a547133031b7de8f6f9bbd70a7148eda0941ee

Truncate narrow results after immediate addition and subtraction in the RISC-V native code generator, matching the general arithmetic path. Without truncation, Word32 0xffffffff + 1 remains 0x100000000 and the carry check fails.

This fixes haskell-data-dword's enumFromTo (-1) 0 and unwrappedMul 0 (-1) test failures for its Int32/Word32 composite type.

Refresh the GCC 15 patch checksum after GitLab shortened the blob IDs in its index line from 12 to 11 characters. The code changes are identical, but the old checksum prevents source verification.