### PR TITLE
addpatch: tensorboard 2.21.0-1

### DIFF
--- a/tensorboard/esbuild-riscv64.patch
+++ b/tensorboard/esbuild-riscv64.patch
@@ -1,0 +1,28 @@
+--- a/toolchains/esbuild/esbuild_packages.bzl
++++ b/toolchains/esbuild/esbuild_packages.bzl
+@@ -5,6 +5,7 @@
+ _DARWIN_ARM64_SHA = "4a12abe17bc6d0438f8353862173d65570c70967f804ff383d6828b53befd4cc"
+ _LINUX_AMD64_SHA = "4a8bad6e2d13e7edfef1351e4725f65a8828093b0d63bba3237fcab5e530afa2"
+ _LINUX_ARM64_SHA = "893fb422f0c2759998a125cb23c3055712d5f3f4414ca75f3ec9dd55b03fcc8c"
++_LINUX_RISCV64_SHA = "5e50d8b1a4f64574e492d5d039506c19c0c4cce50eb3f9cd372ecf60037ee6de"
+ _WINDOWS_AMD64_SHA = "00eb7f0b81591c2d842c8824cb9a948089566ffb629882298b640b425de45f2f"
+ _LINUX_PPC64LE_SHA = "c6703bc387c5ad86073135d3837a4a1d47909737b7169b509c4f636bb492fd9f"
+ _LINUX_S390X_SHA = "f27128ae64e19eae5c73c3b43ae11abbc4b0757c36e61df3cc043b7126fe9069"
+@@ -56,6 +57,17 @@
+                 "@platforms//cpu:arm64",
+             ],
+         ),
++        "linux_riscv64": struct(
++            sha = _LINUX_RISCV64_SHA,
++            urls = [
++                "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-%s.tgz" % _VERSION,
++            ],
++            binary_path = "bin/esbuild",
++            exec_compatible_with = [
++                "@platforms//os:linux",
++                "@platforms//cpu:riscv64",
++            ],
++        ),
+         "windows_amd64": struct(
+             sha = _WINDOWS_AMD64_SHA,
+             urls = [

--- a/tensorboard/riscv64.patch
+++ b/tensorboard/riscv64.patch
@@ -1,0 +1,85 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -9,35 +9,71 @@
+ arch=('x86_64')
+ license=('Apache-2.0')
+ depends=('python' 'python-werkzeug' 'python-numpy' 'python-bleach' 'python-markdown'
+-         'python-protobuf' 'python-grpcio' 'python-packaging' 'python-setuptools' 'absl-py')
+-makedepends=('bazel' 'tree' 'rust' 'python-build' 'python-installer' 'python-wheel' 'git')
++         'python-protobuf' 'python-grpcio' 'python-packaging' 'python-setuptools' 'absl-py'
++         'python-pillow')
++makedepends=('bazel' 'tree' 'rust' 'python-build' 'python-installer' 'python-wheel' 'git'
++             'nodejs-lts-iron')
+ optdepends=('python-tensorflow: advanced features for TensorBoard')
+ source=(
+   "${pkgname}-${pkgver}.tar.gz::https://github.com/tensorflow/tensorboard/archive/${pkgver}.tar.gz"
+-  https://github.com/bazelbuild/bazel/releases/download/7.7.0/bazel_nojdk-7.7.0-linux-x86_64
++  https://github.com/bazelbuild/bazel/releases/download/7.7.0/bazel-7.7.0-dist.zip
++  tensorboard-riscv64.patch
++  rules_nodejs-riscv64.patch
++  esbuild-riscv64.patch
+ )
++noextract=('bazel-7.7.0-dist.zip')
+ options=('!lto')
+ sha512sums=('259692247aefa305c49d5062cf25d329cacc9b452261a2b3cf936732415022b88368eba6f0efe95a612313f0f08314c2c2a3d18f31219bef0082396476aa34d2'
+-            '206d9a1c98deba75435fe69597ce47dedfe3bb73b0af145245870516d9b2a534e49a8ece765cea5fe80cec57e254bc6655cdab0b194717a89976ed67d9330cf6')
++            '67d47b2066c54d10f3a1c0a13ab5e577087b40fa54a806802d67fd2391d11709374e2884cfb5910c253dbdc554e3ded65f609adf3a684e5cb1bfd62d244a6439'
++            '61525ef4624088f1c8466365af1be600e2b9b675fa2b7949dd70872a68a45d9ade520ed0da10e54c5f839e611d9131e875dfb0850d39a6e447d5b9e63151f81b'
++            '0f753fd2f1d71c15b3bab27e0480823147cabb443285f6e94ba3bf7dd70a7ea10e6472d234b96d371a8b139481462820b8da821cb463781f7a91fb077fe25e84'
++            'ca14cbff2af3a938ee3f27ef83332fc763ce9e34dfba9af16c193b9c6238b264e2e44f504697280ec6f91794898a2bbcd3df2a1cd298b78305aba51405cf8d2e')
+ 
+ prepare() {
+-  # Since tensorboard is often incompatible with Arch's version of bazel, we have to use a separate one.
+-  install -Dm755 "${srcdir}"/bazel_nojdk-7.7.0-linux-x86_64 bazel/bazel
+-  export PATH="${srcdir}/bazel:$PATH"
+-  bazel --version
++  mkdir -p bazel
++  bsdtar -xf bazel-7.7.0-dist.zip -C bazel
++
++  # Avoid Abseil's privileged rdcycle instruction on RISC-V; update its GoogleTest dependency too.
++  # https://github.com/bazelbuild/bazel/pull/25699
++  sed -i -e '/name = "abseil-cpp"/s/20230125.1/20240722.1/' \
++         -e '/name = "googletest"/s/1.14.0/1.15.2/' bazel/MODULE.bazel
++
++  # Fix the RISC-V JNI include path, which prevents Bazel from finding jni_md.h.
++  # https://github.com/bazelbuild/bazel/pull/25699
++  sed -i '/name = "rules_java"/s/7.6.5/7.12.5/' bazel/{MODULE.bazel,src/MODULE.tools}
++
++  # Match rules_java's rules_proto dependency to satisfy the bootstrap's direct dependency check.
++  sed -i '/name = "rules_proto"/s/6.0.0/6.0.2/' bazel/MODULE.bazel
+ 
+   cd "$pkgname-$pkgver"
+ 
++  # Add RISC-V Node.js and esbuild toolchains to rules_nodejs 5.8.1.
++  patch -Np1 -i "$srcdir/tensorboard-riscv64.patch"
++  cp "$srcdir/"{rules_nodejs,esbuild}-riscv64.patch patches/
++
+   # Remove fixed version requirements as we usually ship more up-to-date
+   # versions than are specified and it tends to work fine anyhow.
+   sed -i "s/[<>=].*//" tensorboard/pip_package/requirements.txt
++
++  # Keep the locked TLS stack, using the overlay's RISC-V backport of ring 0.16.20.
++  printf '\n[patch.crates-io]\nring = { git = "https://github.com/felixonmars/ring", rev = "80697f42ff68b7e2aacfd2179be29fd2f2d251d5" }\n' >> tensorboard/data/server/Cargo.toml
++  cargo update --manifest-path tensorboard/data/server/Cargo.toml -p ring
+ }
+ 
+ build() {
+-  cd "$pkgname-$pkgver"
++  # TensorBoard requires Bazel 7, whose releases lack a riscv64 binary.
++  cd "$srcdir/bazel"
++  # The first bootstrap stage lacks a version, so bazel_features assumes newer APIs.
++  # https://github.com/bazelbuild/bazel/issues/27401
++  EMBED_LABEL=7.7.0 BAZEL_DEV_VERSION_OVERRIDE=7.7.0 \
++    EXTRA_BAZEL_ARGS="--tool_java_runtime_version=local_jdk" ./compile.sh
++  export PATH="$srcdir/bazel/output:$PATH"
++  bazel --version
++
++  cd "$srcdir/$pkgname-$pkgver"
+ 
+-  PYTHONWARNINGS=ignore bazel build //tensorboard
+-  bazel build //tensorboard/pip_package:build_pip_package
++  PYTHONWARNINGS=ignore bazel build --tool_java_runtime_version=local_jdk --extra_toolchains=@local_jdk//:all //tensorboard
++  bazel build --tool_java_runtime_version=local_jdk --extra_toolchains=@local_jdk//:all //tensorboard/pip_package:build_pip_package
+ 
+   cd tensorboard/data/server
+   cargo build --release

--- a/tensorboard/rules_nodejs-riscv64.patch
+++ b/tensorboard/rules_nodejs-riscv64.patch
@@ -1,0 +1,68 @@
+--- a/nodejs/private/os_name.bzl
++++ b/nodejs/private/os_name.bzl
+@@ -26,6 +26,7 @@
+     ("linux", "s390x"),
+     ("linux", "ppc64le"),
+     ("freebsd", "amd64"),
++    ("linux", "riscv64"),
+ ]
+ 
+ OS_NAMES = ["_".join(os_arch_name) for os_arch_name in OS_ARCH_NAMES]
+@@ -59,6 +60,8 @@
+             return OS_NAMES[5]
+         elif arch == "ppc64le":
+             return OS_NAMES[6]
++        elif arch == "riscv64":
++            return OS_NAMES[8]
+     elif os_name.startswith("freebsd"):
+         if arch == "amd64":
+             return OS_NAMES[7]
+@@ -74,7 +77,7 @@
+ 
+ def is_linux_os(rctx):
+     name = os_name(rctx)
+-    return name == OS_NAMES[3] or name == OS_NAMES[4] or name == OS_NAMES[5] or name == OS_NAMES[6]
++    return name == OS_NAMES[3] or name == OS_NAMES[4] or name == OS_NAMES[5] or name == OS_NAMES[6] or name == OS_NAMES[8]
+ 
+ def node_exists_for_os(node_version, os_name, node_repositories):
+     if not node_repositories:
+
+--- a/nodejs/private/toolchains_repo.bzl
++++ b/nodejs/private/toolchains_repo.bzl
+@@ -30,6 +30,12 @@
+             "@platforms//cpu:arm64",
+         ],
+     ),
++    "linux_riscv64": struct(
++        compatible_with = [
++            "@platforms//os:linux",
++            "@platforms//cpu:riscv64",
++        ],
++    ),
+     "linux_s390x": struct(
+         compatible_with = [
+             "@platforms//os:linux",
+
+--- a/nodejs/repositories.bzl
++++ b/nodejs/repositories.bzl
+@@ -363,8 +363,18 @@
+         fail("Invalid node version: %s" % version)
+ 
+ def _nodejs_repo_impl(repository_ctx):
+-    assert_node_exists_for_host(repository_ctx)
+-    _download_node(repository_ctx)
++    if repository_ctx.attr.platform == "linux_riscv64":
++        # Use packaged Node.js and the npm version bundled with Node.js 18.20.8.
++        repository_ctx.symlink("/usr/bin/node", NODE_EXTRACT_DIR + "/bin/node")
++        repository_ctx.download_and_extract(
++            url = "https://registry.npmjs.org/npm/-/npm-10.8.2.tgz",
++            sha256 = "c8c61ba0fa0ab3b5120efd5ba97fdaf0e0b495eef647a97c4413919eda0a878b",
++            stripPrefix = "package",
++            output = NODE_EXTRACT_DIR + "/lib/node_modules/npm",
++        )
++    else:
++        assert_node_exists_for_host(repository_ctx)
++        _download_node(repository_ctx)
+     _prepare_node(repository_ctx)
+ 
+ node_repositories = repository_rule(

--- a/tensorboard/tensorboard-riscv64.patch
+++ b/tensorboard/tensorboard-riscv64.patch
@@ -1,0 +1,37 @@
+--- a/WORKSPACE
++++ b/WORKSPACE
+@@ -196,6 +196,8 @@
+ 
+ http_archive(
+     name = "build_bazel_rules_nodejs",
++    patch_args = ["-p1"],
++    patches = ["//patches:esbuild-riscv64.patch"],
+     sha256 = "f02557f31d4110595ca6e93660018bcd7fdfdbe7d0086089308f1b3af3a7a7ee",
+     urls = [
+         "https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.1/rules_nodejs-5.8.1.tar.gz",
+@@ -204,6 +206,14 @@
+ 
+ load("@build_bazel_rules_nodejs//:repositories.bzl", "build_bazel_rules_nodejs_dependencies")
+ 
++http_archive(
++    name = "rules_nodejs",
++    patch_args = ["-p1"],
++    patches = ["//patches:rules_nodejs-riscv64.patch"],
++    sha256 = "de1ede962d5e517fd866942cd9de6aac36e59b39d09d1aeb882a795dde7a03e9",
++    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/5.8.1/rules_nodejs-core-5.8.1.tar.gz"],
++)
++
+ build_bazel_rules_nodejs_dependencies()
+ 
+ load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "yarn_install")
+--- a/tensorboard/defs/defs.bzl
++++ b/tensorboard/defs/defs.bzl
+@@ -66,6 +66,8 @@
+     esbuild(
+         name = name,
+         visibility = visibility,
++        # Avoid cross-core LR/SC failures in esbuild's old Go runtime on P550.
++        max_threads = 1,
+         # Use "iife" format instead of "esm" because "esm" writes symbols at
+         # the global level and tends to overwrite `window` functions. "iife" is
+         # just a thin wrapper around "esm" (it adds 11 bytes) and doesn't


### PR DESCRIPTION
Bootstrap Bazel 7.7.0 with the system JDK: its bundled x86_64 binary fails with "Exec format error", and TensorBoard requires Bazel 7. Set the bootstrap's development version to avoid bazel_features selecting newer APIs and failing with "name 'macro' is not defined".

Apply the dependency updates from Bazel's RISC-V proposal: Abseil and GoogleTest avoid privileged rdcycle instructions, rules_java fixes the JNI include path, and rules_proto matches its direct dependency. Use local JDK toolchains for TensorBoard's otherwise unresolved Java runtime.

Extend rules_nodejs 5.8.1 host detection and toolchains to fix "Unsupported operating system linux architecture riscv64". Use packaged Node.js 20 and npm 10.8.2, as bundled with the configured Node.js 18.20.8. The system npm 12 requires newer Node.js and rejects the legacy --scripts-prepend-node-path option with EUNKNOWNCONFIG. Register the matching esbuild 0.15.17 RISC-V binary.

Separate the rules_nodejs file diffs with blank lines. Bazel 7.7.0's native patcher otherwise combines their hunks against repositories.bzl and fails with CONTENT_DOES_NOT_MATCH_TARGET near line 74.

Pin the overlay's ring 0.16.20 RISC-V backport for the locked TLS stack; the published crate panics at build.rs:358 on this architecture. Add python-pillow, required by TensorBoard's image detector at startup, to fix "ModuleNotFoundError: No module named 'PIL'" in the installed CLI.

Limit TensorBoard's centralized esbuild rule to one Go scheduler thread. The prebuilt esbuild 0.15.17 binary uses LR.aq/SC.aq for runtime CAS, and its parallel service crashes on the P550 in runtime.casgstatus with "mspan.sweep: m is not locked" and "morestack on gsignal". Keep Bazel actions parallel while avoiding esbuild's cross-core LR/SC path. No exact esbuild or Go issue for this failure was found upstream.

https://github.com/bazelbuild/bazel/issues/27401
https://github.com/bazelbuild/bazel/blob/7.7.0/src/test/shell/bazel/bazel_bootstrap_distfile_test.sh https://github.com/bazelbuild/bazel/pull/25699
https://github.com/bazelbuild/rules_java/blob/7.12.5/MODULE.bazel https://github.com/bazelbuild/rules_java/blob/7.12.5/toolchains/BUILD https://bazel.build/versions/7.7.0/docs/bazel-and-java https://github.com/tensorflow/tensorboard/blob/2.21.0/WORKSPACE https://github.com/bazel-contrib/rules_nodejs/blob/5.8.1/nodejs/private/os_name.bzl https://github.com/bazel-contrib/rules_nodejs/blob/5.8.1/nodejs/repositories.bzl https://github.com/bazel-contrib/rules_nodejs/blob/5.8.1/toolchains/esbuild/esbuild_packages.bzl https://github.com/nodejs/node/blob/v18.20.8/deps/npm/package.json https://github.com/bazelbuild/bazel/blob/7.7.0/src/main/java/com/google/devtools/build/lib/bazel/repository/PatchUtil.java https://github.com/felixonmars/ring/commit/80697f42ff68b7e2aacfd2179be29fd2f2d251d5 https://github.com/briansmith/ring/commit/5dedf6145ad8cda0c76961136fb01cda45436a00 https://github.com/tensorflow/tensorboard/blob/2.21.0/tensorboard/pip_package/requirements.txt https://github.com/open-mpi/ompi/issues/13762
https://github.com/bazelbuild/rules_nodejs/blob/5.8.1/packages/esbuild/esbuild.bzl https://github.com/tensorflow/tensorboard/blob/2.21.0/tensorboard/defs/defs.bzl