### PR TITLE
addpatch: signstar-request-signature 0.1.3-1

### DIFF
--- a/signstar-request-signature/generator-lockfile.patch
+++ b/signstar-request-signature/generator-lockfile.patch
@@ -1,0 +1,12 @@
+--- a/justfile
++++ b/justfile
+@@ -548,6 +548,9 @@
+ 
+     script="$(mktemp --suffix=.rs)"
+     sed "s/PKG/{{ pkg }}/;s#PATH#$PWD/{{ pkg }}#g;s/KIND/{{ kind }}/g" > "$script" <<< '{{ render-script }}'
++    # Reuse the workspace dependency versions when compiling the generator.
++    script_package="$(rust-script --package "$script")"
++    cp Cargo.lock "$script_package/Cargo.lock"
+     rust-script "$script" "$output_dir/{{ kind }}"
+     rm --force "$script"
+ 

--- a/signstar-request-signature/riscv64.patch
+++ b/signstar-request-signature/riscv64.patch
@@ -1,0 +1,18 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -27,6 +27,7 @@
+ 
+ prepare() {
+   cd $_name
++  patch -Np1 -i "$srcdir/generator-lockfile.patch"
+   export RUSTUP_TOOLCHAIN=stable
+   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+ }
+@@ -57,3 +58,7 @@
+   install -vDm 644 $_name/target/shell_completions/_$pkgname -t "$pkgdir/usr/share/zsh/site-functions/"
+   install -vDm 644 $_name/target/shell_completions/$pkgname.fish -t "$pkgdir/usr/share/fish/vendor_completions.d/"
+ }
++
++source+=(generator-lockfile.patch)
++sha512sums+=('84e781297673a9178539a76b58db96ef00d8a498e6b597558015ff4559430fb7533a8db0bdcbbb8e6945ca7cab0a46492783b00406bc30f5ec4130e7f678797a')
++b2sums+=('3de251109010d5d71dd1fe3eea706f52ccdcbed849a46e33ac4bcf5498884d7415387debdc00c7854e9a76d051ffdb306afc2f3fbbe5d63e3a31b3b87a879c5f')


### PR DESCRIPTION
Seed rust-script's generated Cargo project with the workspace lockfile before building completions and man pages. Its independent dependency resolution otherwise pairs sha2 0.11.0-rc.0 with an incompatible digest, failing on crypto_common and SerializableState after the main build has succeeded with the locked versions.