### PR TITLE
updpatch: nodejs 26.8.2-1

### DIFF
--- a/nodejs/hwy-broken-rvv.diff
+++ b/nodejs/hwy-broken-rvv.diff
@@ -10,13 +10,3 @@
            ['v8_target_arch=="ppc64" or v8_target_arch=="s390x"', {
              'defines': ['TOOLCHAIN_MISS_ASM_HWCAP_H',],
            }],
-@@ -2482,6 +2485,9 @@
-         ['v8_target_arch=="arm64"', {
-           'defines': ['HWY_BROKEN_TARGETS=HWY_ALL_SVE',],
-         }],
-+        ['v8_target_arch=="riscv64"', {
-+          'defines': ['HWY_BROKEN_TARGETS=HWY_RVV',],
-+        }],
-         ['v8_target_arch=="ppc64" or v8_target_arch=="s390x"', {
-           'defines': ['TOOLCHAIN_MISS_ASM_HWCAP_H',],
-         }],

--- a/nodejs/riscv64.patch
+++ b/nodejs/riscv64.patch
@@ -1,24 +1,21 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -56,6 +56,9 @@
+@@ -56,6 +56,25 @@
    # /usr/lib/libnode.so uses malloc_usable_size, which is incompatible with fortification level 3
    CFLAGS="${CFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
    CXXFLAGS="${CXXFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
 +  # https://github.com/riscv-forks/electron/issues/7
 +  export CC=/usr/bin/clang
 +  export CXX=/usr/bin/clang++
- }
- 
- prepare() {
-@@ -64,6 +67,18 @@
-   # Fix the CCM empty-message test with newer OpenSSL behavior:
-   # https://github.com/nodejs/node/commit/7e2254fc8ba5ac88fe6f35715e7bb6e78597846b
-   git cherry-pick -n 7e2254fc8ba5ac88fe6f35715e7bb6e78597846b
++}
++
++prepare() {
++  cd node
 +
 +  # Fix truncated RISC-V lazy-compilation jumps in large Wasm modules.
 +  patch -Np1 -d deps/v8 -i "$srcdir/v8-wasm-lazy-jump.patch"
 +
-+  # Disable Highway RVV code; Arch RISC-V targets rv64gc, not RVV.
++  # Disable Highway RVV code in dependent targets as well as Highway itself.
 +  patch -Np1 -i ../hwy-broken-rvv.diff
 +
 +  # Fix inverted floating-point branches in V8's RISC-V backend.
@@ -29,7 +26,7 @@
  }
  
  build() {
-@@ -112,6 +127,9 @@
+@@ -104,6 +123,9 @@
    # https://github.com/nodejs/node/issues/63914
    rm test/parallel/test-snapshot-reproducible.js
  
@@ -39,16 +36,15 @@
    make test-only
  }
  
-@@ -122,4 +140,13 @@
+@@ -114,4 +136,12 @@
    install -Dm644 LICENSE -t "$pkgdir"/usr/share/licenses/$pkgname
  }
  
-+
 +makedepends+=(clang)
 +source+=("hwy-broken-rvv.diff"
 +         "v8-wasm-lazy-jump.patch::https://github.com/v8/v8/commit/def38dd3f8726ed595932624ee5d681a3f02ed4a.patch"
 +         "v8-riscv-float-branch.patch")
-+sha512sums+=('b4f21e06bef85f8eba9536e9a110d4aec3d230f9f3e76ee3d98a8cd88086c77f8593427c6379de51e5e7fe668273803f8e9ea8c30ab225010186dcb404c0b164'
++sha512sums+=('55d1bb5c1319846d1dbc616c8bc5c4d0cc9895f3b0f2523fe6038608ab9c82c40f1cad48d5ff2c93851580708dd7e9fb84d22b46688d1a3b0fa94cb7460bd617'
 +            '1743a2759134a32324e0b271fd99a246cfd3540ccf7b1dc3011ab76f0843181366b7b749e52331c5ea41d68949cc5cfd280a3929f90ef68df9f9ffe5d2dcd2f3'
 +            'e7943296c30c8089c5ca5d536373bffca72f73024b8b0294e7bd133bb9af1742e849835d2ab5782ab1b594bb5671095de6be9d6749b8de87e7ec9fa55be599f5')
 +


### PR DESCRIPTION
Refresh the PKGBUILD overlay after Arch removed prepare(). Recreate it for the existing RISC-V backports and WPT concurrency adjustment.

Drop the Highway RVV exclusion already present on the library target, retaining the exclusion for its dependent targets.

https://github.com/nodejs/node/blob/v26.8.2/tools/v8_gypfiles/v8.gyp#L2488