### PR TITLE
updpatch: biome 2.5.13-1

### DIFF
--- a/biome/increase-workspace-timeout.patch
+++ b/biome/increase-workspace-timeout.patch
@@ -5,7 +5,7 @@
                      }
                  }
 -                _ = sleep(Duration::from_secs(15)) => {
-+                _ = sleep(Duration::from_secs(60)) => {
++                _ = sleep(Duration::from_secs(120)) => {
                      Err(TransportError::Timeout)
                  }
              }

--- a/biome/riscv64.patch
+++ b/biome/riscv64.patch
@@ -14,4 +14,4 @@
  }
 +
 +source+=(increase-workspace-timeout.patch)
-+sha256sums+=('bd734ad62d9cfffee67564f2257a564db4fb48e40c8aeb545f48b6487e7fc8a6')
++sha256sums+=('a02f5e3ff6011a5af29afe42a298f719bb8994c08ce118498b1b237e4837b63a')


### PR DESCRIPTION
Increase the socket workspace request timeout from 60 to 120 seconds. The native RISC-V 2.5.13 check still reports 29 CLI test failures with "the request to the remote workspace timed out" at the current limit. Keep test concurrency and assertions unchanged.

The previous 60-second workaround reduced timeout failures from 141 to
29. The separate commands::lint::include_files_in_symlinked_subdir test passes in 2.5.13 and does not require an adjustment.

No upstream fix was found; Biome 2.5.13 and current main still use a 15-second timeout. Retain the narrow workaround and extend its limit.

https://github.com/biomejs/biome/blob/@biomejs/biome@2.5.13/crates/biome_cli/src/service/mod.rs