### PR TITLE
addpatch: python-warlock 2.1.0-2

### DIFF
--- a/python-warlock/riscv64.patch
+++ b/python-warlock/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -15,6 +15,8 @@
+ 
+ prepare() {
+   cd warlock
++  # Allow flit_core 4 to build warlock's PEP 621 metadata.
++  sed -i 's/flit_core ~=3\.2/flit_core >=3.2,<5/' pyproject.toml
+   sed -i '/--cov/d' pytest.ini
+ }
+ 


### PR DESCRIPTION
Allow flit_core 4 in the build-system requirement. The riscv64 build fails with "ERROR Missing dependencies: flit_core~=3.2" despite having flit_core 4.0.2 installed. Keep the minimum version and cap at <5.

No upstream fix was found. Warlock 2.1.0 uses PEP 621 metadata, which Flit 4 supports.
https://github.com/bcwaldon/warlock/blob/2.1.0/pyproject.toml https://github.com/pypa/flit/blob/4.0.2/doc/history.rst