### PR TITLE
updpatch: bcachefs-tools 3:1.39.6-1

### DIFF
--- a/bcachefs-tools/riscv64.patch
+++ b/bcachefs-tools/riscv64.patch
@@ -1,6 +1,6 @@
 --- PKGBUILD
 +++ PKGBUILD
-@@ -58,6 +58,9 @@
+@@ -59,6 +59,9 @@
    export CFLAGS="${CFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
    export CXXFLAGS="${CXXFLAGS/_FORTIFY_SOURCE=3/_FORTIFY_SOURCE=2}"
  
@@ -10,3 +10,14 @@
    make \
      LIBEXECDIR=/usr/lib \
      DESTDIR="${pkgdir}" \
+@@ -68,7 +71,9 @@
+ 
+ check() {
+   cd ${pkgname}
+-  cargo test --profile release -- --no-capture
++  # LLD pulls unused static wrappers whose C implementations are not linked here.
++  RUSTFLAGS="${RUSTFLAGS//-C link-arg=-Wl,--icf=safe/} -C link-arg=-fuse-ld=bfd" \
++    cargo test --profile release -- --no-capture
+ }
+ 
+ package_bcachefs-tools() {


### PR DESCRIPTION
Keep the canonical Clang target override for build(). Upstream v1.39.6 normalizes bch_bindgen, but its newer fs/codegen.rs path still passes Rust's riscv64gc triple directly to bindgen; libclang rejects it. This is also tracked upstream and fixed the same way in NixOS.

Use BFD for check(). Arch Rust's default LLD revisits the generated static-wrapper archive after later Rust objects introduce references, then reports the wrappers' unlinked userspace C implementations as undefined. Retain the complete cargo test suite.

https://github.com/koverstreet/bcachefs-tools/issues/850

https://github.com/NixOS/nixpkgs/pull/550473