### PR TITLE
updpatch: vtk 9.6.2-7

### DIFF
--- a/vtk/anari-sdk-0.16.patch
+++ b/vtk/anari-sdk-0.16.patch
@@ -1,0 +1,108 @@
+--- a/Rendering/ANARI/vtkAnariLightNode.cxx
++++ b/Rendering/ANARI/vtkAnariLightNode.cxx
+@@ -21,12 +21,45 @@
+ #include <anari/anari_cpp.hpp>
+ #include <anari/anari_cpp/ext/std.h>
+ 
++#include <type_traits>
+ #include <vector>
+ 
+ using vec3 = anari::std_types::vec3;
+ 
+ VTK_ABI_NAMESPACE_BEGIN
+ 
++namespace
++{
++
++// The ANARI 1.0 specification's KHR_AREA_LIGHTS extension for light visibility was removed in
++// ANARI 1.1.
++template <typename ExtensionsT, typename = void>
++struct AnariHasPrimaryVisibility : std::false_type
++{
++};
++
++template <typename ExtensionsT>
++struct AnariHasPrimaryVisibility<ExtensionsT,
++  decltype(void(std::declval<const ExtensionsT&>().ANARI_KHR_LIGHT_PRIMARY_VISIBILITY))>
++  : std::true_type
++{
++};
++
++template <typename ExtensionsT>
++bool AnariSupportsLightVisibility(const ExtensionsT& extensions)
++{
++  if constexpr (AnariHasPrimaryVisibility<ExtensionsT>::value)
++  {
++    return extensions.ANARI_KHR_LIGHT_PRIMARY_VISIBILITY != 0;
++  }
++  else
++  {
++    return extensions.ANARI_KHR_AREA_LIGHTS != 0;
++  }
++}
++
++} // anonymous namespace
++
+ struct vtkAnariLightNodeInternals
+ {
+   vtkAnariSceneGraph* RendererNode{ nullptr };
+@@ -329,18 +362,9 @@
+         anari::setParameter(anariDevice, anariLight, "position", lightPosition);
+         // The overall amount of light emitted by the light in a direction in W/sr
+         anari::setParameter(anariDevice, anariLight, "intensity", lightIntensity);
+-
+         // The size of the point light
+-        if (anariExtensions.ANARI_KHR_AREA_LIGHTS)
+-        {
+-          float radius = static_cast<float>(vtkAnariLightNode::GetRadius(light));
+-          anari::setParameter(anariDevice, anariLight, "radius", radius);
+-        }
+-        else
+-        {
+-          this->Internals->RendererNode->WarningMacroOnce(
+-            this, " doesn't support KHR_AREA_LIGHTS::radius");
+-        }
++        float radius = static_cast<float>(vtkAnariLightNode::GetRadius(light));
++        anari::setParameter(anariDevice, anariLight, "radius", radius);
+       }
+       else
+       {
+@@ -392,17 +416,9 @@
+           vtkMath::Distance2BetweenPoints(position, focalPoint));
+       anari::setParameter(anariDevice, anariLight, "irradiance", irradiance);
+ 
+-      if (anariExtensions.ANARI_KHR_AREA_LIGHTS)
+-      {
+-        float radius = static_cast<float>(vtkAnariLightNode::GetRadius(light));
+-        // apparent size (angle in radians) of the light
+-        anari::setParameter(anariDevice, anariLight, "angularDiameter", radius);
+-      }
+-      else
+-      {
+-        this->Internals->RendererNode->WarningMacroOnce(
+-          this, " doesn't support KHR_AREA_LIGHTS::angularDiameter");
+-      }
++      float radius = static_cast<float>(vtkAnariLightNode::GetRadius(light));
++      // apparent size (angle in radians) of the light
++      anari::setParameter(anariDevice, anariLight, "angularDiameter", radius);
+     }
+     else
+     {
+@@ -416,7 +432,7 @@
+     // All light sources accept the following parameters
+     anari::setParameter(anariDevice, anariLight, "color", lightColor);
+ 
+-    if (anariExtensions.ANARI_KHR_AREA_LIGHTS)
++    if (::AnariSupportsLightVisibility(anariExtensions))
+     {
+       bool isVisible = light->GetSwitch() ? true : false;
+       anari::setParameter(anariDevice, anariLight, "visible", isVisible);
+@@ -424,7 +440,7 @@
+     else
+     {
+       this->Internals->RendererNode->WarningMacroOnce(
+-        this, " doesn't support KHR_AREA_LIGHTS::visible");
++        this, " doesn't support light visibility (KHR_LIGHT_PRIMARY_VISIBILITY::visible).");
+     }
+ 
+     anari::commitParameters(anariDevice, anariLight);

--- a/vtk/riscv64.patch
+++ b/vtk/riscv64.patch
@@ -21,7 +21,35 @@
    'openmpi: OpenMPI support'
    'viskores: accelerators support'
    'adios2: IO module'
-@@ -178,6 +174,7 @@ build() {
+@@ -155,13 +151,16 @@ source=(
+   $url/files/release/${pkgver%.*}/VTK-$pkgver.tar.gz
+   gdal-3.13.patch
+   fmt-12.2.patch
++  anari-sdk-0.16.patch
+ )
+ sha256sums=('aed12cec12a9609179bf66329070266627ca64244a10856a452b2a17ffb04a1d'
+             'b56f176de0fdf233f37d61bc41514ede03492987c50dc7cdb633adaa5d9f433c'
+-            'b784782cac02e11a129da68cc9feef2175b1cabb9dcc7b6c036f60becf77d8f6')
++            'b784782cac02e11a129da68cc9feef2175b1cabb9dcc7b6c036f60becf77d8f6'
++            'd884ad3f2c9a6fb26552f0b92646b6b6906d89afcfc2ff7fcd111f4c82825345')
+ b2sums=('343e3ee333ec0f5541014faf07fb66ac00f935e389af3dc588e1d75a023b77b2ecb2b57d8522ef46f77f0060811ee7c1c417becca5b605282704bcdf2bc750db'
+         '3492d04286f15ed5978bb7c39fcdf0e9a4922b57c580da8056ffc10c38226c01abfb6dc5d1018db4fab51896ed1d298330a1ab96e40ce33803fdb59caf11d770'
+-        'db47a96696f124de4588b289d01f01d1fb28c6b2408d68b505cb59f38244ae2c2e75787a9f43d4820441bf074e3f47246d7a5de9248cb8d3ff2dcaaa0b545640')
++        'db47a96696f124de4588b289d01f01d1fb28c6b2408d68b505cb59f38244ae2c2e75787a9f43d4820441bf074e3f47246d7a5de9248cb8d3ff2dcaaa0b545640'
++        '6e06621fdbdfa209c6ea9ca489b14dbd394c62497a6361c8944cf33a6e9c275f43afe0bfdd7f486a870984bee7504b2d569aca3f12429870f5146628cb351744')
+ 
+ prepare() {
+   cd ${pkgname^^}-${pkgver}
+@@ -175,6 +174,8 @@ prepare() {
+ 
+   # Fix build with fmt 12.2.0 https://gitlab.kitware.com/vtk/vtk/-/work_items/20092
+   patch -p1 -i ../fmt-12.2.patch
++
++  patch -p1 -i ../anari-sdk-0.16.patch # Fix build with ANARI SDK 0.16
+ }
+ 
+ build() {
+@@ -189,6 +190,7 @@ build() {
      -G Ninja
      -Wno-dev
      -DCMAKE_BUILD_TYPE=Release
@@ -29,11 +57,11 @@
      -DCMAKE_CXX_FLAGS="$CXXFLAGS -ffat-lto-objects"
      -DCMAKE_INSTALL_PREFIX=/usr
      -DCMAKE_INSTALL_LICENSEDIR=share/licenses/vtk
-@@ -210,6 +207,8 @@ build() {
+@@ -221,6 +223,8 @@ build() {
      -DVTK_MODULE_ENABLE_VTK_IOCatalystConduit=YES
      # building with the usd package does not work: https://gitlab.archlinux.org/archlinux/packaging/packages/usd/-/issues/7
      -DVTK_MODULE_ENABLE_VTK_IOUSD=NO
-+    # Depends on binary LookingGlass libraries not available for RISCV
++    # Depends on binary LookingGlass libraries not available for RISC-V
 +    -DVTK_MODULE_ENABLE_VTK_RenderingLookingGlass=NO
      -DHDF5_NO_FIND_PACKAGE_CONFIG_FILE=ON
      -DHDF5_C_COMPILER_EXECUTABLE=h5hlcc


### PR DESCRIPTION
Refresh the riscv64 patch for vtk 9.6.2-7.

Keep OSPRay and RenderingLookingGlass disabled. LookingGlass fetches an x86-64-only HoloPlayCore library; VTK 9.6.2 skips remote modules on the first configure pass, but upstream has fixed that behavior.

Backport ANARI 1.1 light parameter and visibility changes to build against anari-sdk 0.16, which removed ANARI_KHR_AREA_LIGHTS.

https://gitlab.kitware.com/vtk/vtk/-/commit/5a65a165132348e0c66504656c13cb7c65a6179f

https://github.com/Kitware/LookingGlassVTKModule/issues/66

https://gitlab.kitware.com/vtk/vtk/-/commit/c02fc7daf3790e48c07628c5096867b1eb272d77

https://gitlab.kitware.com/vtk/vtk/-/commit/7b88eefcbfa22442052d2c8a1790b5000cbce975