### PR TITLE
addpatch: libdbi 0.9.0-8

### DIFF
--- a/libdbi/fix-riscv-conversions.patch
+++ b/libdbi/fix-riscv-conversions.patch
@@ -1,0 +1,41 @@
+diff --unified --recursive --text --new-file libdbi-0.9.0.orig/include/dbi/dbi-dev.h libdbi-0.9.0/include/dbi/dbi-dev.h
+--- libdbi-0.9.0.orig/include/dbi/dbi-dev.h	2013-01-09 07:54:30.000000000 +0800
++++ libdbi-0.9.0/include/dbi/dbi-dev.h	2026-09-12 16:19:26.206081256 +0800
+@@ -41,7 +41,7 @@
+ typedef struct _field_binding_s *_field_binding_t_pointer;
+ 
+ typedef union dbi_data_u {
+-	char d_char;
++	signed char d_char;
+ 	short d_short;
+         int d_long; /* misnomer */
+ 	long long d_longlong;
+diff --unified --recursive --text --new-file libdbi-0.9.0.orig/src/dbi_result.c libdbi-0.9.0/src/dbi_result.c
+--- libdbi-0.9.0.orig/src/dbi_result.c	2013-01-09 07:54:30.000000000 +0800
++++ libdbi-0.9.0/src/dbi_result.c	2026-09-12 16:22:51.868280995 +0800
+@@ -1383,6 +1383,13 @@
+   return dbi_result_get_as_longlong_idx(Result, fieldidx+1);
+ }
+ 
++static long long _dbi_decimal_to_longlong(double value) {
++  if (!isfinite(value) || value >= (double)LLONG_MAX || value < (double)LLONG_MIN) {
++    return LLONG_MIN;
++  }
++  return (long long)value;
++}
++
+ long long dbi_result_get_as_longlong_idx(dbi_result Result, unsigned int fieldidx) {
+   long long my_ERROR = 0;
+   fieldidx--;
+@@ -1406,9 +1413,9 @@
+   case DBI_TYPE_DECIMAL:
+     switch (RESULT->field_attribs[fieldidx] & DBI_DECIMAL_SIZEMASK) {
+     case DBI_DECIMAL_SIZE4:
+-      return (long long)RESULT->rows[RESULT->currowidx]->field_values[fieldidx].d_float;
++      return _dbi_decimal_to_longlong(RESULT->rows[RESULT->currowidx]->field_values[fieldidx].d_float);
+     case DBI_DECIMAL_SIZE8:
+-      return (long long)RESULT->rows[RESULT->currowidx]->field_values[fieldidx].d_double;
++      return _dbi_decimal_to_longlong(RESULT->rows[RESULT->currowidx]->field_values[fieldidx].d_double);
+     default:
+       _error_handler(RESULT->conn, DBI_ERROR_BADTYPE);
+       return my_ERROR;

--- a/libdbi/riscv64.patch
+++ b/libdbi/riscv64.patch
@@ -1,0 +1,17 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -21,6 +21,7 @@
+ 
+ prepare() {
+   cd $pkgbase-$pkgver
++  patch -Np1 -i ../fix-riscv-conversions.patch
+   autoreconf -fiv
+ }
+ 
+@@ -43,3 +44,6 @@
+   cd $pkgbase-$pkgver
+   make -C doc DESTDIR="$pkgdir" install
+ }
++
++source+=(fix-riscv-conversions.patch)
++b2sums+=('8fbadb0489f9e896db1bb12866a9f4db781fb4973b9e850944c080853fca7c8878595053d57d5fd4dbce3c0af8c4c83a12bc85b8ea4109b65a44077bfc0d18ca')


### PR DESCRIPTION
Make the internal one-byte integer storage explicitly signed. RISC-V defaults plain char to unsigned, so libdbi-drivers get_as_longlong and get_as_string returned 129 instead of -127.

Return LLONG_MIN for non-finite or out-of-range decimal conversions instead of relying on undefined floating-to-integer behavior. The same test reported -1 instead of LLONG_MIN for both float and double fields.

No matching upstream fix was found; the 0.9.0 release and current master retain both conversions.