### PR TITLE
addpatch: vectorchord 1.1.1-2

### DIFF
--- a/vectorchord/riscv64.patch
+++ b/vectorchord/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -34,6 +34,9 @@
+   # use system sqlite
+   export LIBSQLITE3_SYS_USE_PKG_CONFIG=1
+ 
++  # RISC-V CPU feature detection requires unstable Rust features.
++  export RUSTC_BOOTSTRAP=simd
++
+   CFLAGS+=' -ffat-lto-objects' make build
+ }
+ 


### PR DESCRIPTION
Enable RUSTC_BOOTSTRAP only for simd, following upstream RISC-V CI. Its stdarch_riscv_feature_detection gate otherwise fails with E0554 on stable Rust.

https://github.com/tensorchord/VectorChord/blob/1.1.1/.github/workflows/check.yml#L781