### PR TITLE
updpatch: handbrake 1.11.2-1

### DIFF
--- a/handbrake/riscv64.patch
+++ b/handbrake/riscv64.patch
@@ -1,16 +1,20 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -42,7 +42,8 @@ build() {
+@@ -29,9 +29,10 @@
  
    ./configure \
      --prefix=/usr \
--    --enable-qsv
+-    --enable-qsv \
+-    --enable-vce \
+-    --enable-nvdec
 +    --disable-qsv \
++    --disable-vce \
++    --disable-nvdec \
 +    --disable-nvenc
    make -C build
  }
  
-@@ -53,7 +54,6 @@ package_handbrake() {
+@@ -42,7 +43,6 @@
    optdepends=('gst-plugins-good: for video previews'
                'gst-libav: for video previews'
                'gvfs: for CD/DVD drive access'
@@ -18,7 +22,7 @@
                'libdvdcss: for decoding encrypted DVDs')
  
    cd HandBrake/build
-@@ -65,8 +65,7 @@ package_handbrake() {
+@@ -54,8 +54,7 @@
  package_handbrake-cli() {
    pkgdesc="Multithreaded video transcoder (CLI)"
    depends=("${_commondeps[@]}")


### PR DESCRIPTION
Refresh for the new --enable-vce and --enable-nvdec arguments, which make the first PKGBUILD hunk fail. Disable the AMF and CUDA backends on riscv64 alongside QSV and NVENC, retaining the removal of Intel Media SDK optional dependencies.

https://github.com/HandBrake/HandBrake/blob/1.11.2/make/configure.py https://github.com/HandBrake/HandBrake/blob/1.11.2/contrib/ffmpeg/module.defs