### PR TITLE
addpatch: opensearch-dashboards 3.8.0-1

### DIFF
--- a/opensearch-dashboards/riscv64.patch
+++ b/opensearch-dashboards/riscv64.patch
@@ -1,0 +1,37 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -61,8 +61,26 @@
+ build() {
+   cd "OpenSearch-Dashboards"
+ 
+-  yarn osd bootstrap
+-  yarn build --skip-os-packages
++  # ChromeDriver is only needed for browser tests; no riscv64 binary is provided.
++  export CHROMEDRIVER_SKIP_DOWNLOAD=true
++
++  # Use LMDB's Node-API path; its bundled V8 headers are incompatible with Node 22.
++  export ENABLE_V8_FUNCTIONS=false
++
++  # Yarn Classic otherwise skips the wasm32 fallback bindings needed on riscv64.
++  echo '--install.ignore-platform true' >> .yarnrc
++
++  # Rspack 2.1 has native riscv64 bindings; its WASM fallback requires SIMD.
++  # Lightning CSS has no native riscv64 binding; use its same-version WASM build.
++  jq '.devDependencies["@rspack/cli", "@rspack/core"] = "2.1.0" |
++      .resolutions["**/lightningcss"] = "npm:lightningcss-wasm@1.32.0"' package.json > package.json.new
++  mv package.json{.new,}
++
++  # Rspack's GCC 11-built mimalloc lacks release ordering; avoid cross-CPU races.
++  # https://github.com/gcc-mirror/gcc/commit/d199d2e56da2379004e7e0457150409c0c99d3e6
++  local cpu=$(awk '/Cpus_allowed_list/ {split($2, cpus, /[-,]/); print cpus[1]}' /proc/self/status)
++  taskset -c "$cpu" yarn osd bootstrap
++  taskset -c "$cpu" yarn build --skip-os-packages
+ 
+   # TODO: How to tell yarn that we don't want to create a SNAPSHOT version?
+   sed -i "s/  \"version\": \"${pkgver}-SNAPSHOT\",/  \"version\": \"${pkgver}\",/" "build/opensearch-dashboards/package.json"
+@@ -101,3 +119,5 @@
+ }
+ 
+ # vim: ts=2 sw=2 et:
++
++makedepends+=(jq)

--- a/qemu-user-blacklist.txt
+++ b/qemu-user-blacklist.txt
@@ -102,6 +102,7 @@ nushell
 odin2-synthesizer
 openh264
 openldap
+opensearch-dashboards
 opensearch-sql-plugin
 osquery
 pangomm-2.48

--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -18,6 +18,7 @@ llama-cpp
 navidrome
 openbao
 opencode
+opensearch-dashboards
 oxyromon
 phpldapadmin
 prettier


### PR DESCRIPTION
Set CHROMEDRIVER_SKIP_DOWNLOAD=true to avoid the bootstrap failure: "No official Chromedriver binary is available for RISC-V 64-bit". ChromeDriver is a development dependency used for browser tests, which the PKGBUILD does not run.

Enable --install.ignore-platform in the project's .yarnrc so Yarn Classic installs the locked WASM fallback bindings. Rspack 2.0.8 has no native riscv64 package, and Yarn skips its fallback because it declares cpu: ["wasm32"], leaving @osd/monaco bootstrap failing with "Cannot find native binding". Keep engine checks enabled.

Update @rspack/core and @rspack/cli to 2.1.0, which ships native riscv64 bindings. With the WASM package installed, 2.0.8 still fails on monferno: "WebAssembly.Module(): Wasm SIMD unsupported @+1235". The loader hides this error behind the native-binding diagnostic. Use the native binding to avoid Rspack's WASM SIMD requirement.

Use jq to update the two dependency versions while preserving Yarn's workspaces object and nohoist rules. npm pkg set rejects that format with EWORKSPACESINVALID: "workspaces should be an array of strings."

Keep the Yarn platform override and Sv39 blacklist for the remaining WASM fallbacks, including Tailwind oxide and @rspack/resolver, which still require a larger address space.

Upstream: https://github.com/web-infra-dev/rspack/pull/14447

Set ENABLE_V8_FUNCTIONS=false for LMDB 2.8.5, which builds from source on riscv64. Its bundled V8 header declares the old three-argument CFunctionInfo constructor, but Node 22 requires a fourth argument. Bootstrap fails loading lmdb.node with:
"undefined symbol: _ZN2v813CFunctionInfoC2ERKNS_9CTypeInfoEjPS2_".

Use LMDB's supported Node-API implementation, as upstream does for its portable prebuilt binaries. This retains database functionality without the incompatible optional V8 acceleration or a dependency version bump.

https://github.com/kriszyp/lmdb-js/blob/189f52bf720f1bda436dc5162e88af4686c6218c/package.json

Add opensearch-dashboards to the QEMU-user blacklist. On magby, LMDB loads but opening the compiler cache fails with "Operation not supported". mdb_env_setup_locks() initializes process-shared robust mutexes; QEMU-user returns ENOSYS for the robust-list syscalls, so glibc returns ENOTSUP from pthread_mutex_init(). Standalone LMDB is already blacklisted for the same failure (a75042c3). Keep robust locking and the existing Sv39 exclusion intact.

Work around the native Rspack SIGSEGV while bootstrapping @osd/ui-shared-deps on abomasnow. Its prebuilt riscv64 binding contains mimalloc compiled with GCC 11.4, which emits LR.aq/SC.aq for acquire- release compare-exchange without the required release ordering. A freed block can become visible to another CPU before its next-pointer is initialized, corrupting mimalloc's cross-thread free list.

GDB stops in that list traversal at binding offset 0x229786a. Restoring release ordering to mimalloc's SC instructions in process memory makes the same bundle complete; an unmodified control run crashes again.

Pin both Yarn build commands and their child threads to the first CPU in the allowed affinity set. The original binary completes the bundle with this restriction, avoiding cross-CPU ordering failures without rebuilding or modifying the binding. This sacrifices build parallelism until the prebuilt binding is rebuilt with a corrected C toolchain.

The WASM binding is not a usable alternative on this builder: explicitly loading 2.1.0 still fails with "Wasm SIMD unsupported @+1373" because Node 22 requires RVV for WASM SIMD, which the P550 lacks.

GCC fix: https://github.com/gcc-mirror/gcc/commit/d199d2e56da2379004e7e0457150409c0c99d3e6

Resolve lightningcss to npm:lightningcss-wasm@1.32.0. Tailwind 4.2.4 requires Lightning CSS 1.32.0, which has no native riscv64 binding. Plugin CSS compilation fails with:
"Cannot find module '../lightningcss.linux-riscv64-gnu.node'".

Use the published WASM build at the same version, following oxyromon's override. Its Node entry point provides the synchronous transform API and Features constants used by Tailwind, without requiring WASM SIMD. Add the Yarn resolution through the existing jq manifest edit.