### PR TITLE
updpatch: python-mitmproxy-rs 0.12.11-1

### DIFF
--- a/python-mitmproxy-rs/riscv64.patch
+++ b/python-mitmproxy-rs/riscv64.patch
@@ -1,13 +1,27 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -51,4 +51,10 @@ package() {
-   install -Dm0644 LICENSE "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
- }
+@@ -16,7 +16,7 @@
+ makedepends=(
+   git
+   bpf-linker
+-  rustup
++  rust
+   maturin
+   python-installer
+   rust-src
+@@ -29,14 +29,12 @@
+ build() {
+   cd "$pkgname"
  
-+prepare() {
-+  cd ${_pyname}-${pkgver}
-+  sed -i '/\[patch\.crates-io\]/a aya-ebpf-bindings = { git = "https://github.com/hack3ric/aya", branch = "riscv64" }' Cargo.toml
-+  sed -i '/\[patch\.crates-io\]/a aya-ebpf = { git = "https://github.com/hack3ric/aya", branch = "riscv64" }' Cargo.toml
-+}
-+
- # vim: ts=2 sw=2 et:
+-  export RUSTUP_TOOLCHAIN=nightly
+-  rustup component add rust-src --toolchain "nightly-${CARCH}-unknown-linux-gnu"
+-
+   pushd mitmproxy-rs
+   maturin build --release --strip
+   popd
+   
+   pushd mitmproxy-linux
++  # Build eBPF's core library with stable Rust and the system LLVM.
+   RUSTC_BOOTSTRAP=1 maturin build --release --strip
+   popd
+ }


### PR DESCRIPTION
Use system Rust and rust-src so mitmproxy's eBPF bitcode matches the LLVM used by bpf-linker, avoiding nightly's incompatible LLVM 23 bitcode.

Drop the obsolete Aya fork overrides: the locked crates already use aya-build's riscv64 target normalization.

https://github.com/aya-rs/bpf-linker/blob/v0.11.0/BUILDING.md https://github.com/aya-rs/aya/pull/1491
https://github.com/aya-rs/aya/blob/302985c72850cd9a8f1d791a11d247a4fbe1c5b1/aya-build/src/lib.rs https://github.com/mitmproxy/mitmproxy_rs/blob/v0.12.11/Cargo.lock