### PR TITLE
updpatch: atuin 18.22.0-1

### DIFF
--- a/atuin/meta-test-timeout.patch
+++ b/atuin/meta-test-timeout.patch
@@ -1,0 +1,24 @@
+--- a/crates/atuin-client/src/meta.rs
++++ b/crates/atuin-client/src/meta.rs
+@@ -273,10 +273,11 @@
+     use rstest::*;
+ 
+     use super::*;
++    use crate::settings::test_local_timeout;
+ 
+     #[fixture]
+     async fn store() -> MetaStore {
+-        MetaStore::in_memory(Duration::from_secs(2)).await.unwrap()
++        MetaStore::in_memory(test_local_timeout()).await.unwrap()
+     }
+ 
+     #[rstest]
+@@ -350,7 +351,7 @@
+ 
+     #[tokio::test]
+     async fn memory_store_skips_file_migration() {
+-        let store = MetaStore::new(":memory:", Duration::from_secs(2)).await.unwrap();
++        let store = MetaStore::new(":memory:", test_local_timeout()).await.unwrap();
+ 
+         assert_eq!(store.get(KEY_FILES_MIGRATED).await.unwrap(), None);
+     }

--- a/atuin/riscv64.patch
+++ b/atuin/riscv64.patch
@@ -1,6 +1,18 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -50,6 +50,8 @@
+@@ -33,6 +33,11 @@
+ prepare() {
+ 	_srcenv
+ 
++	# Honor the test timeout override in metadata-store tests too.
++	patch -Np1 -i "$srcdir/meta-test-timeout.patch"
++	# Secret-redaction timing tests exceed 10s on slower RISC-V builders.
++	patch -Np1 -i "$srcdir/secrets-test-timeout.patch"
++
+ 	# Fully lock down user
+ 	sed -i 's/^u /u! /' systemd/atuin-server.sysusers
+ 
+@@ -50,6 +55,8 @@
  
  check() {
  	_srcenv
@@ -9,3 +21,11 @@
  	cargo test --frozen --all-features --workspace --lib
  }
  
+@@ -77,3 +84,7 @@
+ 	install -Dm0644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md "crates/$pkgname/server.toml"
+ 	install -Dm0644 -t "$pkgdir/usr/share/licenses/$pkgname/" LICENSE
+ }
++
++source+=(meta-test-timeout.patch secrets-test-timeout.patch)
++sha256sums+=('ae69cd0acc5a16ea3d7d0fd4735336a033c808993d84ee8849699df98cbc87fe'
++            '0999060694b3ad96b08d256102a0378e7fa4641789b3b8aca0fc01664fc71e9f')

--- a/atuin/secrets-test-timeout.patch
+++ b/atuin/secrets-test-timeout.patch
@@ -1,0 +1,30 @@
+--- a/crates/atuin-common/src/secrets.rs
++++ b/crates/atuin-common/src/secrets.rs
+@@ -1102,7 +1102,7 @@
+     /// The login patterns' search window is bounded, so a line mentioning `atuin login` many times
+     /// costs linear time. Unbounded, this input took about 17 minutes in a debug build (23.6 s release) and
+     /// stalled the capture sink long enough to drop later commands' output; bounded it is under
+-    /// 2 s debug. The budget leaves room for a slow CI box while still catching a return to
++    /// 2 s debug on faster hosts. Allow 120 s for slow RISC-V builders while still catching a return to
+     /// quadratic.
+     #[test]
+     fn many_login_mentions_on_one_line_stay_linear() {
+@@ -1114,7 +1114,7 @@
+         let took = started.elapsed();
+ 
+         assert!(
+-            took < Duration::from_secs(10),
++            took < Duration::from_secs(120),
+             "took {took:?}; the login patterns have gone quadratic again"
+         );
+     }
+@@ -1143,7 +1143,8 @@
+         assert!(matches!(redact(&line), Cow::Borrowed(_)));
+         let took = started.elapsed();
+ 
+-        assert!(took < Duration::from_secs(10), "took {took:?}");
++        // Match the RISC-V budget for the regularly spaced input above.
++        assert!(took < Duration::from_secs(120), "took {took:?}");
+     }
+ 
+     #[test]


### PR DESCRIPTION
Use test_local_timeout() in metadata-store tests so they honor the existing 30s SQLite timeout override instead of failing pool setup under their hard-coded 2s limit.

Raise both secret-redaction timing budgets from 10s to 120s. The latest riscv64 log records 31.208s and 32.808s for the bounded login scans in a debug build. Keep their full inputs and assertions; the budget remains below the documented 17-minute unbounded regression.

No upstream fix for these timing failures was found. https://github.com/atuinsh/atuin/pull/2337
https://github.com/atuinsh/atuin/commit/6e80127d941262b38ce988e5c1a289228ef06b85