### PR TITLE
addpatch: openbao-plugin-secrets-aws 0.3.1-1

### DIFF
--- a/openbao-plugin-secrets-aws/riscv64.patch
+++ b/openbao-plugin-secrets-aws/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -28,7 +28,6 @@
+ build() {
+   cd "${pkgname}"
+ 
+-  export CGO_ENABLED=0
+   export GOPATH="${srcdir}"
+ 
+   go build \


### PR DESCRIPTION
Remove CGO_ENABLED=0 so native riscv64 builds use the default cgo setting. PIE requires external linking on riscv64, and forcing cgo off aborts the build.