### PR TITLE
addpatch: chrony 4.9-1

### DIFF
--- a/chrony/riscv64.patch
+++ b/chrony/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -72,7 +72,8 @@
+ 
+ check() {
+   cd $pkgname
+-  make check
++  # The keys constant-time timing heuristic is unreliable on riscv64 builders.
++  NO_TIMING_TESTS=1 make check
+ }
+ 
+ package() {


### PR DESCRIPTION
Use upstream's NO_TIMING_TESTS switch for the keys timing assertion that fails at test/unit/keys.c:214 on riscv64. Keep the functional key/MAC checks and the rest of make check enabled.

The failing build calls nettle_memeql_sec() on each timing iteration; the installed implementation has no data-dependent branches or early exits.

https://gitlab.com/chrony/chrony/-/commit/d115449e854728662647b0edd95559b8a09c2b8c