### PR TITLE
addpatch: arduino-cli 1.5.1-1

### DIFF
--- a/arduino-cli/dependency-test-host.patch
+++ b/arduino-cli/dependency-test-host.patch
@@ -1,0 +1,15 @@
+--- a/internal/arduino/cores/packagemanager/package_manager_test.go
++++ b/internal/arduino/cores/packagemanager/package_manager_test.go
+@@ -795,6 +795,12 @@
+ func TestFindPlatformReleaseDependencies(t *testing.T) {
+ 	pmb := NewBuilder(nil, nil, nil, nil, nil, "test", downloader.GetDefaultConfig())
+ 	pmb.LoadPackageIndexFromFile(paths.New("testdata", "package_tooltest_index.json"))
++	// These fixture tools are only used to resolve dependencies, never executed.
++	for _, tool := range pmb.packages["test"].Tools {
++		for _, release := range tool.Releases {
++			release.Flavors[0].OS = "all"
++		}
++	}
+ 	pmb.calculateCompatibleReleases()
+ 	pm := pmb.Build()
+ 	pme, release := pm.NewExplorer()

--- a/arduino-cli/riscv64.patch
+++ b/arduino-cli/riscv64.patch
@@ -1,0 +1,19 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,11 +14,14 @@
+   'git'
+   'go'
+ )
+-source=("git+$url.git#tag=v$pkgver")
+-b2sums=('9e57cabb66b018f3771f729e3c0004ff06cd8f8540d5fec3cc295679dcad2aeeae165f27c07222be872dfbe29e7de68209def7e97863cbb19ad2c7b7a7e291a3')
++source=("git+$url.git#tag=v$pkgver"
++        'dependency-test-host.patch')
++b2sums=('9e57cabb66b018f3771f729e3c0004ff06cd8f8540d5fec3cc295679dcad2aeeae165f27c07222be872dfbe29e7de68209def7e97863cbb19ad2c7b7a7e291a3'
++        '290f3ec524d7d28ae5b37ddfd6964b775cf60251b1106158e2a1983df8ada3722580a57677f29a8c0cbbb87c098ffdea47456be0a69029d208da8159293eb786')
+ 
+ prepare() {
+   cd $pkgname
++  patch -Np1 -i ../dependency-test-host.patch
+   GOFLAGS="-mod=readonly" go mod vendor -v
+ }
+ 


### PR DESCRIPTION
Make the dependency-resolution fixture tools host independent. Their index lacks riscv64 entries, causing TestFindPlatformReleaseDependencies to fail with "platform is not available for your OS".

Use the existing "all" host match for these unexecuted fixture tools and keep the dependency assertions and package test suite enabled.

https://github.com/arduino/arduino-cli/issues/3106 https://github.com/arduino/arduino-cli/blob/v1.5.1/internal/arduino/cores/tools.go#L146-L148