### PR TITLE
updpatch: materialx 1.39.5-1

### DIFF
--- a/materialx/riscv64.patch
+++ b/materialx/riscv64.patch
@@ -1,25 +1,6 @@
---- PKGBUILD	2026-05-02 14:57:41.077295986 +0800
-+++ PKGBUILD	2026-05-02 14:57:41.107217738 +0800
-@@ -18,14 +18,16 @@
-         "${pkgname}-nanogui::git+https://github.com/mitsuba-renderer/nanogui"
-         "materialx-grapheditor.desktop"
-         "materialx-view.desktop"
--        "materialx.xml")
-+        "materialx.xml"
-+        "nanogui-do-not-fallback-to-nehalem.patch::https://github.com/mitsuba-renderer/nanogui/pull/156.diff")
- sha256sums=('a3200358c13f8ce332cb46136a1ec67b2bbf7f22ab6b0e57466c3ab863baaa05'
-             'SKIP'
-             'SKIP'
-             'SKIP'
-             '88e5ecafa8088b90f799b49c36af59f8462ca7426cdec58215332ee283556ddb'
-             '2f2b675540fea39a749f89083a9c341319c1f7b478fbb049a77bd66c29b2ee01'
--            'db3315226919914b85370a5793fa7e57f524ee939f9e7c3dd60a260f0f541867')
-+            'db3315226919914b85370a5793fa7e57f524ee939f9e7c3dd60a260f0f541867'
-+            'fe60c485ddc71df9be0bd79ddda8bdd127d1ff8beec7b6fc2ffc4e1dcc0bbb70')
- 
- _pyver=$(python -c 'import sys; print(".".join(map(str, sys.version_info[:2])))')
- 
-@@ -49,6 +51,7 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -49,6 +49,7 @@
    sed -i 's|"libraries"|"/usr/share/materialx/libraries"|g' source/MaterialXGenShader/GenOptions.h
  
    dos2unix python/Scripts/*
@@ -27,3 +8,10 @@
  }
  
  build() {
+@@ -104,3 +105,6 @@
+   # Remove empty dirs
+   find ${pkgdir}/usr -empty -type d -delete
+ }
++
++source+=("nanogui-do-not-fallback-to-nehalem.patch::https://github.com/mitsuba-renderer/nanogui/pull/156.diff")
++sha256sums+=('fe60c485ddc71df9be0bd79ddda8bdd127d1ff8beec7b6fc2ffc4e1dcc0bbb70')


### PR DESCRIPTION
Refresh patch. Append the NanoGUI patch source and checksum at EOF to avoid version-specific source checksum context.