### PR TITLE
addpatch: python-coverage 7.15.4-1

### DIFF
--- a/python-coverage/riscv64.patch
+++ b/python-coverage/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -23,6 +23,8 @@
+ 
+ check() {
+   cd $_pkgname
++  # Slow input generation trips Hypothesis's health check on riscv64.
++  sed -i 's/settings(deadline=400)/settings(deadline=400, suppress_health_check=["too_slow"])/' tests/test_numbits.py
+   python -m venv --system-site-packages test-env
+   test-env/bin/python -m installer dist/*.whl
+   test-env/bin/python setup.py --quiet build_ext --inplace


### PR DESCRIPTION
Suppress Hypothesis's too_slow health check for numbits input generation. The riscv64 logs fail test_any_intersection after 9.11s and test_union after 3.10s. Keep all generated cases, assertions and test-body deadlines.

No upstream fix was found. Hypothesis documents this suppression for slow input generation and supports string health-check names in 6.168.0. https://github.com/coveragepy/coveragepy/blob/7.15.4/tests/test_numbits.py https://github.com/HypothesisWorks/hypothesis/blob/v6.168.0/hypothesis/src/hypothesis/_settings.py