### PR TITLE
addpatch: python-term-image 0.7.2-4

### DIFF
--- a/python-term-image/pillow-get-flattened-data.patch
+++ b/python-term-image/pillow-get-flattened-data.patch
@@ -1,0 +1,38 @@
+--- a/src/term_image/image/common.py
++++ b/src/term_image/image/common.py
+@@ -1496,7 +1496,7 @@
+         if alpha is None or img.mode in {"1", "L", "RGB", "HSV", "CMYK"}:
+             convert_resize_img("RGB")
+             if pixel_data:
+-                rgb = list(img.getdata())
++                rgb = list(img.get_flattened_data())
+                 a = [255] * mul(*size)
+         else:
+             convert_resize_img("RGBA")
+@@ -1512,7 +1512,7 @@
+                     a = [255] * mul(*size)
+             else:
+                 if pixel_data:
+-                    a = list(img.getdata(3))
++                    a = list(img.get_flattened_data(3))
+                     if round_alpha:
+                         alpha = round(alpha * 255)
+                         a = [0 if val < alpha else 255 for val in a]
+@@ -1527,7 +1527,7 @@
+                     img = bg
+ 
+             if pixel_data:
+-                rgb = list((img if img.mode == "RGB" else img.convert("RGB")).getdata())
++                rgb = list((img if img.mode == "RGB" else img.convert("RGB")).get_flattened_data())
+ 
+         return (img, *(pixel_data and (rgb, a) or (None, None)))
+ 
+@@ -2005,7 +2005,7 @@
+                 self._close_image(orig_img)
+ 
+             img = quantized_img
+-            rgb = [index + 16 for index in img.getdata(0)]
++            rgb = [index + 16 for index in img.get_flattened_data(0)]
+ 
+         return (img, rgb, a)
+ 

--- a/python-term-image/riscv64.patch
+++ b/python-term-image/riscv64.patch
@@ -1,0 +1,23 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -26,6 +26,12 @@
+ sha512sums=('11b244ab554385a697d14734757a031acbbe0c424f7bc824f25716ef98404882830c5d322e80582e5f7d4abdfef3d268956ad09da189d515d689242d1e3990e7')
+ b2sums=('20935e58bf75783c4538722929cfea9656c103d0cadbb991786ee0ec247771155b42bd3008763c55bf8b141f1e832cb7388755917dc82ce6565917f60be4b486')
+ 
++prepare() {
++  cd "$pkgname"
++
++  patch -Np1 -i "$srcdir/pillow-get-flattened-data.patch"
++}
++
+ build() {
+   cd "$pkgname"
+ 
+@@ -50,3 +56,7 @@
+   # license
+   install -vDm644 -t "$pkgdir/usr/share/licenses/$pkgname" LICENSE
+ }
++
++source+=(pillow-get-flattened-data.patch)
++sha512sums+=('98716b4421adc13dfd9ab527e0b043e6ec12d42b1e62f47fe58bc50e7f703f5968bda3d5b01e6efc122424a1736d4763843b0ff47491275185c032f27b326f6d')
++b2sums+=('3063bdd50648b287d4d91ab9d2acd0703161f1c18a5025f2376dfe5679d5887aa91553e0716a7817ace4cb04be649c4f20e19001f3bcca73a5e2f4a159d8d511')


### PR DESCRIPTION
Replace Pillow Image.getdata() calls with get_flattened_data(). Pillow 12.3 emits a DeprecationWarning and upstream configures pytest to treat warnings as errors, aborting test collection.

Cover all four call sites in v0.7.2. The closed, unmerged upstream PR only covers the three calls that remain on the newer main branch.

Upstream: https://github.com/AnonymouX47/term-image/pull/195