### PR TITLE
addpatch: python-mcp 1.29.0-1

### DIFF
--- a/python-mcp/config-generation-test.patch
+++ b/python-mcp/config-generation-test.patch
@@ -1,0 +1,38 @@
+--- a/tests/client/test_config.py
++++ b/tests/client/test_config.py
+@@ -2 +1,0 @@
+-import subprocess
+@@ -26,2 +25,2 @@
+-def test_command_execution(mock_config_path: Path):
+-    """Test that the generated command can actually be executed."""
++def test_command_generation(mock_config_path: Path):
++    """Test that the generated command contains the expected arguments."""
+@@ -32,3 +31,3 @@
+-    # Update config
+-    success = update_claude_config(file_spec=file_spec, server_name=server_name)
+-    assert success
++    with patch("mcp.cli.claude.get_uv_path", return_value="/usr/bin/uv"):
++        success = update_claude_config(file_spec=file_spec, server_name=server_name)
++        assert success
+@@ -42,9 +41,12 @@
+-    command = server_config["command"]
+-    args = server_config["args"]
+-
+-    test_args = [command] + args + ["--help"]
+-
+-    result = subprocess.run(test_args, capture_output=True, text=True, timeout=20, check=False)
+-
+-    assert result.returncode == 0
+-    assert "usage" in result.stdout.lower()
++    assert server_config == {
++        "command": "/usr/bin/uv",
++        "args": [
++            "run",
++            "--frozen",
++            "--with",
++            "mcp[cli]",
++            "mcp",
++            "run",
++            f"{Path('test_server.py').resolve()}:app",
++        ],
++    }

--- a/python-mcp/riscv64.patch
+++ b/python-mcp/riscv64.patch
@@ -1,0 +1,21 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -43,3 +43,2 @@
+   ruff
+-  uv
+ )
+@@ -54,5 +53,4 @@
+   cd python-sdk
+-  # uv may take longer than the hardcoded subprocess timeout while creating its
+-  # transient environment in a clean build.
+-  sed -i 's/, timeout=20//' tests/client/test_config.py
++  patch -Np1 -i "$srcdir/settings-model-rebuild.patch"
++  patch -Np1 -i "$srcdir/config-generation-test.patch"
+ }
+@@ -76 +74,6 @@
+ }
++
++source+=("settings-model-rebuild.patch::https://github.com/modelcontextprotocol/python-sdk/commit/ae3338f6b396378217921aeadeca10a68e273c2d.patch"
++         config-generation-test.patch)
++b2sums+=('cbb9f41784e2b170f339f5e25615324f9508ea62041fb13f371aced73d5eb6b82f6ebd1c5bdf109cb04d106ed4b7c3ca187fe37270d91413ac27d0047b408cd7'
++         '97319c83ea9575ba88fcde3c189fd9f4b6eb0de5afdef4b4d9e667b9f5c08f03229a1dee60cb1222b51ade802979b20dbae372193d92ac00553e9af0a247a04e')


### PR DESCRIPTION
Apply the upstream FastMCP Settings model rebuild. pydantic-settings 2.15 reports the unresolved lifespan forward reference as IncompleteFieldDefinitionWarning, and upstream promotes warnings to errors, causing 142 failures and 274 errors.

Replace the external uv execution test with a direct assertion of the generated command, following upstream's merged test rewrite. The uv subprocess resolves the full locked development and documentation graph, fails to build cryptography on riscv64, and in the four-worker retry overlaps the stdio startup test; that test times out and leaves the process resources reported by the following tool-manager test.

Remove uv and libjpeg-turbo from checkdepends because no remaining test executes that external environment.

https://github.com/modelcontextprotocol/python-sdk/commit/ae3338f6b396378217921aeadeca10a68e273c2d

https://github.com/modelcontextprotocol/python-sdk/commit/883d89309755def3048d2c8b6ad85a2b9861130b