### PR TITLE
updpatch: grafana-zabbix 6.7.0-1

### DIFF
--- a/grafana-zabbix/riscv64.patch
+++ b/grafana-zabbix/riscv64.patch
@@ -1,25 +1,9 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -7,15 +7,19 @@ arch=('any')
- url="https://github.com/alexanderzobnin/grafana-zabbix"
- license=('APACHE')
- depends=('grafana')
--makedepends=(yarn libfaketime go git nodejs-lts-gallium)
-+makedepends=(yarn libfaketime go git nodejs-lts-gallium python)
- source=("$pkgname-$pkgver-retagged-1.tar.gz::https://github.com/alexanderzobnin/grafana-zabbix/archive/v$pkgver.tar.gz")
- sha256sums=('7b97156b53c4d5d5d55158a8fa57da7fc3a4105cddd55d4744c8aa6f1fd2f71c')
- 
- build() {
- 	cd "$pkgname-$pkgver"
- 	make install
--	make build
--	make dist
-+	# Work-around for webpack4
-+	export NODE_OPTIONS=--openssl-legacy-provider
-+	make build-frontend
-+	go build -o ./dist/zabbix-plugin_linux_$CARCH ./pkg
-+
-+	go build -v -ldflags="-s -w" -o ./dist/zabbix-plugin_linux_$CARCH ./pkg
- }
- 
- check() {
+@@ -19,0 +20,4 @@
++	# SWC has no riscv64 binary and its automatic WASM fallback is broken.
++	# https://github.com/swc-project/swc/pull/12064
++	npm install --package-lock-only --ignore-scripts --save-dev --save-exact \
++		@swc/core@npm:@swc/wasm@1.15.46
+@@ -27 +30,0 @@
+-	make dist-backend-linux

--- a/sv39-blacklist.txt
+++ b/sv39-blacklist.txt
@@ -8,6 +8,7 @@ forgejo
 gemini-cli
 gitea
 grafana
+grafana-zabbix
 grafana-agent
 jenkins
 jupyter-nbclassic


### PR DESCRIPTION
Refresh the obsolete 4.2-era PKGBUILD patch for the current npm and Mage build. Use version-matched @swc/wasm because @swc/core 1.15.46 has no riscv64 binary, and retain mage build:backend's native linux-riscv64 output instead of overwriting it with dist-backend-linux's amd64 binary.

Add grafana-zabbix to the Sv39 blacklist because the frontend build and Jest suite execute SWC WebAssembly in parallel.

No upstream RISC-V fix was found.

https://github.com/swc-project/swc/pull/12064

https://github.com/grafana/grafana-zabbix/blob/v6.7.0/Makefile

https://github.com/grafana/grafana-plugin-sdk-go/blob/v0.296.4/build/common.go