### PR TITLE
addpatch: ansible-navigator 26.8.0-1

### DIFF
--- a/ansible-navigator/riscv64.patch
+++ b/ansible-navigator/riscv64.patch
@@ -1,0 +1,11 @@
+--- PKGBUILD
++++ PKGBUILD
+@@ -14,7 +14,7 @@
+             'docker: To use docker as a container runtime'
+             'podman: To use podman as a container runtime')
+ source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/refs/tags/v${pkgver}.tar.gz")
+-sha256sums=('a90f6b9f1571be4e694cd90beee9e80e7bd85a8bfdff197abc012a952f3df99b')
++sha256sums=('ed20a74b8c821f0954a53efd387cae4b8507f7f5f1e7365a29cf89de8c6d2d60')
+ 
+ build() {
+ 	cd "${pkgname}-${pkgver}"


### PR DESCRIPTION
Update the stale checksum for GitHub’s regenerated v26.8.0 tag archive. Source validation currently rejects the archive before extraction; two downloads produced the same replacement digest, and the tag still points to the signed packaged commit.

No upstream ansible-navigator or Arch packaging fix was found.

https://github.com/ansible/ansible-navigator/commit/30e0b3d0f454a524e3520f9de0cbf18620b1b790

https://gitlab.archlinux.org/archlinux/packaging/packages/ansible-navigator/-/blob/26.8.0-1/PKGBUILD