### PR TITLE
updpatch: arrow 25.0.1-5

### DIFF
--- a/arrow/riscv64.patch
+++ b/arrow/riscv64.patch
@@ -1,8 +1,6 @@
-diff --git PKGBUILD PKGBUILD
-index 3cd0f68..26aa4ea 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -71,6 +71,10 @@ prepare() {
+@@ -78,6 +78,10 @@
  }
  
  build() {
@@ -13,3 +11,12 @@ index 3cd0f68..26aa4ea 100644
    # workaround for cmake 4.0 - arrow bundles several old dependencies https://github.com/apache/arrow/issues/45985
    # (note that ExternalProject does not propagate this as a CMake variable so we need to export an environment variable)
    export CMAKE_POLICY_VERSION_MINIMUM=3.5
+@@ -139,7 +143,7 @@
+     # execute tests in parallel
+     --parallel $(nproc)
+     # limit execution time for each test
+-    --timeout 200
++    --timeout 600
+     # exclude problematic tests
+     --exclude-regex "$excluded_tests"
+   )


### PR DESCRIPTION
Refresh the overlay and increase the CTest timeout from 200 to 600 seconds. arrow-acero-hash-join-node-test reaches the existing limit on the RISC-V builder while the other 100 tests pass.

Keep the existing compiler workaround and all selected tests enabled.