### PR TITLE
addpatch: curl 8.22.0-1

### DIFF
--- a/curl/riscv64-fixes.patch
+++ b/curl/riscv64-fixes.patch
@@ -1,0 +1,90 @@
+--- a/lib/thrdpool.c
++++ b/lib/thrdpool.c
+@@ -255,6 +255,8 @@
+     struct thrdslot *tslot = Curl_node_elem(e);
+     n = Curl_node_next(e);
+     if(tslot->idle) {
++      /* A pending wakeup is not idle, even before the worker runs. */
++      tslot->idle = FALSE;
+       Curl_cond_signal(&tslot->await);
+       --nthreads;
+     }
+--- a/lib/urlapi.c
++++ b/lib/urlapi.c
+@@ -1194,7 +1194,7 @@
+                                             CURLU_DEFAULT_SCHEME));
+ 
+   /* handle the file: scheme */
+-  if(schemelen && !strcmp(schemebuf, "file")) {
++  if((schemelen == 4) && !memcmp(schemebuf, "file", 4)) {
+     is_file = TRUE;
+     ures = parse_file(url, urllen, u, &path, &pathlen);
+   }
+--- a/tests/libtest/lib677.c
++++ b/tests/libtest/lib677.c
+@@ -46,7 +46,7 @@
+   if(curl_multi_add_handle(mcurl, curl))
+     goto test_cleanup;
+ 
+-  while(time(NULL) - start < 5) {
++  while(time(NULL) - start < 30) {
+     struct curl_waitfd waitfd;
+ 
+     multi_perform(mcurl, &mrun);
+--- a/tests/testutil.pm
++++ b/tests/testutil.pm
+@@ -160,13 +160,11 @@
+ 
+     # days
+     while($$thing =~ s/%days\[(.*?)\]/%%DAYS%%/i) {
+-        # convert to now + given days in epoch seconds, align to a 60 second
+-        # boundary. Then provide two alternatives.
+-        my $now = time();
+-        my $d = ($1 * 24 * 3600) + $now + 30;
+-        $d = int($d / 60) * 60;
+-        my $d2 = $d + 60;
+-        $$thing =~ s/%%DAYS%%/%alternatives[$d,$d2]/;
++        # Record the earliest minute-rounded expiry. The upper bound is
++        # calculated during verification to allow for slow test startup.
++        my $days = $1;
++        my $d = int((time() + $days * 24 * 3600 + 30) / 60) * 60;
++        $$thing =~ s/%%DAYS%%/%expires[$days,$d]/;
+     }
+ 
+     # include a file
+--- a/tests/getpart.pm
++++ b/tests/getpart.pm
+@@ -378,6 +378,21 @@
+         return 1;
+     }
+ 
++    if($second =~ /%expires\[(\d+),(\d+)\]/) {
++        my ($days, $earliest) = ($1, $2);
++        my $prefix = substr($second, 0, $-[0]);
++        return 1 unless $first =~ /\A\Q$prefix\E(\d+)/;
++        my $expires = $1;
++        my $latest = int((time() + $days * 24 * 3600 + 30) / 60) * 60;
++        return 1 if(($expires % 60) || ($expires < $earliest) ||
++                    ($expires > $latest));
++
++        my $alt = $second;
++        $alt =~ s/%expires\[\d+,\d+\]/$expires/;
++        my @expected = ($alt);
++        return compareparts($firstref, \@expected);
++    }
++
+     if($first ne $second) {
+         return 1;
+     }
+--- a/docs/tests/FILEFORMAT.md
++++ b/docs/tests/FILEFORMAT.md
+@@ -100,7 +100,8 @@
+ Mostly to test capped cookie expire dates: `%days[NUM]` inserts the number of
+ seconds for the given number of days into the future, aligned to the nearest
+ minute. That is the same calculation the cookie engine uses to cap expiration
+-dates.
++dates. Comparisons allow timestamps between test preprocessing and result
++verification, so slow startup does not make the expected expiry stale.
+ 
+ ## Include file
+ 

--- a/curl/riscv64.patch
+++ b/curl/riscv64.patch
@@ -1,0 +1,18 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -64,6 +64,8 @@
+     -e "/\WLIBCURL_TIMESTAMP\W/c #define LIBCURL_TIMESTAMP \"$(git log -1 --format=%cs "curl-${pkgver//./_}")\"" \
+     include/curl/curlver.h
+ 
++  patch -Np1 -i "$srcdir/riscv64-fixes.patch"
++
+   autoreconf -fi
+ }
+ 
+@@ -228,3 +230,6 @@
+   install -dm 0755 "${pkgdir}"/usr/share/licenses
+   ln -s curl "${pkgdir}"/usr/share/licenses/libcurl-gnutls
+ }
++
++source+=(riscv64-fixes.patch)
++sha512sums+=('b032bb272d91675e47a00be72510e210241b17c083a7f7dbdf67682254d4c0bb3ffeb767a10e9dab69d1bfbc35a77d335a957f4e160cde706ee51b6332acc8af')


### PR DESCRIPTION
Mark signalled thread-pool workers busy before they wake so the idle wait cannot return while queued work remains, as seen in test 3301.

Check the scheme length before comparing four bytes with "file" to avoid the short-string comparison flagged by Valgrind in test 1560.

Allow 30 seconds for IMAP test 677, which exhausts its five-second budget under Valgrind before sending the expected commands.

Check capped cookie expiry against the interval from test preparation to verification. Tests 46 and 61 otherwise reject correct timestamps when startup exceeds their one-minute allowance. Keep the 400-day lifetime and minute-alignment checks.