### PR TITLE
addpatch: grpc 1.83.1-2

### DIFF
--- a/grpc/riscv64.patch
+++ b/grpc/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -80,6 +80,8 @@
+ 
+   cd "$srcdir/$pkgbase-$pkgver"
+   cmake -Bbuild \
++    -DCMAKE_JOB_POOLS=link=2 \
++    -DCMAKE_JOB_POOL_LINK=link \
+     -DCMAKE_BUILD_TYPE=None \
+     -DCMAKE_CXX_FLAGS="${CXXFLAGS} -DNDEBUG -trigraphs -Wno-attributes -Wno-deprecated-declarations -Wno-return-type -Wno-non-virtual-dtor" \
+     -DgRPC_INSTALL=ON \


### PR DESCRIPTION
Limit Ninja to two concurrent links to reduce load and memory pressure from overlapping LTO worker pools. Concurrent links on shinx cause lto1 processes to be killed.