### PR TITLE
addpatch: pythia8 8.3.17-2

### DIFF
--- a/pythia8/riscv64.patch
+++ b/pythia8/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -27,7 +27,7 @@
+     'root: integrated examples with CERN ROOT data analysis framework'
+ )
+ replaces=(python-pythia8)
+-source=("https://pythia.org/download/pythia${_pkgpre}/${_pkgid}.tgz"
++source=("https://pythia.org/releases/pythia${_pkgpre}/${_pkgid}.tgz"
+         'pythia8.sh'
+         'fix-rpath.patch')
+ b2sums=('93d28e1e7b60a89fa948d3de784f8a251e44fe9ff189770828065e333497adbecaf6cbe76c966383088bc763ad68f6dd762a3be4fcb6cfc6c3d7b28d2a619eaf'


### PR DESCRIPTION
Use the archive's current /releases/ URL instead of /download/, which returns 404. The archive matches the existing BLAKE2 checksum.