### PR TITLE
addpatch: bird 3.3.2-1

### DIFF
--- a/bird/riscv64.patch
+++ b/bird/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -25,6 +25,8 @@
+ 
+ prepare() {
+   cd $pkgname-v$pkgver
++  # Random prefix matching exceeds the 60-second timeout on riscv64.
++  sed -i 's/bt_test_suite(t_match_random_net,/bt_test_suite_extra(t_match_random_net, BT_FORKING, 600,/' nest/rt-fib_test.c
+   autoreconf -fiv
+ }
+ 


### PR DESCRIPTION
Allow ten minutes for t_match_random_net, which hits the default 60-second timeout on riscv64. Use the existing per-suite timeout API and retain the complete workload and make check suite.

Upstream previously raised test timeouts for slow/virtual machines: https://gitlab.nic.cz/labs/bird/-/commit/dc139fb6438f0864e83a9dc71e7c212c5acaf3ef