### PR TITLE
updpatch: jenkins 2.581-1

### DIFF
--- a/jenkins/riscv64.patch
+++ b/jenkins/riscv64.patch
@@ -9,15 +9,16 @@
  provides=('jenkins-ci')
  conflicts=('jenkins-ci')
  replaces=('jenkins-ci')
-@@ -35,6 +35,7 @@
+@@ -34,6 +34,8 @@
  prepare() {
  	cd "${pkgname}"
  	patch -Np1 -i "${srcdir}/skip-failing-test.patch"
 +	patch -Np1 -i "${srcdir}/use-system-corepack.patch"
++	patch -Np1 -i "${srcdir}/use-rolldown-wasm.patch"
  }
  
  build() {
-@@ -46,7 +47,7 @@
+@@ -45,7 +47,7 @@
  check() {
  	cd "${pkgname}"
  	export PATH="/usr/lib/jvm/java-${_java}-openjdk/bin:${PATH}"
@@ -26,10 +27,11 @@
  }
  
  package() {
-@@ -58,3 +59,6 @@
+@@ -57,3 +59,7 @@
  	install -Dm 644 "${srcdir}/${pkgname}.conf" "${pkgdir}/etc/conf.d/${pkgname}"
  	install -Dm 644 LICENSE.txt "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
  }
 +
-+source+=('use-system-corepack.patch')
-+sha512sums+=('b4e0aa2ff77c94fd3e63b54ff0549b0f4caf6ce40068d390f0fb58bc2449aed98e5fed0e69aff4cad5df963baadd53c0d7bfb53b4c0b32b817c6bc132211cfa2')
++source+=('use-system-corepack.patch' 'use-rolldown-wasm.patch')
++sha512sums+=('88d8eb21704b36833ffb912169acb7b02bd181764520c5a2aad0a7fd739fb0e6b2888ddd60c814a090b10788ddf9d77dec8b6a0dbdddf7a2fd483e6a1c46e7a2'
++            'd14417be40462e1f1eb859f2c3a73cf7d29815e1aa5abe0ad0d639501b33981aa75b0a6147958bc741953c92b10b845ad80acc62368b88141062278b303cdc51')

--- a/jenkins/use-rolldown-wasm.patch
+++ b/jenkins/use-rolldown-wasm.patch
@@ -1,0 +1,10 @@
+--- a/package.json
++++ b/package.json
+@@ -29,6 +29,7 @@
+     "@babel/core": "8.0.1",
+     "@babel/preset-env": "8.0.2",
+     "@eslint/js": "10.0.1",
++    "@rolldown/binding-wasm32-wasi": "1.2.7",
+     "babel-loader": "10.1.1",
+     "clean-webpack-plugin": "4.0.0",
+     "css-loader": "7.1.5",

--- a/jenkins/use-system-corepack.patch
+++ b/jenkins/use-system-corepack.patch
@@ -1,12 +1,12 @@
 --- a/pom.xml
 +++ b/pom.xml
-@@ -431,39 +431,37 @@
+@@ -462,52 +462,53 @@
        <build>
          <plugins>
            <plugin>
 -            <groupId>com.github.eirslett</groupId>
 -            <artifactId>frontend-maven-plugin</artifactId>
--            <version>2.0.0</version>
+-            <version>2.0.2</version>
 +            <groupId>org.codehaus.mojo</groupId>
 +            <artifactId>exec-maven-plugin</artifactId>
 +            <version>3.0.0</version>
@@ -20,6 +20,7 @@
 -                <configuration>
 -                  <nodeVersion>v${node.version}</nodeVersion>
 -                  <nodeDownloadRoot>https://repo.jenkins-ci.org/nodejs-dist/</nodeDownloadRoot>
+-                  <skip>${skip.frontend}</skip>
 -                </configuration>
 -              </execution>
 -              <execution>
@@ -36,9 +37,9 @@
 +                    <argument>yarn</argument>
 +                    <argument>install</argument>
 +                  </arguments>
+                   <skip>${skip.frontend}</skip>
                  </configuration>
                </execution>
-+
                <execution>
                  <id>yarn build</id>
                  <goals>
@@ -53,16 +54,34 @@
 +                    <argument>yarn</argument>
 +                    <argument>build</argument>
 +                  </arguments>
+                   <skip>${skip.frontend}</skip>
+                 </configuration>
+               </execution>
+               <execution>
+                 <id>yarn test</id>
+                 <goals>
+-                  <goal>corepack</goal>
++                  <goal>exec</goal>
+                 </goals>
+                 <phase>test</phase>
+                 <configuration>
+-                  <arguments>yarn test</arguments>
++                  <executable>corepack</executable>
++                  <arguments>
++                    <argument>yarn</argument>
++                    <argument>test</argument>
++                  </arguments>
++                  <skip>${skipTests}</skip>
                  </configuration>
                </execution>
              </executions>
-@@ -509,31 +507,41 @@
+@@ -549,31 +550,41 @@
        <build>
          <plugins>
            <plugin>
 -            <groupId>com.github.eirslett</groupId>
 -            <artifactId>frontend-maven-plugin</artifactId>
--            <version>2.0.0</version>
+-            <version>2.0.2</version>
 +            <groupId>org.codehaus.mojo</groupId>
 +            <artifactId>exec-maven-plugin</artifactId>
 +            <version>3.0.0</version>
@@ -106,13 +125,13 @@
                  </configuration>
                </execution>
              </executions>
-@@ -554,18 +562,22 @@
+@@ -594,18 +605,22 @@
        <build>
          <plugins>
            <plugin>
 -            <groupId>com.github.eirslett</groupId>
 -            <artifactId>frontend-maven-plugin</artifactId>
--            <version>2.0.0</version>
+-            <version>2.0.2</version>
 +            <groupId>org.codehaus.mojo</groupId>
 +            <artifactId>exec-maven-plugin</artifactId>
 +            <version>3.0.0</version>

--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -9,6 +9,7 @@ gemini-cli
 gitea
 grafana
 grafana-agent
+jenkins
 jupyter-nbclassic
 jupyter-notebook
 jupyterlab


### PR DESCRIPTION
Refresh the Corepack patch for frontend-maven-plugin 2.0.2 and updated Yarn executions, including yarn test and the upstream skip controls.

Add Rolldown's matching 1.2.7 WASM binding. check() fails with "Cannot find module '@rolldown/binding-wasm32-wasi'": the locked release has no native riscv64 package and does not declare its WASM fallback as a dependency. Keep the frontend tests enabled.

Avoid sv39 builders for Yarn's parallel WASM libzip workers and Rolldown's threaded WASM runtime. Upstream recommends the WASM fallback for riscv64; no native fix is included in this release.

https://github.com/jenkinsci/jenkins/blob/jenkins-2.581/pom.xml https://github.com/rolldown/rolldown/issues/7605
https://registry.npmjs.org/rolldown/1.2.7
https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/1.2.7