### PR TITLE
addpatch: google-glog 0.7.1-2

### DIFF
--- a/google-glog/riscv64.patch
+++ b/google-glog/riscv64.patch
@@ -1,0 +1,16 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -23,6 +23,13 @@
+ source=("$pkgname::git+$url.git#tag=v$pkgver")
+ b2sums=('77316382ba8a0534ec3de7e894e8abc6cd2a3a7cf453c9791d783a76e0b21ad20c7c260857f4c8f3e1e997e404d48ae4e1c47576163d1b7c1eb09f235d20ba75')
+ 
++source+=(symbolize-skip-tls.patch)
++b2sums+=('bebc0a4c8f2229f43641aee1e35125bf392a7da63124f879c676958b1da7ce7efbae9a2f5f7277e9e16db4c7eb0dcfb6a72f9abe074343996d5966043e380b91')
++
++prepare() {
++  patch -d $pkgname -p1 -i "$srcdir/symbolize-skip-tls.patch"
++}
++
+ build() {
+   cmake -B build -S $pkgname \
+     -D CMAKE_INSTALL_PREFIX=/usr \

--- a/google-glog/symbolize-skip-tls.patch
+++ b/google-glog/symbolize-skip-tls.patch
@@ -1,0 +1,15 @@
+https://github.com/google/glog/issues/813
+
+--- a/src/symbolize.cc
++++ b/src/symbolize.cc
+@@ -322,6 +322,10 @@
+     GLOG_SAFE_ASSERT(num_symbols_in_buf <= num_symbols_to_read);
+     for (unsigned j = 0; j < num_symbols_in_buf; ++j) {
+       const ElfW(Sym)& symbol = buf[j];
++      // TLS symbol values are offsets within the TLS block, not addresses.
++      if (ELF64_ST_TYPE(symbol.st_info) == STT_TLS) {
++        continue;
++      }
+       uint64_t start_address = symbol.st_value;
+       start_address += symbol_offset;
+       uint64_t end_address = start_address + symbol.st_size;


### PR DESCRIPTION
Exclude STT_TLS symbols from address lookup: their values are offsets in the TLS block, not virtual addresses. This fixes the false match behind CHECK_STREQ failed: symbol == "main" (google::thread_msg_data vs. main) in the 0.7.1-2.1 riscv64 check log, keeping symbolize enabled.

No applicable upstream fix was found.
https://github.com/google/glog/issues/813