### PR TITLE
updpatch: ldc 3:1.43.0-1

### DIFF
--- a/ldc/fix-riscv-floating-point-control.patch
+++ b/ldc/fix-riscv-floating-point-control.patch
@@ -1,0 +1,70 @@
+--- a/std/math/hardware.d
++++ b/std/math/hardware.d
+@@ -716,6 +716,18 @@
+             }
+         }
+     }
++    else version (RISCV_Any)
++    {
++        // Rounding occupies FCSR bits 7:5; libc FE_* values are unshifted.
++        enum : RoundingMode
++        {
++            roundToNearest = 0x00,
++            roundDown      = 0x40,
++            roundUp        = 0x60,
++            roundToZero    = 0x20,
++            roundingMask   = 0xE0,
++        }
++    }
+     else
+     {
+         enum : RoundingMode
+@@ -946,6 +958,8 @@
+             return true;
+         else version (SPARC_Any)
+             return true;
++        else version (RISCV_Any)
++            return false; // RISC-V records exception flags without trapping.
+         else version (ARM_Any)
+         {
+             // The hasExceptionTraps_impl function is basically pure,
+@@ -1087,6 +1101,10 @@
+             {
+                 resetIeeeFlags();
+             }
++            else version (RISCV_Any)
++            {
++                resetIeeeFlags();
++            }
+             else
+                 static assert(false, "Not implemented for this architecture");
+         }
+@@ -1332,6 +1350,28 @@
+     assert(lrint(1.5) == 2.0);
+ }
+ 
++version (RISCV_Any)
++@optStrategy("none") // Observe each hardware register update.
++@system unittest
++{
++    import core.stdc.fenv : fegetround, FE_DOWNWARD;
++
++    alias FPC = FloatingPointControl;
++    const saved = FPC.getControlState();
++    scope(exit) FPC.setControlState(saved);
++    assert(!FPC.hasExceptionTraps);
++
++    // Start in round-to-nearest, ties-to-max-magnitude, with all flags set.
++    FPC.setControlState((saved & ~0xFFu) | 0x80u | FPC.allExceptions);
++    {
++        FPC ctrl;
++        ctrl.rounding = FPC.roundDown;
++        assert(fegetround() == FE_DOWNWARD);
++        assert((FPC.getControlState() & FPC.allExceptions) == 0);
++    }
++    assert((FPC.getControlState() & 0xE0u) == 0x80u);
++}
++
+ @safe unittest
+ {
+     void ensureDefaults()

--- a/ldc/riscv64.patch
+++ b/ldc/riscv64.patch
@@ -1,17 +1,16 @@
-diff --git PKGBUILD PKGBUILD
-index 6a6cda4..77872ff 100644
 --- PKGBUILD
 +++ PKGBUILD
-@@ -34,6 +34,8 @@ prepare() {
+@@ -34,6 +34,9 @@
  
      # LLVMDebuginfod required curl
      sed -i "s/-lLLVMDebuginfod/-lLLVMDebuginfod -lcurl/" tools/CMakeLists.txt
 +
 +    patch -Np1 -d runtime/phobos -i "$srcdir/disable-static-NaN-tests.patch"
++    patch -Np1 -d runtime/phobos -i "$srcdir/fix-riscv-floating-point-control.patch"
  }
  
  build() {
-@@ -49,7 +51,7 @@ build() {
+@@ -49,7 +52,7 @@
      -DBUILD_SHARED_LIBS=BOTH \
      -DBUILD_LTO_LIBS=ON \
      -DLDC_WITH_LLD=OFF \
@@ -20,10 +19,12 @@ index 6a6cda4..77872ff 100644
      -DADDITIONAL_DEFAULT_LDC_SWITCHES="\"-link-defaultlib-shared\"," \
      ..
      ninja
-@@ -101,3 +103,6 @@ package_liblphobos() {
+@@ -108,3 +111,8 @@
      # licenses
      install -D -m644 "$srcdir/ldc/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
  }
 +
-+source+=("disable-static-NaN-tests.patch")
-+sha256sums+=('22b9132b58dde320d6da3c22d2eeabbc0c4d6a079348e9e0fbe5172ef4b86aba')
++source+=("disable-static-NaN-tests.patch"
++         "fix-riscv-floating-point-control.patch")
++sha256sums+=('22b9132b58dde320d6da3c22d2eeabbc0c4d6a079348e9e0fbe5172ef4b86aba'
++            '9d8f868594cee9e44aba17def72a734d6eafebe09a6c9ae4292b110449768ce8')


### PR DESCRIPTION
LDC now defines D_HardFloat on RISC-V, exposing incomplete Phobos FloatingPointControl support. Building Phobos fails in clearExceptions() with std/math/hardware.d(1091): Error: static assert: "Not implemented for this architecture".

Reuse resetIeeeFlags() to clear RISC-V exception flags and report exception traps as unsupported. Encode rounding modes in FCSR bits 7:5 rather than using unshifted libc constants, masking all three bits so transitions from round-to-nearest, ties-to-max-magnitude also work.

Add a regression test covering flag clearing, rounding selection and restoration, including the third rounding bit.