### PR TITLE
addpatch: migraphx 7.2.3-7

### DIFF
--- a/migraphx/riscv64.patch
+++ b/migraphx/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -79,6 +79,8 @@
+     -D BUILD_TESTING=OFF \
+     -D CMAKE_PREFIX_PATH="${srcdir}"/deps/usr/lib/cmake
+     -D GPU_TARGETS="$(rocm-supported-gfx)"
++    # Compile embedded headers with the target ABI instead of using ld -r.
++    -D EMBED_USE=CArrays
+     -D MIGRAPHX_ENABLE_PYTHON=OFF
+     -D MIGRAPHX_USE_COMPOSABLEKERNEL=OFF
+     -D MIGRAPHX_USE_HIPBLASLT=OFF


### PR DESCRIPTION
Use EMBED_USE=CArrays to compile embedded kernel headers with the target ABI. The default ld -r --format=binary path produces objects without the lp64d floating-point ABI flags, so lld rejects them when linking libmigraphx_gpu against the system startup objects.

The existing CArrays mode retains the embedded data while using the normal compiler flags.