### PR TITLE
updpatch: fpc 3.2.2-11

### DIFF
--- a/fpc/riscv64-backport.patch
+++ b/fpc/riscv64-backport.patch
@@ -60,6 +60,10 @@ Backport the saved-register array declarations from
 Include the .option directive tables from
 2b78a8fd3dec629d91b9fb74a01d06d904384117 required by the RISC-V assembler reader.
 
+Expand large virtual-method offsets in interface wrappers with the reserved x6
+register. These wrappers bypass register allocation, so using the generic
+reference helper leaves imaginary registers in the generated assembly.
+
 Backport .dc.a and combined section flags from
 4be5f07f276e2f8c9080a05f7c297fc9d578b5d5, including the section flag sets
 from 245b58c249b4b29ffc54e6c1e50a1474cc84f7b1 needed by the startup units.
@@ -1080,6 +1084,18 @@ make the Comp and Int64 TValue operators duplicate declarations.
                  paramanager.freecgpara(list,paraloc2);
 --- a/fpcsrc/compiler/riscv/hlcgrv.pas
 +++ b/fpcsrc/compiler/riscv/hlcgrv.pas
+@@ -118,0 +119 @@
++        vmtoffset: longint;
+@@ -123 +124,8 @@
+-        reference_reset_base(href,voidpointertype,NR_X5,tobjectdef(procdef.struct).vmtmethodoffset(procdef.extnumber),ctempposinvalid, sizeof(pint),[]);
++        vmtoffset:=tobjectdef(procdef.struct).vmtmethodoffset(procdef.extnumber);
++        if not is_imm12(vmtoffset) then
++          begin
++            cg.a_load_const_reg(list,OS_ADDR,vmtoffset,NR_X6);
++            cg.a_op_reg_reg(list,OP_ADD,OS_ADDR,NR_X6,NR_X5);
++            vmtoffset:=0;
++          end;
++        reference_reset_base(href,voidpointertype,NR_X5,vmtoffset,ctempposinvalid, sizeof(pint),[]);
 @@ -152,7 +152,7 @@
        if make_global then
          list.concat(Tai_symbol.Createname_global(labelname,AT_FUNCTION,0,voidcodepointertype))

--- a/fpc/riscv64.patch
+++ b/fpc/riscv64.patch
@@ -7,7 +7,7 @@
 +source+=("fpc-riscv64-90afbc8114.tar.gz::https://gitlab.com/freepascal.org/fpc/source/-/archive/90afbc8114/source-90afbc8114.tar.gz"
 +         riscv64-backport.patch)
 +sha512sums+=('edbb40804aa8296cd4862be00d39a4ca39785fc86eb985772beac2b4a2a1dcc190af8c599a9fc63282041c3dda41d6e52fa3b12f046d970b0fa872500b6383c6'
-+             'bad0fe9811e4227cca498df291f6b348f0257c106d31d8a68b8879cc99df8b7d75fa5c8ec6fe77ddc29b330073ddf640eba12745fc8041cfebd203343c829a4c')
++             '17aab2cd1e41034c35de165d6de2ea0737a69f4fab43f568463df731071d9b550e2ed39e0f13f201ca6cb11934fe0047d9fe35e5cf10fca17b10c225ac56992d')
 +
  prepare() {
    cd "${srcdir}"/fpcbuild-${pkgver}


### PR DESCRIPTION
Expand large virtual-method offsets in RISC-V interface wrappers with the reserved x6 register. These wrappers bypass register allocation, so generic reference expansion leaked ireg32 and ireg33 into Lazarus assembly.