### PR TITLE
addpatch: python-opentelemetry-exporter-otlp-proto-grpc 1.44.0-1

### DIFF
--- a/python-opentelemetry-exporter-otlp-proto-grpc/retry-info-timing.patch
+++ b/python-opentelemetry-exporter-otlp-proto-grpc/retry-info-timing.patch
@@ -1,0 +1,14 @@
+--- a/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_exporter_mixin.py
++++ b/exporter/opentelemetry-exporter-otlp-proto-grpc/tests/test_otlp_exporter_mixin.py
+@@ -504,8 +504,9 @@
+         )
+         after = time.time()
+         self.assertEqual(mock_trace_service.num_requests, 6)
+-        # 1 second plus wiggle room so the test passes consistently.
+-        self.assertAlmostEqual(after - before, 1, 1)
++        # Five 200 ms waits, plus time for gRPC on slower builders.
++        self.assertGreaterEqual(after - before, 1)
++        self.assertLess(after - before, 2)
+ 
+         metrics_data = self.metric_reader.get_metrics_data()
+         scope_metrics = metrics_data.resource_metrics[0].scope_metrics[0]

--- a/python-opentelemetry-exporter-otlp-proto-grpc/riscv64.patch
+++ b/python-opentelemetry-exporter-otlp-proto-grpc/riscv64.patch
@@ -1,0 +1,21 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -30,6 +30,11 @@
+ source=("git+https://github.com/open-telemetry/opentelemetry-python.git#tag=v${pkgver}")
+ sha256sums=('de185f6c14474a3bee91ea09e14bbc41efef7fb9724c0bf98b7600cfdaee7529')
+ 
++prepare() {
++  cd opentelemetry-python
++  patch -Np1 -i "$srcdir/retry-info-timing.patch"
++}
++
+ build() {
+   cd opentelemetry-python/exporter/opentelemetry-exporter-otlp-proto-grpc
+   python -m build --wheel --no-isolation
+@@ -46,3 +51,6 @@
+   cd opentelemetry-python/exporter/opentelemetry-exporter-otlp-proto-grpc
+   python -m installer --destdir="$pkgdir" dist/*.whl
+ }
++
++source+=(retry-info-timing.patch)
++sha256sums+=('166326c6e24de3c71e1a8d47cd94886a56c146ed027c8735429398d5e6952205')


### PR DESCRIPTION
Allow up to two seconds for the retry-info timing test, which takes 1.11 seconds on the RISC-V builder and exceeds its roughly 50 ms margin. Keep the one-second minimum for five 200 ms waits, the six-request assertion and the metric checks.