### PR TITLE
addpatch: doublecmd 1.2.8-1

### DIFF
--- a/doublecmd/fix-riscv64-time-type.patch
+++ b/doublecmd/fix-riscv64-time-type.patch
@@ -1,0 +1,11 @@
+--- a/components/doublecmd/dcunix.pas
++++ b/components/doublecmd/dcunix.pas
+@@ -69,7 +69,7 @@
+ type
+ {$IF DEFINED(LINUX)}
+   TUnixTime =
+-    {$IF DEFINED(CPUAARCH64)}
++    {$IF DEFINED(CPUAARCH64) OR DEFINED(CPURISCV64)}
+       Int64
+     {$ELSEIF DEFINED(CPUMIPS)}
+       LongInt

--- a/doublecmd/riscv64.patch
+++ b/doublecmd/riscv64.patch
@@ -1,0 +1,22 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -23,8 +23,10 @@
+ )
+ source=(
+     "https://downloads.sourceforge.net/project/$pkgbase/Double%20Commander%20Source/$pkgbase-$pkgver-src.tar.gz"
++    'fix-riscv64-time-type.patch'
+ )
+-sha512sums=('55432468baae690e58f3ae90d4a4a6bcd91233aee38225813f833b743d2ff1c19bc1f5d413e411c36a9480254d90336a75da7655daf857156cd3105de2586e7b')
++sha512sums=('55432468baae690e58f3ae90d4a4a6bcd91233aee38225813f833b743d2ff1c19bc1f5d413e411c36a9480254d90336a75da7655daf857156cd3105de2586e7b'
++            '5299c0566506d087766f7ad9737352b3f408672795d89805634446eca82fb5635d4255c604bbf13c4830ef20f1cda967af4aaeb8b7bb9df8e17ab0b7ab3875d2')
+ 
+ prepare() {
+     cp -a /usr/lib/lazarus ./
+@@ -33,6 +35,7 @@
+     sed -e 's/LIB_SUFFIX=.*/LIB_SUFFIX=/g' -i install/linux/install.sh
+     sed -e "s@=\$(which lazbuild)@=\"\$(which lazbuild) --lazarusdir=$srcdir/lazarus\"@" -i build.sh
+     sed -e '/doublecmd.zdli/d' -i install/linux/install.sh
++    patch -Np1 -i "$srcdir/fix-riscv64-time-type.patch"
+ }
+ 
+ build() {


### PR DESCRIPTION
Use signed Int64 for TUnixTime on RISC-V. FPC defines the architecture's stat timestamps as signed cLong, while Double Commander falls back to unsigned UIntPtr and fails with "Incompatible types: got Int64 expected QWord".

No upstream fix was found; v1.2.8 and current master retain the unsigned fallback.

https://github.com/doublecmd/doublecmd/blob/v1.2.8/components/doublecmd/dcunix.pas#L69-L76

https://gitlab.com/freepascal.org/fpc/source/-/blob/90afbc8114/rtl/linux/riscv64/stat.inc#L41-46