### PR TITLE
addpatch: bpf-linker 0.11.0-1

### DIFF
--- a/bpf-linker/riscv64.patch
+++ b/bpf-linker/riscv64.patch
@@ -1,0 +1,22 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -20,8 +20,9 @@
+ 
+ build() {
+   cd "$pkgname-$pkgver"
++  # Enable the compatibility handling for the system LLVM 22.
+   RUSTFLAGS+=" -C link-arg=-fuse-ld=lld" \
+-    cargo build --release --frozen
++    cargo build --release --frozen --no-default-features --features llvm-22
+ }
+ 
+ check() {
+@@ -31,7 +32,7 @@
+   # failed to build sysroot: "/usr/lib/rustlib/src/rust/library" does not seem to be a rust library
+   # source folder: `src/Cargo.toml` not found
+   RUSTFLAGS+=" -C link-arg=-fuse-ld=lld" \
+-    CARGO_MANIFEST_DIR="$PWD" cargo test --frozen \
++    CARGO_MANIFEST_DIR="$PWD" cargo test --frozen --no-default-features --features llvm-22 \
+     -- --skip compile_test --skip test_link_ir_files
+ }
+ 


### PR DESCRIPTION
Select llvm-22 for build and check to match libLLVM.so.22.1. The default llvm-23 feature disables LLVM 22 memory-libcall handling, causing python-mitmproxy-rs 0.12.11-1 to fail with
"A call to built-in function 'memset' is not supported."

https://github.com/aya-rs/bpf-linker/blob/v0.11.0/BUILDING.md https://github.com/aya-rs/bpf-linker/blob/v0.11.0/src/linker.rs#L866-L884