### PR TITLE
blacklist: exclude REAPER extensions

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -58,6 +58,10 @@ python-numba-cuda-mlir
 python-nvidia-ml-py
 python-pycuda
 
+# Requires binary-only REAPER, which has no RISC-V build
+reapack
+sws
+
 # Entirely x86-centric software
 fasm
 


### PR DESCRIPTION
REAPER is binary-only and has no riscv64 release, leaving reapack and sws with an unsatisfied runtime dependency. Exclude both extensions until a native REAPER package is available.