### PR TITLE
updpatch: fvm 4.3.1-1

### DIFF
--- a/fvm/riscv64-test-deadlines.patch
+++ b/fvm/riscv64-test-deadlines.patch
@@ -1,3 +1,14 @@
+--- test/utils/which_test.dart
++++ test/utils/which_test.dart
+@@ -21,7 +21,7 @@
+ 
+     // Platform-specific performance expectations
+     // Windows PATH lookup is significantly slower than Unix systems
+-    final expectedMaxTime = Platform.isWindows ? 50.0 : 1.0;
++    final expectedMaxTime = Platform.isWindows ? 50.0 : 5.0;
+ 
+     expect(
+       perInvocationSpeed,
 --- test/src/commands/remove_command_non_tty_test.dart
 +++ test/src/commands/remove_command_non_tty_test.dart
 @@ -69,7 +69,7 @@
@@ -20,6 +31,33 @@
 +    timeout: const Timeout(Duration(minutes: 4)),
    );
  }
+--- test/src/services/process_service_sigint_pty_test.dart
++++ test/src/services/process_service_sigint_pty_test.dart
+@@ -88,7 +88,7 @@
+       expect(report['parentExitCode'], 130);
+     },
+     skip: Platform.isWindows ? 'POSIX pseudo-terminal required' : false,
+-    timeout: const Timeout(Duration(minutes: 2)),
++    timeout: const Timeout(Duration(minutes: 4)),
+   );
+ }
+ 
+--- test/support_assets/process_service_sigint_pty.py
++++ test/support_assets/process_service_sigint_pty.py
+@@ -97,11 +97,11 @@
+         os.set_blocking(master_fd, False)
+         _configure_terminal(master_fd)
+ 
+-        _wait_for(master_fd, output, PARENT_CONTEXT, 20)
++        _wait_for(master_fd, output, PARENT_CONTEXT, 60)
+         if os.tcgetpgrp(master_fd) != parent_pid:
+             raise RuntimeError("Dart parent is not the PTY foreground process group")
+ 
+-        _wait_for(master_fd, output, b"FVM_PTY_TEST:CHILD_READY:", 20)
++        _wait_for(master_fd, output, b"FVM_PTY_TEST:CHILD_READY:", 60)
+         child_match = CHILD_READY_PATTERN.search(output)
+         if child_match is None:
+             raise RuntimeError("Could not parse the fake Flutter child PID")
 --- test/services/flutter_service_test.dart
 +++ test/services/flutter_service_test.dart
 @@ -495,7 +495,7 @@

--- a/fvm/riscv64.patch
+++ b/fvm/riscv64.patch
@@ -5,11 +5,11 @@
  depends=('git' 'glibc' 'unzip')
  makedepends=('dart')
 -source=("git+https://github.com/leoafarias/${pkgname}.git#tag=${pkgver}")
--sha256sums=('90653d9b61ba5e33c23c3f81a5473b885808f1143368e99ea5fe38f8608a95e4')
+-sha256sums=('a98573a6477893b7d281275e63fdd9730063d9ea91f971c670775b3b1fcdf4d4')
 +source=("git+https://github.com/leoafarias/${pkgname}.git#tag=${pkgver}"
 +        "riscv64-test-deadlines.patch")
-+sha256sums=('90653d9b61ba5e33c23c3f81a5473b885808f1143368e99ea5fe38f8608a95e4'
-+            '8c9675f3302accf71bfd88b4c07fb11823fd332c379cf2b2bd4dc4dec4c078c0')
++sha256sums=('a98573a6477893b7d281275e63fdd9730063d9ea91f971c670775b3b1fcdf4d4'
++            'b8996c7bb58928024f434b9d3048d5a4cb8428c4d4cd8843771c67a080f17b8a')
  options=('!strip' '!debug')
  
  prepare() {
@@ -22,13 +22,14 @@
  	# Disable analytics
  	dart --disable-analytics
  
-@@ -31,7 +37,8 @@
+@@ -31,7 +37,9 @@
  
  check() {
  	cd "${pkgname}/"
 -	dart test
 +	# The sdk tests need Flutter artifacts unavailable on riscv64 builders.
-+	dart test --exclude-tags=sdk
++	# Run test files serially so nested Dart processes are not starved.
++	dart test --concurrency=1 --exclude-tags=sdk
  }
  
  package() {


### PR DESCRIPTION
Refresh the packaging patch for 4.3.1 and run test files serially on riscv64. With upstream's two-file concurrency, nested Dart subprocess checks still exhaust their 180- and 60-second deadlines while another heavy test file runs; keep the non-TTY and PTY assertions enabled instead of extending them again.

Raise the Unix which() benchmark ceiling from 1 to 5 ms per call. The latest riscv64 check records 3.569 ms while retaining all 1000 invocations.

Upstream 4.3.1 and current main retain these timing assumptions. The benchmark replacement exists only on the unreleased release/5.0 branch, and no relevant fix was found for the subprocess starvation.

https://github.com/leoafarias/fvm/blob/4.3.1/dart_test.yaml

https://github.com/leoafarias/fvm/blob/4.3.1/test/utils/which_test.dart