### PR TITLE
addpatch: scrapy 2.19.0-1

### DIFF
--- a/scrapy/riscv64.patch
+++ b/scrapy/riscv64.patch
@@ -1,0 +1,12 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -84,6 +84,9 @@
+ check() {
+   cd "$pkgname"
+ 
++  # Benchmark command tests exceed the 15-second limit on riscv64.
++  sed -i 's/timeout=15,/timeout=60,/' tests/utils/cmdline.py
++
+   # temporary install
+   python -m installer --destdir="$(pwd)/tmp" dist/*.whl
+   local site_packages=$(python -c "import site; print(site.getsitepackages()[0])")


### PR DESCRIPTION
Allow 60 seconds for command-test subprocesses. Both benchmark reactor configurations exceed the 15-second limit on riscv64 and fail with "Command took too much time to complete". Keep the existing test suite and assertions enabled.

No upstream fix for this timeout was found.
https://github.com/scrapy/scrapy/blob/2.19.0/tests/utils/cmdline.py https://github.com/scrapy/scrapy/pull/6933