### PR TITLE
addpatch: xrt 2.21.75-14

### DIFF
--- a/xrt/riscv64-sysinfo.patch
+++ b/xrt/riscv64-sysinfo.patch
@@ -1,0 +1,11 @@
+--- a/src/runtime_src/core/common/detail/linux/sysinfo.h
++++ b/src/runtime_src/core/common/detail/linux/sysinfo.h
+@@ -11,7 +11,7 @@
+ #include <sys/utsname.h>
+ #include <thread>
+ 
+-#if defined(__aarch64__) || defined(__arm__) || defined(__mips__)
++#if defined(__aarch64__) || defined(__arm__) || defined(__mips__) || defined(__riscv)
+   #define MACHINE_NODE_PATH "/proc/device-tree/model"
+ #elif defined(__PPC64__)
+   #define MACHINE_NODE_PATH "/proc/device-tree/model-name"

--- a/xrt/riscv64.patch
+++ b/xrt/riscv64.patch
@@ -1,0 +1,17 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -61,6 +61,7 @@
+ 
+   git -C src/runtime_src/core/common/aiebu/ checkout 4bf58d5a8d46089847130ecffb8952504482feb5
+   patch -Np1 -i ../install-to-bin.patch
++  patch -Np1 -i ../riscv64-sysinfo.patch
+ }
+ 
+ build() {
+@@ -86,3 +87,6 @@
+   install -Dm644 "$pkgname/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+   rm -f "$pkgdir/usr/include/CL/cl_ext.h"
+ }
++
++source+=(riscv64-sysinfo.patch)
++sha256sums+=('cebd4a8ddf23e457531393fe8c57f91d7d0c2798b001890c82f197f373e0bf78')


### PR DESCRIPTION
Read the device-tree model on RISC-V hosts. The missing architecture case makes sysinfo.cpp fail with #error "Unsupported platform".

No upstream fix was found; the same guard remains on master. https://github.com/Xilinx/XRT/blob/2.21.75/src/runtime_src/core/common/detail/linux/sysinfo.h