### PR TITLE
updpatch: opencode 1.18.29-1

### DIFF
--- a/opencode/opentui-riscv64.patch
+++ b/opencode/opentui-riscv64.patch
@@ -1,0 +1,122 @@
+--- a/chunk-bun-t2myhmwd.js
++++ b/chunk-bun-t2myhmwd.js
+@@ -1,4 +1,5 @@
+ // @bun
++import koffi from "./koffi.node";
+ var __defProp = Object.defineProperty;
+ var __returnValue = (v) => v;
+ function __exportSetter(name, newValue) {
+@@ -198,7 +199,7 @@
+ var backend = loadBackend();
+ function loadBackend() {
+   if (isBun) {
+-    return createBunBackend(requireModule("bun:ffi"));
++    return createKoffiBackend(requireModule("bun:ffi"));
+   }
+   try {
+     const nodeFfi = requireModule("node:ffi");
+@@ -207,6 +208,75 @@
+     return createUnsupportedBackend(error);
+   }
+ }
++function createKoffiBackend(bun) {
++  // Bun's engine FFI requires JIT; Koffi uses static RISC-V call trampolines.
++  const types = {
++    i8: "int8_t", u8: "uint8_t", i16: "int16_t", u16: "uint16_t",
++    i32: "int32_t", u32: "uint32_t", i64: "int64_t", u64: "uint64_t",
++    f32: "float", f64: "double", usize: "size_t", cstring: "str",
++    ptr: "void *", pointer: "void *", buffer: "void *",
++    function: "void *", callback: "void *"
++  };
++  const ffiType = (type = "void") => types[type] ?? type;
++  const isPointer = (type) => types[type] === "void *";
++  // Preserve non-null empty buffers, which Koffi otherwise passes as NULL.
++  const emptyBuffer = new Uint8Array(1);
++  function toNative(type, value) {
++    if (type === "bool") return Boolean(value);
++    if (!isPointer(type)) return value;
++    if (typeof value === "number") return toSafeBigIntPointer(value);
++    if (value != null && value.byteLength === 0) return emptyBuffer;
++    return value;
++  }
++  function toJS(type, value) {
++    if (isPointer(type)) return value == null ? null : toSafeNumberPointer(value);
++    if (["i64", "u64", "int64_t", "uint64_t"].includes(type)) return BigInt(value);
++    return value;
++  }
++  return createBunBackend({
++    // Raw memory access does not use Bun's JIT-dependent call trampolines.
++    ptr: bun.ptr,
++    toArrayBuffer: bun.toArrayBuffer,
++    suffix: bun.suffix,
++    dlopen(path, definitions) {
++      const lib = koffi.load(path instanceof URL ? fileURLToPath(path) : path);
++      const symbols = {};
++      try {
++        for (const [name, definition] of Object.entries(definitions)) {
++          if (definition.ptr != null) {
++            throw new Error("Koffi backend does not support FFIFunction.ptr overrides");
++          }
++          const args = definition.args ?? [];
++          const fn = lib.func(name, ffiType(definition.returns), args.map(ffiType));
++          symbols[name] = (...values) => toJS(definition.returns,
++            fn(...values.map((value, index) => toNative(args[index], value))));
++        }
++      } catch (error) {
++        lib.unload();
++        throw error;
++      }
++      return { symbols, close: () => lib.unload() };
++    },
++    JSCallback: class {
++      constructor(callback, definition) {
++        if (definition.threadsafe) {
++          throw new Error("OpenTUI Koffi callbacks must be same-thread");
++        }
++        const args = definition.args ?? [];
++        const proto = koffi.proto(ffiType(definition.returns), args.map(ffiType));
++        this.callback = koffi.register((...values) => toNative(definition.returns,
++          callback(...values.map((value, index) => toJS(args[index], value)))), koffi.pointer(proto));
++        this.ptr = toSafeNumberPointer(this.callback);
++        this.threadsafe = false;
++      }
++      close() {
++        if (this.ptr === null) return;
++        koffi.unregister(this.callback);
++        this.ptr = null;
++      }
++    }
++  });
++}
+ function toPointer(value) {
+   if (isBun && typeof value === "bigint") {
+     return toSafeNumberPointer(value);
+@@ -7902,7 +7972,7 @@
+   win32: "opentui.dll"
+ };
+ function getNativeAssetDescriptor(target) {
+-  if (!Object.hasOwn(NATIVE_FILE_NAMES, target.platform) || target.arch !== "arm64" && target.arch !== "x64") {
++  if (!Object.hasOwn(NATIVE_FILE_NAMES, target.platform) || target.arch !== "arm64" && target.arch !== "x64" && !(target.platform === "linux" && target.arch === "riscv64")) {
+     throw new Error(`Unsupported OpenTUI Node asset target: ${String(target.platform)}-${String(target.arch)}`);
+   }
+   if (target.libc !== undefined && target.libc !== "glibc" && target.libc !== "musl") {
+@@ -7961,6 +8031,10 @@
+     }
+   }
+   if (process.platform === "linux") {
++    if (process.arch === "riscv64") {
++      // Koffi's dlopen cannot resolve Bun's embedded virtual filesystem.
++      return "/usr/lib/opencode/libopentui.so";
++    }
+     if (process.arch === "x64") {
+       if (process.env.OPENTUI_LIBC === "musl") {
+         return (await import("@opentui/core-linux-x64-musl")).default;
+@@ -11044,7 +11118,7 @@
+   console.error("FATAL ERROR:", message);
+   throw new Error(message);
+ }
+-var pointerSize = process.arch === "x64" || process.arch === "arm64" ? 8 : 4;
++var pointerSize = process.arch === "x64" || process.arch === "arm64" || process.arch === "riscv64" ? 8 : 4;
+ var isBun2 = typeof process !== "undefined" && "bun" in process.versions;
+ var typeSizes = {
+   u8: 1,

--- a/opencode/riscv64-target.patch
+++ b/opencode/riscv64-target.patch
@@ -32,3 +32,13 @@
      }
    },
    "devDependencies": {
+--- a/package.json
++++ b/package.json
+@@ -146,6 +146,7 @@
+     "@types/node": "catalog:"
+   },
+   "patchedDependencies": {
++    "@opentui/core@0.4.5": "patches/opentui-riscv64.patch",
+     "@tailwindcss/oxide-wasm32-wasi@4.1.11": "patches/fix-oxide-worker-exit.patch",
+     "@dnd-kit/dom@0.5.0": "patches/@dnd-kit%2Fdom@0.5.0.patch",
+     "@npmcli/agent@4.0.2": "patches/@npmcli%2Fagent@4.0.2.patch",

--- a/opencode/riscv64.patch
+++ b/opencode/riscv64.patch
@@ -1,21 +1,32 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -21,6 +21,7 @@
+@@ -12,6 +12,8 @@
+   'curl'
+   'glibc'
+   'icu'
++  'libgcc'
++  'libstdc++'
+   'ripgrep'
+   'tar'
+ )
+@@ -20,7 +22,9 @@
+ #)
  makedepends=(
    'bun'
++  'cmake'
    'git'
 +  'nodejs'
  )
  optdepends=(
    'wl-clipboard: clipboard support on Wayland'
-@@ -35,7 +36,14 @@
+@@ -35,11 +39,30 @@
  
  prepare() {
    cd $pkgname
 -  bun install --frozen-lockfile --ignore-scripts
 +  patch -Np1 -i ../wasm-css.patch
 +  patch -Np1 -i ../riscv64-target.patch
-+  cp ../fix-oxide-worker-exit.patch patches/
++  cp ../fix-oxide-worker-exit.patch ../opentui-riscv64.patch patches/
 +  # The lockfile records RISC-V optional dependencies with an unsupported CPU.
 +  sed -i '/linux-riscv64/s/"cpu": "none"/"cpu": "riscv64"/' bun.lock
 +  # Install Oxide's threaded WASM fallback on the host architecture.
@@ -24,7 +35,24 @@
  }
  
  build() {
-@@ -60,6 +68,7 @@
+-  cd $pkgname/packages/opencode
++  # Koffi's prebuilt RISC-V addon requires RVV and crashes on baseline CPUs.
++  cd "$srcdir/package"
++  node ./cnoke.cjs -P . -D src/koffi --release \
++    -d "CMAKE_C_FLAGS=$CFLAGS -march=rv64gc -mabi=lp64d" \
++    -d "CMAKE_CXX_FLAGS=$CXXFLAGS -march=rv64gc -mabi=lp64d" \
++    -d 'CMAKE_ASM_FLAGS=-march=rv64gc -mabi=lp64d'
++  cp build/koffi/linux_riscv64d/koffi.node "$srcdir/$pkgname/packages/opencode/node_modules/@opentui/core/"
++
++  # OpenTUI 0.4.5 needs Zig 0.15.2 and does not publish a RISC-V renderer.
++  cd "$srcdir/opentui-0.4.5/packages/core/src/zig"
++  "$srcdir/zig-riscv64-linux-0.15.2/zig" build -Doptimize=ReleaseFast -Dtarget=riscv64-linux-gnu.2.27
++
++  cd "$srcdir/$pkgname/packages/opencode"
+   OPENCODE_VERSION=$pkgver bun run ./script/build.ts --single --baseline --skip-install
+ }
+ 
+@@ -60,9 +83,12 @@
    cd $pkgname
    case $CARCH in
    aarch64) dir=opencode-linux-arm64 ;;
@@ -32,12 +60,25 @@
    x86_64) dir=opencode-linux-x64-baseline ;;
    esac
    install -vDm755 -t "$pkgdir/usr/bin" "packages/opencode/dist/$dir/bin/opencode"
-@@ -71,3 +80,8 @@
++  install -vDm755 -t "$pkgdir/usr/lib/opencode" \
++    "$srcdir/opentui-0.4.5/packages/core/src/zig/lib/riscv64-linux-gnu.2.27/libopentui.so"
+ 
+   install -vDm644 -t "$pkgdir/usr/share/licenses/$pkgname" LICENSE
+ 
+@@ -71,3 +97,16 @@
    SHELL=/bin/zsh "$pkgdir/usr/bin/opencode" completion \
      | install -vDm644 /dev/stdin "$pkgdir/usr/share/zsh/site-functions/_opencode"
  }
 +
-+source+=(wasm-css.patch fix-oxide-worker-exit.patch riscv64-target.patch)
++source+=(wasm-css.patch fix-oxide-worker-exit.patch riscv64-target.patch
++         opentui-riscv64.patch
++         'opentui-0.4.5.tar.gz::https://github.com/anomalyco/opentui/archive/refs/tags/v0.4.5.tar.gz'
++         'https://ziglang.org/download/0.15.2/zig-riscv64-linux-0.15.2.tar.xz'
++         'https://registry.npmjs.org/koffi/-/koffi-3.2.1.tgz')
 +b2sums+=('b4fab5bac8f8f6c57c5ddbc404df67687abe8210773fac182cce0d5ee0b7e97a589701c32a150e61406f3c46a3690bbf133ac3fd5dbe645bbdc9b247f853b7a6'
 +         '8ccefc948e86b53c43f77cc3f3ef3de557cd4c104a444fb0eb8b2626cfc607ae20825370ffa29eab66604514c5c76eeaa0c86d45a3b65776ac15edae374278b1'
-+         '9f627012736692b0cebe7238e0abf1f43d41875de8e78b1b82f18873acae0645a608705dbaac5aecf65bd9a23334d3adb109a3ffb56824394c0a85cad8900c17')
++         'f997385f7b1f6c68b2f6e958b68f9a8f76aa8cfcddd17d34a81e50243ef65b4b0d18a5928afed71ecee787b8e9f1526276f9203f760a081366ec670a8497964c'
++         'f8cf829d4278196af59c3529945cf54ecaf2585e7d9afb69f9897a7bbda31e5485488d5fff6134fafe920d4676d6560cefa06f6ccaa971b326cc3c1aad8d527a'
++         '98dfcd07b756eb9f25e3b9066f32d2fce20ed668e9fa9989ee229d1b16dcf5e0635cbae28f9c803d731c45b3b18b5a14e2d3cfd80f5c766891f8771118dac4be'
++         'e5f6ef23373ed163d5064f78e0973dda93b5848b98ecda41bb4bc706804ab18fab9938192d7299bb0449bf9c44e8902270a4efbe3577f23e54f00b718d195b50'
++         'c521ab108a3d52606ab8514cd532fe7d989d50f2d6f60bca40d20858a64403e5588b0cbdf9f3727dcd298c6fcd6413b19a054d4d836c3494b6a6485929c3148b')


### PR DESCRIPTION
Build the missing OpenTUI 0.4.5 RISC-V renderer with Zig 0.15.2 and install it under /usr/lib/opencode.

Use Koffi for native calls and callbacks because Bun's interpreter-only RISC-V runtime rejects its engine FFI with "bun:ffi requires the JIT". Preserve pointer and integer representations, callback ownership and raw memory access. Fix the bundled struct code treating RISC-V pointers as 32-bit.

Build Koffi 3.2.1 from source with rv64gc/lp64d for C, C++ and assembly. Its prebuilt addon executes RVV instructions during module initialization, causing "Illegal instruction" while loading the embedded .node module on baseline CPUs. Drop the prebuilt dependency and embed the locally built addon through a static import. Keep its libgcc/libstdc++ dependencies and libopentui.so on disk because Koffi cannot resolve Bun's virtual filesystem.

Copy the addon into packages/opencode/node_modules/@opentui/core for Bun's isolated workspace layout. The root node_modules destination is absent, making build() fail with "No such file or directory" after Koffi has compiled successfully.

No upstream fix for the prebuilt CPU mismatch was found. Koffi documents source builds, and OpenTUI's earlier Node.js proposal provides precedent for the backend.
https://koffi.dev/contribute#build-from-source
https://github.com/oven-sh/bun/pull/35246
https://github.com/anomalyco/opentui/pull/939
https://github.com/anomalyco/opentui/pull/1445