### PR TITLE
addpatch: java25-openjdk 25.0.4.1.u1-1

### DIFF
--- a/java25-openjdk/boot-jdk26-interim-langtools.patch
+++ b/java25-openjdk/boot-jdk26-interim-langtools.patch
@@ -1,0 +1,33 @@
+--- a/make/CompileInterimLangtools.gmk
++++ b/make/CompileInterimLangtools.gmk
+@@ -68,6 +68,22 @@
+ TARGETS += $(BUILDTOOLS_OUTPUTDIR)/gensrc/java.compiler.interim/javax/tools/ToolProvider.java
+ 
+ ################################################################################
++# Accept non-preview JDK 26 boot classes only in the interim compiler. Keep the
++# shipped compiler's class-file version checks and all other warnings unchanged.
++
++$(BUILDTOOLS_OUTPUTDIR)/gensrc/jdk.compiler.interim/com/sun/tools/javac/jvm/ClassReader.java: \
++    $(TOPDIR)/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
++	$(call LogInfo, Generating ClassReader.java for jdk.compiler.interim)
++	$(call MakeDir, $(@D))
++	$(SED) 's/int maxMajor = Version.MAX().major;/int maxMajor = Version.MAX().major + (minorVersion == ClassFile.PREVIEW_MINOR_VERSION ? 0 : 1);/' \
++	    $< > $@
++
++jdk.compiler.interim_EXTRA_FILES := \
++    $(BUILDTOOLS_OUTPUTDIR)/gensrc/jdk.compiler.interim/com/sun/tools/javac/jvm/ClassReader.java
++
++TARGETS += $(jdk.compiler.interim_EXTRA_FILES)
++
++################################################################################
+ # Use the up-to-date PreviewFeature.java and NoPreview.java from the current
+ # sources, instead of the versions from the boot JDK, as javac may be referring
+ # to constants from the up-to-date versions.
+@@ -98,6 +114,7 @@
+       EXCLUDES := sun, \
+       EXCLUDE_FILES := $(TOPDIR)/src/$1/share/classes/module-info.java \
+           $(TOPDIR)/src/$1/share/classes/javax/tools/ToolProvider.java \
++          $(TOPDIR)/src/$1/share/classes/com/sun/tools/javac/jvm/ClassReader.java \
+           $(TOPDIR)/src/$1/share/classes/com/sun/tools/javac/launcher/Main.java \
+           $(TOPDIR)/src/$1/share/classes/com/sun/tools/javac/launcher/MemoryClassLoader.java \
+           $(TOPDIR)/src/$1/share/classes/com/sun/tools/javac/launcher/MemoryContext.java \

--- a/java25-openjdk/riscv64.patch
+++ b/java25-openjdk/riscv64.patch
@@ -1,0 +1,44 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -26,7 +26,7 @@
+ url='https://openjdk.java.net/'
+ license=('LicenseRef-Java')
+ makedepends=(
+-  "java-environment=25"
++  "java-environment=26"
+   alsa-lib
+   bash
+   cpio
+@@ -103,6 +103,17 @@
+   nss
+ )
+ 
++prepare() {
++  cd ${_jdkdir}
++  # Bootstrap the missing JDK 25 with the repository's JDK 26.
++  sed -i 's/DEFAULT_ACCEPTABLE_BOOT_VERSIONS="24 25"/DEFAULT_ACCEPTABLE_BOOT_VERSIONS="24 25 26"/' \
++    make/conf/version-numbers.conf
++  # Interim langtools reads JDK 26 annotations using this source enum.
++  sed -i '/^        STABLE_VALUES,$/a\        LAZY_CONSTANTS,' \
++    src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
++  patch -Np1 -i "${srcdir}/boot-jdk26-interim-langtools.patch"
++}
++
+ build() {
+   cd ${_jdkdir}
+ 
+@@ -142,6 +153,7 @@
+ 
+ 
+   bash configure \
++    --with-boot-jdk=/usr/lib/jvm/java-26-openjdk \
+     --with-version-string="${_majorver}.${_minorver}.${_securityver}" \
+     --with-stdc++lib=dynamic \
+     --with-extra-cflags="${_CFLAGS}" \
+@@ -457,3 +469,6 @@
+ }
+ 
+ # vim: ts=2 sw=2 et:
++
++source+=(boot-jdk26-interim-langtools.patch)
++sha256sums+=('e9ec0522da241ae9b9699b98fd412bdc4624e2b73f7d4db20e0622bdb7c4164a')


### PR DESCRIPTION
Bootstrap with the repository's JDK 26: the original dependency fails with "target not found: java-environment=25". Accept boot versions 24-26 and select JDK 26 explicitly, retaining the existing bytecode targets.

Retain LAZY_CONSTANTS in PreviewFeature.Feature for the JDK 26 annotations read by interim langtools, without adding lazy-constants functionality.

Generate an interim-only ClassReader that accepts non-preview class-file version 70. Otherwise JDK 26 modules and ct.sym entries trigger "major version 70 is newer than 69" warnings, failing build tools and JRTFS under -Werror. Keep other warnings, preview checks, and the shipped compiler's version checks unchanged.

Upstream accepts only boot JDKs 24 and 25; JDK 26 bootstrapping remains experimental. (Added here as a demo, will be removed.)

https://github.com/openjdk/jdk25u/blob/jdk-25.0.4.1%2B1/make/conf/version-numbers.conf https://github.com/openjdk/jdk25u/blob/jdk-25.0.4.1%2B1/make/CompileInterimLangtools.gmk https://github.com/openjdk/jdk25u/blob/jdk-25.0.4.1%2B1/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java