### PR TITLE
addpatch: hugin 2025.0.1-4

### DIFF
--- a/hugin/riscv64.patch
+++ b/hugin/riscv64.patch
@@ -1,0 +1,20 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -50,6 +50,8 @@
+ # This is required for reproducible builds
+   cd "$_archive"
+   patch -Np1 -i "$srcdir/ignore_gzip_timestamps.patch"
++  patch -Np1 -i "$srcdir/fix-vigra-1.12.4.patch"
++  patch -Np1 -i "$srcdir/fix-python-swig-4.5.patch"
+ }
+ 
+ build() {
+@@ -65,3 +67,8 @@
+ package() {
+   make -C build DESTDIR="$pkgdir" install
+ }
++
++source+=("fix-vigra-1.12.4.patch::http://hg.code.sf.net/p/hugin/hugin/raw-rev/5dad0e83e6c58dc2425ca3d56659f4c229761870"
++         "fix-python-swig-4.5.patch::http://hg.code.sf.net/p/hugin/hugin/raw-rev/0040e8c06949f0422c1324a7c18014aeb1e915d3")
++sha256sums+=('1d91800861e1382cfbab2ba1772116452b08e24ee1f0057b57f754ffd6685922'
++             '4c37218f849d7b134a50140be925cc232018efad01f78d17e6a2791fb48c48e8')


### PR DESCRIPTION
Backport the upstream VIGRA 1.12.4 version parser. VIGRA 1.12.4 constructs VIGRA_VERSION from numeric macros, leaving Hugin’s quoted-value regex empty and causing CMake’s VERSION_EQUAL call to fail.

Replace the removed PyInt_AsLong API with PyLong_AsLong. After configuration succeeds, SWIG 4.5.1 exposes this Python 3 compatibility failure while compiling hugin_python_interface.

https://sourceforge.net/p/hugin/hugin/ci/5dad0e83e6c58dc2425ca3d56659f4c229761870/

https://sourceforge.net/p/hugin/hugin/ci/0040e8c06949f0422c1324a7c18014aeb1e915d3/

https://github.com/ukoethe/vigra/blob/Version-1-12-4/include/vigra/config_version.hxx