### PR TITLE
updpatch: aida-x 1.1.0-2

### DIFF
--- a/aida-x/riscv64.patch
+++ b/aida-x/riscv64.patch
@@ -8,7 +8,7 @@
 +  aida-x-{clap,lv2,standalone,vst}
  )
  pkgver=1.1.0
- pkgrel=1
+ pkgrel=2
 @@ -24,9 +24,12 @@ makedepends=(
  checkdepends=(
    lv2lint
@@ -37,7 +37,15 @@
  build() {
    local cmake_options=(
      -B build
-@@ -154,23 +162,3 @@ package_aida-x-vst() {
+@@ -60,6 +68,6 @@
+ package_aida-x() {
+   depends=(
+-    $pkgbase-{clap,lv2,standalone,vst,vst3}=$pkgver
++    $pkgbase-{clap,lv2,standalone,vst}=$pkgver
+   )
+   # there is no install target :(
+   # https://github.com/AidaDSP/AIDA-X/issues/26
+@@ -159,24 +167,3 @@
    # mv -v $pkgname/* "$pkgdir"
    install -vDm 755 build/bin/$_name-vst2.so -t "$pkgdir/usr/lib/vst/"
  }
@@ -50,9 +58,10 @@
 -  )
 -  depends=(
 -    dbus
--    gcc-libs
 -    glibc
+-    libgcc
 -    libglvnd
+-    libstdc++
 -    libx11
 -    libxext
 -    vst3-host


### PR DESCRIPTION
Refresh for the libgcc and libstdc++ dependency split, which made the VST3 package-removal hunk fail. Remove aida-x-vst3 from the meta-package dependencies alongside its split package.

AIDA-X 1.1.0 vendors DPF 1504e7d, whose CMake VST3 architecture selector still rejects riscv64. No relevant upstream AIDA-X issue or fix was found.

https://github.com/AidaDSP/AIDA-X/tree/1.1.0

https://github.com/DISTRHO/DPF/blob/1504e7d327bfe0eac6a889cecd199c963d35532f/cmake/DPF-plugin.cmake#L452-L465