### PR TITLE
updpatch: pacman 7.1.0.r9.g54d9411-2

### DIFF
--- a/pacman/riscv64.patch
+++ b/pacman/riscv64.patch
@@ -1,8 +1,18 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -62,9 +62,9 @@
+@@ -52,6 +52,7 @@
+         "revertme-makepkg-remove-libdepends-and-libprovides.patch::https://gitlab.archlinux.org/pacman/pacman/-/commit/354a300cd26bb1c7e6551473596be5ecced921de.patch"
+         "patch-reproducible-builds.patch::https://gitlab.archlinux.org/pacman/pacman/-/commit/f4bdb77470528019aaba4d8b8f947e918c6db17d.patch"
+         '0001-libalpm-invalidate-curl-data-in-child.patch'
++        "retain-download-user.patch::https://gitlab.archlinux.org/felixonmars/pacman/-/commit/7c3eac06d943e93e87ece38e1edd7484d044e958.patch"
+         pacman.conf
+         makepkg.conf
+         alpm.sysusers
+@@ -61,10 +62,11 @@
+             'b3bce9d662e189e8e49013b818f255d08494a57e13fc264625f852f087d3def2'
              'de428b496a825772ef49ec5555a386a4b23ffa10b9dfd9907f0671d5c1dc2178'
              '9a734e5d75be603d58aa92e8d29a15466b3ac2af6b7d6f6728dd5c3e5ed8758d'
++            '7a44113e7debc2945edf2b8df5954572ec715c150ee71dd795abba46ee60aa3e'
              'd6f6ca86104df026462ab634efa1ecc850bccfa748ed5a6a88283e7659ec90c5'
 -            '20497c90cbb678a9ca1a71eca66cf2a1d0c991c3e695f7b7d10fb68fc0ac4f12'
 +            'faa3e8d07212d5edc09f24ac7aad549681e9884ca6c0c16afa1d86d1bdc768b2'


### PR DESCRIPTION
Apply 7c3eac06 to retain DownloadUser and private download directories when kernel sandboxing is disabled.

Submitted at https://gitlab.archlinux.org/pacman/pacman/-/merge_requests/375