### PR TITLE
updpatch: apko 1.3.0-1

### DIFF
--- a/apko/riscv64.patch
+++ b/apko/riscv64.patch
@@ -1,11 +1,17 @@
---- PKGBUILD	2026-03-02 22:51:09.734437455 +0800
-+++ PKGBUILD	2026-03-02 22:51:09.736143852 +0800
-@@ -41,7 +41,7 @@
- check() {
-   cd "${pkgname}-${pkgver}"
-   # skip TestPublish: https://github.com/chainguard-dev/apko/issues/881
--  go test ./... -skip 'TestPublish|TestBuild'
-+  go test ./... -skip 'TestPublish|TestBuild|TestLock|TestLdsoCache|TestAuth_good|TestTarFS'
- }
- 
- package() {
+--- PKGBUILD
++++ PKGBUILD
+@@ -18,3 +18,11 @@
+-source=("https://github.com/chainguard-dev/apko/archive/v${pkgver}/apko-${pkgver}.tar.gz")
+-sha256sums=('0f9e882489b04b3a36b2c620ab4df6ae485dd84dbed3cab742d70b2b56655ef9')
+-b2sums=('160a902576fd9c2ce6795a2803691b7639eedfa49567c7b24f02b728f59fc9e24e389c2eabb0d9ce096bcc1b88673a55318ad80a9a7d3925015b95f9922202d0')
++source=("https://github.com/chainguard-dev/apko/archive/v${pkgver}/apko-${pkgver}.tar.gz"
++        'test-fixture-arch.patch')
++sha256sums=('0f9e882489b04b3a36b2c620ab4df6ae485dd84dbed3cab742d70b2b56655ef9'
++            'c3432487cc099b63eee4864c18f96d5f7d8ac99ef14339d17b18007bf8bad174')
++b2sums=('160a902576fd9c2ce6795a2803691b7639eedfa49567c7b24f02b728f59fc9e24e389c2eabb0d9ce096bcc1b88673a55318ad80a9a7d3925015b95f9922202d0'
++        'a4d95fd6520c0fdf928fb7d55bbbf231e9ef70a120a61efa002bd21793adfda2df2e2ecf763052ad9e0e7cd1815a142b953ffe2388cf7f8824848af3473804e2')
++
++prepare() {
++  cd "${pkgname}-${pkgver}"
++  patch -Np1 -i ../test-fixture-arch.patch
++}

--- a/apko/test-fixture-arch.patch
+++ b/apko/test-fixture-arch.patch
@@ -1,0 +1,128 @@
+--- a/internal/cli/build_cpio_test.go
++++ b/internal/cli/build_cpio_test.go
+@@ -26,6 +26,7 @@
+ 	"chainguard.dev/apko/internal/cli"
+ 
+ 	"chainguard.dev/apko/pkg/build"
++	"chainguard.dev/apko/pkg/build/types"
+ )
+ 
+ func TestBuildCPIOCmd(t *testing.T) {
+@@ -34,7 +35,10 @@
+ 	t.Run("gz suffix produces gzip-compressed output", func(t *testing.T) {
+ 		dest := filepath.Join(t.TempDir(), "out.cpio.gz")
+ 
+-		err := cli.BuildCPIOCmd(ctx, dest, build.WithConfig("testdata/apko.yaml", []string{}))
++		err := cli.BuildCPIOCmd(ctx, dest,
++			build.WithConfig("testdata/apko.yaml", []string{}),
++			build.WithArch(types.ParseArchitecture("arm64")),
++		)
+ 		require.NoError(t, err)
+ 
+ 		f, err := os.Open(dest)
+@@ -49,7 +53,10 @@
+ 	t.Run("non-gz suffix produces plain cpio output", func(t *testing.T) {
+ 		dest := filepath.Join(t.TempDir(), "out.cpio")
+ 
+-		err := cli.BuildCPIOCmd(ctx, dest, build.WithConfig("testdata/apko.yaml", []string{}))
++		err := cli.BuildCPIOCmd(ctx, dest,
++			build.WithConfig("testdata/apko.yaml", []string{}),
++			build.WithArch(types.ParseArchitecture("arm64")),
++		)
+ 		require.NoError(t, err)
+ 
+ 		f, err := os.Open(dest)
+--- a/pkg/build/build_test.go
++++ b/pkg/build/build_test.go
+@@ -41,6 +41,7 @@
+ 
+ 	opts := []build.Option{
+ 		build.WithConfig("layering.yaml", []string{"testdata"}),
++		build.WithArch(types.ParseArchitecture("arm64")),
+ 	}
+ 
+ 	bc, err := build.New(ctx, fs.NewMemFS(), opts...)
+@@ -62,6 +63,7 @@
+ 	// Use the empty-layering.yaml file we created in testdata
+ 	opts := []build.Option{
+ 		build.WithConfig("empty-layering.yaml", []string{"testdata"}),
++		build.WithArch(types.ParseArchitecture("arm64")),
+ 	}
+ 
+ 	bc, err := build.New(ctx, fs.NewMemFS(), opts...)
+@@ -107,6 +109,7 @@
+ 
+ 	opts := []build.Option{
+ 		build.WithConfig("apko.yaml", []string{"testdata"}),
++		build.WithArch(types.ParseArchitecture("arm64")),
+ 	}
+ 
+ 	bc, err := build.New(ctx, fs.NewMemFS(), opts...)
+@@ -254,6 +257,7 @@
+ 
+ 	opts := []build.Option{
+ 		build.WithConfig("apko-certs.yaml", []string{"testdata"}),
++		build.WithArch(types.ParseArchitecture("arm64")),
+ 	}
+ 
+ 	fsys := fs.NewMemFS()
+@@ -324,6 +328,7 @@
+ 	opts := []build.Option{
+ 		build.WithConfig(filepath.Join("testdata", "apko.yaml"), []string{}),
+ 		build.WithLockFile(filepath.Join("testdata", "apko.lock.json")),
++		build.WithArch(types.ParseArchitecture("arm64")),
+ 	}
+ 
+ 	bc, err := build.New(ctx, fs.NewMemFS(), opts...)
+@@ -353,6 +358,7 @@
+ 	opts := []build.Option{
+ 		build.WithConfig(filepath.Join("testdata", "apko.yaml"), []string{}),
+ 		build.WithLockFile(filepath.Join("testdata", "apko.pre-0.13.lock.json")),
++		build.WithArch(types.ParseArchitecture("arm64")),
+ 	}
+ 
+ 	bc, err := build.New(ctx, fs.NewMemFS(), opts...)
+@@ -395,6 +401,7 @@
+ 			},
+ 			Archs: types.ParseArchitectures([]string{"amd64", "arm64"}),
+ 		}),
++		build.WithArch(types.ParseArchitecture("arm64")),
+ 		build.WithAuthenticator(auth.StaticAuth(host, testUser, testPass)))
+ 	if err != nil {
+ 		t.Fatal(err)
+--- a/pkg/build/ldsocache_test.go
++++ b/pkg/build/ldsocache_test.go
+@@ -5,6 +5,7 @@
+ 	"testing"
+ 
+ 	"chainguard.dev/apko/pkg/apk/fs"
++	"chainguard.dev/apko/pkg/build/types"
+ )
+ 
+ func TestLdsoCache(t *testing.T) {
+@@ -12,6 +13,7 @@
+ 
+ 	opts := []Option{
+ 		WithConfig("apko.yaml", []string{"testdata"}),
++		WithArch(types.ParseArchitecture("arm64")),
+ 	}
+ 
+ 	bc, err := New(ctx, fs.NewMemFS(), opts...)
+--- a/pkg/tarfs/fs_test.go
++++ b/pkg/tarfs/fs_test.go
+@@ -28,6 +28,7 @@
+ 	"chainguard.dev/apko/pkg/apk/apk"
+ 
+ 	"chainguard.dev/apko/pkg/build"
++	"chainguard.dev/apko/pkg/build/types"
+ 	"chainguard.dev/apko/pkg/tarfs"
+ )
+ 
+@@ -37,6 +38,7 @@
+ 
+ 	opts := []build.Option{
+ 		build.WithConfig(filepath.Join("testdata", "apko.yaml"), []string{}),
++		build.WithArch(types.ParseArchitecture("arm64")),
+ 	}
+ 
+ 	bc, err := build.New(ctx, tfs, opts...)


### PR DESCRIPTION
The refreshed suite reaches TestBuildCPIOCmd and six pkg/build tests that default to runtime.GOARCH, then fail because the bundled package repository has only x86_64 and aarch64 indexes. TestBuildImageFromTooOldResolvedFile subsequently dereferences the unexpected nil error.

Run each fixture-dependent test against its bundled arm64/aarch64 packages, including the previously excluded ldso, auth, and tarfs cases. Keep go test ./... unfiltered; the test logic still executes natively on riscv64.

Upstream v1.3.0 and current main still lack riscv64 package fixtures, and no relevant fix was found.

https://github.com/chainguard-dev/apko/issues/935