### PR TITLE
addpatch: python-statsmodels 0.14.6-2

### DIFF
--- a/python-statsmodels/fix-duplicate-test-params.patch
+++ b/python-statsmodels/fix-duplicate-test-params.patch
@@ -1,0 +1,17 @@
+Backport the duplicate test case fix from upstream's broader lint cleanup.
+https://github.com/statsmodels/statsmodels/commit/f49757024b9c12737b9a54a642f25298e4af3b2f
+
+--- a/statsmodels/stats/tests/test_moment_helpers.py
++++ b/statsmodels/stats/tests/test_moment_helpers.py
+@@ -104,9 +104,9 @@
+     assert_almost_equal(mvsk2mc(mc2mvsk(test_vals).T).T, test_vals)
+ 
+ 
+-@pytest.mark.parametrize('func_name', ['cum2mc', 'cum2mc', 'mc2cum', 'mc2mnc',
++@pytest.mark.parametrize('func_name', ['cum2mc', 'mc2cum', 'mc2mnc',
+                                        'mc2mvsk', 'mnc2cum', 'mnc2mc',
+-                                       'mnc2mc', 'mvsk2mc', 'mvsk2mnc'])
++                                       'mvsk2mc', 'mvsk2mnc'])
+ def test_moment_conversion_types(func_name):
+     # written in 2009
+     # TODO: why did I use list as return type?

--- a/python-statsmodels/riscv64.patch
+++ b/python-statsmodels/riscv64.patch
@@ -1,0 +1,23 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -21,6 +21,9 @@
+ 
+ prepare() {
+   sed -e 's/,<9//' -e '/oldest-supported-numpy/d' -i statsmodels/pyproject.toml
++  patch -Np1 -d statsmodels -i "$srcdir/fix-duplicate-test-params.patch"
++  patch -Np1 -d statsmodels -i "$srcdir/fix-scipy-1.18-apply-where.patch"
++  patch -Np1 -d statsmodels -i "$srcdir/fix-numpy-2.5-complex-casting.patch"
+ }
+ 
+ build() {
+@@ -39,3 +42,10 @@
+   python -m installer --destdir="$pkgdir" dist/*.whl
+   install -Dm644 LICENSE.txt -t "${pkgdir}"/usr/share/licenses/${pkgname}
+ }
++
++source+=(fix-duplicate-test-params.patch
++         "fix-scipy-1.18-apply-where.patch::https://github.com/statsmodels/statsmodels/commit/d72a99c908c939cc744312b1c33facb754199295.patch"
++         "fix-numpy-2.5-complex-casting.patch::https://github.com/statsmodels/statsmodels/commit/7cda9e610a1a7d72fccebad99d4dd30a077f0eba.patch")
++sha256sums+=('5a292d525d2d40390151b0392332f3dabdba8e7eb456adeef042f1e85aa226bc'
++             'ce0823e2fa14a859953409d882ebccc99a999815b124136be7ba99dc5a4395e4'
++             '681a983c4a386b97e60bc2e7c3bb689f5a33c2465eff3709b912f8cb68f3e75d')


### PR DESCRIPTION
Backport the moment_helpers fix from upstream’s broader lint cleanup. Pytest 9.1.1 aborts collection with duplicate parametrization IDs for cum2mc and mnc2mc.

The subsequent full check reaches 42 failures and 3 errors: SciPy 1.18 moves array_api_extra, causing 26 failures and 3 setup errors to fall through to the removed _lazywhere, while NumPy 2.5 exposes complex-valued knockoff products in 16 failures. Apply the two upstream compatibility fixes and keep the full suite enabled.

https://github.com/statsmodels/statsmodels/commit/f49757024b9c12737b9a54a642f25298e4af3b2f

https://github.com/statsmodels/statsmodels/commit/d72a99c908c939cc744312b1c33facb754199295

https://github.com/statsmodels/statsmodels/commit/7cda9e610a1a7d72fccebad99d4dd30a077f0eba