### PR TITLE
updpatch: staticcheck 2026.2.1-2

### DIFF
--- a/staticcheck/riscv64.patch
+++ b/staticcheck/riscv64.patch
@@ -1,11 +1,12 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -41,7 +41,7 @@ build(){
+@@ -41,7 +41,8 @@
  
  check(){
    cd "go-tools-$pkgver"
 -  GOROOT="/usr/lib/go" go test -v ./...
-+  GOROOT="/usr/lib/go" go test -v ./... -timeout 20m
++  # TestStdlib exceeds 20 minutes while building IR on riscv64.
++  GOROOT="/usr/lib/go" go test -v ./... -timeout 1h
  }
  
  package(){


### PR DESCRIPTION
Raise the check timeout to one hour. TestStdlib is still building IR when go/ir fails with "panic: test timed out after 20m0s" on riscv64 with Go 1.27.1. Keep the full test suite enabled.

No targeted upstream fix was found; newer IR optimizations are not confirmed to resolve this timeout.
https://github.com/dominikh/go-tools/blob/2026.2.1/go/ir/stdlib_test.go