### PR TITLE
updpatch: pnpm 11.26.0-1

### DIFF
--- a/pnpm/riscv64.patch
+++ b/pnpm/riscv64.patch
@@ -1,16 +1,18 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -21,7 +21,12 @@
+@@ -38,7 +38,14 @@
+   fi
  
- prepare() {
-   cd $pkgname/$pkgname
+   cd $pkgname/${pkgname}11/$pkgname
 -  pnpm install --frozen-lockfile
 +  rm -r artifacts
 +
-+  # Upstream Node.js and tsgo binaries are unavailable for riscv64.
-+  sed -i '/"runtime": {/,/^    }/s/"download"/"ignore"/' ../package.json
++  # Use installed pnpm and Node.js; upstream native binaries lack riscv64.
++  sed -i -e '/^  "packageManager":/d' \
++    -e '/^    "packageManager": {/,/^    },/d' \
++    -e '/"runtime": {/,/^    }/s/"download"/"ignore"/' ../../package.json
 +  sed -i 's/tsgo --build/tsc --build/; s/pnx node@runtime:24.6.0/node/' package.json
 +  pnpm install --no-frozen-lockfile
+ 
  }
  
- build() {


### PR DESCRIPTION
Refresh the patch for the pnpm11/pnpm source layout and updated prepare(). The previous hunk fails before the build starts, and the runtime declaration now lives two directories above the CLI package.

Remove both package-manager pins from the root manifest so installation uses the installed pnpm instead of downloading pnpm 12.3.4, whose native binaries do not include riscv64.

Retain system Node.js, the workspace TypeScript compiler, artifact removal and lockfile updates while preserving dependency patches.