### PR TITLE
addpatch: libdbi-drivers 0.9.0-13

### DIFF
--- a/libdbi-drivers/riscv64.patch
+++ b/libdbi-drivers/riscv64.patch
@@ -1,0 +1,10 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -38,6 +38,7 @@
+ 
+ prepare() {
+   cd $pkgname-$pkgver
++  cp -f /usr/share/autoconf/build-aux/config.{guess,sub} .
+   patch -Np1 < ../$pkgname-fix-bundled-cgreen-build.patch
+   patch -Np1 < ../$pkgname-fix-test-datetime-types.patch
+   patch -Np1 < ../$pkgname-fix-vla-buffer-overflow-in-getTables.patch


### PR DESCRIPTION
Update config.guess and config.sub for RISC-V. Force replacement because the 0.9.0 release archive marks both stale helper files read-only, causing prepare() to fail with Permission denied.

No upstream RISC-V fix was found; current upstream regenerates the autotools files after the packaged 0.9.0 release.