### PR TITLE
addpatch: sing-box 1.14.0-3

### DIFF
--- a/sing-box/0004-riscv64-test-timeout.patch
+++ b/sing-box/0004-riscv64-test-timeout.patch
@@ -1,0 +1,11 @@
+--- a/dns/router_race_test.go
++++ b/dns/router_race_test.go
+@@ -353,7 +353,7 @@ func TestDNSRaceImmediateRouteCommits(t
+ 	require.NoError(t, result.err)
+ 	require.Equal(t, netip.MustParseAddr("192.0.2.9"), responseAddress(t, result.response))
+ 	require.Equal(t, int32(1), transportFinal.queryCount.Load())
+-	require.Less(t, time.Since(startTime), 100*time.Millisecond)
++	require.Less(t, time.Since(startTime), 150*time.Millisecond)
+ }
+ 
+ // Without race, rule order decides even when a later response arrives first.

--- a/sing-box/riscv64.patch
+++ b/sing-box/riscv64.patch
@@ -1,0 +1,33 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -17,6 +17,7 @@
+         "0001-build-use-the-system-toolchain.patch"
+         "0002-build-drop-unknown-clang-flag.patch"
+         "0003-Fix-h2mux-with-Go-1.27.patch"
++        "0004-riscv64-test-timeout.patch"
+         "https://github.com/chromium/chromium/raw/refs/tags/150.0.7871.63/tools/generate_shim_headers/generate_shim_headers.py")
+ sha256sums=('87baf6852e37941cbe40bdd94bec81c957c88a56751cecd6bbf0e6108bc69398'
+             '74061e1f81b2fab9a996db6463eb1fa56447594502e650e748694f8ddc0526bc'
+@@ -24,6 +25,7 @@
+             '58c83e0ab0587a8bb020d98ee5cd787e32f692041824b2ae6b78812ec912c5a0'
+             'b941918a0af49840bd929d16be947cc473b0c8b27a4ceab16da34e9b288a57dd'
+             'd98d913120c4a073addb649978035b845a7590f4487fea50cd6be73e2be38516'
++            '261ee4207f85eb11d7352fc035186e5955ad3e28b8a41e0729463cc88c98ba3f'
+             'b64f3bc06e74955d1027e3720a2ef14b6203722a5e7fe4c777a6b1051b9744dd')
+ depends=('glibc' 'libgcc')
+ makedepends=('clang' 'git' 'gn' 'go>=1.25' 'lld' 'llvm' 'ninja' 'python')
+@@ -79,10 +81,14 @@
+ 
+     cd "${srcdir}/${pkgname}-${pkgver}"
+     patch -Np1 -i "${srcdir}/0003-Fix-h2mux-with-Go-1.27.patch"
++    patch -Np1 -i "${srcdir}/0004-riscv64-test-timeout.patch"
+     go mod download -modcacherw
+ }
+ 
+ build() {
++    # Clang treats -fno-plt as unused on riscv64, which fails runtime/cgo under -Werror.
++    CFLAGS=${CFLAGS/-fno-plt/}
++    CXXFLAGS=${CXXFLAGS/-fno-plt/}
+     export CGO_CPPFLAGS="${CPPFLAGS}"
+     export CGO_CFLAGS="${CFLAGS}"
+     export CGO_CXXFLAGS="${CXXFLAGS}"


### PR DESCRIPTION
Remove -fno-plt from CFLAGS and CXXFLAGS before exporting cgo flags. Clang treats it as unused on riscv64, causing runtime/cgo to fail under -Werror.

Raise TestDNSRaceImmediateRouteCommits from 100ms to 150ms. The riscv64 check log records 112.368538ms; keep the test and its 200ms regression boundary active.

No relevant upstream fix was found. Clang 22.1.8 accepts -fno-plt only for x86 and AArch64 ELF targets, and upstream v1.14.0 retains the 100ms test limit.

https://github.com/llvm/llvm-project/blob/llvmorg-22.1.8/clang/lib/Driver/ToolChains/Clang.cpp#L5977-L5978

https://github.com/SagerNet/sing-box/blob/v1.14.0/dns/router_race_test.go#L322-L356