### PR TITLE
addpatch: snapper-fmt 0.11.1-1

### DIFF
--- a/snapper-fmt/riscv64.patch
+++ b/snapper-fmt/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,6 +14,7 @@
+ )
+ makedepends=(
+   cargo
++  protobuf
+ )
+ source=($pkgname-$pkgver.tar.gz::$url/archive/refs/tags/v$pkgver.tar.gz)
+ b2sums=('67ecdfe34490778f0a3de9443e88600d213fc028007157b10bffbf093aea01acde1d075bc9a97d007af33e3ca594b980ef8b8a58dc89215b78807e7a9372999e')


### PR DESCRIPTION
Add protobuf to makedepends so prost-build 0.9.0 can find protoc on PATH. Its bundled binaries do not cover riscv64, causing build() to abort with "Failed to find the protoc binary".

https://github.com/tokio-rs/prost/blob/v0.9.0/prost-build/build.rs