### PR TITLE
addpatch: gemini-cli 1:0.50.0-1

### DIFF
--- a/gemini-cli/riscv64-support.patch
+++ b/gemini-cli/riscv64-support.patch
@@ -1,0 +1,46 @@
+--- a/packages/core/src/sandbox/linux/LinuxSandboxManager.ts
++++ b/packages/core/src/sandbox/linux/LinuxSandboxManager.ts
+@@ -60,6 +60,9 @@
+   } else if (arch === 'arm64') {
+     AUDIT_ARCH = 0xc00000b7; // AUDIT_ARCH_AARCH64
+     SYS_ptrace = 117;
++  } else if (arch === 'riscv64') {
++    AUDIT_ARCH = 0xc00000f3; // AUDIT_ARCH_RISCV64
++    SYS_ptrace = 117;
+   } else if (arch === 'arm') {
+     AUDIT_ARCH = 0x40000028; // AUDIT_ARCH_ARM
+     SYS_ptrace = 26;
+--- a/packages/test-utils/src/test-rig.ts
++++ b/packages/test-utils/src/test-rig.ts
+@@ -16,7 +16,7 @@
+   GEMINI_DIR,
+ } from '@google/gemini-cli-core';
+ export { GEMINI_DIR };
+-import * as pty from '@lydell/node-pty';
++import type * as pty from '@lydell/node-pty';
+ import stripAnsi from 'strip-ansi';
+ import * as os from 'node:os';
+ import type { TestMcpConfig } from './test-mcp-server.js';
+@@ -1666,7 +1666,9 @@
+     };
+ 
+     const executable = command === 'node' ? process.execPath : command;
+-    const ptyProcess = pty.spawn(executable, commandArgs, ptyOptions);
++    // Only interactive runs require a platform-specific PTY binary.
++    const { spawn: spawnPty } = await import('@lydell/node-pty');
++    const ptyProcess = spawnPty(executable, commandArgs, ptyOptions);
+ 
+     const run = new InteractiveRun(ptyProcess);
+     this._interactiveRuns.push(run);
+--- a/packages/cli/src/ui/components/shared/performance.test.ts
++++ b/packages/cli/src/ui/components/shared/performance.test.ts
+@@ -75,7 +75,8 @@
+     const end = Date.now();
+ 
+     const duration = end - start;
+-    expect(duration).toBeLessThan(5000);
++    // Allow slower builders to complete the same 100-insertion workload.
++    expect(duration).toBeLessThan(30000);
+   });
+ 
+   it('should highlight many lines efficiently', () => {

--- a/gemini-cli/riscv64.patch
+++ b/gemini-cli/riscv64.patch
@@ -1,0 +1,42 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -39,6 +39,9 @@
+ 
+ prepare() {
+   cd $pkgname
++  patch -Np1 -i ../riscv64-support.patch
++  # Match the lockfile registry so npm 12 accepts @google tarballs.
++  npm config delete @google:registry --location=project
+   npm clean-install --ignore-scripts
+ }
+ 
+@@ -54,14 +57,21 @@
+   )
+   local bundled=$(jq '.dependencies + .optionalDependencies | keys' package.json)
+   npm pkg set --json bundledDependencies="$bundled"
++  # Overrides are already applied; npm 12 rejects them in bundled packages.
++  npm pkg delete overrides
+   npm pack
+ }
+ 
+ check() {
+   cd $pkgname
+-  npm run build
++  # Avoid npm-run-all's config flags, which npm 12 rejects.
++  CI=1 npm run build
+   # Deselect failing tests
++  # FileCommandLoader/pathReader: mock-fs cannot intercept Node 26.8 fs.readFile.
++  # https://github.com/tschaub/mock-fs/issues/447
+   npm run test --workspaces --if-present -- \
++    --exclude='**/FileCommandLoader.test.ts' \
++    --exclude='**/pathReader.test.ts' \
+     --exclude='**/BuiltinCommandLoader.test.ts' \
+     --exclude='**/config.integration.test.ts' \
+     --exclude='**/gemini.test.tsx' \
+@@ -79,3 +89,6 @@
+   install -vDm644 -t "$pkgdir/usr/share/doc/$pkgname" README.md
+   install -vDm644 -t "$pkgdir/usr/share/licenses/$pkgname" LICENSE
+ }
++
++source+=(riscv64-support.patch)
++b2sums+=('acec401a0aa0cfa735e79cf4619596c36e4faaba22e9d59bd8607df01dc07bc08489c2664cff897bb692e2fbf62258d140b6902eee3cde3efaf61f74dfef2158')

--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -2,6 +2,7 @@ argocd
 corepack
 eslint
 forgejo
+gemini-cli
 gitea
 grafana
 grafana-agent


### PR DESCRIPTION
Remove the project-specific @google registry override before npm ci. With npm 12.0.2, the publishing registry differs from the npmjs.org @google/genai tarball URL in the lockfile, causing EALLOWREMOTE. Use the default registry without changing the lockfile or relaxing allow-remote.

Remove root overrides after installation and bundling, before npm pack, to avoid EBUNDLEOVERRIDE for bundled wrap-ansi with npm 12. The installed versions satisfy the bundled dependency ranges; leave the lockfile and resolved dependency tree unchanged.

Upstream: https://github.com/npm/cli/pull/9271

Use CI=1 for the check-stage build. npm-run-all 4.1.5 forwards sandboxImageUri as a CLI config flag, which npm 12 rejects with EUNKNOWNCONFIG. Upstream's CI path builds all workspaces sequentially using native npm workspace support. Keep sandbox metadata intact and scope CI to the build command, leaving the test environment unchanged.

https://github.com/google-gemini/gemini-cli/blob/v0.50.0/scripts/build.js#L36

Add gemini-cli to the sv39 blacklist because its shell-parser tests initialize web-tree-sitter and the Bash grammar through WebAssembly.

Add AUDIT_ARCH_RISCV64 (0xc00000f3) and the RISC-V ptrace syscall number (117) to the Linux seccomp filter. This fixes "Unsupported architecture for seccomp filter: riscv64" without weakening the sandbox's ptrace ban.

Load @lydell/node-pty only when the test rig starts an interactive run. Its eager import prevents nine unrelated test suites from collecting because no linux-riscv64 prebuilt binary exists. Keep PTY-required runs explicitly dependent on the module and leave runtime fallback unchanged.

Exclude FileCommandLoader and pathReader tests until mock-fs supports Node 26.8. The new native ReadFileJob path bypasses its binding.open interception, so loading mock-fs throws while accessing prototype.read. A null guard alone would still leave reads bypassing the mocked filesystem.

https://github.com/tschaub/mock-fs/issues/447

Allow 30 seconds instead of 5 for the 100-character insertion benchmark on a 5,000-line buffer. The latest riscv64 check takes 10.287 seconds (11.423 seconds in the preceding run) and fails only this assertion. Keep the workload and the other benchmark limits unchanged.