### PR TITLE
addpatch: ruby 3.4.10-1

### DIFF
--- a/ruby/increase-objspace-timeout.patch
+++ b/ruby/increase-objspace-timeout.patch
@@ -1,0 +1,11 @@
+--- a/test/objspace/test_objspace.rb
++++ b/test/objspace/test_objspace.rb
+@@ -308,7 +308,7 @@
+   def test_trace_object_allocations_compaction_freed_pages
+     omit "compaction is not supported on this platform" unless GC.respond_to?(:compact)
+ 
+-    assert_normal_exit(<<~RUBY)
++    assert_normal_exit(<<~RUBY, timeout: 60)
+       require "objspace"
+ 
+       objs = []

--- a/ruby/riscv64.patch
+++ b/ruby/riscv64.patch
@@ -1,0 +1,29 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -163,6 +163,9 @@
+ prepare() {
+   cd "ruby-${pkgver}"
+ 
++  # This object tracing test exceeds its 10-second subprocess timeout on riscv64.
++  patch -Np1 -i "${srcdir}/increase-objspace-timeout.patch"
++
+   autoreconf -fiv
+ }
+ 
+@@ -193,6 +196,8 @@
+   # this uses malloc_usable_size, which is incompatible with fortification level 3
+   export CFLAGS="${CFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
+   export CXXFLAGS="${CXXFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
++  # The ruby_buildpack integration fixture exceeds SyntaxSuggest's one-second limit on riscv64.
++  export SYNTAX_SUGGEST_TIMEOUT=60
+ 
+   make check
+ }
+@@ -363,3 +368,7 @@
+ }
+ 
+ # vim: tabstop=2 shiftwidth=2 expandtab:
++
++source+=(increase-objspace-timeout.patch)
++sha512sums+=('016a9b38f17e2bf5863747898ff864d51299bfd53b0198fa5bb20209761233022f184a7501a8b7596259bda66c7a7d57dfebb3479911aab477b57a1562a6d021')
++b2sums+=('d9503f49aba8f3f9eff25077891e136d925baa3c83c4f01eabc5edf224930b6cdb86298f996aafdec0639630548b575d4e5c89f8df027f70ca9f2225cd59e01b')


### PR DESCRIPTION
Raise TestObjSpace#test_trace_object_allocations_compaction_freed_pages' subprocess timeout from 10 to 60 seconds. The riscv64 check reached the watchdog twice while allocating and compacting one million traced objects; keep the full test and retry behavior enabled. The separate WeakKeyMap timeout passed on retry and remains unchanged.

Set SYNTAX_SUGGEST_TIMEOUT=60 for check(). The follow-up build applies the object-space fix and passes Ruby's full core and spec suites, then the issues/95 ruby_buildpack integration fixture exceeds SyntaxSuggest's one-second search limit. Ruby documents this environment control and uses 30 to 60 seconds in CI; retain every SyntaxSuggest fixture and assertion.

Current Ruby and syntax_suggest main retain the one-second default and the same issues/95 fixture; no source fix for the timeout was found.

https://github.com/ruby/ruby/commit/5e8f9ea4953af1737a477613aa31e72ca81031c6

https://github.com/ruby/ruby/blob/v3_4_10/lib/syntax_suggest/api.rb

https://github.com/ruby/ruby/blob/v3_4_10/doc/contributing/building_ruby.md