### PR TITLE
addpatch: libmms 0.6.4-6

### DIFF
--- a/libmms/riscv64.patch
+++ b/libmms/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -22,6 +22,8 @@
+ 
+   # Remove "Requires: glib-2.0" since libmms no longer depends on GLib.
+   patch -p1 -i "$srcdir/libmms-Remove-requires-glib2.0.patch"
++
++  autoreconf -vfi
+ }
+ 
+ build() {


### PR DESCRIPTION
Restore autoreconf to refresh the bundled config scripts, which fail with "config.guess: unable to guess system type" on riscv64. Arch fixed this on main after the 0.6.4-6 release tag used by riscvu, so the tagged PKGBUILD still needs the overlay.

https://gitlab.archlinux.org/archlinux/packaging/packages/libmms/-/commit/bc3d813c4d3ba96f5f5a4804242e6294c276f84a