### PR TITLE
addpatch: orca 50.2-1

### DIFF
--- a/orca/riscv64.patch
+++ b/orca/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -72,7 +72,7 @@
+ 
+ check() {
+   dbus-run-session xvfb-run -s '-nolisten local' \
+-    meson test -C build --print-errorlogs
++    meson test -C build --print-errorlogs --timeout-multiplier 3
+ }
+ 
+ package() {


### PR DESCRIPTION
Triple Meson's test timeouts so unit-test files have 90 seconds instead of 30. Ten files time out while their individual tests are still passing on the RISC-V builder. Keep all tests and assertions enabled.